### PR TITLE
Fix gradlew file ending on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force all text files to have LF line endings
+* text=auto eol=lf


### PR DESCRIPTION
Closes #40

## What I have made

See issue for description. Now all files are checked out with LF.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~ (not required)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (not required)
- [x] (for reviewer) I have checked the implementation against the requirements
