### PR TITLE
Added input validation layer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,11 +43,14 @@ dependencies {
 
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.assertj.core)
+    testImplementation(libs.assertj.arrow.core)
     testImplementation(libs.h2)
     testImplementation(libs.mockk)
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
+
+    implementation(libs.arrow.core)
 
     implementation(libs.grpc.kotlin)
     implementation(libs.grpc.protobuf)
@@ -92,6 +95,7 @@ kover {
                     "se.uulm.snowballr.backend.db", // production database
                     "se.uulm.snowballr.backend.env", // environment variables
                     "se.uulm.snowballr.backend.grpc", // grpc server implementation
+                    "se.uulm.snowballr.backend.model", // model classes, no logic
                 )
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ dotenv-version = "6.5.1"
 assertj-version = "3.27.3"
 h2-version = "2.3.232"
 mockk-version = "1.14.2"
+arrow-version = "2.0.1"
+assertj-arrow-core-version = "1.2.0"
 detekt-version = "1.23.8"
 kotlinx-kover-version = "0.9.1"
 kotlinter-version = "5.1.0"
@@ -49,6 +51,10 @@ assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-ver
 h2 = { module = "com.h2database:h2", version.ref = "h2-version" }
 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk-version" }
+
+arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow-version" }
+
+assertj-arrow-core = { module = "in.rcard:assertj-arrow-core", version.ref = "assertj-arrow-core-version" }
 
 grpc-kotlin = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpc-kotlin-version" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc-protobuf-version" }

--- a/src/main/kotlin/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/grpc/SnowballRServer.kt
@@ -40,6 +40,7 @@ class SnowballRServer(
         ServerBuilder
             .forPort(port)
             .intercept(loggingInterceptor)
+            .intercept(validationInterceptor)
             .addService(SnowballRService())
             .build()
 

--- a/src/main/kotlin/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/grpc/SnowballRServer.kt
@@ -39,8 +39,8 @@ class SnowballRServer(
     private val server: Server =
         ServerBuilder
             .forPort(port)
-            .addService(SnowballRService())
             .intercept(loggingInterceptor)
+            .addService(SnowballRService())
             .build()
 
     /**

--- a/src/main/kotlin/grpc/ValidationInterceptor.kt
+++ b/src/main/kotlin/grpc/ValidationInterceptor.kt
@@ -1,0 +1,84 @@
+package se.uulm.snowballr.backend.grpc
+
+import arrow.core.Either
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import se.uulm.snowballr.backend.validation.validateRequest
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * A [ServerInterceptor] implementation responsible for validating incoming requests in gRPC communication.
+ *
+ * This interceptor wraps the original server call listener using a custom [ValidationCallListener],
+ * which performs input validation on received messages. If validation fails, the listener closes
+ * the call with an [Status.INVALID_ARGUMENT] status and a detailed error description.
+ */
+val validationInterceptor =
+    object : ServerInterceptor {
+        override fun <ReqT : Any?, RespT : Any?> interceptCall(
+            call: ServerCall<ReqT?, RespT?>?,
+            headers: Metadata?,
+            next: ServerCallHandler<ReqT?, RespT?>?,
+        ): ServerCall.Listener<ReqT?> {
+            val originalListener = next?.startCall(call, headers)
+            return ValidationCallListener(call, headers, originalListener)
+        }
+    }
+
+private class ValidationCallListener<ReqT, RespT>(
+    private val call: ServerCall<ReqT?, RespT?>?,
+    @Suppress("unused") private val headers: Metadata?,
+    listener: ServerCall.Listener<ReqT?>?,
+) : SimpleForwardingServerCallListener<ReqT>(listener) {
+    // Track whether the call was already closed and return if that's the case
+    private var callClosedByInterceptor = false
+
+    override fun onMessage(message: ReqT?) {
+        // Perform input validation
+        val result = validateRequest(message)
+
+        // Return `INVALID_ARGUMENT` status if input validation failed
+        if (result is Either.Left) {
+            val reasons = result.value.toList().map { it.toString() }
+            logger.debug { "Received invalid request: $reasons" }
+            call?.close(
+                Status.INVALID_ARGUMENT
+                    .withDescription("Request validation failed: $reasons"),
+                Metadata(),
+            )
+            callClosedByInterceptor = true
+            // Stop further processing
+            return
+        }
+
+        // Continue to the next interceptor or actual service method
+        super.onMessage(message)
+    }
+
+    override fun onHalfClose() {
+        if (callClosedByInterceptor) {
+            return
+        }
+        super.onHalfClose()
+    }
+
+    override fun onCancel() {
+        if (callClosedByInterceptor) {
+            return
+        }
+        super.onCancel()
+    }
+
+    override fun onComplete() {
+        if (callClosedByInterceptor) {
+            return
+        }
+        super.onComplete()
+    }
+}

--- a/src/main/kotlin/model/ValidationIssue.kt
+++ b/src/main/kotlin/model/ValidationIssue.kt
@@ -1,0 +1,59 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Represents a validation issue that can occur during the validation process.
+ *
+ * Instances of [ValidationIssue] are typically used in validation workflows
+ * to encapsulate specific validation failures, such as blank fields or fields
+ * exceeding a maximum length. They can be leveraged in functional or reactive
+ * validation models using constructs like [arrow.core.Either] or
+ * [arrow.core.EitherNel] for error accumulation and handling.
+ */
+sealed interface ValidationIssue
+
+/**
+ * Represents a validation issue indicating an unrecognized or unsupported request type.
+ *
+ * This issue is returned when a request is encountered that cannot be handled by the validation logic,
+ * typically when the request type does not match any of the expected types in the validation workflow.
+ *
+ * It serves as a fallback mechanism to ensure that all unsupported or unrecognized inputs can be properly flagged
+ * and handled, preventing silent failures or undefined behavior.
+ */
+data object UnknownRequest : ValidationIssue
+
+/**
+ * Represents a validation issue for a field that is empty or contains only whitespace characters, i.e., is blank.
+ *
+ * @property name The name of the field that is blank.
+ */
+data class BlankField(
+    val name: String,
+) : ValidationIssue {
+    override fun toString() =
+        "The field '$name' must not be empty and must contain at least one non whitespace character."
+}
+
+/**
+ * Represents a validation issue where a field exceeds its maximum allowed length.
+ *
+ * @property name The name of the field that exceeded the maximum length.
+ * @property maxLength The maximum allowed length for the field.
+ */
+data class TooLongField(
+    val name: String,
+    val maxLength: Int,
+) : ValidationIssue {
+    override fun toString(): String = "The '$name' must not be longer than $maxLength characters."
+}
+
+/**
+ * Represents a validation issue where an enumeration field has the `UNSPECIFIED` value.
+ *
+ * @property name The name of the enum field that has the `UNSPECIFIED` value.
+ */
+data class EnumUnspecified(
+    val name: String,
+) : ValidationIssue {
+    override fun toString(): String = "The enum field '$name' must not have the `UNSPECIFIED` value."
+}

--- a/src/main/kotlin/validation/CriterionValidator.kt
+++ b/src/main/kotlin/validation/CriterionValidator.kt
@@ -1,0 +1,38 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.CriterionOuterClass.Criterion
+
+const val CRITERION_TAG_MAX_LENGTH = 10
+const val CRITERION_NAME_MAX_LENGTH = 50
+const val CRITERION_DESCRIPTION_MAX_LENGTH = 200
+
+/**
+ * An object that validates the requests for [Criterion] objects.
+ */
+object CriterionValidator {
+    fun validateCreateRequest(request: Criterion.Create): EitherNel<ValidationIssue, Unit> =
+        either {
+            zipOrAccumulate(
+                { ensureFieldNonBlank("project_id", request.projectId) },
+                {
+                    ensureFieldNonBlank("tag", request.tag)
+                    ensureFieldLength("tag", request.tag, CRITERION_TAG_MAX_LENGTH)
+                },
+                {
+                    ensureFieldNonBlank("name", request.name)
+                    ensureFieldLength("name", request.name, CRITERION_NAME_MAX_LENGTH)
+                },
+                {
+                    ensureFieldNonBlank("description", request.description)
+                    ensureFieldLength("description", request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
+                },
+                {
+                    ensureEnumNotUnspecified("category", request.category)
+                },
+            ) { _, _, _, _, _ -> }
+        }
+}

--- a/src/main/kotlin/validation/ProjectValidator.kt
+++ b/src/main/kotlin/validation/ProjectValidator.kt
@@ -1,0 +1,19 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.ProjectOuterClass.Project
+
+const val PROJECT_NAME_MAX_LENGTH = 100
+
+/**
+ * An object that validates the requests for [Project] objects.
+ */
+object ProjectValidator {
+    fun validateCreateRequest(request: Project.Create): EitherNel<ValidationIssue, Unit> =
+        either {
+            ensureFieldNonBlank("name", request.name)
+            ensureFieldLength("name", request.name, PROJECT_NAME_MAX_LENGTH)
+        }.toEitherNel()
+}

--- a/src/main/kotlin/validation/ValidationHelper.kt
+++ b/src/main/kotlin/validation/ValidationHelper.kt
@@ -1,0 +1,48 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
+import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.EnumUnspecified
+import se.uulm.snowballr.backend.model.TooLongField
+import se.uulm.snowballr.backend.model.ValidationIssue
+
+/**
+ * Ensures that the given field value is not blank (i.e., it contains at least one non-whitespace character).
+ * If the value is blank, a [BlankField] validation issue is raised.
+ *
+ * @param name The name of the field being validated.
+ * @param value The value of the field to check for blankness.
+ */
+fun Raise<ValidationIssue>.ensureFieldNonBlank(
+    name: String,
+    value: String,
+) = ensure(value.isNotBlank()) { BlankField(name) }
+
+/**
+ * Ensures that the given field value does not exceed the specified maximum length.
+ * If the value exceeds the maximum length, a [TooLongField] validation issue is raised.
+ *
+ * @param name The name of the field being validated.
+ * @param value The value of the field to check for its length.
+ * @param maxLength The maximum allowed length for the field value.
+ */
+fun Raise<ValidationIssue>.ensureFieldLength(
+    name: String,
+    value: String,
+    maxLength: Int,
+) = ensure(value.length <= maxLength) { TooLongField(name, maxLength) }
+
+/**
+ * Ensures that the provided enum value is not the `UNSPECIFIED` value.
+ * If the value is `UNSPECIFIED`, an [EnumUnspecified] validation issue is raised.
+ *
+ * It is assumed that all gRPC enums have an `UNSPECIFIED` value with ordinal 0.
+ *
+ * @param name The name of the enum field being validated.
+ * @param value The enum value to check for being `UNSPECIFIED`.
+ */
+fun Raise<ValidationIssue>.ensureEnumNotUnspecified(
+    name: String,
+    value: Enum<*>,
+) = ensure(value.ordinal > 0) { EnumUnspecified(name) }

--- a/src/main/kotlin/validation/Validator.kt
+++ b/src/main/kotlin/validation/Validator.kt
@@ -1,0 +1,44 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.Either
+import arrow.core.EitherNel
+import arrow.core.nonEmptyListOf
+import se.uulm.snowballr.backend.model.UnknownRequest
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.CriterionOuterClass
+import snowballr.ProjectOuterClass
+
+/**
+ * Validates a given request object and returns either a collection of validation issues
+ * or an indication that the validation was successful.
+ *
+ * This function delegates validation to specific validators depending on the type of the provided request.
+ * If the request type is unknown, an error containing [UnknownRequest] is returned.
+ *
+ * @param T The generic type of the request being validated.
+ * @param request The request object to be validated.
+ * @return An [EitherNel] containing a collection of [ValidationIssue] objects if validation issues are found,
+ *         or `Unit` if the validation is successful.
+ */
+fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> =
+    when (request) {
+        // Project
+        is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
+        // Criterion
+        is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
+        else -> Either.Left(nonEmptyListOf(UnknownRequest))
+    }
+
+/**
+ * Creates a [arrow.core.NonEmptyList] from this [Either].
+ *
+ * While some validation methods use [arrow.core.raise.zipOrAccumulate] to process several input validation conditions,
+ * others might require only validating one parameter and use a simple [arrow.core.raise.either].
+ * For the latter, one can use this method to create a [arrow.core.NonEmptyList] to get the same data type as the other
+ * methods that accumulate the validation results.
+ */
+fun Either<ValidationIssue, Unit>.toEitherNel() =
+    when (this) {
+        is Either.Left -> Either.Left(nonEmptyListOf(this.value))
+        is Either.Right -> Either.Right(Unit)
+    }

--- a/src/test/kotlin/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/validation/CriterionValidatorTest.kt
@@ -1,0 +1,94 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.Either
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.EnumUnspecified
+import se.uulm.snowballr.backend.model.TooLongField
+import snowballr.CriterionOuterClass.Criterion.Create
+import snowballr.CriterionOuterClass.CriterionCategory
+
+class CriterionValidatorTest {
+    @Nested
+    inner class CreateRequest {
+        private val validCreateRequestBuilder: Create.Builder =
+            Create
+                .newBuilder()
+                .setProjectId("1")
+                .setTag("C1")
+                .setName("Valid Criterion")
+                .setDescription("A valid criterion")
+                .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validCreateRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["project_id", "tag", "name", "description"])
+        fun `When a blank field is validated, then the 'BlankField' issue is returned`(fieldName: String) {
+            val request =
+                validCreateRequestBuilder
+                    .setField(Create.getDescriptor().findFieldByName(fieldName), "")
+                    .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isLeft()
+            val value = (result as Either.Left).value
+            assertThat(value.size).isEqualTo(1)
+            val issue = value.first()
+            assertThat(issue).isInstanceOf(BlankField::class.java)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "tag:${CRITERION_TAG_MAX_LENGTH}",
+                "name:${CRITERION_NAME_MAX_LENGTH}",
+                "description:${CRITERION_DESCRIPTION_MAX_LENGTH}",
+            ],
+            delimiter = ':',
+        )
+        fun `When a too long field is validated, then the 'TooLongField' issue is returned`(
+            fieldName: String,
+            length: Int,
+        ) {
+            val request =
+                validCreateRequestBuilder
+                    .setField(Create.getDescriptor().findFieldByName(fieldName), "a".repeat(length + 1))
+                    .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isLeft()
+            val value = (result as Either.Left).value
+            assertThat(value.size).isEqualTo(1)
+            val issue = value.first()
+            assertThat(issue).isInstanceOf(TooLongField::class.java)
+        }
+
+        @Test
+        fun `When the category is 'UNSPECIFIED' and is validated, then the 'EnumUnspecified' issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .setCategory(CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED)
+                    .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isLeft()
+            val value = (result as Either.Left).value
+            assertThat(value.size).isEqualTo(1)
+            val issue = value.first()
+            assertThat(issue).isInstanceOf(EnumUnspecified::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/validation/ProjectValidatorTest.kt
@@ -1,0 +1,58 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.Either
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.TooLongField
+import snowballr.ProjectOuterClass.Project.Create
+
+class ProjectValidatorTest {
+    @Nested
+    inner class CreateRequest {
+        private val validCreateRequestBuilder: Create.Builder =
+            Create
+                .newBuilder()
+                .setName("Valid Project Name")
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validCreateRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a blank name is validated, then the 'BlankField' issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .setName("")
+                    .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isLeft()
+            val value = (result as Either.Left).value
+            assertThat(value.size).isEqualTo(1)
+            val issue = value.first()
+            assertThat(issue).isInstanceOf(BlankField::class.java)
+        }
+
+        @Test
+        fun `When a too long name is validated, then the 'TooLongField' issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .setName("a".repeat(PROJECT_NAME_MAX_LENGTH + 1))
+                    .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isLeft()
+            val value = (result as Either.Left).value
+            assertThat(value.size).isEqualTo(1)
+            val issue = value.first()
+            assertThat(issue).isInstanceOf(TooLongField::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/validation/ValidatorTest.kt
+++ b/src/test/kotlin/validation/ValidatorTest.kt
@@ -1,0 +1,20 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.Either
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.UnknownRequest
+
+class ValidatorTest {
+    @Test
+    fun `When an unknown request is validated, then the 'UnknownRequest' issue is returned`() {
+        val result = validateRequest(object {})
+
+        EitherAssert.assertThat(result).isLeft()
+        val value = (result as Either.Left).value
+        assertThat(value.size).isEqualTo(1)
+        val issue = value.first()
+        assertThat(issue).isInstanceOf(UnknownRequest::class.java)
+    }
+}


### PR DESCRIPTION
Closes #16 

## What I have made

To validate incoming requests, I added a new interceptor, which is executed after logging incoming calls, but before the server calls the internal handling method.
The interceptor calls a validation method and if the method returns an invalid result, the call is closed with an according error message including the reasons why the validation failed.

The validation starts in `Validator.kt` where according to the class of the incoming request an according validation method is called, i.e., `Project.Create` -> `ProjectValidator.validateCreateRequest`.
We're using the arrow library to declare validation conditions such as "the name of a project cannot be blank". Each condition returns an `ValidationIssue` if the condition is not met. All issues are then accumulated and returned. This way, we gather all validation issues at once. More on that will be explained in the wiki.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
