### PR TITLE
Added exception handler into facade layer

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -53,7 +53,7 @@ jobs:
             - name: Check for Broken Links in Wiki
               uses: becheran/mlc@v0.22.0
               with:
-                  args: wiki/
+                  args: --ignore-links "https://stackoverflow.com/questions/6720050/foreign-key-constraints-when-to-use-on-update-and-on-delete/6720458#6720458" wiki/
 
     publish-wiki:
         name: Publish Wiki

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,21 @@ services:
             - grpc_network
         profiles: ["registry"]
 
+    # Proxy that listens to localhost instead of a service; can be used for local development
+    proxy:
+        build:
+            context: .
+            dockerfile: Dockerfile.proxy
+        ports:
+            - "${WEB_PORT:-8081}:${WEB_PORT:-8081}"
+        command:
+            # Point to the backend on the machine's host
+            - --backend_addr=host.docker.internal:${PORT:-8080}
+            - --allow_all_origins # Crucial for local dev where frontend is on different origin
+            - --run_tls_server=false # Don't require TLS
+            - --server_http_debug_port=${WEB_PORT:-8081} # Proxy listens on this port inside the container
+        profiles: ["proxy-only"]
+
 networks:
     db_network:
         driver: bridge

--- a/src/main/kotlin/grpc/ExceptionInterceptor.kt
+++ b/src/main/kotlin/grpc/ExceptionInterceptor.kt
@@ -1,0 +1,115 @@
+package se.uulm.snowballr.backend.grpc
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.ForwardingServerCall
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import se.uulm.snowballr.backend.model.SnowballRException
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * A [ServerInterceptor] that intercepts server calls and provides
+ * custom exception handling behavior. It ensures that exceptions are captured and translated
+ * into appropriate gRPC status codes before being sent to the client.
+ *
+ * The interceptor wraps the gRPC server call in an instance of [ExceptionCall], which is
+ * responsible for processing exceptions and mapping them to appropriate gRPC statuses.
+ */
+val exceptionInterceptor =
+    object : ServerInterceptor {
+        override fun <ReqT : Any?, RespT : Any?> interceptCall(
+            call: ServerCall<ReqT?, RespT?>,
+            headers: Metadata?,
+            next: ServerCallHandler<ReqT?, RespT?>,
+        ): ServerCall.Listener<ReqT?> =
+            next.startCall(
+                ExceptionCall(call),
+                headers,
+            )
+    }
+
+@Suppress("TooGenericExceptionCaught")
+private class ExceptionCall<ReqT, RespT>(
+    delegate: ServerCall<ReqT, RespT>,
+) : ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(delegate) {
+    override fun close(
+        status: Status?,
+        trailers: Metadata?,
+    ) {
+        var newStatus = status
+        if (status == null) {
+            logger.error { "gRPC call closed with null status." }
+        } else if (!status.isOk) {
+            // This block is executed when the gRPC call is being closed
+            // with an error status, regardless of whether the error
+            // originated from your suspend function or elsewhere.
+            // When no StatusException is thrown, the status is UNKNOWN, and the cause contains the thrown exception
+            // We check the cause and depending on its type return the correct status code
+            val cause = status.cause
+            if (cause != null) {
+                newStatus = handleException(cause)
+            }
+        }
+
+        super.close(newStatus, trailers)
+    }
+
+    /**
+     * Returns a status for the passed [Throwable], which then can be returned to the user.
+     */
+    private fun handleException(e: Throwable): Status =
+        when (e) {
+            // Handle all specific application exceptions
+            is SnowballRException -> getStatusForSnowballRException(e)
+
+            // Handle specific unexpected exceptions
+            is IllegalArgumentException -> getStatusForSpecificUnexpectedException(Status.INVALID_ARGUMENT, e)
+            is NoSuchElementException -> getStatusForSpecificUnexpectedException(Status.NOT_FOUND, e)
+            is IllegalStateException -> getStatusForSpecificUnexpectedException(Status.FAILED_PRECONDITION, e)
+
+            // Handle the rest of unexpected exceptions
+            else -> getStatusForUnexpectedException(e)
+        }
+
+    /**
+     * The [SnowballRException]s are deliberately thrown in this application, e.g., when preconditions aren't met.
+     */
+    private fun getStatusForSnowballRException(e: SnowballRException): Status {
+        val status =
+            when (e) {
+                is SnowballRException.NotFoundException -> Status.NOT_FOUND
+            }.withDescription(e.message).withCause(e.cause)
+
+        logger.debug {
+            "gRPC call failed due to ${e::class.qualifiedName} with status: ${status.code}." +
+                " Message: ${status.description}"
+        }
+        logger.trace { e.stackTraceToString() }
+        return status
+    }
+
+    /**
+     * Specific unexpected exceptions point to missing exception handling in this application.
+     * They are logged as warning so that they can be handled in the future.
+     */
+    private fun getStatusForSpecificUnexpectedException(
+        status: Status,
+        e: Exception,
+    ): Status {
+        logger.warn(e) { "gRPC call failed due to unexpected ${e::class.simpleName} with message: ${e.message}" }
+        return status
+    }
+
+    /**
+     * All other unexpected exceptions point to bugs or missing exception handling in this application.
+     * Therefore, they are logged as error.
+     */
+    private fun getStatusForUnexpectedException(e: Throwable): Status {
+        logger.error(e) { "gRPC call failed due to an unexpected exception" }
+        return Status.INTERNAL.withDescription("An unexpected error occurred")
+    }
+}

--- a/src/main/kotlin/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/grpc/SnowballRServer.kt
@@ -56,14 +56,20 @@ class SnowballRServer(
      *
      * This server is configured to:
      * - Listen on the specified port.
+     * - Apply a logging interceptor to intercept and log incoming requests.
+     * - Apply a validation interceptor to intercept and validate incoming requests.
+     * - Apply an exception interceptor to catch exceptions and provide appropriate status codes.
      * - Register the gRPC service implementation [SnowballRService].
-     * - Apply a logging interceptor to intercept and log incoming and outgoing requests.
+     * - Register the gRPC health service implementation [HealthStatusManager.healthService].
      */
     private val server: Server =
         ServerBuilder
             .forPort(port)
-            .intercept(loggingInterceptor)
+            // Interceptors in reverse order of execution
+            .intercept(exceptionInterceptor)
             .intercept(validationInterceptor)
+            .intercept(loggingInterceptor)
+            // Services
             .addService(SnowballRService())
             .addService(healthManager.healthService)
             .build()

--- a/src/main/kotlin/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/grpc/SnowballRServer.kt
@@ -176,6 +176,15 @@ class SnowballRServer(
         override suspend fun getPapersToReviewForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
             super.getPapersToReviewForProject(request)
 
+        override suspend fun getNextPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
+            super.getNextPaper(request)
+
+        override suspend fun getNextPaperToReview(request: Base.Id): ProjectOuterClass.Project.Paper =
+            super.getNextPaperToReview(request)
+
+        override suspend fun getPreviousPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
+            super.getPreviousPaper(request)
+
         override suspend fun getUserSettings(request: Base.Nothing): UserSettingsOuterClass.UserSettings =
             super.getUserSettings(request)
 

--- a/src/main/kotlin/model/SnowballRException.kt
+++ b/src/main/kotlin/model/SnowballRException.kt
@@ -1,0 +1,36 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Base class for all exceptions in the SnowballR application.
+ *
+ * Used to encapsulate specific error details and provide a consistent exception structure.
+ * Can be extended to create more detailed exceptions specific to various error scenarios.
+ *
+ * @constructor Creates an instance of [SnowballRException] with an optional message and cause.
+ * @param message Detailed message describing the reason for the exception, or null if not provided.
+ * @param cause The cause of the exception, which can be another exception, or null if not provided.
+ */
+sealed class SnowballRException(
+    message: String? = null,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause) {
+    /**
+     * Represents a specific type of exception that occurs when an entity cannot be found.
+     *
+     * This exception is intended to provide a clear and structured way to handle
+     * scenarios where a particular entity, identified by its name and ID, is not found.
+     * It serves as a base class to define more specific "not found" exceptions for various entities.
+     *
+     * @constructor Creates a [NotFoundException] with the name and ID of the missing entity.
+     * @param entityName The name of the entity that could not be found.
+     * @param entityId The unique identifier of the missing entity.
+     */
+    sealed class NotFoundException(
+        entityName: String,
+        entityId: String,
+    ) : SnowballRException("$entityName #$entityId not found.") {
+        class Project(
+            projectId: String,
+        ) : NotFoundException("Project", projectId)
+    }
+}

--- a/src/main/kotlin/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/repository/CriterionTableRepo.kt
@@ -1,11 +1,10 @@
 package se.uulm.snowballr.backend.repository
 
-import io.grpc.Status
-import io.grpc.StatusException
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.CriterionTable.toCriterion
 import se.uulm.snowballr.backend.table.ProjectTable
@@ -39,7 +38,8 @@ class CriterionTableRepo(
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion =
         db.dbQuery {
             // Get project reference
-            val projectEntityId = ProjectTable.getEntityId(request.projectId) ?: throw StatusException(Status.NOT_FOUND)
+            val projectEntityId =
+                ProjectTable.getEntityId(request.projectId) ?: throw NotFoundException.Project(request.projectId)
 
             // Create criterion
             val criterionId =

--- a/src/test/kotlin/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/repository/CriterionTableRepoTest.kt
@@ -1,12 +1,12 @@
 package se.uulm.snowballr.backend.repository
 
-import io.grpc.StatusException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.testCoroutine
@@ -67,7 +67,7 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
                     .setProjectId("0")
                     .build()
 
-            assertThrows<StatusException> { repo.createCriterion(request) }
+            assertThrows<SnowballRException.NotFoundException.Project> { repo.createCriterion(request) }
         }
 
         @Test

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -76,7 +76,8 @@ Follow these few conventions when creating or modifying a table:
       [EnumOrdinalTest.kt](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/test/kotlin/model/EnumOrdinalTest.kt))
 * use `uniqueIndex()` for [natural keys](https://en.wikipedia.org/wiki/Natural_key), such as the users' email
 * if there's a foreign key, provide reference options, such as `RESTRICT` or `CASCADE` for `onDelete` and `onUpdate`and
-  provide a comment which describes why the reference option was chosen
+  provide a comment which describes why the reference option was chosen (read more in
+  [this post](https://stackoverflow.com/questions/6720050/foreign-key-constraints-when-to-use-on-update-and-on-delete/6720458#6720458))
 
 As each entity is represented by a class in this project, always provide a mapping method:
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -67,7 +67,7 @@ Follow these few conventions when creating or modifying a table:
 
 * always use `text(...)` for properties that contain a text
     * there's also `varchar(...)`, which requires a maximum length
-    * [as PostgreSQL uses the same C data type for each text-related type, we can simply use the one that causes the least headache](https://www.depesz.com/index.php/2010/03/02/charx-vs-varcharx-vs-varchar-vs-text/)
+    * [as PostgreSQL uses the same C data type for each text-related type, we can simply use the one that causes the least headache](https://www.depesz.com/2010/03/02/charx-vs-varcharx-vs-varchar-vs-text/)
 * always use `enumeration(...)` for enums
     * this only stores the ordinal value
     * as gRPC enforces unique enum ordinals, even if some are removed, we can ensure that this doesn't mess up our


### PR DESCRIPTION
Closes #43 

## What I have made

- I added a layer that catches every exception thrown in the execution of the gRPC calls
- this enables handling exceptions at a common place and returning appropriate status codes
- why not throwing `StatusCodeException`s?
  - good question
  - first, this would only return status codes for exceptions that we deliberately throw
  - other exceptions would lead to the status code `UNKNOWN` and no logging
  - second, this couples gRPC-specific details with internal code, which in general is a bad practice
  - we design our layers to be as independent of each other
  - by having our own exception structure, we can be as specific as required and provide good error messages

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (not required)
- [ ] (for reviewer) I have checked the implementation against the requirements
