### PR TITLE
Added access check for `getUserById` and `getUserByEmail`

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -122,6 +122,8 @@ complexity:
             - 'with'
     LabeledExpression:
         active: true
+        ignoredLabels:
+            - dbQuery
     LargeClass:
         active: true
         threshold: 600

--- a/src/main/kotlin/Module.kt
+++ b/src/main/kotlin/Module.kt
@@ -12,6 +12,8 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.ProjectTableRepo
 import se.uulm.snowballr.backend.repository.UserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.ProjectMemberTableRepo
 import se.uulm.snowballr.backend.service.IMainService
 import se.uulm.snowballr.backend.service.MainService
 
@@ -33,6 +35,7 @@ val snowballRModule =
         singleOf(::ProjectTableRepo) { bind<IProjectTableRepo>() }
         singleOf(::CriterionTableRepo) { bind<ICriterionTableRepo>() }
         singleOf(::UserTableRepo) { bind<IUserTableRepo>() }
+        singleOf(::ProjectMemberTableRepo) { bind<IProjectMemberTableRepo>() }
         // The main service comes last
         singleOf(::MainService) { bind<IMainService>() }
     }

--- a/src/main/kotlin/model/SnowballRException.kt
+++ b/src/main/kotlin/model/SnowballRException.kt
@@ -88,7 +88,12 @@ sealed class SnowballRException(
             currentUserId: String,
             accessedEntityType: String,
             accessedEntityId: String,
-        ) : UnauthorizedException(currentUserId, "$accessedEntityType with ID '$accessedEntityId'.")
+        ) : UnauthorizedException(currentUserId, "$accessedEntityType with ID '$accessedEntityId'.") {
+            class User(
+                currentUserId: String,
+                accessedUserId: String,
+            ) : Single(currentUserId, "user", accessedUserId)
+        }
 
         sealed class All(
             currentUserId: String,

--- a/src/main/kotlin/model/SnowballRException.kt
+++ b/src/main/kotlin/model/SnowballRException.kt
@@ -60,6 +60,10 @@ sealed class SnowballRException(
         class Criterion(
             criterionId: String,
         ) : EntityNotPersistedException("Criterion", criterionId)
+
+        class ProjectMember(
+            projectMemberId: String,
+        ) : EntityNotPersistedException("ProjectMember", projectMemberId)
     }
 
     /**

--- a/src/main/kotlin/model/SnowballRException.kt
+++ b/src/main/kotlin/model/SnowballRException.kt
@@ -87,14 +87,14 @@ sealed class SnowballRException(
         sealed class Single(
             currentUserId: String,
             accessedEntityType: String,
-            identifier: String? = "ID",
             accessedEntityId: String,
+            identifier: String? = "ID",
         ) : UnauthorizedException(currentUserId, "$accessedEntityType with $identifier '$accessedEntityId'.") {
             class User(
                 currentUserId: String,
                 identifier: String? = "ID",
                 accessedUserId: String,
-            ) : Single(currentUserId, "user", identifier, accessedUserId)
+            ) : Single(currentUserId, "user", accessedUserId, identifier)
         }
 
         sealed class All(

--- a/src/main/kotlin/model/SnowballRException.kt
+++ b/src/main/kotlin/model/SnowballRException.kt
@@ -87,12 +87,14 @@ sealed class SnowballRException(
         sealed class Single(
             currentUserId: String,
             accessedEntityType: String,
+            identifier: String? = "ID",
             accessedEntityId: String,
-        ) : UnauthorizedException(currentUserId, "$accessedEntityType with ID '$accessedEntityId'.") {
+        ) : UnauthorizedException(currentUserId, "$accessedEntityType with $identifier '$accessedEntityId'.") {
             class User(
                 currentUserId: String,
+                identifier: String? = "ID",
                 accessedUserId: String,
-            ) : Single(currentUserId, "user", accessedUserId)
+            ) : Single(currentUserId, "user", identifier, accessedUserId)
         }
 
         sealed class All(

--- a/src/main/kotlin/model/dto/Invitation.kt
+++ b/src/main/kotlin/model/dto/Invitation.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
 import kotlinx.datetime.Instant
-import org.jetbrains.exposed.dao.id.CompositeID
 import se.uulm.snowballr.backend.table.association.InvitationTable
 import java.util.UUID
 
@@ -9,7 +8,7 @@ import java.util.UUID
  * DTO of [InvitationTable].
  */
 data class Invitation(
-    val id: CompositeID,
+    val id: String,
     val projectId: UUID,
     val userId: UUID,
     val token: String,

--- a/src/main/kotlin/model/dto/ProjectMember.kt
+++ b/src/main/kotlin/model/dto/ProjectMember.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.model.dto
 
-import org.jetbrains.exposed.dao.id.CompositeID
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import snowballr.ProjectOuterClass
 import java.time.OffsetDateTime
@@ -10,7 +9,7 @@ import java.util.UUID
  * DTO of [ProjectMemberTable].
  */
 data class ProjectMember(
-    val id: CompositeID,
+    val id: String,
     val projectId: UUID,
     val userId: UUID,
     val role: ProjectOuterClass.MemberRole,

--- a/src/main/kotlin/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/repository/CriterionTableRepo.kt
@@ -6,11 +6,13 @@ import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.dto.Criterion
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.CriterionTable.toCriterion
 import se.uulm.snowballr.backend.table.getProjectEntityId
 import se.uulm.snowballr.backend.table.getUserEntityId
 import snowballr.CriterionOuterClass
+import java.util.UUID
 
 /**
  * Defines an interface for repository operations related to the [CriterionTable].
@@ -20,7 +22,10 @@ import snowballr.CriterionOuterClass
  * criteria can remain decoupled from the specifics of the database layer.
  */
 interface ICriterionTableRepo {
-    suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String): Criterion
+    /**
+     * Creates a criterion for the user with the passed [userId].
+     */
+    suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion
 }
 
 /**
@@ -36,13 +41,15 @@ interface ICriterionTableRepo {
 class CriterionTableRepo(
     private val db: IDatabase,
 ) : ICriterionTableRepo {
-    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String): Criterion =
+    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =
         db.dbQuery {
+            val projectUUID = parseUUID(request.projectId, "project")
+
             // Get user reference
             val userEntityId = getUserEntityId(userId)
 
             // Get project reference
-            val projectEntityId = getProjectEntityId(request.projectId)
+            val projectEntityId = getProjectEntityId(projectUUID)
 
             // Create criterion
             val criterionId =

--- a/src/main/kotlin/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/repository/ProjectTableRepo.kt
@@ -11,6 +11,7 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.ProjectTable.toProject
 import se.uulm.snowballr.backend.table.getUserEntityId
 import snowballr.ProjectOuterClass
+import java.util.UUID
 
 /**
  * Defines an interface for repository operations related to the [ProjectTable].
@@ -20,7 +21,7 @@ import snowballr.ProjectOuterClass
  * for creating and managing projects can remain decoupled from the specifics of the database layer.
  */
 interface IProjectTableRepo {
-    suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String): Project
+    suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: UUID): Project
 }
 
 /**
@@ -35,35 +36,34 @@ interface IProjectTableRepo {
 class ProjectTableRepo(
     private val db: IDatabase,
 ) : IProjectTableRepo {
-    override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String): Project =
-        db.dbQuery {
-            // Get user reference
-            val userEntityId = getUserEntityId(userId)
+    override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: UUID): Project = db.dbQuery {
+        // Get user reference
+        val userEntityId = getUserEntityId(userId)
 
-            // Create project
-            val projectId =
-                ProjectTable
-                    .insertAndGetId {
-                        it[name] = request.name
-                        it[status] = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
-                        it[currentStage] = 0
-                        it[maxStage] = 0
-                        // TODO: Fetch default settings from user
-                        it[similarityThreshold] = 0F
-                        it[snowballingType] = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
-                        it[reviewMaybeAllowed] = true
-                        it[reviewDecisionMatrixBinary] =
-                            ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
-                        it[fetcherApis] = FetcherApi.entries.toList()
-                        it[createdBy] = userEntityId
-                    }.value
-
-            // Return created project
+        // Create project
+        val projectId =
             ProjectTable
-                .selectAll()
-                .andWhere { ProjectTable.id eq projectId }
-                .map { it.toProject() }
-                .singleOrNull()
-                ?: throw EntityNotPersistedException.Project(projectId.toString())
-        }
+                .insertAndGetId {
+                    it[name] = request.name
+                    it[status] = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
+                    it[currentStage] = 0
+                    it[maxStage] = 0
+                    // TODO: Fetch default settings from user
+                    it[similarityThreshold] = 0F
+                    it[snowballingType] = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+                    it[reviewMaybeAllowed] = true
+                    it[reviewDecisionMatrixBinary] =
+                        ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+                    it[fetcherApis] = FetcherApi.entries.toList()
+                    it[createdBy] = userEntityId
+                }.value
+
+        // Return created project
+        ProjectTable
+            .selectAll()
+            .andWhere { ProjectTable.id eq projectId }
+            .map { it.toProject() }
+            .singleOrNull()
+            ?: throw EntityNotPersistedException.Project(projectId.toString())
+    }
 }

--- a/src/main/kotlin/repository/UserTableRepo.kt
+++ b/src/main/kotlin/repository/UserTableRepo.kt
@@ -4,9 +4,9 @@ import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.UserTable.toUser
+import java.util.UUID
 
 /**
  * Defines an interface for repository operations related to the [UserTable].
@@ -16,10 +16,20 @@ import se.uulm.snowballr.backend.table.UserTable.toUser
  * for creating and managing users can remain decoupled from the specifics of the database layer.
  */
 interface IUserTableRepo {
-    suspend fun getUserById(id: String): User
+    /**
+     * Returns a user by its id or throws a [NotFoundException.User] if the user with the passed [id] doesn't exist.
+     */
+    suspend fun getUserById(id: UUID): User
 
+    /**
+     * Returns a user by its email or throws a [NotFoundException.User] if the user with the passed [email] doesn't
+     * exist.
+     */
     suspend fun getUserByEmail(email: String): User
 
+    /**
+     * Returns all users stored on the server.
+     */
     suspend fun getAllUsers(): List<User>
 }
 
@@ -35,15 +45,13 @@ interface IUserTableRepo {
 class UserTableRepo(
     private val db: IDatabase,
 ) : IUserTableRepo {
-    override suspend fun getUserById(id: String): User = db.dbQuery {
-        val uuid = parseUUID(id, "user")
-
+    override suspend fun getUserById(id: UUID): User = db.dbQuery {
         UserTable
             .selectAll()
-            .where { UserTable.id eq uuid }
+            .where { UserTable.id eq id }
             .map { it.toUser() }
             .singleOrNull()
-            ?: throw NotFoundException.User(id)
+            ?: throw NotFoundException.User(id.toString())
     }
 
     override suspend fun getUserByEmail(email: String): User = db.dbQuery {

--- a/src/main/kotlin/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/repository/association/ProjectMemberTableRepo.kt
@@ -1,0 +1,120 @@
+package se.uulm.snowballr.backend.repository.association
+
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.alias
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.ProjectMember
+import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.UserTable
+import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.table.association.ProjectMemberTable.toProjectMember
+import se.uulm.snowballr.backend.table.getEntityId
+import snowballr.ProjectOuterClass
+
+/**
+ * Defines an interface for repository operations related to the [ProjectMemberTable].
+ *
+ * This interface provides abstraction for handling persistence and retrieval
+ * operations for project members. By using this interface, the functionality for creating
+ * project members can remain decoupled from the specifics of the database layer.
+ */
+interface IProjectMemberTableRepo {
+    /**
+     * Adds a user with the passed [userId] as member to the project with the passed [projectId].
+     *
+     * @return The added [ProjectMember].
+     */
+    suspend fun addUserToProject(userId: String, projectId: String): ProjectMember
+
+    /**
+     * Returns all project members of the project with the passed [projectId].
+     */
+    suspend fun getProjectMembersOfProject(projectId: String): List<ProjectMember>
+
+    /**
+     * Returns all project members, which are in the same projects as the user with the passed [userId].
+     *
+     * The user itself is not part of the resulting list.
+     */
+    suspend fun getProjectMembersInSameProjectsAsUser(userId: String): List<ProjectMember>
+}
+
+/**
+ * Repository implementation for managing the [ProjectMemberTable] in the database.
+ *
+ * This class provides functionality to handle persistence and retrieval operations
+ * for project member data by leveraging the database abstraction defined in [IDatabase]. It
+ * facilitates CRUD operations on project member records associated with a given project and
+ * ensures database transactions are handled properly.
+ *
+ * @param db The database abstraction used for executing queries within a transaction.
+ */
+class ProjectMemberTableRepo(
+    private val db: IDatabase,
+) : IProjectMemberTableRepo {
+    override suspend fun addUserToProject(userId: String, projectId: String) = db.dbQuery {
+        // Get user reference
+        val userEntityId = UserTable.getEntityId(userId) ?: throw NotFoundException.User(userId)
+
+        // Get project reference
+        val projectEntityId =
+            ProjectTable.getEntityId(projectId) ?: throw NotFoundException.Project(projectId)
+
+        // Return when the user is already a project member
+        val projectMembers = getProjectMembersOfProject(projectId)
+        val existingMember = projectMembers.find { it.userId == userEntityId.value }
+        if (existingMember != null) {
+            return@dbQuery existingMember
+        }
+
+        val projectMemberId =
+            ProjectMemberTable
+                .insertAndGetId {
+                    it[this.userId] = userEntityId
+                    it[this.projectId] = projectEntityId
+                    it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
+                }
+
+        ProjectMemberTable
+            .selectAll()
+            .where { ProjectMemberTable.id eq projectMemberId }
+            .map { it.toProjectMember() }
+            .singleOrNull()
+            ?: throw EntityNotPersistedException.ProjectMember(projectMemberId.toString())
+    }
+
+    override suspend fun getProjectMembersOfProject(projectId: String): List<ProjectMember> = db.dbQuery {
+        val uuid = parseUUID(projectId, "project")
+
+        ProjectMemberTable
+            .selectAll()
+            .where { ProjectMemberTable.projectId eq uuid }
+            .map { it.toProjectMember() }
+    }
+
+    override suspend fun getProjectMembersInSameProjectsAsUser(userId: String): List<ProjectMember> = db.dbQuery {
+        val uuid = parseUUID(userId, "project")
+
+        // We join the ProjectMemberTable with itself but aliasing one instance to represent the user's membership.
+        val userMembership = ProjectMemberTable.alias("userMembership")
+
+        ProjectMemberTable
+            .join(
+                userMembership,
+                JoinType.INNER,
+                onColumn = ProjectMemberTable.projectId,
+                otherColumn = userMembership[ProjectMemberTable.projectId],
+            ) {
+                // Condition to find projects where the specific user is a member
+                userMembership[ProjectMemberTable.userId] eq uuid
+            }.selectAll()
+            // Filter out the calling user
+            .where { ProjectMemberTable.userId neq uuid }
+            .map { it.toProjectMember() }
+    }
+}

--- a/src/main/kotlin/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/repository/association/ProjectMemberTableRepo.kt
@@ -6,15 +6,13 @@ import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
-import se.uulm.snowballr.backend.model.parseUUID
-import se.uulm.snowballr.backend.table.ProjectTable
-import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable.toProjectMember
-import se.uulm.snowballr.backend.table.getEntityId
+import se.uulm.snowballr.backend.table.getProjectEntityId
+import se.uulm.snowballr.backend.table.getUserEntityId
 import snowballr.ProjectOuterClass
+import java.util.UUID
 
 /**
  * Defines an interface for repository operations related to the [ProjectMemberTable].
@@ -29,19 +27,19 @@ interface IProjectMemberTableRepo {
      *
      * @return The added [ProjectMember].
      */
-    suspend fun addUserToProject(userId: String, projectId: String): ProjectMember
+    suspend fun addUserToProject(userId: UUID, projectId: UUID): ProjectMember
 
     /**
      * Returns all project members of the project with the passed [projectId].
      */
-    suspend fun getProjectMembersOfProject(projectId: String): List<ProjectMember>
+    suspend fun getProjectMembersOfProject(projectId: UUID): List<ProjectMember>
 
     /**
      * Returns all project members, which are in the same projects as the user with the passed [userId].
      *
      * The user itself is not part of the resulting list.
      */
-    suspend fun getProjectMembersInSameProjectsAsUser(userId: String): List<ProjectMember>
+    suspend fun getProjectMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember>
 }
 
 /**
@@ -57,13 +55,12 @@ interface IProjectMemberTableRepo {
 class ProjectMemberTableRepo(
     private val db: IDatabase,
 ) : IProjectMemberTableRepo {
-    override suspend fun addUserToProject(userId: String, projectId: String) = db.dbQuery {
+    override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.dbQuery {
         // Get user reference
-        val userEntityId = UserTable.getEntityId(userId) ?: throw NotFoundException.User(userId)
+        val userEntityId = getUserEntityId(userId)
 
         // Get project reference
-        val projectEntityId =
-            ProjectTable.getEntityId(projectId) ?: throw NotFoundException.Project(projectId)
+        val projectEntityId = getProjectEntityId(projectId)
 
         // Return when the user is already a project member
         val projectMembers = getProjectMembersOfProject(projectId)
@@ -88,18 +85,14 @@ class ProjectMemberTableRepo(
             ?: throw EntityNotPersistedException.ProjectMember(projectMemberId.toString())
     }
 
-    override suspend fun getProjectMembersOfProject(projectId: String): List<ProjectMember> = db.dbQuery {
-        val uuid = parseUUID(projectId, "project")
-
+    override suspend fun getProjectMembersOfProject(projectId: UUID): List<ProjectMember> = db.dbQuery {
         ProjectMemberTable
             .selectAll()
-            .where { ProjectMemberTable.projectId eq uuid }
+            .where { ProjectMemberTable.projectId eq projectId }
             .map { it.toProjectMember() }
     }
 
-    override suspend fun getProjectMembersInSameProjectsAsUser(userId: String): List<ProjectMember> = db.dbQuery {
-        val uuid = parseUUID(userId, "project")
-
+    override suspend fun getProjectMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember> = db.dbQuery {
         // We join the ProjectMemberTable with itself but aliasing one instance to represent the user's membership.
         val userMembership = ProjectMemberTable.alias("userMembership")
 
@@ -111,10 +104,10 @@ class ProjectMemberTableRepo(
                 otherColumn = userMembership[ProjectMemberTable.projectId],
             ) {
                 // Condition to find projects where the specific user is a member
-                userMembership[ProjectMemberTable.userId] eq uuid
+                userMembership[ProjectMemberTable.userId] eq userId
             }.selectAll()
             // Filter out the calling user
-            .where { ProjectMemberTable.userId neq uuid }
+            .where { ProjectMemberTable.userId neq userId }
             .map { it.toProjectMember() }
     }
 }

--- a/src/main/kotlin/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/repository/association/ProjectMemberTableRepo.kt
@@ -32,14 +32,14 @@ interface IProjectMemberTableRepo {
     /**
      * Returns all project members of the project with the passed [projectId].
      */
-    suspend fun getProjectMembersOfProject(projectId: UUID): List<ProjectMember>
+    suspend fun getMembersOfProject(projectId: UUID): List<ProjectMember>
 
     /**
      * Returns all project members, which are in the same projects as the user with the passed [userId].
      *
      * The user itself is not part of the resulting list.
      */
-    suspend fun getProjectMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember>
+    suspend fun getMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember>
 }
 
 /**
@@ -63,7 +63,7 @@ class ProjectMemberTableRepo(
         val projectEntityId = getProjectEntityId(projectId)
 
         // Return when the user is already a project member
-        val projectMembers = getProjectMembersOfProject(projectId)
+        val projectMembers = getMembersOfProject(projectId)
         val existingMember = projectMembers.find { it.userId == userEntityId.value }
         if (existingMember != null) {
             return@dbQuery existingMember
@@ -85,14 +85,14 @@ class ProjectMemberTableRepo(
             ?: throw EntityNotPersistedException.ProjectMember(projectMemberId.toString())
     }
 
-    override suspend fun getProjectMembersOfProject(projectId: UUID): List<ProjectMember> = db.dbQuery {
+    override suspend fun getMembersOfProject(projectId: UUID): List<ProjectMember> = db.dbQuery {
         ProjectMemberTable
             .selectAll()
             .where { ProjectMemberTable.projectId eq projectId }
             .map { it.toProjectMember() }
     }
 
-    override suspend fun getProjectMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember> = db.dbQuery {
+    override suspend fun getMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember> = db.dbQuery {
         // We join the ProjectMemberTable with itself but aliasing one instance to represent the user's membership.
         val userMembership = ProjectMemberTable.alias("userMembership")
 

--- a/src/main/kotlin/service/CriterionService.kt
+++ b/src/main/kotlin/service/CriterionService.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import snowballr.CriterionOuterClass
 
@@ -26,7 +27,9 @@ interface ICriterionService {
 class CriterionService(
     private val repo: ICriterionTableRepo,
 ) : ICriterionService {
-    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion =
+    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion {
         // TODO: remove dummy user when user management is implemented
-        repo.createCriterion(request, dummyUserId!!).toGrpcCriterion()
+        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        return repo.createCriterion(request, requestingUserId).toGrpcCriterion()
+    }
 }

--- a/src/main/kotlin/service/MainService.kt
+++ b/src/main/kotlin/service/MainService.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 
 /**
  * The [IMainService] interface provides a unified contract that combines the responsibilities of all sub-services. It
@@ -27,12 +28,14 @@ interface IMainService :
  * @param projectRepo The repository responsible for handling persistence operations related to projects.
  * @param criterionRepo The repository responsible for handling persistence operations related to criteria.
  * @param userRepo The repository responsible for handling persistence operations related to users.
+ * @param projectMemberRepo The repository responsible for handling persistence operations related to project members.
  */
 class MainService(
     private val projectRepo: IProjectTableRepo,
     private val criterionRepo: ICriterionTableRepo,
     private val userRepo: IUserTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IMainService,
     IProjectService by ProjectService(projectRepo),
     ICriterionService by CriterionService(criterionRepo),
-    IUserService by UserService(userRepo)
+    IUserService by UserService(userRepo, projectMemberRepo)

--- a/src/main/kotlin/service/ProjectService.kt
+++ b/src/main/kotlin/service/ProjectService.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import snowballr.ProjectOuterClass
 
@@ -25,7 +26,9 @@ interface IProjectService {
 class ProjectService(
     private val repo: IProjectTableRepo,
 ) : IProjectService {
-    override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project =
+    override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project {
         // TODO: remove dummy user when user management is implemented
-        repo.createProject(request, dummyUserId!!).toGrpcProject()
+        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        return repo.createProject(request, requestingUserId).toGrpcProject()
+    }
 }

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -54,7 +54,7 @@ class UserService(
         // Check whether requesting user is in a same project as the requested user
         val isInSameProject =
             projectMemberRepo
-                .getProjectMembersInSameProjectsAsUser(currentUser.id)
+                .getMembersInSameProjectsAsUser(currentUser.id)
                 .any { it.userId == currentUser.id }
         if (isInSameProject) return
 

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -42,11 +42,7 @@ class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IUserService {
-    private suspend fun verifyUserAccess(
-        currentUser: User,
-        requestedUserId: String,
-        identifier: String,
-    ) {
+    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: String, identifier: String) {
         // Check whether requesting user is server admin
         if (currentUser.role == UserRole.USER_ROLE_ADMIN) return
 

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -3,8 +3,10 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
@@ -13,12 +15,12 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.getUserById].
      */
-    suspend fun getUserById(id: Base.Id): UserOuterClass.User
+    suspend fun getUserById(request: Base.Id): UserOuterClass.User
 
     /**
      * Service implementation of [SnowballRService.getUserByEmail].
      */
-    suspend fun getUserByEmail(email: Base.Email): UserOuterClass.User
+    suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User
 
     /**
      * Service implementation of [SnowballRService.getAllUsers].
@@ -33,28 +35,59 @@ interface IUserService {
  * delegating the actual persistence operations to the [IUserTableRepo] repository.
  *
  * @constructor Initializes the [UserService] with a user repository.
- * @param repo The repository responsible for managing persistence operations for users.
+ * @param userRepo The repository responsible for managing persistence operations for users.
+ * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
  */
 class UserService(
-    private val repo: IUserTableRepo,
+    private val userRepo: IUserTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IUserService {
-    override suspend fun getUserById(id: Base.Id): UserOuterClass.User =
-        // TODO: think about who can request each user by ID
-        repo.getUserById(id.id).toGrpcUser()
+    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: String) {
+        // Check whether requesting user is server admin
+        if (currentUser.role == UserRole.USER_ROLE_ADMIN) return
 
-    override suspend fun getUserByEmail(email: Base.Email): UserOuterClass.User =
+        // Check whether requesting user is requested user
+        if (requestedUserId == currentUser.id.toString()) return
+
+        // Check whether requesting user is in a same project as the requested user
+        val isInSameProject =
+            projectMemberRepo
+                .getProjectMembersInSameProjectsAsUser(currentUser.id.toString())
+                .any { it.userId == currentUser.id }
+        if (isInSameProject) return
+
+        // Requesting user is not authorized
+        throw UnauthorizedException.Single.User(currentUser.id.toString(), requestedUserId)
+    }
+
+    override suspend fun getUserById(request: Base.Id): UserOuterClass.User {
+        val currentUser = userRepo.getUserById(dummyUserId!!)
+
+        verifyUserAccess(currentUser, request.id)
+
+        val isRequestedUser = request.id == currentUser.id.toString()
+
+        // Don't rerequest the user if it is the current user itself
+        return if (isRequestedUser) {
+            currentUser.toGrpcUser()
+        } else {
+            userRepo.getUserById(request.id).toGrpcUser()
+        }
+    }
+
+    override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User =
         // TODO: think about who can request each user by email
-        repo.getUserByEmail(email.email).toGrpcUser()
+        userRepo.getUserByEmail(request.email).toGrpcUser()
 
     override suspend fun getAllUsers(): UserOuterClass.User.List {
-        val currentUser = repo.getUserById(dummyUserId!!)
+        val currentUser = userRepo.getUserById(dummyUserId!!)
         // Check whether the current user has access to retrieve all users
         // TODO: remove dummy user when user management is implemented
         if (currentUser.role != UserRole.USER_ROLE_ADMIN) {
             throw UnauthorizedException.All.User(dummyUserId!!)
         }
 
-        val users = repo.getAllUsers()
+        val users = userRepo.getAllUsers()
 
         val builder = UserOuterClass.User.List.newBuilder()
         users.forEach { builder.addUsers(it.toGrpcUser()) }

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -71,7 +71,7 @@ class UserService(
 
         val isRequestedUser = requestingUserId == currentUser.id
 
-        // Don't rerequest the user if it is the current user itself
+        // Don't re-request the user if it is the current user itself
         return if (isRequestedUser) {
             currentUser.toGrpcUser()
         } else {

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
@@ -11,6 +12,7 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 interface IUserService {
@@ -72,11 +74,21 @@ class UserService(
         val isRequestedUser = requestingUserId == currentUser.id
 
         // Don't re-request the user if it is the current user itself
-        return if (isRequestedUser) {
-            currentUser.toGrpcUser()
-        } else {
-            userRepo.getUserById(requestedUserId).toGrpcUser()
+        val result =
+            if (isRequestedUser) {
+                currentUser
+            } else {
+                userRepo.getUserById(requestedUserId)
+            }
+
+        // Only active or active unconfirmed users can be retrieved
+        if (result.status != UserStatus.USER_STATUS_ACTIVE &&
+            result.status != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
+        ) {
+            throw NotFoundException.User(request.id)
         }
+
+        return result.toGrpcUser()
     }
 
     override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User {
@@ -87,6 +99,13 @@ class UserService(
         val requestedUser = userRepo.getUserByEmail(request.email)
 
         verifyUserAccess(currentUser, requestingUserId, "email")
+
+        // Only active or active unconfirmed users can be retrieved
+        if (requestedUser.status != UserStatus.USER_STATUS_ACTIVE &&
+            requestedUser.status != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
+        ) {
+            throw NotFoundException.User(request.email, "email")
+        }
 
         return requestedUser.toGrpcUser()
     }

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -42,7 +42,11 @@ class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IUserService {
-    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: String) {
+    private suspend fun verifyUserAccess(
+        currentUser: User,
+        requestedUserId: String,
+        identifier: String,
+    ) {
         // Check whether requesting user is server admin
         if (currentUser.role == UserRole.USER_ROLE_ADMIN) return
 
@@ -57,13 +61,13 @@ class UserService(
         if (isInSameProject) return
 
         // Requesting user is not authorized
-        throw UnauthorizedException.Single.User(currentUser.id.toString(), requestedUserId)
+        throw UnauthorizedException.Single.User(currentUser.id.toString(), identifier, requestedUserId)
     }
 
     override suspend fun getUserById(request: Base.Id): UserOuterClass.User {
         val currentUser = userRepo.getUserById(dummyUserId!!)
 
-        verifyUserAccess(currentUser, request.id)
+        verifyUserAccess(currentUser, request.id, "ID")
 
         val isRequestedUser = request.id == currentUser.id.toString()
 
@@ -75,9 +79,16 @@ class UserService(
         }
     }
 
-    override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User =
-        // TODO: think about who can request each user by email
-        userRepo.getUserByEmail(request.email).toGrpcUser()
+    override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User {
+        val currentUser = userRepo.getUserById(dummyUserId!!)
+
+        // We have to request the user first to get the ID for the access checks
+        val requestedUser = userRepo.getUserByEmail(request.email)
+
+        verifyUserAccess(currentUser, requestedUser.id.toString(), "email")
+
+        return requestedUser.toGrpcUser()
+    }
 
     override suspend fun getAllUsers(): UserOuterClass.User.List {
         val currentUser = userRepo.getUserById(dummyUserId!!)

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -54,7 +54,7 @@ class UserService(
         // Check whether requesting user is in a same project as the requested user
         val isInSameProject =
             projectMemberRepo
-                .getMembersInSameProjectsAsUser(currentUser.id)
+                .getMembersInSameProjectsAsUser(requestedUserId)
                 .any { it.userId == currentUser.id }
         if (isInSameProject) return
 

--- a/src/main/kotlin/service/UserService.kt
+++ b/src/main/kotlin/service/UserService.kt
@@ -5,11 +5,13 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
+import java.util.UUID
 
 interface IUserService {
     /**
@@ -42,52 +44,57 @@ class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IUserService {
-    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: String, identifier: String) {
+    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: UUID, identifier: String) {
         // Check whether requesting user is server admin
         if (currentUser.role == UserRole.USER_ROLE_ADMIN) return
 
         // Check whether requesting user is requested user
-        if (requestedUserId == currentUser.id.toString()) return
+        if (requestedUserId == currentUser.id) return
 
         // Check whether requesting user is in a same project as the requested user
         val isInSameProject =
             projectMemberRepo
-                .getProjectMembersInSameProjectsAsUser(currentUser.id.toString())
+                .getProjectMembersInSameProjectsAsUser(currentUser.id)
                 .any { it.userId == currentUser.id }
         if (isInSameProject) return
 
         // Requesting user is not authorized
-        throw UnauthorizedException.Single.User(currentUser.id.toString(), identifier, requestedUserId)
+        throw UnauthorizedException.Single.User(currentUser.id.toString(), identifier, requestedUserId.toString())
     }
 
     override suspend fun getUserById(request: Base.Id): UserOuterClass.User {
-        val currentUser = userRepo.getUserById(dummyUserId!!)
+        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val requestedUserId = parseUUID(request.id, "user")
+        val currentUser = userRepo.getUserById(requestingUserId)
 
-        verifyUserAccess(currentUser, request.id, "ID")
+        verifyUserAccess(currentUser, requestingUserId, "ID")
 
-        val isRequestedUser = request.id == currentUser.id.toString()
+        val isRequestedUser = requestingUserId == currentUser.id
 
         // Don't rerequest the user if it is the current user itself
         return if (isRequestedUser) {
             currentUser.toGrpcUser()
         } else {
-            userRepo.getUserById(request.id).toGrpcUser()
+            userRepo.getUserById(requestedUserId).toGrpcUser()
         }
     }
 
     override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User {
-        val currentUser = userRepo.getUserById(dummyUserId!!)
+        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val currentUser = userRepo.getUserById(requestingUserId)
 
         // We have to request the user first to get the ID for the access checks
         val requestedUser = userRepo.getUserByEmail(request.email)
 
-        verifyUserAccess(currentUser, requestedUser.id.toString(), "email")
+        verifyUserAccess(currentUser, requestingUserId, "email")
 
         return requestedUser.toGrpcUser()
     }
 
     override suspend fun getAllUsers(): UserOuterClass.User.List {
-        val currentUser = userRepo.getUserById(dummyUserId!!)
+        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val currentUser = userRepo.getUserById(requestingUserId)
+
         // Check whether the current user has access to retrieve all users
         // TODO: remove dummy user when user management is implemented
         if (currentUser.role != UserRole.USER_ROLE_ADMIN) {

--- a/src/main/kotlin/table/TableHelper.kt
+++ b/src/main/kotlin/table/TableHelper.kt
@@ -2,9 +2,7 @@ package se.uulm.snowballr.backend.table
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
-import se.uulm.snowballr.backend.model.parseUUID
 import java.util.UUID
 
 /**
@@ -16,19 +14,13 @@ import java.util.UUID
  * to get the [EntityID] and then pass it to the `entity_id` column of table A.
  *
  * @param id The ID of the entity as [String].
- * @param entityType The type of the entity.
  * @return The ID of the entity as [EntityID], or null if no entity exists.
- * @throws InvalidIdException.UUID If [id] cannot be parsed to a UUID.
  */
-private fun UUIDTable.getEntityId(id: String, entityType: String): EntityID<UUID>? {
-    val uuid = parseUUID(id, entityType)
-
-    return this
-        .select(this.id)
-        .where { this@getEntityId.id eq uuid }
-        .map { it[this.id] }
-        .singleOrNull()
-}
+fun UUIDTable.getEntityId(id: UUID): EntityID<UUID>? = this
+    .select(this.id)
+    .where { this@getEntityId.id eq id }
+    .map { it[this.id] }
+    .singleOrNull()
 
 /**
  * Returns the entity ID of the user with the passed [id] or throws a [NotFoundException.User] if the user doesn't
@@ -36,7 +28,7 @@ private fun UUIDTable.getEntityId(id: String, entityType: String): EntityID<UUID
  *
  * @see getEntityId
  */
-fun getUserEntityId(id: String): EntityID<UUID> = UserTable.getEntityId(id, "user") ?: throw NotFoundException.User(id)
+fun getUserEntityId(id: UUID): EntityID<UUID> = UserTable.getEntityId(id) ?: throw NotFoundException.User(id.toString())
 
 /**
  * Returns the entity ID of the project with the passed [id] or throws a [NotFoundException.Project] if the project
@@ -44,5 +36,5 @@ fun getUserEntityId(id: String): EntityID<UUID> = UserTable.getEntityId(id, "use
  *
  * @see getEntityId
  */
-fun getProjectEntityId(id: String): EntityID<UUID> =
-    ProjectTable.getEntityId(id, "project") ?: throw NotFoundException.Project(id)
+fun getProjectEntityId(id: UUID): EntityID<UUID> =
+    ProjectTable.getEntityId(id) ?: throw NotFoundException.Project(id.toString())

--- a/src/main/kotlin/table/association/InvitationTable.kt
+++ b/src/main/kotlin/table/association/InvitationTable.kt
@@ -56,7 +56,7 @@ object InvitationTable : CompositeIdTable("invitation") {
      * Creates an [Invitation] from this [ResultRow].
      */
     fun ResultRow.toInvitation() = Invitation(
-        id = this[id].value,
+        id = this[id].toString(),
         projectId = this[projectId].value,
         userId = this[userId].value,
         token = this[token],

--- a/src/main/kotlin/table/association/ProjectMemberTable.kt
+++ b/src/main/kotlin/table/association/ProjectMemberTable.kt
@@ -64,7 +64,7 @@ object ProjectMemberTable : CompositeIdTable("project_member") {
      * Creates a [ProjectMember] from this [ResultRow].
      */
     fun ResultRow.toProjectMember() = ProjectMember(
-        id = this[id].value,
+        id = this[id].toString(),
         projectId = this[projectId].value,
         userId = this[userId].value,
         role = this[role],

--- a/src/test/kotlin/DataBuilder.kt
+++ b/src/test/kotlin/DataBuilder.kt
@@ -3,8 +3,10 @@ package se.uulm.snowballr.backend
 import se.uulm.snowballr.backend.model.FetcherApi
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.User
 import snowballr.CriterionOuterClass.CriterionCategory
+import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
@@ -100,5 +102,21 @@ object DataBuilder {
         createdAt = createdAt,
         modifiedAt = modifiedAt,
         deletedAt = deletedAt,
+    )
+
+    fun createExampleProjectMember(
+        projectId: UUID = UUID.randomUUID(),
+        userId: UUID = UUID.randomUUID(),
+        id: String = "$projectId-$userId",
+        role: MemberRole = MemberRole.MEMBER_ROLE_UNSPECIFIED,
+        createdAt: OffsetDateTime = OffsetDateTime.now(),
+        modifiedAt: OffsetDateTime? = null,
+    ) = ProjectMember(
+        id = id,
+        projectId = projectId,
+        userId = userId,
+        role = role,
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
     )
 }

--- a/src/test/kotlin/TestSpecificException.kt
+++ b/src/test/kotlin/TestSpecificException.kt
@@ -1,0 +1,7 @@
+package se.uulm.snowballr.backend
+
+/**
+ * An exception that can be thrown for mocking errors in sub-calls. This way, this specific exception can be expected,
+ * which won't be thrown from production code, and therefore it can only be raised by the mocking.
+ */
+class TestSpecificException : Exception("This is a test exception")

--- a/src/test/kotlin/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/repository/CriterionTableRepoTest.kt
@@ -105,7 +105,7 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
                     .setProjectId(UUID.randomUUID().toString())
                     .build()
 
-            assertThrows<NotFoundException.User> { repo.createCriterion(request, UUID.randomUUID().toString()) }
+            assertThrows<NotFoundException.User> { repo.createCriterion(request, UUID.randomUUID()) }
         }
     }
 }

--- a/src/test/kotlin/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/repository/H2DatabaseTest.kt
@@ -24,6 +24,7 @@ import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.table.UserTable
 import snowballr.UserOuterClass
 import java.sql.Connection
+import java.util.UUID
 
 /**
  * Base class for unit tests that interact with the in-memory H2 database.
@@ -73,7 +74,7 @@ open class H2DatabaseTest(
     protected val db = TestDatabase()
 
     /** User for testing. This prevents having to create a user for each test. */
-    protected var testUserId: String = ""
+    protected var testUserId: UUID = UUID.randomUUID()
 
     /**
      * Implementation of [IDatabase] providing a suspension-friendly context for database transactions.
@@ -116,7 +117,7 @@ open class H2DatabaseTest(
                             it[role] = UserOuterClass.UserRole.USER_ROLE_ADMIN
                             it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
                         }
-                    testUserId = userId.value.toString()
+                    testUserId = userId.value
                 }
             }
         }

--- a/src/test/kotlin/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/repository/ProjectTableRepoTest.kt
@@ -67,7 +67,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
                         .setName("Test Project")
                         .build()
 
-                assertThrows<NotFoundException.User> { repo.createProject(request, UUID.randomUUID().toString()) }
+                assertThrows<NotFoundException.User> { repo.createProject(request, UUID.randomUUID()) }
             }
     }
 }

--- a/src/test/kotlin/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/repository/UserTableRepoTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.testCoroutine
@@ -36,7 +35,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
                         }
                     }.value
 
-            val user = repo.getUserById(userId.toString())
+            val user = repo.getUserById(userId)
 
             assertThat(user.id).isEqualTo(userId)
             assertThat(user.email).isEqualTo("test.user@example.com")
@@ -48,12 +47,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
 
         @Test
         fun `When a user is not found, then an exception is thrown`() = testCoroutine {
-            assertThrows<NotFoundException.User> { repo.getUserById(UUID.randomUUID().toString()) }
-        }
-
-        @Test
-        fun `When the uuid is invalid, then an exception is thrown`() = testCoroutine {
-            assertThrows<InvalidIdException.UUID> { repo.getUserById("invalid uuid") }
+            assertThrows<NotFoundException.User> { repo.getUserById(UUID.randomUUID()) }
         }
     }
 

--- a/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
@@ -37,7 +36,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         return projectRepo.createProject(request, testUserId)
     }
 
-    suspend fun addTestMember(index: Int, projectId: String): ProjectMember {
+    suspend fun addTestMember(index: Int, projectId: UUID): ProjectMember {
         val userId =
             db.dbQuery {
                 UserTable
@@ -49,12 +48,12 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
                         it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
                     }.value
             }
-        return repo.addUserToProject(userId.toString(), projectId)
+        return repo.addUserToProject(userId, projectId)
     }
 
     suspend fun setupProject(): Project {
         val project = createExampleProject()
-        repo.addUserToProject(testUserId, project.id.toString())
+        repo.addUserToProject(testUserId, project.id)
 
         return project
     }
@@ -65,12 +64,12 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         fun `When a user is added to a project, then they can be retrieved as project member`() = testCoroutine {
             val project = createExampleProject()
 
-            val member = repo.addUserToProject(testUserId, project.id.toString())
+            val member = repo.addUserToProject(testUserId, project.id)
 
-            assertThat(member.userId.toString()).isEqualTo(testUserId)
+            assertThat(member.userId).isEqualTo(testUserId)
             assertThat(member.projectId).isEqualTo(project.id)
             assertThat(member.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
-            val members = repo.getProjectMembersOfProject(project.id.toString())
+            val members = repo.getProjectMembersOfProject(project.id)
             assertThat(members).hasSize(1)
             assertThat(members).containsExactly(member)
         }
@@ -79,11 +78,11 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         fun `When a user is added to a project twice, then only one member is created`() = testCoroutine {
             val project = createExampleProject()
 
-            val member = repo.addUserToProject(testUserId, project.id.toString())
-            val member1 = repo.addUserToProject(testUserId, project.id.toString())
+            val member = repo.addUserToProject(testUserId, project.id)
+            val member1 = repo.addUserToProject(testUserId, project.id)
 
             assertThat(member).isEqualTo(member1)
-            val members = repo.getProjectMembersOfProject(project.id.toString())
+            val members = repo.getProjectMembersOfProject(project.id)
             assertThat(members).hasSize(1)
             assertThat(members).containsExactly(member)
         }
@@ -91,117 +90,91 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         @Test
         fun `When a user is added to a non-existing project, then an exception is thrown`() = testCoroutine {
             assertThrows<NotFoundException.Project> {
-                repo.addUserToProject(testUserId, UUID.randomUUID().toString())
-            }
-        }
-
-        @Test
-        fun `When a user is added with an invalid project ID, then an exception is thrown`() = testCoroutine {
-            assertThrows<InvalidIdException.UUID> {
-                repo.addUserToProject(testUserId, "invalid project id")
-            }
-        }
-
-        @Test
-        fun `When a non-existing user is added to a project, then an exception is thrown`() = testCoroutine {
-            val project = createExampleProject()
-
-            assertThrows<NotFoundException.User> {
-                repo.addUserToProject(UUID.randomUUID().toString(), project.id.toString())
-            }
-        }
-
-        @Test
-        fun `When a user with invalid ID is added to a project, then an exception is thrown`() = testCoroutine {
-            val project = createExampleProject()
-
-            assertThrows<InvalidIdException.UUID> {
-                repo.addUserToProject("invalid user id", project.id.toString())
+                repo.addUserToProject(testUserId, UUID.randomUUID())
             }
         }
     }
 
-    @Nested
-    inner class GetProjectMembersOfProject {
-        @Test
-        fun `When no members are in a project, then the list is empty`() = testCoroutine {
-            val project = createExampleProject()
+    @Test
+    fun `When a non-existing user is added to a project, then an exception is thrown`() = testCoroutine {
+        val project = createExampleProject()
 
-            val members = repo.getProjectMembersOfProject(project.id.toString())
-
-            assertThat(members).isEmpty()
-        }
-
-        @Test
-        fun `When a member is in a project, then they are part of the list`() = testCoroutine {
-            val project = setupProject()
-            val member1 = addTestMember(1, project.id.toString())
-            val member2 = addTestMember(2, project.id.toString())
-
-            val members = repo.getProjectMembersOfProject(project.id.toString())
-
-            assertThat(members).hasSize(3)
-            val member = members.first()
-            assertThat(member.userId.toString()).isEqualTo(testUserId)
-            assertThat(member1).isEqualTo(members[1])
-            assertThat(member2).isEqualTo(members[2])
-        }
-
-        @Test
-        fun `When several members are in a project, then they are part of the list`() = testCoroutine {
-            val project = setupProject()
-
-            val members = repo.getProjectMembersOfProject(project.id.toString())
-
-            assertThat(members).hasSize(1)
-            val member = members.first()
-            assertThat(member.userId.toString()).isEqualTo(testUserId)
-        }
-
-        @Test
-        fun `When the members of a project with an invalid ID is fetched, then an exception is thrown`() =
-            testCoroutine {
-                assertThrows<InvalidIdException.UUID> { repo.getProjectMembersOfProject("invalid project id") }
-            }
-    }
-
-    @Nested
-    inner class GetProjectMembersInSameProjectsAsUser {
-        @Test
-        fun `When the user is in no projects, then the list of members is empty`() = testCoroutine {
-            val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
-
-            assertThat(result).isEmpty()
-        }
-
-        @Test
-        fun `When the user is in a project, then they are not part of the list of members`() = testCoroutine {
-            setupProject()
-
-            val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
-
-            assertThat(result).isEmpty()
-        }
-
-        @Test
-        fun `When the user is in projects with other users, then all members are part of the list`() = testCoroutine {
-            val project1 = setupProject()
-            val project2 = setupProject()
-            val project3 = setupProject()
-
-            val member1 = addTestMember(1, project1.id.toString())
-            val member2 = addTestMember(2, project2.id.toString())
-            val member3 = addTestMember(3, project3.id.toString())
-
-            val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
-
-            assertThat(result).hasSize(3)
-            assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
-        }
-
-        @Test
-        fun `When the passed userId is invalid, then an exception is thrown`() = testCoroutine {
-            assertThrows<InvalidIdException.UUID> { repo.getProjectMembersInSameProjectsAsUser("invalid uuid") }
+        assertThrows<NotFoundException.User> {
+            repo.addUserToProject(UUID.randomUUID(), project.id)
         }
     }
+}
+
+@Nested
+inner class GetProjectMembersOfProject {
+    @Test
+    fun `When no members are in a project, then the list is empty`() = testCoroutine {
+        val project = createExampleProject()
+
+        val members = repo.getProjectMembersOfProject(project.id)
+
+        assertThat(members).isEmpty()
+    }
+
+    @Test
+    fun `When a member is in a project, then they are part of the list`() = testCoroutine {
+        val project = setupProject()
+        val member1 = addTestMember(1, project.id)
+        val member2 = addTestMember(2, project.id)
+
+        val members = repo.getProjectMembersOfProject(project.id)
+
+        assertThat(members).hasSize(3)
+        val member = members.first()
+        assertThat(member.userId).isEqualTo(testUserId)
+        assertThat(member1).isEqualTo(members[1])
+        assertThat(member2).isEqualTo(members[2])
+    }
+
+    @Test
+    fun `When several members are in a project, then they are part of the list`() = testCoroutine {
+        val project = setupProject()
+
+        val members = repo.getProjectMembersOfProject(project.id)
+
+        assertThat(members).hasSize(1)
+        val member = members.first()
+        assertThat(member.userId).isEqualTo(testUserId)
+    }
+}
+
+@Nested
+inner class GetProjectMembersInSameProjectsAsUser {
+    @Test
+    fun `When the user is in no projects, then the list of members is empty`() = testCoroutine {
+        val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `When the user is in a project, then they are not part of the list of members`() = testCoroutine {
+        setupProject()
+
+        val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `When the user is in projects with other users, then all members are part of the list`() = testCoroutine {
+        val project1 = setupProject()
+        val project2 = setupProject()
+        val project3 = setupProject()
+
+        val member1 = addTestMember(1, project1.id)
+        val member2 = addTestMember(2, project2.id)
+        val member3 = addTestMember(3, project3.id)
+
+        val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+
+        assertThat(result).hasSize(3)
+        assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
+    }
+}
 }

--- a/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
@@ -1,0 +1,207 @@
+package se.uulm.snowballr.backend.repository.association
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.ProjectMember
+import se.uulm.snowballr.backend.repository.H2DatabaseTest
+import se.uulm.snowballr.backend.repository.ProjectTableRepo
+import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.UserTable
+import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.MemberRole
+import snowballr.UserOuterClass
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
+    private val repo = ProjectMemberTableRepo(db)
+    private val projectRepo = ProjectTableRepo(db)
+
+    suspend fun createExampleProject(): Project {
+        val request =
+            ProjectOuterClass.Project.Create
+                .newBuilder()
+                .setName("Test Project")
+                .build()
+        return projectRepo.createProject(request, testUserId)
+    }
+
+    suspend fun addTestMember(index: Int, projectId: String): ProjectMember {
+        val userId =
+            db.dbQuery {
+                UserTable
+                    .insertAndGetId {
+                        it[email] = "test.user.$index@example.com"
+                        it[firstName] = "Test"
+                        it[lastName] = "User"
+                        it[role] = UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                        it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+                    }.value
+            }
+        return repo.addUserToProject(userId.toString(), projectId)
+    }
+
+    suspend fun setupProject(): Project {
+        val project = createExampleProject()
+        repo.addUserToProject(testUserId, project.id.toString())
+
+        return project
+    }
+
+    @Nested
+    inner class AddUserToProject {
+        @Test
+        fun `When a user is added to a project, then they can be retrieved as project member`() = testCoroutine {
+            val project = createExampleProject()
+
+            val member = repo.addUserToProject(testUserId, project.id.toString())
+
+            assertThat(member.userId.toString()).isEqualTo(testUserId)
+            assertThat(member.projectId).isEqualTo(project.id)
+            assertThat(member.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
+            val members = repo.getProjectMembersOfProject(project.id.toString())
+            assertThat(members).hasSize(1)
+            assertThat(members).containsExactly(member)
+        }
+
+        @Test
+        fun `When a user is added to a project twice, then only one member is created`() = testCoroutine {
+            val project = createExampleProject()
+
+            val member = repo.addUserToProject(testUserId, project.id.toString())
+            val member1 = repo.addUserToProject(testUserId, project.id.toString())
+
+            assertThat(member).isEqualTo(member1)
+            val members = repo.getProjectMembersOfProject(project.id.toString())
+            assertThat(members).hasSize(1)
+            assertThat(members).containsExactly(member)
+        }
+
+        @Test
+        fun `When a user is added to a non-existing project, then an exception is thrown`() = testCoroutine {
+            assertThrows<NotFoundException.Project> {
+                repo.addUserToProject(testUserId, UUID.randomUUID().toString())
+            }
+        }
+
+        @Test
+        fun `When a user is added with an invalid project ID, then an exception is thrown`() = testCoroutine {
+            assertThrows<InvalidIdException.UUID> {
+                repo.addUserToProject(testUserId, "invalid project id")
+            }
+        }
+
+        @Test
+        fun `When a non-existing user is added to a project, then an exception is thrown`() = testCoroutine {
+            val project = createExampleProject()
+
+            assertThrows<NotFoundException.User> {
+                repo.addUserToProject(UUID.randomUUID().toString(), project.id.toString())
+            }
+        }
+
+        @Test
+        fun `When a user with invalid ID is added to a project, then an exception is thrown`() = testCoroutine {
+            val project = createExampleProject()
+
+            assertThrows<InvalidIdException.UUID> {
+                repo.addUserToProject("invalid user id", project.id.toString())
+            }
+        }
+    }
+
+    @Nested
+    inner class GetProjectMembersOfProject {
+        @Test
+        fun `When no members are in a project, then the list is empty`() = testCoroutine {
+            val project = createExampleProject()
+
+            val members = repo.getProjectMembersOfProject(project.id.toString())
+
+            assertThat(members).isEmpty()
+        }
+
+        @Test
+        fun `When a member is in a project, then they are part of the list`() = testCoroutine {
+            val project = setupProject()
+            val member1 = addTestMember(1, project.id.toString())
+            val member2 = addTestMember(2, project.id.toString())
+
+            val members = repo.getProjectMembersOfProject(project.id.toString())
+
+            assertThat(members).hasSize(3)
+            val member = members.first()
+            assertThat(member.userId.toString()).isEqualTo(testUserId)
+            assertThat(member1).isEqualTo(members[1])
+            assertThat(member2).isEqualTo(members[2])
+        }
+
+        @Test
+        fun `When several members are in a project, then they are part of the list`() = testCoroutine {
+            val project = setupProject()
+
+            val members = repo.getProjectMembersOfProject(project.id.toString())
+
+            assertThat(members).hasSize(1)
+            val member = members.first()
+            assertThat(member.userId.toString()).isEqualTo(testUserId)
+        }
+
+        @Test
+        fun `When the members of a project with an invalid ID is fetched, then an exception is thrown`() =
+            testCoroutine {
+                assertThrows<InvalidIdException.UUID> { repo.getProjectMembersOfProject("invalid project id") }
+            }
+    }
+
+    @Nested
+    inner class GetProjectMembersInSameProjectsAsUser {
+        @Test
+        fun `When the user is in no projects, then the list of members is empty`() = testCoroutine {
+            val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `When the user is in a project, then they are not part of the list of members`() = testCoroutine {
+            setupProject()
+
+            val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `When the user is in projects with other users, then all members are part of the list`() = testCoroutine {
+            val project1 = setupProject()
+            val project2 = setupProject()
+            val project3 = setupProject()
+
+            val member1 = addTestMember(1, project1.id.toString())
+            val member2 = addTestMember(2, project2.id.toString())
+            val member3 = addTestMember(3, project3.id.toString())
+
+            val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+
+            assertThat(result).hasSize(3)
+            assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
+        }
+
+        @Test
+        fun `When the passed userId is invalid, then an exception is thrown`() = testCoroutine {
+            assertThrows<InvalidIdException.UUID> { repo.getProjectMembersInSameProjectsAsUser("invalid uuid") }
+        }
+    }
+}

--- a/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
@@ -69,7 +69,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
             assertThat(member.userId).isEqualTo(testUserId)
             assertThat(member.projectId).isEqualTo(project.id)
             assertThat(member.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
-            val members = repo.getProjectMembersOfProject(project.id)
+            val members = repo.getMembersOfProject(project.id)
             assertThat(members).hasSize(1)
             assertThat(members).containsExactly(member)
         }
@@ -82,7 +82,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
             val member1 = repo.addUserToProject(testUserId, project.id)
 
             assertThat(member).isEqualTo(member1)
-            val members = repo.getProjectMembersOfProject(project.id)
+            val members = repo.getMembersOfProject(project.id)
             assertThat(members).hasSize(1)
             assertThat(members).containsExactly(member)
         }
@@ -106,12 +106,12 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
 }
 
 @Nested
-inner class GetProjectMembersOfProject {
+inner class GetMembersOfProject {
     @Test
     fun `When no members are in a project, then the list is empty`() = testCoroutine {
         val project = createExampleProject()
 
-        val members = repo.getProjectMembersOfProject(project.id)
+        val members = repo.getMembersOfProject(project.id)
 
         assertThat(members).isEmpty()
     }
@@ -122,7 +122,7 @@ inner class GetProjectMembersOfProject {
         val member1 = addTestMember(1, project.id)
         val member2 = addTestMember(2, project.id)
 
-        val members = repo.getProjectMembersOfProject(project.id)
+        val members = repo.getMembersOfProject(project.id)
 
         assertThat(members).hasSize(3)
         val member = members.first()
@@ -135,7 +135,7 @@ inner class GetProjectMembersOfProject {
     fun `When several members are in a project, then they are part of the list`() = testCoroutine {
         val project = setupProject()
 
-        val members = repo.getProjectMembersOfProject(project.id)
+        val members = repo.getMembersOfProject(project.id)
 
         assertThat(members).hasSize(1)
         val member = members.first()
@@ -144,10 +144,10 @@ inner class GetProjectMembersOfProject {
 }
 
 @Nested
-inner class GetProjectMembersInSameProjectsAsUser {
+inner class GetMembersInSameProjectsAsUser {
     @Test
     fun `When the user is in no projects, then the list of members is empty`() = testCoroutine {
-        val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+        val result = repo.getMembersInSameProjectsAsUser(testUserId)
 
         assertThat(result).isEmpty()
     }
@@ -156,7 +156,7 @@ inner class GetProjectMembersInSameProjectsAsUser {
     fun `When the user is in a project, then they are not part of the list of members`() = testCoroutine {
         setupProject()
 
-        val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+        val result = repo.getMembersInSameProjectsAsUser(testUserId)
 
         assertThat(result).isEmpty()
     }
@@ -171,7 +171,7 @@ inner class GetProjectMembersInSameProjectsAsUser {
         val member2 = addTestMember(2, project2.id)
         val member3 = addTestMember(3, project3.id)
 
-        val result = repo.getProjectMembersInSameProjectsAsUser(testUserId)
+        val result = repo.getMembersInSameProjectsAsUser(testUserId)
 
         assertThat(result).hasSize(3)
         assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)

--- a/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
@@ -27,7 +27,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
     private val repo = ProjectMemberTableRepo(db)
     private val projectRepo = ProjectTableRepo(db)
 
-    suspend fun createExampleProject(): Project {
+    private suspend fun createExampleProject(): Project {
         val request =
             ProjectOuterClass.Project.Create
                 .newBuilder()
@@ -36,7 +36,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         return projectRepo.createProject(request, testUserId)
     }
 
-    suspend fun addTestMember(index: Int, projectId: UUID): ProjectMember {
+    private suspend fun addTestMember(index: Int, projectId: UUID): ProjectMember {
         val userId =
             db.dbQuery {
                 UserTable
@@ -51,40 +51,51 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         return repo.addUserToProject(userId, projectId)
     }
 
-    suspend fun setupProject(): Project {
+    private suspend fun setupProject(
+        numberOfTestMembers: Int = 0,
+        addTestUser: Boolean = true,
+    ): Pair<Project, List<ProjectMember>> {
         val project = createExampleProject()
-        repo.addUserToProject(testUserId, project.id)
+        val members = mutableListOf<ProjectMember>()
 
-        return project
+        if (addTestUser) {
+            repo.addUserToProject(testUserId, project.id).also { members.add(it) }
+        }
+
+        for (i in 1..numberOfTestMembers) {
+            addTestMember(i, project.id).also { members.add(it) }
+        }
+
+        return project to members
     }
 
     @Nested
     inner class AddUserToProject {
         @Test
         fun `When a user is added to a project, then they can be retrieved as project member`() = testCoroutine {
-            val project = createExampleProject()
-
-            val member = repo.addUserToProject(testUserId, project.id)
+            val (project, members) = setupProject()
+            val member = members.first()
 
             assertThat(member.userId).isEqualTo(testUserId)
             assertThat(member.projectId).isEqualTo(project.id)
             assertThat(member.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
-            val members = repo.getMembersOfProject(project.id)
-            assertThat(members).hasSize(1)
-            assertThat(members).containsExactly(member)
+
+            val actualMembers = repo.getMembersOfProject(project.id)
+            assertThat(actualMembers).hasSize(1)
+            assertThat(actualMembers).containsExactly(member)
         }
 
         @Test
         fun `When a user is added to a project twice, then only one member is created`() = testCoroutine {
-            val project = createExampleProject()
-
-            val member = repo.addUserToProject(testUserId, project.id)
+            val (project, members) = setupProject()
+            val member = members.first()
             val member1 = repo.addUserToProject(testUserId, project.id)
 
             assertThat(member).isEqualTo(member1)
-            val members = repo.getMembersOfProject(project.id)
-            assertThat(members).hasSize(1)
-            assertThat(members).containsExactly(member)
+
+            val actualMembers = repo.getMembersOfProject(project.id)
+            assertThat(actualMembers).hasSize(1)
+            assertThat(actualMembers).containsExactly(member)
         }
 
         @Test
@@ -109,7 +120,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
 inner class GetMembersOfProject {
     @Test
     fun `When no members are in a project, then the list is empty`() = testCoroutine {
-        val project = createExampleProject()
+        val (project, _) = setupProject(0, false)
 
         val members = repo.getMembersOfProject(project.id)
 
@@ -117,30 +128,30 @@ inner class GetMembersOfProject {
     }
 
     @Test
-    fun `When a member is in a project, then they are part of the list`() = testCoroutine {
-        val project = setupProject()
-        val member1 = addTestMember(1, project.id)
-        val member2 = addTestMember(2, project.id)
+    fun `When one member is in a project, then they are part of the list`() = testCoroutine {
+        val (project, _) = setupProject()
 
-        val members = repo.getMembersOfProject(project.id)
+        val actualMembers = repo.getMembersOfProject(project.id)
 
-        assertThat(members).hasSize(3)
-        val member = members.first()
+        assertThat(actualMembers).hasSize(1)
+        val member = actualMembers.first()
         assertThat(member.userId).isEqualTo(testUserId)
-        assertThat(member1).isEqualTo(members[1])
-        assertThat(member2).isEqualTo(members[2])
     }
 
     @Test
     fun `When several members are in a project, then they are part of the list`() = testCoroutine {
-        val project = setupProject()
+        val (project, members) = setupProject(3)
 
-        val members = repo.getMembersOfProject(project.id)
+        val actualMembers = repo.getMembersOfProject(project.id)
 
-        assertThat(members).hasSize(1)
-        val member = members.first()
-        assertThat(member.userId).isEqualTo(testUserId)
+        assertThat(actualMembers).hasSize(4)
+        assertThat(actualMembers[0].userId).isEqualTo(testUserId)
+        assertThat(actualMembers[0]).isEqualTo(members[0])
+        assertThat(actualMembers[1]).isEqualTo(members[1])
+        assertThat(actualMembers[2]).isEqualTo(members[2])
+        assertThat(actualMembers[3]).isEqualTo(members[3])
     }
+}
 }
 
 @Nested
@@ -163,9 +174,9 @@ inner class GetMembersInSameProjectsAsUser {
 
     @Test
     fun `When the user is in projects with other users, then all members are part of the list`() = testCoroutine {
-        val project1 = setupProject()
-        val project2 = setupProject()
-        val project3 = setupProject()
+        val project1 = setupProject().first
+        val project2 = setupProject().first
+        val project3 = setupProject().first
 
         val member1 = addTestMember(1, project1.id)
         val member2 = addTestMember(2, project2.id)

--- a/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/repository/association/ProjectMemberTableRepoTest.kt
@@ -104,88 +104,86 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
                 repo.addUserToProject(testUserId, UUID.randomUUID())
             }
         }
-    }
 
-    @Test
-    fun `When a non-existing user is added to a project, then an exception is thrown`() = testCoroutine {
-        val project = createExampleProject()
+        @Test
+        fun `When a non-existing user is added to a project, then an exception is thrown`() = testCoroutine {
+            val project = createExampleProject()
 
-        assertThrows<NotFoundException.User> {
-            repo.addUserToProject(UUID.randomUUID(), project.id)
+            assertThrows<NotFoundException.User> {
+                repo.addUserToProject(UUID.randomUUID(), project.id)
+            }
         }
     }
-}
 
-@Nested
-inner class GetMembersOfProject {
-    @Test
-    fun `When no members are in a project, then the list is empty`() = testCoroutine {
-        val (project, _) = setupProject(0, false)
+    @Nested
+    inner class GetMembersOfProject {
+        @Test
+        fun `When no members are in a project, then the list is empty`() = testCoroutine {
+            val (project, _) = setupProject(0, false)
 
-        val members = repo.getMembersOfProject(project.id)
+            val members = repo.getMembersOfProject(project.id)
 
-        assertThat(members).isEmpty()
+            assertThat(members).isEmpty()
+        }
+
+        @Test
+        fun `When one member is in a project, then they are part of the list`() = testCoroutine {
+            val (project, _) = setupProject()
+
+            val actualMembers = repo.getMembersOfProject(project.id)
+
+            assertThat(actualMembers).hasSize(1)
+            val member = actualMembers.first()
+            assertThat(member.userId).isEqualTo(testUserId)
+        }
+
+        @Test
+        fun `When several members are in a project, then they are part of the list`() = testCoroutine {
+            val (project, members) = setupProject(3)
+
+            val actualMembers = repo.getMembersOfProject(project.id)
+
+            assertThat(actualMembers).hasSize(4)
+            assertThat(actualMembers[0].userId).isEqualTo(testUserId)
+            assertThat(actualMembers[0]).isEqualTo(members[0])
+            assertThat(actualMembers[1]).isEqualTo(members[1])
+            assertThat(actualMembers[2]).isEqualTo(members[2])
+            assertThat(actualMembers[3]).isEqualTo(members[3])
+        }
     }
 
-    @Test
-    fun `When one member is in a project, then they are part of the list`() = testCoroutine {
-        val (project, _) = setupProject()
+    @Nested
+    inner class GetMembersInSameProjectsAsUser {
+        @Test
+        fun `When the user is in no projects, then the list of members is empty`() = testCoroutine {
+            val result = repo.getMembersInSameProjectsAsUser(testUserId)
 
-        val actualMembers = repo.getMembersOfProject(project.id)
+            assertThat(result).isEmpty()
+        }
 
-        assertThat(actualMembers).hasSize(1)
-        val member = actualMembers.first()
-        assertThat(member.userId).isEqualTo(testUserId)
+        @Test
+        fun `When the user is in a project, then they are not part of the list of members`() = testCoroutine {
+            setupProject()
+
+            val result = repo.getMembersInSameProjectsAsUser(testUserId)
+
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `When the user is in projects with other users, then all members are part of the list`() = testCoroutine {
+            val project1 = setupProject().first
+            val project2 = setupProject().first
+            val project3 = setupProject().first
+
+            val member1 = addTestMember(1, project1.id)
+            val member2 = addTestMember(2, project2.id)
+            val member3 = addTestMember(3, project3.id)
+
+            val result = repo.getMembersInSameProjectsAsUser(testUserId)
+
+            assertThat(result).hasSize(3)
+            assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
+        }
     }
-
-    @Test
-    fun `When several members are in a project, then they are part of the list`() = testCoroutine {
-        val (project, members) = setupProject(3)
-
-        val actualMembers = repo.getMembersOfProject(project.id)
-
-        assertThat(actualMembers).hasSize(4)
-        assertThat(actualMembers[0].userId).isEqualTo(testUserId)
-        assertThat(actualMembers[0]).isEqualTo(members[0])
-        assertThat(actualMembers[1]).isEqualTo(members[1])
-        assertThat(actualMembers[2]).isEqualTo(members[2])
-        assertThat(actualMembers[3]).isEqualTo(members[3])
-    }
-}
-}
-
-@Nested
-inner class GetMembersInSameProjectsAsUser {
-    @Test
-    fun `When the user is in no projects, then the list of members is empty`() = testCoroutine {
-        val result = repo.getMembersInSameProjectsAsUser(testUserId)
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `When the user is in a project, then they are not part of the list of members`() = testCoroutine {
-        setupProject()
-
-        val result = repo.getMembersInSameProjectsAsUser(testUserId)
-
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `When the user is in projects with other users, then all members are part of the list`() = testCoroutine {
-        val project1 = setupProject().first
-        val project2 = setupProject().first
-        val project3 = setupProject().first
-
-        val member1 = addTestMember(1, project1.id)
-        val member2 = addTestMember(2, project2.id)
-        val member3 = addTestMember(3, project3.id)
-
-        val result = repo.getMembersInSameProjectsAsUser(testUserId)
-
-        assertThat(result).hasSize(3)
-        assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
-    }
-}
 }

--- a/src/test/kotlin/service/MainServiceTest.kt
+++ b/src/test/kotlin/service/MainServiceTest.kt
@@ -19,6 +19,7 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
+import java.util.UUID
 
 /**
  * Unit test class for the [MainService] class.
@@ -88,7 +89,7 @@ internal open class MainServiceTest {
     @BeforeEach
     fun setUpTest() {
         // TODO: remove when user management is implemented
-        dummyUserId = "test_user_id"
+        dummyUserId = UUID.randomUUID().toString()
     }
 
     @AfterEach

--- a/src/test/kotlin/service/MainServiceTest.kt
+++ b/src/test/kotlin/service/MainServiceTest.kt
@@ -79,6 +79,10 @@ internal open class MainServiceTest {
     @BeforeAll
     fun setUp() {
         Dispatchers.setMain(threadContext)
+    }
+
+    @BeforeEach
+    fun setUpTest() {
         // TODO: remove when user management is implemented
         dummyUserId = "test_user_id"
     }

--- a/src/test/kotlin/service/MainServiceTest.kt
+++ b/src/test/kotlin/service/MainServiceTest.kt
@@ -55,10 +55,10 @@ import java.util.UUID
  *             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
  *
  *             // Mock the behavior of the repositories
- *             coEvery { exampleRepoMock.createExample(any()) } throws Exception("Example creation failed")
+ *             coEvery { exampleRepoMock.createExample(any()) } throws TestSpecificException()
  *
  *             // Assert service behavior
- *             assertThrows<Exception> { mainService.createExample(request) }
+ *             assertThrows<TestSpecificException> { mainService.createExample(request) }
  *         }
  * }
  * ```

--- a/src/test/kotlin/service/MainServiceTest.kt
+++ b/src/test/kotlin/service/MainServiceTest.kt
@@ -11,11 +11,13 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
 
 /**
@@ -69,11 +71,13 @@ internal open class MainServiceTest {
     val projectRepoMock = mockk<IProjectTableRepo>(relaxed = true)
     val criterionRepoMock = mockk<ICriterionTableRepo>(relaxed = true)
     val userRepoMock = mockk<IUserTableRepo>(relaxed = true)
+    val projectMemberRepoMock = mockk<IProjectMemberTableRepo>(relaxed = true)
     val mainService =
         MainService(
             projectRepoMock,
             criterionRepoMock,
             userRepoMock,
+            projectMemberRepoMock,
         )
 
     @BeforeAll

--- a/src/test/kotlin/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/service/criterion/CreateCriterionTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -42,10 +43,10 @@ internal class CreateCriterionTest : MainServiceTest() {
     fun `When an error occurs while a criterion is created, then an exception is thrown`() = testCoroutine {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
 
-        coEvery { criterionRepoMock.createCriterion(any(), any()) } throws Exception("Failed to create criterion")
+        coEvery { criterionRepoMock.createCriterion(any(), any()) } throws TestSpecificException()
 
         dummyUserId = UUID.randomUUID().toString()
 
-        assertThrows<Exception> { mainService.createCriterion(request) }
+        assertThrows<TestSpecificException> { mainService.createCriterion(request) }
     }
 }

--- a/src/test/kotlin/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/service/criterion/CreateCriterionTest.kt
@@ -7,19 +7,33 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.CriterionOuterClass
+import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 internal class CreateCriterionTest : MainServiceTest() {
+    @Test
+    fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
+        val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
+
+        dummyUserId = "invalid-UUID"
+
+        assertThrows<InvalidIdException.UUID> { mainService.createCriterion(request) }
+    }
+
     @Test
     fun `When a criterion is correctly created, then no exception is thrown`() = testCoroutine {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
         val criterion = DataBuilder.createExampleCriterion()
 
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+
+        dummyUserId = UUID.randomUUID().toString()
 
         assertDoesNotThrow { mainService.createCriterion(request) }
     }
@@ -29,6 +43,8 @@ internal class CreateCriterionTest : MainServiceTest() {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
 
         coEvery { criterionRepoMock.createCriterion(any(), any()) } throws Exception("Failed to create criterion")
+
+        dummyUserId = UUID.randomUUID().toString()
 
         assertThrows<Exception> { mainService.createCriterion(request) }
     }

--- a/src/test/kotlin/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/service/project/CreateProjectTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.ProjectOuterClass
@@ -14,6 +16,15 @@ import snowballr.ProjectOuterClass
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 internal class CreateProjectTest : MainServiceTest() {
+    @Test
+    fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
+        val request = ProjectOuterClass.Project.Create.getDefaultInstance()
+
+        dummyUserId = "invalid-UUID"
+
+        assertThrows<InvalidIdException.UUID> { mainService.createProject(request) }
+    }
+
     @Test
     fun `When a project is correctly created, then no exception is thrown`() = testCoroutine {
         val request = ProjectOuterClass.Project.Create.getDefaultInstance()

--- a/src/test/kotlin/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/service/project/CreateProjectTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -39,8 +40,8 @@ internal class CreateProjectTest : MainServiceTest() {
     fun `When an error occurs while a project is created, then an exception is thrown`() = testCoroutine {
         val request = ProjectOuterClass.Project.Create.getDefaultInstance()
 
-        coEvery { projectRepoMock.createProject(any(), any()) } throws Exception("Failed to create project")
+        coEvery { projectRepoMock.createProject(any(), any()) } throws TestSpecificException()
 
-        assertThrows<Exception> { mainService.createProject(request) }
+        assertThrows<TestSpecificException> { mainService.createProject(request) }
     }
 }

--- a/src/test/kotlin/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/service/user/GetAllUsersTest.kt
@@ -3,24 +3,41 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.UserOuterClass.UserRole
+import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 internal class GetAllUsersTest : MainServiceTest() {
+    private var dummyUserUUID: UUID = UUID.randomUUID()
+
+    @BeforeEach
+    fun setup() {
+        dummyUserUUID = UUID.fromString(dummyUserId!!)
+    }
+
+    @Test
+    fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
+        dummyUserId = "invalid-UUID"
+
+        assertThrows<InvalidIdException.UUID> { mainService.getAllUsers() }
+    }
+
     @Test
     fun `When all users are retrieved by an admin, then no exception is thrown`() = testCoroutine {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllUsers() }
@@ -28,7 +45,7 @@ internal class GetAllUsersTest : MainServiceTest() {
 
     @Test
     fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws Exception("Failed to retrieve user")
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
         assertThrows<Exception> { mainService.getAllUsers() }
@@ -38,7 +55,7 @@ internal class GetAllUsersTest : MainServiceTest() {
     fun `When all users are retrieved by an non-admin, then an exception is thrown`() = testCoroutine {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns nonAdminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns nonAdminUser
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
         assertThrows<UnauthorizedException.All.User> { mainService.getAllUsers() }
@@ -48,7 +65,7 @@ internal class GetAllUsersTest : MainServiceTest() {
     fun `When retrieving all users fails, then an exception is thrown`() = testCoroutine {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { userRepoMock.getAllUsers() } throws Exception("Failed to retrieve users")
 
         assertThrows<Exception> { mainService.getAllUsers() }

--- a/src/test/kotlin/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/service/user/GetAllUsersTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -45,10 +46,10 @@ internal class GetAllUsersTest : MainServiceTest() {
 
     @Test
     fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws TestSpecificException()
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
-        assertThrows<Exception> { mainService.getAllUsers() }
+        assertThrows<TestSpecificException> { mainService.getAllUsers() }
     }
 
     @Test
@@ -66,8 +67,8 @@ internal class GetAllUsersTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
-        coEvery { userRepoMock.getAllUsers() } throws Exception("Failed to retrieve users")
+        coEvery { userRepoMock.getAllUsers() } throws TestSpecificException()
 
-        assertThrows<Exception> { mainService.getAllUsers() }
+        assertThrows<TestSpecificException> { mainService.getAllUsers() }
     }
 }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -3,11 +3,13 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
@@ -19,27 +21,43 @@ import java.util.UUID
 @DelicateCoroutinesApi
 internal class GetUserByEmailTest : MainServiceTest() {
     private val requestEmail = "test.user@example.com"
+    private var dummyUserUUID = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Email
+        .newBuilder()
+        .setEmail(requestEmail)
+        .build()
+
+    @BeforeEach
+    fun setup() {
+        dummyUserUUID = UUID.fromString(dummyUserId!!)
+    }
+
+    @Test
+    fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
+        val request = getExampleRequest()
+
+        dummyUserId = "invalid-UUID"
+
+        assertThrows<InvalidIdException.UUID> { mainService.getUserByEmail(request) }
+    }
 
     @Test
     fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
-        val request = Base.Email.newBuilder().build()
+        val request = getExampleRequest()
 
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws Exception("Failed to retrieve user")
 
         assertThrows<Exception> { mainService.getUserByEmail(request) }
     }
 
     @Test
     fun `When the requesting user has no access, then an exception is thrown`() = testCoroutine {
-        val request =
-            Base.Email
-                .newBuilder()
-                .setEmail(requestEmail)
-                .build()
+        val request = getExampleRequest()
 
         val noAccessUser = DataBuilder.createExampleUser()
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns noAccessUser
-        coEvery { userRepoMock.getUserByEmail(dummyUserId!!) } returns DataBuilder.createExampleUser()
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertThrows<UnauthorizedException.Single.User> { mainService.getUserByEmail(request) }
@@ -47,14 +65,10 @@ internal class GetUserByEmailTest : MainServiceTest() {
 
     @Test
     fun `When the requesting user is a server admin, then the user can be retrieved`() = testCoroutine {
-        val request =
-            Base.Email
-                .newBuilder()
-                .setEmail(requestEmail)
-                .build()
+        val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
@@ -63,16 +77,13 @@ internal class GetUserByEmailTest : MainServiceTest() {
 
     @Test
     fun `When the requesting user is the requested user, then the user can be retrieved`() = testCoroutine {
-        dummyUserId = UUID.randomUUID().toString()
+        dummyUserUUID = UUID.randomUUID()
+        dummyUserId = dummyUserUUID.toString()
 
-        val request =
-            Base.Email
-                .newBuilder()
-                .setEmail(requestEmail)
-                .build()
+        val request = getExampleRequest()
 
         val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns requestingUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns requestingUser
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
@@ -82,16 +93,12 @@ internal class GetUserByEmailTest : MainServiceTest() {
     @Test
     fun `When the requesting user is in the same project as requested user, then the user can be retrieved`() =
         testCoroutine {
-            val request =
-                Base.Email
-                    .newBuilder()
-                    .setEmail(requestEmail)
-                    .build()
+            val request = getExampleRequest()
 
             val otherUser = DataBuilder.createExampleUser()
             val member = DataBuilder.createExampleProjectMember(userId = otherUser.id)
 
-            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns otherUser
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns otherUser
             coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
             coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf(member)
 
@@ -100,14 +107,10 @@ internal class GetUserByEmailTest : MainServiceTest() {
 
     @Test
     fun `When an error occurs while the user is retrieved, then an exception is thrown`() = testCoroutine {
-        val request =
-            Base.Email
-                .newBuilder()
-                .setEmail(requestEmail)
-                .build()
+        val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } throws Exception("Failed to retrieve user")
 
         assertThrows<Exception> { mainService.getUserByEmail(request) }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -46,9 +47,9 @@ internal class GetUserByEmailTest : MainServiceTest() {
     fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
         val request = getExampleRequest()
 
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws TestSpecificException()
 
-        assertThrows<Exception> { mainService.getUserByEmail(request) }
+        assertThrows<TestSpecificException> { mainService.getUserByEmail(request) }
     }
 
     @Test
@@ -111,8 +112,8 @@ internal class GetUserByEmailTest : MainServiceTest() {
 
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
-        coEvery { userRepoMock.getUserByEmail(requestEmail) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } throws TestSpecificException()
 
-        assertThrows<Exception> { mainService.getUserByEmail(request) }
+        assertThrows<TestSpecificException> { mainService.getUserByEmail(request) }
     }
 }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -7,28 +7,108 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.Base
+import snowballr.UserOuterClass
+import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 internal class GetUserByEmailTest : MainServiceTest() {
-    @Test
-    fun `When a user is correctly retrieved, then no exception is thrown`() = testCoroutine {
-        val request = Base.Email.newBuilder().build()
-        val user = DataBuilder.createExampleUser()
+    private val requestEmail = "test.user@example.com"
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns user
+    @Test
+    fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
+        val request = Base.Email.newBuilder().build()
+
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
+
+        assertThrows<Exception> { mainService.getUserByEmail(request) }
+    }
+
+    @Test
+    fun `When the requesting user has no access, then an exception is thrown`() = testCoroutine {
+        val request =
+            Base.Email
+                .newBuilder()
+                .setEmail(requestEmail)
+                .build()
+
+        val noAccessUser = DataBuilder.createExampleUser()
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns noAccessUser
+        coEvery { userRepoMock.getUserByEmail(dummyUserId!!) } returns DataBuilder.createExampleUser()
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        assertThrows<UnauthorizedException.Single.User> { mainService.getUserByEmail(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a server admin, then the user can be retrieved`() = testCoroutine {
+        val request =
+            Base.Email
+                .newBuilder()
+                .setEmail(requestEmail)
+                .build()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertDoesNotThrow { mainService.getUserByEmail(request) }
     }
 
     @Test
-    fun `When an error occurs while a user is retrieved, then an exception is thrown`() = testCoroutine {
-        val request = Base.Email.newBuilder().build()
+    fun `When the requesting user is the requested user, then the user can be retrieved`() = testCoroutine {
+        dummyUserId = UUID.randomUUID().toString()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } throws Exception("Failed to retrieve user")
+        val request =
+            Base.Email
+                .newBuilder()
+                .setEmail(requestEmail)
+                .build()
+
+        val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns requestingUser
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } returns requestingUser
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        assertDoesNotThrow { mainService.getUserByEmail(request) }
+    }
+
+    @Test
+    fun `When the requesting user is in the same project as requested user, then the user can be retrieved`() =
+        testCoroutine {
+            val request =
+                Base.Email
+                    .newBuilder()
+                    .setEmail(requestEmail)
+                    .build()
+
+            val otherUser = DataBuilder.createExampleUser()
+            val member = DataBuilder.createExampleProjectMember(userId = otherUser.id)
+
+            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns otherUser
+            coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
+            coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf(member)
+
+            assertDoesNotThrow { mainService.getUserByEmail(request) }
+        }
+
+    @Test
+    fun `When an error occurs while the user is retrieved, then an exception is thrown`() = testCoroutine {
+        val request =
+            Base.Email
+                .newBuilder()
+                .setEmail(requestEmail)
+                .build()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } throws Exception("Failed to retrieve user")
 
         assertThrows<Exception> { mainService.getUserByEmail(request) }
     }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -11,11 +11,13 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.Base
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
@@ -68,9 +70,10 @@ internal class GetUserByEmailTest : MainServiceTest() {
     fun `When the requesting user is a server admin, then the user can be retrieved`() = testCoroutine {
         val request = getExampleRequest()
 
-        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
-        coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
+        val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } returns user
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertDoesNotThrow { mainService.getUserByEmail(request) }
@@ -83,7 +86,11 @@ internal class GetUserByEmailTest : MainServiceTest() {
 
         val request = getExampleRequest()
 
-        val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+        val requestingUser =
+            DataBuilder.createExampleUser(
+                id = UUID.fromString(dummyUserId),
+                status = UserStatus.USER_STATUS_ACTIVE,
+            )
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns requestingUser
 
@@ -99,7 +106,8 @@ internal class GetUserByEmailTest : MainServiceTest() {
             val member = DataBuilder.createExampleProjectMember(userId = otherUser.id)
 
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns otherUser
-            coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
+            val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
+            coEvery { userRepoMock.getUserByEmail(requestEmail) } returns user
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf(member)
 
             assertDoesNotThrow { mainService.getUserByEmail(request) }
@@ -109,10 +117,43 @@ internal class GetUserByEmailTest : MainServiceTest() {
     fun `When an error occurs while the user is retrieved, then an exception is thrown`() = testCoroutine {
         val request = getExampleRequest()
 
-        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(request) }
+    }
+
+    @Test
+    fun `When the requested user is active unconfirmed, then they can be retrieved`() = testCoroutine {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
+        coEvery { userRepoMock.getUserByEmail(requestEmail) } returns user
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        assertDoesNotThrow { mainService.getUserByEmail(request) }
+    }
+
+    @Test
+    fun `When the requested user is inactive, then an exception is thrown`() = testCoroutine {
+        val values =
+            UserStatus.entries.filter {
+                it != UserStatus.USER_STATUS_ACTIVE &&
+                    it != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
+            }
+        for (status in values) {
+            val request = getExampleRequest()
+
+            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+            val user = DataBuilder.createExampleUser(status = status)
+            coEvery { userRepoMock.getUserByEmail(requestEmail) } returns user
+            coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
+
+            assertThrows<NotFoundException.User> { mainService.getUserByEmail(request) }
+        }
     }
 }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -44,7 +44,7 @@ internal class GetUserByEmailTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
+    fun `When requesting the current user fails, then an exception is thrown`() = testCoroutine {
         val request = getExampleRequest()
 
         coEvery { userRepoMock.getUserById(dummyUserUUID) } throws TestSpecificException()
@@ -86,7 +86,6 @@ internal class GetUserByEmailTest : MainServiceTest() {
         val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns requestingUser
-        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertDoesNotThrow { mainService.getUserByEmail(request) }
     }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -59,7 +59,7 @@ internal class GetUserByEmailTest : MainServiceTest() {
         val noAccessUser = DataBuilder.createExampleUser()
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertThrows<UnauthorizedException.Single.User> { mainService.getUserByEmail(request) }
     }
@@ -71,7 +71,7 @@ internal class GetUserByEmailTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertDoesNotThrow { mainService.getUserByEmail(request) }
     }
@@ -86,7 +86,7 @@ internal class GetUserByEmailTest : MainServiceTest() {
         val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns requestingUser
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertDoesNotThrow { mainService.getUserByEmail(request) }
     }
@@ -101,7 +101,7 @@ internal class GetUserByEmailTest : MainServiceTest() {
 
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns otherUser
             coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
-            coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf(member)
+            coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf(member)
 
             assertDoesNotThrow { mainService.getUserByEmail(request) }
         }

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -7,28 +7,120 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.Base
+import snowballr.UserOuterClass
+import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 internal class GetUserByIdTest : MainServiceTest() {
-    @Test
-    fun `When a user is correctly retrieved, then no exception is thrown`() = testCoroutine {
-        val request = Base.Id.newBuilder().build()
-        val user = DataBuilder.createExampleUser()
+    private val requestId = UUID.randomUUID().toString()
 
-        coEvery { userRepoMock.getUserById(any()) } returns user
+    @Test
+    fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
+        val request = Base.Id.newBuilder().build()
+
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
+
+        assertThrows<Exception> { mainService.getUserById(request) }
+    }
+
+    @Test
+    fun `When the requesting user has no access, then an exception is thrown`() = testCoroutine {
+        val request =
+            Base.Id
+                .newBuilder()
+                .setId(requestId)
+                .build()
+
+        val noAccessUser = DataBuilder.createExampleUser()
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns noAccessUser
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        assertThrows<UnauthorizedException.Single.User> { mainService.getUserById(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a server admin, then the user can be retrieved`() = testCoroutine {
+        val request =
+            Base.Id
+                .newBuilder()
+                .setId(requestId)
+                .build()
+
+        // Mock access check
+        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        // Mock user retrieval
+        coEvery { userRepoMock.getUserById(requestId) } returns DataBuilder.createExampleUser()
 
         assertDoesNotThrow { mainService.getUserById(request) }
     }
 
     @Test
-    fun `When an error occurs while a user is retrieved, then an exception is thrown`() = testCoroutine {
-        val request = Base.Id.newBuilder().build()
+    fun `When the requesting user is the requested user, then the user can be retrieved`() = testCoroutine {
+        dummyUserId = UUID.randomUUID().toString()
 
-        coEvery { userRepoMock.getUserById(any()) } throws Exception("Failed to retrieve user")
+        val request =
+            Base.Id
+                .newBuilder()
+                .setId(dummyUserId)
+                .build()
+
+        // Mock access check
+        val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns requestingUser
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        // Mock user retrieval
+        coEvery { userRepoMock.getUserById(requestId) } returns requestingUser
+
+        assertDoesNotThrow { mainService.getUserById(request) }
+    }
+
+    @Test
+    fun `When the requesting user is in the same project as requested user, then the user can be retrieved`() =
+        testCoroutine {
+            val request =
+                Base.Id
+                    .newBuilder()
+                    .setId(requestId)
+                    .build()
+
+            val otherUser = DataBuilder.createExampleUser()
+            val member = DataBuilder.createExampleProjectMember(userId = otherUser.id)
+
+            // Mock access check
+            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns otherUser
+            coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf(member)
+
+            // Mock user retrieval
+            coEvery { userRepoMock.getUserById(requestId) } returns DataBuilder.createExampleUser()
+
+            assertDoesNotThrow { mainService.getUserById(request) }
+        }
+
+    @Test
+    fun `When an error occurs while the user is retrieved, then an exception is thrown`() = testCoroutine {
+        val request =
+            Base.Id
+                .newBuilder()
+                .setId(requestId)
+                .build()
+
+        // Mock access check
+        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        // Mock user retrieval
+        coEvery { userRepoMock.getUserById(requestId) } throws Exception("Failed to retrieve user")
 
         assertThrows<Exception> { mainService.getUserById(request) }
     }

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -55,7 +55,7 @@ internal class GetUserByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
+    fun `When requesting the current user fails, then an exception is thrown`() = testCoroutine {
         val request = getExampleRequest()
 
         coEvery { userRepoMock.getUserById(dummyUserUUID) } throws TestSpecificException()

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -11,11 +11,13 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.Base
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
@@ -79,12 +81,13 @@ internal class GetUserByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         // Mock access check
-        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
-        coEvery { userRepoMock.getUserById(requestId) } returns DataBuilder.createExampleUser()
+        val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
+        coEvery { userRepoMock.getUserById(requestId) } returns user
 
         assertDoesNotThrow { mainService.getUserById(request) }
     }
@@ -101,7 +104,11 @@ internal class GetUserByIdTest : MainServiceTest() {
                 .build()
 
         // Mock access check
-        val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+        val requestingUser =
+            DataBuilder.createExampleUser(
+                id = UUID.fromString(dummyUserId),
+                status = UserStatus.USER_STATUS_ACTIVE,
+            )
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
@@ -124,7 +131,8 @@ internal class GetUserByIdTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf(member)
 
             // Mock user retrieval
-            coEvery { userRepoMock.getUserById(requestId) } returns DataBuilder.createExampleUser()
+            val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
+            coEvery { userRepoMock.getUserById(requestId) } returns user
 
             assertDoesNotThrow { mainService.getUserById(request) }
         }
@@ -134,7 +142,7 @@ internal class GetUserByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         // Mock access check
-        val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
@@ -142,5 +150,44 @@ internal class GetUserByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserById(request) }
+    }
+
+    @Test
+    fun `When the requested user is active unconfirmed, then they can be retrieved`() = testCoroutine {
+        val request = getExampleRequest()
+
+        // Mock access check
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
+
+        // Mock user retrieval
+        val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
+        coEvery { userRepoMock.getUserById(requestId) } returns user
+
+        assertDoesNotThrow { mainService.getUserById(request) }
+    }
+
+    @Test
+    fun `When the requested user is inactive, then an exception is thrown`() = testCoroutine {
+        val values =
+            UserStatus.entries.filter {
+                it != UserStatus.USER_STATUS_ACTIVE &&
+                    it != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
+            }
+        for (status in values) {
+            val request = getExampleRequest()
+
+            // Mock access check
+            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+            coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
+
+            // Mock user retrieval
+            val user = DataBuilder.createExampleUser(status = status)
+            coEvery { userRepoMock.getUserById(requestId) } returns user
+
+            assertThrows<NotFoundException.User> { mainService.getUserById(request) }
+        }
     }
 }

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -3,11 +3,13 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
@@ -18,27 +20,54 @@ import java.util.UUID
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 internal class GetUserByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID().toString()
+    private val requestId = UUID.randomUUID()
+    private var dummyUserUUID = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestId.toString())
+        .build()
+
+    @BeforeEach
+    fun setup() {
+        dummyUserUUID = UUID.fromString(dummyUserId!!)
+    }
+
+    @Test
+    fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
+        val request = getExampleRequest()
+
+        dummyUserId = "invalid-UUID"
+
+        assertThrows<InvalidIdException.UUID> { mainService.getUserById(request) }
+    }
+
+    @Test
+    fun `When the requested user has an invalid ID, then an exception is thrown`() = testCoroutine {
+        val request =
+            Base.Id
+                .newBuilder()
+                .setId("invalid-UUID")
+                .build()
+
+        assertThrows<InvalidIdException.UUID> { mainService.getUserById(request) }
+    }
 
     @Test
     fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
-        val request = Base.Id.newBuilder().build()
+        val request = getExampleRequest()
 
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws Exception("Failed to retrieve user")
 
         assertThrows<Exception> { mainService.getUserById(request) }
     }
 
     @Test
     fun `When the requesting user has no access, then an exception is thrown`() = testCoroutine {
-        val request =
-            Base.Id
-                .newBuilder()
-                .setId(requestId)
-                .build()
+        val request = getExampleRequest()
 
         val noAccessUser = DataBuilder.createExampleUser()
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns noAccessUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertThrows<UnauthorizedException.Single.User> { mainService.getUserById(request) }
@@ -46,15 +75,11 @@ internal class GetUserByIdTest : MainServiceTest() {
 
     @Test
     fun `When the requesting user is a server admin, then the user can be retrieved`() = testCoroutine {
-        val request =
-            Base.Id
-                .newBuilder()
-                .setId(requestId)
-                .build()
+        val request = getExampleRequest()
 
         // Mock access check
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
@@ -65,7 +90,8 @@ internal class GetUserByIdTest : MainServiceTest() {
 
     @Test
     fun `When the requesting user is the requested user, then the user can be retrieved`() = testCoroutine {
-        dummyUserId = UUID.randomUUID().toString()
+        dummyUserUUID = UUID.randomUUID()
+        dummyUserId = dummyUserUUID.toString()
 
         val request =
             Base.Id
@@ -75,7 +101,7 @@ internal class GetUserByIdTest : MainServiceTest() {
 
         // Mock access check
         val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns requestingUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
@@ -87,17 +113,13 @@ internal class GetUserByIdTest : MainServiceTest() {
     @Test
     fun `When the requesting user is in the same project as requested user, then the user can be retrieved`() =
         testCoroutine {
-            val request =
-                Base.Id
-                    .newBuilder()
-                    .setId(requestId)
-                    .build()
+            val request = getExampleRequest()
 
             val otherUser = DataBuilder.createExampleUser()
             val member = DataBuilder.createExampleProjectMember(userId = otherUser.id)
 
             // Mock access check
-            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns otherUser
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns otherUser
             coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf(member)
 
             // Mock user retrieval
@@ -108,15 +130,11 @@ internal class GetUserByIdTest : MainServiceTest() {
 
     @Test
     fun `When an error occurs while the user is retrieved, then an exception is thrown`() = testCoroutine {
-        val request =
-            Base.Id
-                .newBuilder()
-                .setId(requestId)
-                .build()
+        val request = getExampleRequest()
 
         // Mock access check
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -69,7 +69,7 @@ internal class GetUserByIdTest : MainServiceTest() {
 
         val noAccessUser = DataBuilder.createExampleUser()
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         assertThrows<UnauthorizedException.Single.User> { mainService.getUserById(request) }
     }
@@ -81,7 +81,7 @@ internal class GetUserByIdTest : MainServiceTest() {
         // Mock access check
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
         coEvery { userRepoMock.getUserById(requestId) } returns DataBuilder.createExampleUser()
@@ -103,7 +103,7 @@ internal class GetUserByIdTest : MainServiceTest() {
         // Mock access check
         val requestingUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns requestingUser
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
         coEvery { userRepoMock.getUserById(requestId) } returns requestingUser
@@ -121,7 +121,7 @@ internal class GetUserByIdTest : MainServiceTest() {
 
             // Mock access check
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns otherUser
-            coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf(member)
+            coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf(member)
 
             // Mock user retrieval
             coEvery { userRepoMock.getUserById(requestId) } returns DataBuilder.createExampleUser()
@@ -136,7 +136,7 @@ internal class GetUserByIdTest : MainServiceTest() {
         // Mock access check
         val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
-        coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
+        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
         coEvery { userRepoMock.getUserById(requestId) } throws TestSpecificException()

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -57,9 +58,9 @@ internal class GetUserByIdTest : MainServiceTest() {
     fun `When the requesting the current user fails, then an exception is thrown`() = testCoroutine {
         val request = getExampleRequest()
 
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } throws TestSpecificException()
 
-        assertThrows<Exception> { mainService.getUserById(request) }
+        assertThrows<TestSpecificException> { mainService.getUserById(request) }
     }
 
     @Test
@@ -138,8 +139,8 @@ internal class GetUserByIdTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembersInSameProjectsAsUser(any()) } returns listOf()
 
         // Mock user retrieval
-        coEvery { userRepoMock.getUserById(requestId) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(requestId) } throws TestSpecificException()
 
-        assertThrows<Exception> { mainService.getUserById(request) }
+        assertThrows<TestSpecificException> { mainService.getUserById(request) }
     }
 }

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -132,10 +132,10 @@ class CreateExampleTest : MainServiceTest() {
             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
 
             // Mock the behavior of the repositories
-            coEvery { exampleRepoMock.createExample(any()) } throws Exception("Example creation failed")
+            coEvery { exampleRepoMock.createExample(any()) } throws TestSpecificException()
 
             // Assert service behavior
-            assertThrows<Exception> { mainService.createExample(request) }
+            assertThrows<TestSpecificException> { mainService.createExample(request) }
         }
 }
 ```


### PR DESCRIPTION
Closes #54 

## What I have made

Now, only

- the server admin,
- the requested user itself, or
- a user who is in a project together with the requested user

can access a user by its ID or Email.

This required implementing some repository methods in `ProjectMemberTableRepo`.

I also changed the code so that the repo layer only uses UUIDs and not strings as IDs because always converting the strings to UUIDs was getting cumbersome and ugly. As the dummy user will be replaced soon, it will be less of a problem in the service layer.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
