### PR TITLE
Added docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
     java_distribution: ${{ vars.JAVA_DISTRIBUTION }}
     REGISTRY: ghcr.io
     IMAGE_NAME: ${{github.repository}}
-    CONTAINER_NAME: ${{ github.event.repository.name }} # only repository name
 
 jobs:
     build-jar:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
                   java_distribution: ${{ env.java_distribution }}
 
             - name: Build the jar file
-              run: ./gradlew jar --stacktrace
+              run: ./gradlew shadowJar --stacktrace
 
             - name: Upload jar file
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+    push:
+
+env:
+    java_version: ${{ vars.JAVA_VERSION }}
+    java_distribution: ${{ vars.JAVA_DISTRIBUTION }}
+
+jobs:
+    build:
+        name: Building the application
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  submodules: "recursive"
+
+            - name: Setup
+              uses: ./.github/workflows/setup/
+              with:
+                  java_version: ${{ env.java_version }}
+                  java_distribution: ${{ env.java_distribution }}
+
+            - name: Build the jar file
+              run: ./gradlew jar --stacktrace
+
+            - name: Upload jar file
+              if: (github.ref_name == 'develop' || github.ref_name == 'main') && github.ref_type == 'branch'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: backend-jar
+                  path: build/libs/*.jar
+                  if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,21 @@ name: Build
 
 on:
     push:
+        branches: ["develop"]
+        tags: ["v*"]
+    pull_request:
+    workflow_dispatch:
 
 env:
     java_version: ${{ vars.JAVA_VERSION }}
     java_distribution: ${{ vars.JAVA_DISTRIBUTION }}
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{github.repository}}
+    CONTAINER_NAME: ${{ github.event.repository.name }} # only repository name
 
 jobs:
-    build:
-        name: Building the application
+    build-jar:
+        name: Building the application as jar file
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
@@ -27,9 +34,82 @@ jobs:
               run: ./gradlew jar --stacktrace
 
             - name: Upload jar file
-              if: (github.ref_name == 'develop' || github.ref_name == 'main') && github.ref_type == 'branch'
               uses: actions/upload-artifact@v4
               with:
-                  name: backend-jar
+                  name: snowballr-backend-jar
                   path: build/libs/*.jar
                   if-no-files-found: error
+
+    build-and-push-docker-image:
+        name: Building and pushing the docker image
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+            attestations: write
+            id-token: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  submodules: "recursive"
+
+            # Only push artifacts on the develop branch or on a new tag
+            - name: Determine if artifacts should be pushed
+              id: check-push
+              run: |
+                  echo "should_push=${{ github.ref_type == 'tag' || (github.ref_type == 'branch' && github.ref_name == 'develop') }}" >> $GITHUB_OUTPUT
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            # This step uses metadata-action to extract tags and labels that will be
+            # applied to the specified image. The `id` "meta" allows the output of
+            # this step to be referenced in a subsequent step. The `images` value
+            # provides the base name for the tags and labels.
+            # We add the following tags
+            # - version tags: for v1.2.3 -> v1, v1.2, v1.2.3
+            # - latest tags: for develop -> latest-dev; for tag -> latest
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                  tags: |
+                      type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
+                      type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
+                      type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' }}
+                      type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+                      type=raw,value=latest-dev,enable=${{ github.ref_name == 'develop' }}
+                  flavor: |
+                      latest=false
+
+            - name: Login to GitHub Container Registry
+              if: ${{ steps.check-push.outputs.should_push == 'true' }}
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push Docker image
+              id: push
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  push: ${{ steps.check-push.outputs.should_push == 'true' }}
+                  # Only build for ARM when we intend to push the image, as the emulation takes a lot of time
+                  platforms: linux/amd64 ${{ steps.check-push.outputs.should_push == 'true' && ', linux/arm64' || '' }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+
+            - name: Generate artifact attestation
+              if: ${{ steps.check-push.outputs.should_push == 'true' }}
+              uses: actions/attest-build-provenance@v2
+              with:
+                  subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+                  subject-digest: ${{ steps.push.outputs.digest }}
+                  push-to-registry: true

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -22,12 +22,11 @@ jobs:
               with:
                   submodules: "recursive"
 
-            - name: Setup Java
-              uses: actions/setup-java@v4
+            - name: Setup
+              uses: ./.github/workflows/setup/
               with:
-                  distribution: ${{ env.java_distribution }}
-                  java-version: ${{ env.java_version }}
-                  cache: "gradle"
+                  java_version: ${{ env.java_version }}
+                  java_distribution: ${{ env.java_distribution }}
 
             - name: Check formatting
               run: ./gradlew lintKotlin
@@ -41,12 +40,11 @@ jobs:
               with:
                   submodules: "recursive"
 
-            - name: Setup Java
-              uses: actions/setup-java@v4
+            - name: Setup
+              uses: ./.github/workflows/setup/
               with:
-                  distribution: ${{ env.java_distribution }}
-                  java-version: ${{ env.java_version }}
-                  cache: "gradle"
+                  java_version: ${{ env.java_version }}
+                  java_distribution: ${{ env.java_distribution }}
 
             - name: Check linting
               run: ./gradlew detekt
@@ -63,12 +61,11 @@ jobs:
               with:
                   submodules: "recursive"
 
-            - name: Setup Java
-              uses: actions/setup-java@v4
+            - name: Setup
+              uses: ./.github/workflows/setup/
               with:
-                  distribution: ${{ env.java_distribution }}
-                  java-version: ${{ env.java_version }}
-                  cache: "gradle"
+                  java_version: ${{ env.java_version }}
+                  java_distribution: ${{ env.java_distribution }}
 
             - name: Run tests and collect coverage
               run: |

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -1,0 +1,23 @@
+name: Setup
+description: Setup Backend CI/CD pipeline
+inputs:
+    java_version:
+        description: "Java version"
+        required: true
+    java_distribution:
+        description: "Java distribution"
+        required: true
+runs:
+    using: composite
+    steps:
+        - name: Setup Java
+          uses: actions/setup-java@v4
+          with:
+              java-version: ${{ inputs.java_version }}
+              distribution: ${{ inputs.java_distribution }}
+
+        - name: Setup Gradle
+          uses: gradle/actions/setup-gradle@v4
+          with:
+              # Only write to cache on main or develop branch
+              cache-read-only: ${{ github.ref_name != 'main' && github.ref_name != 'develop' }}

--- a/.idea/runConfigurations/DB_only.xml
+++ b/.idea/runConfigurations/DB_only.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="DB-only" type="docker-deploy" factoryName="docker-compose.yml"
+                   server-name="Docker">
+        <deployment type="docker-compose.yml">
+            <settings>
+                <option name="envFilePath" value=""/>
+                <option name="profiles">
+                    <list>
+                        <option value="db-only"/>
+                    </list>
+                </option>
+                <option name="sourceFilePath" value="docker-compose.yml"/>
+            </settings>
+        </deployment>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.idea/runConfigurations/Run_latest.xml
+++ b/.idea/runConfigurations/Run_latest.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run latest" type="docker-deploy" factoryName="docker-compose.yml"
+                   server-name="Docker">
+        <deployment type="docker-compose.yml">
+            <settings>
+                <option name="envFilePath" value=""/>
+                <option name="profiles">
+                    <list>
+                        <option value="latest"/>
+                    </list>
+                </option>
+                <option name="sourceFilePath" value="docker-compose.yml"/>
+            </settings>
+        </deployment>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.idea/runConfigurations/Run_latest_dev.xml
+++ b/.idea/runConfigurations/Run_latest_dev.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run latest-dev" type="docker-deploy" factoryName="docker-compose.yml"
+                   server-name="Docker">
+        <deployment type="docker-compose.yml">
+            <settings>
+                <option name="envFilePath" value=""/>
+                <option name="profiles">
+                    <list>
+                        <option value="latest-dev"/>
+                    </list>
+                </option>
+                <option name="sourceFilePath" value="docker-compose.yml"/>
+            </settings>
+        </deployment>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.idea/runConfigurations/Run_local.xml
+++ b/.idea/runConfigurations/Run_local.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run local" type="docker-deploy" factoryName="docker-compose.yml"
+                   server-name="Docker">
+        <deployment type="docker-compose.yml">
+            <settings>
+                <option name="envFilePath" value=""/>
+                <option name="sourceFilePath" value="docker-compose.yml"/>
+            </settings>
+        </deployment>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/proto api/proto
 
 # Grant execution rights to the Gradle wrapper script and build the jar file
 RUN chmod +x gradlew \
-    && ./gradlew jar --no-daemon --stacktrace
+    && ./gradlew shadowJar --no-daemon --stacktrace
 
 # Stage 2: Run the application
 FROM eclipse-temurin:21-jre-alpine-3.21 AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application
+FROM gradle:8.10.2-jdk21-jammy AS build
+
+WORKDIR /app
+
+# Copy the Gradle wrapper files
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# Copy the project's source code and proto files
+COPY src/main src/main
+COPY api/proto api/proto
+
+# Grant execution rights to the Gradle wrapper script and build the jar file
+RUN chmod +x gradlew \
+    && ./gradlew jar --no-daemon --stacktrace
+
+# Stage 2: Run the application
+FROM eclipse-temurin:21-jre-alpine-3.21 AS final
+
+WORKDIR /app
+
+# Run the application as a non-root user.
+RUN adduser -D backend-user && chown -R backend-user /app
+USER backend-user
+
+# Copy built jar file
+COPY --from=build /app/build/libs/snowballr-backend-*.jar app.jar
+
+# Start execute the jar file when starting the container
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ cp .env.example .env
 
 The environment variables are as follows:
 
-| Variable            |      Required      | Default | Description                                                                      |
-|---------------------|:------------------:|:-------:|----------------------------------------------------------------------------------|
-| `PORT`              | :white_check_mark: |    -    | The port where the backend is served                                             |
-| `LOG_LEVEL`         |        :x:         | `DEBUG` | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
-| `DATABASE_PASSWORD` | :white_check_mark: |    -    | Password for the database e.g. `postgres_password`                               |
+| Variable            |      Required      |   Default   | Description                                                                      |
+|---------------------|:------------------:|:-----------:|----------------------------------------------------------------------------------|
+| `PORT`              | :white_check_mark: |      -      | The port where the backend is served                                             |
+| `LOG_LEVEL`         |        :x:         |   `DEBUG`   | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
+| `DATABASE_PASSWORD` | :white_check_mark: |      -      | Password for the database e.g. `postgres_password`                               |
+| `DATABASE_HOST`     |        :x:         | `localhost` | Hostname of database connection                                                  |
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -1,60 +1,50 @@
 # SnowballR Backend
 
 This is the backend of the SnowballR application.
+Have a look at the [wiki of our frontend repo](https://github.com/SE-UUlm/snowballr-frontend/wiki) to learn more about
+SLRs and Snowballing. Also have a look at the [wiki of this repo](https://github.com/SE-UUlm/snowballr-backend/wiki) to
+find about our architecture, how to get the backend started, and how to contribute.
 
-## Commands
+## Getting Started
 
-### Starting the server
-
-First, provide a `.env` file with all required environment variables shown in the section below.
-
-As the server assumes a database to be running, we first need to start the database.
-The best way to do this is to use the docker compose file. Run it with `docker compose up`.
-If the database is up and running, we can start the server. This can either be done by executing the built JAR file or
-by using the Gradle command:
+The fastest way to get started is to use the provided Docker setup. To do so, run the following commands:
 
 ```bash
-java -jar build/libs/snowballr-backend-<version>.jar
-# or
-./gradlew run
+git clone git@github.com:SE-UUlm/snowballr-backend.git
+cd snowballr-backend
+git submodule update --init --recursive
+docker compose up
 ```
 
-If you're using IntelliJ IDEA, you can use the added run configuration "Run Backend", which does the same as executing
-`./gradlew run`.
+Be sure to have the environment variables set or create a `.env` file in the root directory of the project (see
+[below](#environment-variables)).
 
-### Formatting
+We provide several docker compose profiles for different setups.
 
-```bash
-# Format files
-./gradlew formatKotlin
+- \<no-arguments\>: Starts the backend together with the database.
+- `db-only`: Only starts the database (for local development)
+- `latest`: Starts the published backend image with the 'latest' tag together with the database.
+- `latest-dev`: Starts the published backend image with the 'latest-dev' tag together with the database.
 
-# Verify formatting
-./gradlew lintKotlin
-```
-
-### Linting
-
-```bash
-./gradlew detekt
-```
-
-### Testing
-
-```bash
-./gradlew test
-```
-
-### Build Jar
-
-```bash
-./gradlew jar
-# Jar can be found in build/libs/snowballr-backend-<version>.jar
-```
+Use `docker compose --profile <profile> up` to start the frontend with the desired profile.
 
 ## Environment Variables
 
+The app requires a set of environment variables to run. You can set them in a `.env` file in the root directory of the
+project. Either create the file manually or copy the provided example:
+
+```bash
+cp .env.example .env
+```
+
+The environment variables are as follows:
+
 | Variable            |      Required      | Default | Description                                                                      |
-| ------------------- | :----------------: | :-----: | -------------------------------------------------------------------------------- |
+|---------------------|:------------------:|:-------:|----------------------------------------------------------------------------------|
 | `PORT`              | :white_check_mark: |    -    | The port where the backend is served                                             |
 | `LOG_LEVEL`         |        :x:         | `DEBUG` | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
 | `DATABASE_PASSWORD` | :white_check_mark: |    -    | Password for the database e.g. `postgres_password`                               |
+
+## Building from Source
+
+See [our wiki](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started) to build the project from source.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,10 @@ tasks.withType<Jar> {
     manifest {
         attributes["Main-Class"] = "se.uulm.snowballr.backend.MainKt"
     }
+
+    // Include all runtime dependencies in the JAR file
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,7 @@ detekt {
     config.from("detekt.yml")
 }
 
+// https://github.com/grpc/grpc-kotlin/tree/master/compiler
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.kotlin.version.get()}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.protobuf)
+    alias(libs.plugins.shadow.jar)
     application
 }
 
@@ -63,14 +64,8 @@ kotlin {
     jvmToolchain(21)
 }
 
-tasks.withType<Jar> {
-    manifest {
-        attributes["Main-Class"] = "se.uulm.snowballr.backend.MainKt"
-    }
-
-    // Include all runtime dependencies in the JAR file
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+tasks.shadowJar {
+    archiveClassifier.set("") // omit the "all" suffix
 }
 
 tasks.test {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+    # Use local backend
+    backend:
+        build:
+            context: .
+        environment:
+            PORT: ${PORT:-8080}
+            LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+        ports:
+            - ${PORT:-8080}:${PORT:-8080}
+        depends_on:
+            db:
+                condition: service_healthy
+        profiles: [""]
+
+    # PostgreSQL Database
     db:
         image: postgres:16.1-alpine3.19
         restart: always
@@ -8,11 +24,36 @@ services:
             - "5432:5432"
         volumes:
             - ./db-data:/var/lib/postgresql/data
-        networks:
-            - db
         healthcheck:
             test: "pg_isready -U postgres"
+            start_period: 2s   # wait 2s to let db get ready for accepting connections
+            start_interval: 2s # start first healthcheck after 2s
+        profiles: ["", "db-only", "latest", "latest-dev"]
 
-networks:
-    db:
-        driver: bridge
+    # Use the published backend with the 'latest' tag
+    backend-latest:
+        image: ghcr.io/se-uulm/snowballr-backend:latest
+        environment:
+            PORT: ${PORT:-8080}
+            LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+        ports:
+            - ${PORT:-8080}:${PORT:-8080}
+        depends_on:
+            db:
+                condition: service_healthy
+        profiles: ["latest"]
+
+    # Use the published backend with the 'latest-dev' tag
+    backend-latest-dev:
+        image: ghcr.io/se-uulm/snowballr-backend:latest-dev
+        environment:
+            PORT: ${PORT:-8080}
+            LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+        ports:
+            - ${PORT:-8080}:${PORT:-8080}
+        depends_on:
+            db:
+                condition: service_healthy
+        profiles: ["latest-dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             PORT: ${PORT:-8080}
             LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
             DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+            DATABASE_HOST: db # use db service as db host
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         depends_on:
@@ -37,6 +38,7 @@ services:
             PORT: ${PORT:-8080}
             LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
             DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+            DATABASE_HOST: db # use db service as db host
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         depends_on:
@@ -51,6 +53,7 @@ services:
             PORT: ${PORT:-8080}
             LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
             DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+            DATABASE_HOST: db # use db service as db host
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         depends_on:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ protobuf-version = "0.9.4"
 grpc-kotlin-version = "1.4.3"
 grpc-protobuf-version = "1.73.0"
 protobuf-kotlin-version = "4.31.1"
+shadow-jar-version = "8.3.6"
 
 [libraries]
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-version" }
@@ -67,3 +68,4 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-version" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover-version" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter-version" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-version" }
+shadow-jar = { id = "com.gradleup.shadow", version.ref = "shadow-jar-version" }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -12,15 +12,15 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer
 private val logger = KotlinLogging.logger {}
 
 fun main() {
-    // Start Dependency Injection
-    startKoin {
-        modules(snowballRModule)
-    }
-
     val env = Env()
 
     // Configure Logger
     configureRootLogger(env.miscellaneous.logLevel)
+
+    // Start Dependency Injection
+    startKoin {
+        modules(snowballRModule)
+    }
 
     // Create and run the server
     val server = SnowballRServer(env.http.port)

--- a/src/main/kotlin/db/Database.kt
+++ b/src/main/kotlin/db/Database.kt
@@ -75,7 +75,7 @@ class Database(
                 schema = SCHEMA_NAME
                 transactionIsolation = ISOLATION_LEVEL.toString()
                 dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"
-                addDataSourceProperty("serverName", "host.docker.internal")
+                addDataSourceProperty("serverName", data.host)
                 validate()
             }
         return HikariDataSource(config)

--- a/src/main/kotlin/db/Database.kt
+++ b/src/main/kotlin/db/Database.kt
@@ -75,6 +75,7 @@ class Database(
                 schema = SCHEMA_NAME
                 transactionIsolation = ISOLATION_LEVEL.toString()
                 dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"
+                addDataSourceProperty("serverName", "host.docker.internal")
                 validate()
             }
         return HikariDataSource(config)

--- a/src/main/kotlin/env/Env.kt
+++ b/src/main/kotlin/env/Env.kt
@@ -4,6 +4,7 @@ import io.github.cdimascio.dotenv.dotenv
 
 // Default values
 const val DEFAULT_LOG_LEVEL = "DEBUG"
+const val DEFAULT_DATABASE_HOST = "localhost"
 
 // Http
 private const val PORT = "PORT"
@@ -13,6 +14,7 @@ private const val LOG_LEVEL = "LOG_LEVEL"
 
 // Database
 private const val DATABASE_PASSWORD = "DATABASE_PASSWORD"
+private const val DATABASE_HOST = "DATABASE_HOST"
 
 private val envService = EnvService()
 
@@ -38,6 +40,7 @@ data class Env(
 
     data class Database(
         val password: String = envService[DATABASE_PASSWORD],
+        val host: String = envService.getOrDefault(DATABASE_HOST, DEFAULT_DATABASE_HOST),
     )
 }
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -13,6 +13,9 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
     * [Service](#service)
     * [Input Validation](#input-validation)
   * [Testing](#testing)
+  * [Miscellaneous Commands](#miscellaneous-commands)
+    * [Formatting](#formatting)
+    * [Linting](#linting)
 <!-- TOC -->
 <!-- markdownlint-enable MD007 -->
 
@@ -228,3 +231,21 @@ class, which provides several predefined conditions that might be used more freq
 ## Testing
 
 For information about our testing setup, see [Testing](https://github.com/SE-UUlm/snowballr-frontend/wiki/Testing).
+
+## Miscellaneous Commands
+
+### Formatting
+
+```bash
+# Format files
+./gradlew formatKotlin
+
+# Verify formatting
+./gradlew lintKotlin
+```
+
+### Linting
+
+```bash
+./gradlew detekt
+```

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -230,7 +230,7 @@ class, which provides several predefined conditions that might be used more freq
 
 ## Testing
 
-For information about our testing setup, see [Testing](https://github.com/SE-UUlm/snowballr-frontend/wiki/Testing).
+For information about our testing setup, see [Testing](https://github.com/SE-UUlm/snowballr-backend/wiki/Testing).
 
 ## Miscellaneous Commands
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -45,7 +45,7 @@ To build the project from source, run the following commands:
 git clone git@github.com:SE-UUlm/snowballr-backend.git
 cd snowballr-backend
 git submodule update --init --recursive
-./gradlew jar
+./gradlew shadowJar
 ```
 
 The built JAR file can be found in the `build/libs` directory, named `snowballr-backend-<version>.jar`.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -10,7 +10,14 @@ docker compose up
 Be sure to have the environment variables set or create a `.env` file in the root directory of the project (see
 [below](#environment-variables)).
 
-TODO: more information about the Docker setup.
+We provide several docker compose profiles for different setups.
+
+- \<no-arguments\>: Starts the backend together with the database.
+- `db-only`: Only starts the database (for local development)
+- `latest`: Starts the published backend image with the 'latest' tag together with the database.
+- `latest-dev`: Starts the published backend image with the 'latest-dev' tag together with the database.
+
+Use `docker compose --profile <profile> up` to start the frontend with the desired profile.
 
 ## Environment Variables
 
@@ -50,6 +57,8 @@ The JAR file can be executed with the following command:
 ```bash
 java -jar build/libs/snowballr-backend-<version>.jar
 ```
+
+Remember to provide the environment variables either via a `.env` file or by writing them in front of the command.
 
 If you want to run the project in an IDE, you can import it as a Gradle project. The Gradle wrapper is included, so you
 can run Gradle commands directly from the project root directory. For example, to run the server, you can use:

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -30,11 +30,12 @@ cp .env.example .env
 
 The environment variables are as follows:
 
-| Variable            |      Required      | Default | Description                                                                      |
-|---------------------|:------------------:|:-------:|----------------------------------------------------------------------------------|
-| `PORT`              | :white_check_mark: |    -    | The port where the backend is served                                             |
-| `LOG_LEVEL`         |        :x:         | `DEBUG` | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
-| `DATABASE_PASSWORD` | :white_check_mark: |    -    | Password for the database e.g. `postgres_password`                               |
+| Variable            |      Required      |   Default   | Description                                                                      |
+|---------------------|:------------------:|:-----------:|----------------------------------------------------------------------------------|
+| `PORT`              | :white_check_mark: |      -      | The port where the backend is served                                             |
+| `LOG_LEVEL`         |        :x:         |   `DEBUG`   | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
+| `DATABASE_PASSWORD` | :white_check_mark: |      -      | Password for the database e.g. `postgres_password`                               |
+| `DATABASE_HOST`     |        :x:         | `localhost` | Hostname of database connection                                                  |
 
 ## Building from Source
 


### PR DESCRIPTION
Closes #4 

## What I have made

This PR adds a Dockerfile and with it a CI job to build an image from it.

The image is pushed to the registry with the following tags:
- `latest-dev` on develop
- `latest`, `vx`, `vx.y`, and `vx.y.z` on a tag with the pattern vx.y.z

The image is always built, but not always pushed. This enables us to catch errors with the docker setup.
Because building for the ARM architecture takes much more time (10x) compared to AMD, we only build for ARM, when we also intend to push the image.

I also modified the README.md to be more like the one in the frontend.

I also added a docker compose file with various profiles, which are documented in the README and the wiki.

The `DATABASE_HOST` env variable allows us to control, which URL is used when connecting to the DB. Inside a docker container `localhost` cannot be used for the DB connection, but there we use `db`, i.e., the service name of the DB container. For local development, the default is just fine.

I pushed the current state to registry, you can pull it using `docker pull ghcr.io/se-uulm/snowballr-backend:wip`. This will be deleted after mergin this PR.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
