### PR TITLE
fix: wrong indentation in the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -40,8 +40,8 @@ body:
               1. Send a request to '...'
               2. Use payload '...'
               3. Observe response '...'
-          validations:
-              required: true
+      validations:
+          required: true
 
     - type: textarea
       id: expected-behavior
@@ -60,5 +60,5 @@ body:
               Logs, request examples, links, or any other context that helps us debug the issue.
 
               Tip: You can drag and drop files here.
-          validations:
-              required: false
+      validations:
+          required: false


### PR DESCRIPTION
Fix wrong indentation in the bug report issue template. `validations` was wrongly indented in two occasions.