### PR TITLE
Replaced ktlint with detekt ktlint wrapper

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,3 +32,21 @@ ij_kotlin_allow_trailing_comma = true
 ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^
 ij_kotlin_name_count_to_use_star_import = 99
 ij_kotlin_name_count_to_use_star_import_for_members = 99
+
+[{*.markdown,*.md}]
+ij_markdown_force_one_space_after_blockquote_symbol = true
+ij_markdown_force_one_space_after_header_symbol = true
+ij_markdown_force_one_space_after_list_bullet = true
+ij_markdown_force_one_space_between_words = true
+ij_markdown_format_tables = true
+ij_markdown_insert_quote_arrows_on_wrap = true
+ij_markdown_keep_indents_on_empty_lines = false
+ij_markdown_keep_line_breaks_inside_text_blocks = true
+ij_markdown_max_lines_around_block_elements = 1
+ij_markdown_max_lines_around_header = 1
+ij_markdown_max_lines_between_paragraphs = 1
+ij_markdown_min_lines_around_block_elements = 1
+ij_markdown_min_lines_around_header = 1
+ij_markdown_min_lines_between_paragraphs = 1
+ij_markdown_wrap_text_if_long = true
+ij_markdown_wrap_text_inside_blockquotes = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -79,3 +79,10 @@ ij_shell_minify_program = false
 ij_shell_redirect_followed_by_space = false
 ij_shell_switch_cases_indented = false
 ij_shell_use_unix_line_separator = true
+
+[{*.http,*.rest}]
+ij_continuation_indent_size = 4
+ij_http-request_call_parameters_wrap = normal
+ij_http-request_method_parameters_wrap = split_into_lines
+ij_http-request_space_before_comma = true
+ij_http-request_spaces_around_assignment_operators = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,21 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_size = 4
+ij_continuation_indent_size = 8
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = true
+ij_smart_tabs = false
+ij_visual_guides = unset
+ij_wrap_on_typing = false
+
+[.editorconfig]
+ij_editorconfig_align_group_field_declarations = false
+ij_editorconfig_space_after_colon = false
+ij_editorconfig_space_after_comma = false
+ij_editorconfig_space_before_colon = false
+ij_editorconfig_space_before_comma = false
+ij_editorconfig_spaces_around_assignment_operators = true
 
 [*.{kt,kts}]
 max_line_length = 120

--- a/.editorconfig
+++ b/.editorconfig
@@ -69,3 +69,13 @@ ij_xml_space_after_tag_name = false
 ij_xml_space_around_equals_in_attribute = false
 ij_xml_space_inside_empty_tag = false
 ij_xml_text_wrap = normal
+
+[{*.bash,*.sh,*.zsh}]
+indent_size = 2
+tab_width = 2
+ij_shell_binary_ops_start_line = false
+ij_shell_keep_column_alignment_padding = false
+ij_shell_minify_program = false
+ij_shell_redirect_followed_by_space = false
+ij_shell_switch_cases_indented = false
+ij_shell_use_unix_line_separator = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,7 @@ insert_final_newline = true
 indent_size = 4
 
 [*.{kt,kts}]
-ij_kotlin_packages_to_use_import_on_demand = java.util.*
 max_line_length = 120
+ij_kotlin_packages_to_use_import_on_demand = java.util.*
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -50,3 +50,22 @@ ij_markdown_min_lines_around_header = 1
 ij_markdown_min_lines_between_paragraphs = 1
 ij_markdown_wrap_text_if_long = true
 ij_markdown_wrap_text_inside_blockquotes = true
+
+[{*.ant,*.fxml,*.jhm,*.jnlp,*.jrxml,*.pom,*.rng,*.tld,*.wadl,*.wsdl,*.xml,*.xsd,*.xsl,*.xslt,*.xul}]
+ij_xml_align_attributes = true
+ij_xml_align_text = false
+ij_xml_attribute_wrap = normal
+ij_xml_block_comment_add_space = false
+ij_xml_block_comment_at_first_column = true
+ij_xml_keep_blank_lines = 2
+ij_xml_keep_indents_on_empty_lines = false
+ij_xml_keep_line_breaks = true
+ij_xml_keep_line_breaks_in_text = true
+ij_xml_keep_whitespaces = false
+ij_xml_keep_whitespaces_around_cdata = preserve
+ij_xml_keep_whitespaces_inside_cdata = false
+ij_xml_line_comment_at_first_column = true
+ij_xml_space_after_tag_name = false
+ij_xml_space_around_equals_in_attribute = false
+ij_xml_space_inside_empty_tag = false
+ij_xml_text_wrap = normal

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ indent_size = 4
 
 [*.{kt,kts}]
 max_line_length = 120
-ij_kotlin_packages_to_use_import_on_demand = java.util.*
+ij_kotlin_packages_to_use_import_on_demand =
 ij_kotlin_allow_trailing_comma_on_call_site = true
 ij_kotlin_allow_trailing_comma = true
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^
+ij_kotlin_name_count_to_use_star_import = 99
+ij_kotlin_name_count_to_use_star_import_for_members = 99

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,8 @@ Closes <!-- issue reference -->
 
 ## Checklist
 
-Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.
+Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
+not apply.
 
 - [ ] I have updated the documentation accordingly and commented my code
 - [ ] I have added tests that prove my fix is effective or that my feature works

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -13,24 +13,6 @@ env:
     java_distribution: ${{ vars.JAVA_DISTRIBUTION }}
 
 jobs:
-    formatting:
-        name: Check for valid formatting
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  submodules: "recursive"
-
-            - name: Setup
-              uses: ./.github/workflows/setup/
-              with:
-                  java_version: ${{ env.java_version }}
-                  java_distribution: ${{ env.java_distribution }}
-
-            - name: Check formatting
-              run: ./gradlew lintKotlin
-
     linting:
         name: Check for linting errors
         runs-on: ubuntu-latest
@@ -47,7 +29,7 @@ jobs:
                   java_distribution: ${{ env.java_distribution }}
 
             - name: Check linting
-              run: ./gradlew detekt
+              run: ./gradlew lint
 
     testing:
         name: Run tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,3 +182,24 @@ sourceSets {
         }
     }
 }
+
+// Alias for regular detekt lint check
+tasks.register("lint") {
+    group = "verification"
+    description = "Runs Detekt linter"
+    dependsOn("detekt")
+}
+
+// Custom format task as alias for "detekt --auto-correct"
+tasks.register<io.gitlab.arturbosch.detekt.Detekt>("format") {
+    group = "verification"
+    description = "Runs Detekt with the auto-correct flag to format the code."
+
+    config.setFrom(files("detekt.yml"))
+    autoCorrect = true
+
+    setSource(files("src"))
+
+    include("**/*.kt", "**/*.kts")
+    exclude("**/build/**")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,11 @@
 import kotlinx.kover.gradle.plugin.dsl.AggregationType
 import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
 import kotlinx.kover.gradle.plugin.dsl.GroupingEntityType
-import org.jmailen.gradle.kotlinter.tasks.FormatTask
-import org.jmailen.gradle.kotlinter.tasks.LintTask
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlinx.kover)
-    alias(libs.plugins.kotlinter)
     alias(libs.plugins.protobuf)
     alias(libs.plugins.shadow.jar)
     application
@@ -63,6 +60,8 @@ dependencies {
     implementation(libs.protobuf.kotlin)
 
     runtimeOnly(libs.grpc.netty)
+
+    detektPlugins(libs.detekt.formatting)
 }
 
 kotlin {
@@ -143,14 +142,6 @@ kover {
             }
         }
     }
-}
-
-tasks.withType<LintTask> {
-    this.source = this.source.minus(fileTree("build")).asFileTree
-}
-
-tasks.withType<FormatTask> {
-    this.source = this.source.minus(fileTree("build")).asFileTree
 }
 
 detekt {

--- a/detekt.yml
+++ b/detekt.yml
@@ -366,7 +366,7 @@ formatting:
         autoCorrect: true
         maxLineLength: 120
     FunctionSignature:
-        active: false
+        active: true
         autoCorrect: true
         forceMultilineWhenParameterCountGreaterOrEqualThan: 2147483647
         functionBodyExpressionWrapping: 'default'

--- a/detekt.yml
+++ b/detekt.yml
@@ -359,7 +359,7 @@ formatting:
         active: true
         autoCorrect: true
     FunctionName:
-        active: false
+        active: true
         autoCorrect: true
     FunctionReturnTypeSpacing:
         active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -470,7 +470,7 @@ formatting:
     NoWildcardImports:
         active: true
         autoCorrect: true
-        packagesToUseImportOnDemandProperty: 'java.util.*,kotlinx.android.synthetic.**'
+        packagesToUseImportOnDemandProperty: ''
     NullableTypeSpacing:
         active: true
         autoCorrect: true
@@ -1053,5 +1053,4 @@ style:
         ignoreLateinitVar: false
     WildcardImport:
         active: true
-        excludeImports:
-            - 'java.util.*'
+        excludeImports: [ ]

--- a/detekt.yml
+++ b/detekt.yml
@@ -325,7 +325,7 @@ formatting:
         autoCorrect: true
         indentSize: 4
     ClassName:
-        active: false
+        active: true
         autoCorrect: true
     CommentSpacing:
         active: true
@@ -340,12 +340,12 @@ formatting:
         maxLineLength: 120
         indentSize: 4
     DiscouragedCommentLocation:
-        active: false
+        active: true
     EnumEntryNameCase:
         active: true
         autoCorrect: true
     EnumWrapping:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     Filename:
@@ -379,11 +379,11 @@ formatting:
         active: true
         autoCorrect: true
     IfElseBracing:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     IfElseWrapping:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     ImportOrdering:
@@ -421,7 +421,7 @@ formatting:
         active: true
         autoCorrect: true
     NoBlankLineInList:
-        active: false
+        active: true
         autoCorrect: true
     NoBlankLinesInChainedMethodCalls:
         active: true
@@ -430,13 +430,13 @@ formatting:
         active: true
         autoCorrect: true
     NoConsecutiveComments:
-        active: false
+        active: true
         autoCorrect: true
     NoEmptyClassBody:
         active: true
         autoCorrect: true
     NoEmptyFirstLineInClassBody:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     NoEmptyFirstLineInMethodBlock:
@@ -455,7 +455,7 @@ formatting:
         active: true
         autoCorrect: true
     NoSingleLineBlockComment:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     NoTrailingSpaces:
@@ -478,7 +478,7 @@ formatting:
         active: true
         autoCorrect: true
     ParameterListSpacing:
-        active: false
+        active: true
         autoCorrect: true
     ParameterListWrapping:
         active: true
@@ -543,7 +543,7 @@ formatting:
         active: true
         autoCorrect: true
     StringTemplateIndent:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     TrailingCommaOnCallSite:
@@ -555,15 +555,15 @@ formatting:
         autoCorrect: true
         useTrailingCommaOnDeclarationSite: true
     TryCatchFinallySpacing:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     TypeArgumentListSpacing:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     TypeParameterListSpacing:
-        active: false
+        active: true
         autoCorrect: true
         indentSize: 4
     UnnecessaryParenthesesBeforeTrailingLambda:

--- a/detekt.yml
+++ b/detekt.yml
@@ -402,7 +402,7 @@ formatting:
         active: true
         autoCorrect: true
         maxLineLength: 120
-        ignoreBackTickedIdentifier: false
+        ignoreBackTickedIdentifier: true
     ModifierListSpacing:
         active: true
         autoCorrect: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -174,6 +174,7 @@ complexity:
         ignoreDeprecated: false
         ignorePrivate: false
         ignoreOverridden: false
+        ignoreAnnotatedFunctions: [ ]
 
 coroutines:
     active: true
@@ -694,6 +695,8 @@ style:
         active: true
         max: 2
         excludeGuardClauses: false
+    TrailingWhitespace:
+        active: true
     TrimMultilineRawString:
         active: true
         trimmingMethods:
@@ -780,4 +783,3 @@ style:
         active: true
         excludeImports:
             - 'java.util.*'
-            - 'io.ktor.*'

--- a/detekt.yml
+++ b/detekt.yml
@@ -547,11 +547,11 @@ formatting:
         autoCorrect: true
         indentSize: 4
     TrailingCommaOnCallSite:
-        active: false
+        active: true
         autoCorrect: true
         useTrailingCommaOnCallSite: true
     TrailingCommaOnDeclarationSite:
-        active: false
+        active: true
         autoCorrect: true
         useTrailingCommaOnDeclarationSite: true
     TryCatchFinallySpacing:

--- a/detekt.yml
+++ b/detekt.yml
@@ -303,6 +303,278 @@ exceptions:
             - 'RuntimeException'
             - 'Throwable'
 
+formatting:
+    active: true
+    AnnotationOnSeparateLine:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    AnnotationSpacing:
+        active: true
+        autoCorrect: true
+    ArgumentListWrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+        maxLineLength: 120
+    BlockCommentInitialStarAlignment:
+        active: true
+        autoCorrect: true
+    ChainWrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    ClassName:
+        active: false
+        autoCorrect: true
+    CommentSpacing:
+        active: true
+        autoCorrect: true
+    CommentWrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    ContextReceiverMapping:
+        active: false
+        autoCorrect: true
+        maxLineLength: 120
+        indentSize: 4
+    DiscouragedCommentLocation:
+        active: false
+    EnumEntryNameCase:
+        active: true
+        autoCorrect: true
+    EnumWrapping:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    Filename:
+        active: true
+        autoCorrect: true
+    FinalNewline:
+        active: true
+        autoCorrect: true
+        insertFinalNewLine: true
+    FunKeywordSpacing:
+        active: true
+        autoCorrect: true
+    FunctionName:
+        active: false
+        autoCorrect: true
+    FunctionReturnTypeSpacing:
+        active: true
+        autoCorrect: true
+        maxLineLength: 120
+    FunctionSignature:
+        active: false
+        autoCorrect: true
+        forceMultilineWhenParameterCountGreaterOrEqualThan: 2147483647
+        functionBodyExpressionWrapping: 'default'
+        maxLineLength: 120
+        indentSize: 4
+    FunctionStartOfBodySpacing:
+        active: true
+        autoCorrect: true
+    FunctionTypeReferenceSpacing:
+        active: true
+        autoCorrect: true
+    IfElseBracing:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    IfElseWrapping:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    ImportOrdering:
+        active: true
+        autoCorrect: true
+        layout: '*,java.**,javax.**,kotlin.**,^'
+    Indentation:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    KdocWrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    MaximumLineLength:
+        active: true
+        autoCorrect: true
+        maxLineLength: 120
+        ignoreBackTickedIdentifier: false
+    ModifierListSpacing:
+        active: true
+        autoCorrect: true
+    ModifierOrdering:
+        active: true
+        autoCorrect: true
+    MultiLineIfElse:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    MultilineExpressionWrapping:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    NoBlankLineBeforeRbrace:
+        active: true
+        autoCorrect: true
+    NoBlankLineInList:
+        active: false
+        autoCorrect: true
+    NoBlankLinesInChainedMethodCalls:
+        active: true
+        autoCorrect: true
+    NoConsecutiveBlankLines:
+        active: true
+        autoCorrect: true
+    NoConsecutiveComments:
+        active: false
+        autoCorrect: true
+    NoEmptyClassBody:
+        active: true
+        autoCorrect: true
+    NoEmptyFirstLineInClassBody:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    NoEmptyFirstLineInMethodBlock:
+        active: true
+        autoCorrect: true
+    NoLineBreakAfterElse:
+        active: true
+        autoCorrect: true
+    NoLineBreakBeforeAssignment:
+        active: true
+        autoCorrect: true
+    NoMultipleSpaces:
+        active: true
+        autoCorrect: true
+    NoSemicolons:
+        active: true
+        autoCorrect: true
+    NoSingleLineBlockComment:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    NoTrailingSpaces:
+        active: true
+        autoCorrect: true
+    NoUnitReturn:
+        active: true
+        autoCorrect: true
+    NoUnusedImports:
+        active: true
+        autoCorrect: true
+    NoWildcardImports:
+        active: true
+        autoCorrect: true
+        packagesToUseImportOnDemandProperty: 'java.util.*,kotlinx.android.synthetic.**'
+    NullableTypeSpacing:
+        active: true
+        autoCorrect: true
+    PackageName:
+        active: true
+        autoCorrect: true
+    ParameterListSpacing:
+        active: false
+        autoCorrect: true
+    ParameterListWrapping:
+        active: true
+        autoCorrect: true
+        maxLineLength: 120
+        indentSize: 4
+    ParameterWrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+        maxLineLength: 120
+    PropertyName:
+        active: false
+    PropertyWrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+        maxLineLength: 120
+    SpacingAroundAngleBrackets:
+        active: true
+        autoCorrect: true
+    SpacingAroundColon:
+        active: true
+        autoCorrect: true
+    SpacingAroundComma:
+        active: true
+        autoCorrect: true
+    SpacingAroundCurly:
+        active: true
+        autoCorrect: true
+    SpacingAroundDot:
+        active: true
+        autoCorrect: true
+    SpacingAroundDoubleColon:
+        active: true
+        autoCorrect: true
+    SpacingAroundKeyword:
+        active: true
+        autoCorrect: true
+    SpacingAroundOperators:
+        active: true
+        autoCorrect: true
+    SpacingAroundParens:
+        active: true
+        autoCorrect: true
+    SpacingAroundRangeOperator:
+        active: true
+        autoCorrect: true
+    SpacingAroundUnaryOperator:
+        active: true
+        autoCorrect: true
+    SpacingBetweenDeclarationsWithAnnotations:
+        active: true
+        autoCorrect: true
+    SpacingBetweenDeclarationsWithComments:
+        active: true
+        autoCorrect: true
+    SpacingBetweenFunctionNameAndOpeningParenthesis:
+        active: true
+        autoCorrect: true
+    StringTemplate:
+        active: true
+        autoCorrect: true
+    StringTemplateIndent:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    TrailingCommaOnCallSite:
+        active: false
+        autoCorrect: true
+        useTrailingCommaOnCallSite: true
+    TrailingCommaOnDeclarationSite:
+        active: false
+        autoCorrect: true
+        useTrailingCommaOnDeclarationSite: true
+    TryCatchFinallySpacing:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    TypeArgumentListSpacing:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    TypeParameterListSpacing:
+        active: false
+        autoCorrect: true
+        indentSize: 4
+    UnnecessaryParenthesesBeforeTrailingLambda:
+        active: true
+        autoCorrect: true
+    Wrapping:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+        maxLineLength: 120
+
 naming:
     active: true
     BooleanPropertyNaming:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ arrow-version = "2.0.1"
 assertj-arrow-core-version = "1.2.0"
 detekt-version = "1.23.8"
 kotlinx-kover-version = "0.9.1"
-kotlinter-version = "5.1.0"
 protobuf-version = "0.9.4"
 grpc-kotlin-version = "1.4.3"
 grpc-version = "1.73.0"
@@ -65,13 +64,14 @@ grpc-services = { module = "io.grpc:grpc-services", version.ref = "grpc-version"
 grpc-netty = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc-version" }
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf-kotlin-version" }
 
-archunit = { module = "com.tngtech.archunit:archunit", version.ref = "archunit-version"}
-archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit-version"}
+archunit = { module = "com.tngtech.archunit:archunit", version.ref = "archunit-version" }
+archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit-version" }
+
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-version" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-version" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover-version" }
-kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter-version" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-version" }
 shadow-jar = { id = "com.gradleup.shadow", version.ref = "shadow-jar-version" }

--- a/src/main/kotlin/db/Database.kt
+++ b/src/main/kotlin/db/Database.kt
@@ -136,12 +136,11 @@ class Database(
         return HikariDataSource(config)
     }
 
-    override suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T =
-        newSuspendedTransaction(
-            Dispatchers.IO,
-            Database.connect(dataSource),
-            Connection.TRANSACTION_SERIALIZABLE,
-        ) {
-            block()
-        }
+    override suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T = newSuspendedTransaction(
+        Dispatchers.IO,
+        Database.connect(dataSource),
+        Connection.TRANSACTION_SERIALIZABLE,
+    ) {
+        block()
+    }
 }

--- a/src/main/kotlin/env/Env.kt
+++ b/src/main/kotlin/env/Env.kt
@@ -54,7 +54,7 @@ interface IEnvService {
     @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     operator fun get(key: String): String
 
-    fun getOrDefault(key: String, default: String,): String
+    fun getOrDefault(key: String, default: String): String
 }
 
 /**
@@ -66,7 +66,7 @@ class EnvService : IEnvService {
     @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     override fun get(key: String): String = dotenv[key] ?: throw EnvVariableNotFoundException(key)
 
-    override fun getOrDefault(key: String, default: String,): String = dotenv[key] ?: default
+    override fun getOrDefault(key: String, default: String): String = dotenv[key] ?: default
 
     companion object {
         private fun getEnv() = dotenv {

--- a/src/main/kotlin/env/Env.kt
+++ b/src/main/kotlin/env/Env.kt
@@ -47,8 +47,8 @@ data class Env(
 class EnvVariableNotFoundException(
     key: String,
 ) : Exception(
-        "The env variable with key '$key' could not be found. Please check the variables.",
-    )
+    "The env variable with key '$key' could not be found. Please check the variables.",
+)
 
 interface IEnvService {
     @kotlin.jvm.Throws(EnvVariableNotFoundException::class)

--- a/src/main/kotlin/env/Env.kt
+++ b/src/main/kotlin/env/Env.kt
@@ -54,10 +54,7 @@ interface IEnvService {
     @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     operator fun get(key: String): String
 
-    fun getOrDefault(
-        key: String,
-        default: String,
-    ): String
+    fun getOrDefault(key: String, default: String,): String
 }
 
 /**
@@ -69,16 +66,12 @@ class EnvService : IEnvService {
     @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     override fun get(key: String): String = dotenv[key] ?: throw EnvVariableNotFoundException(key)
 
-    override fun getOrDefault(
-        key: String,
-        default: String,
-    ): String = dotenv[key] ?: default
+    override fun getOrDefault(key: String, default: String,): String = dotenv[key] ?: default
 
     companion object {
-        private fun getEnv() =
-            dotenv {
-                ignoreIfMissing = true
-                ignoreIfMalformed = true
-            }
+        private fun getEnv() = dotenv {
+            ignoreIfMissing = true
+            ignoreIfMalformed = true
+        }
     }
 }

--- a/src/main/kotlin/grpc/ExceptionInterceptor.kt
+++ b/src/main/kotlin/grpc/ExceptionInterceptor.kt
@@ -35,7 +35,7 @@ val exceptionInterceptor =
 private class ExceptionCall<ReqT, RespT>(
     delegate: ServerCall<ReqT, RespT>,
 ) : ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(delegate) {
-    override fun close(status: Status?, trailers: Metadata?,) {
+    override fun close(status: Status?, trailers: Metadata?) {
         var newStatus = status
         if (status == null) {
             logger.error { "gRPC call closed with null status." }
@@ -94,7 +94,7 @@ private class ExceptionCall<ReqT, RespT>(
      * Specific unexpected exceptions point to missing exception handling in this application.
      * They are logged as warning so that they can be handled in the future.
      */
-    private fun getStatusForSpecificUnexpectedException(status: Status, e: Exception,): Status {
+    private fun getStatusForSpecificUnexpectedException(status: Status, e: Exception): Status {
         logger.warn(e) { "gRPC call failed due to unexpected ${e::class.simpleName} with message: ${e.message}" }
         return status
     }

--- a/src/main/kotlin/grpc/ExceptionInterceptor.kt
+++ b/src/main/kotlin/grpc/ExceptionInterceptor.kt
@@ -25,21 +25,17 @@ val exceptionInterceptor =
             call: ServerCall<ReqT?, RespT?>,
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>,
-        ): ServerCall.Listener<ReqT?> =
-            next.startCall(
-                ExceptionCall(call),
-                headers,
-            )
+        ): ServerCall.Listener<ReqT?> = next.startCall(
+            ExceptionCall(call),
+            headers,
+        )
     }
 
 @Suppress("TooGenericExceptionCaught")
 private class ExceptionCall<ReqT, RespT>(
     delegate: ServerCall<ReqT, RespT>,
 ) : ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(delegate) {
-    override fun close(
-        status: Status?,
-        trailers: Metadata?,
-    ) {
+    override fun close(status: Status?, trailers: Metadata?,) {
         var newStatus = status
         if (status == null) {
             logger.error { "gRPC call closed with null status." }
@@ -61,19 +57,18 @@ private class ExceptionCall<ReqT, RespT>(
     /**
      * Returns a status for the passed [Throwable], which then can be returned to the user.
      */
-    private fun handleException(e: Throwable): Status =
-        when (e) {
-            // Handle all specific application exceptions
-            is SnowballRException -> getStatusForSnowballRException(e)
+    private fun handleException(e: Throwable): Status = when (e) {
+        // Handle all specific application exceptions
+        is SnowballRException -> getStatusForSnowballRException(e)
 
-            // Handle specific unexpected exceptions
-            is IllegalArgumentException -> getStatusForSpecificUnexpectedException(Status.INVALID_ARGUMENT, e)
-            is NoSuchElementException -> getStatusForSpecificUnexpectedException(Status.NOT_FOUND, e)
-            is IllegalStateException -> getStatusForSpecificUnexpectedException(Status.FAILED_PRECONDITION, e)
+        // Handle specific unexpected exceptions
+        is IllegalArgumentException -> getStatusForSpecificUnexpectedException(Status.INVALID_ARGUMENT, e)
+        is NoSuchElementException -> getStatusForSpecificUnexpectedException(Status.NOT_FOUND, e)
+        is IllegalStateException -> getStatusForSpecificUnexpectedException(Status.FAILED_PRECONDITION, e)
 
-            // Handle the rest of unexpected exceptions
-            else -> getStatusForUnexpectedException(e)
-        }
+        // Handle the rest of unexpected exceptions
+        else -> getStatusForUnexpectedException(e)
+    }
 
     /**
      * The [SnowballRException]s are deliberately thrown in this application, e.g., when preconditions aren't met.
@@ -99,10 +94,7 @@ private class ExceptionCall<ReqT, RespT>(
      * Specific unexpected exceptions point to missing exception handling in this application.
      * They are logged as warning so that they can be handled in the future.
      */
-    private fun getStatusForSpecificUnexpectedException(
-        status: Status,
-        e: Exception,
-    ): Status {
+    private fun getStatusForSpecificUnexpectedException(status: Status, e: Exception,): Status {
         logger.warn(e) { "gRPC call failed due to unexpected ${e::class.simpleName} with message: ${e.message}" }
         return status
     }

--- a/src/main/kotlin/model/Parser.kt
+++ b/src/main/kotlin/model/Parser.kt
@@ -6,5 +6,5 @@ import java.util.UUID
 /**
  * Parses the passed [uuid] string to a UUID. If the parsing fails an [InvalidIdException.UUID] is thrown.
  */
-fun parseUUID(uuid: String, entityType: String,): UUID =
+fun parseUUID(uuid: String, entityType: String): UUID =
     runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(uuid, entityType)

--- a/src/main/kotlin/model/Parser.kt
+++ b/src/main/kotlin/model/Parser.kt
@@ -6,7 +6,5 @@ import java.util.UUID
 /**
  * Parses the passed [uuid] string to a UUID. If the parsing fails an [InvalidIdException.UUID] is thrown.
  */
-fun parseUUID(
-    uuid: String,
-    entityType: String,
-): UUID = runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(uuid, entityType)
+fun parseUUID(uuid: String, entityType: String,): UUID =
+    runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(uuid, entityType)

--- a/src/main/kotlin/model/dto/Author.kt
+++ b/src/main/kotlin/model/dto/Author.kt
@@ -20,10 +20,9 @@ data class Author(
 /**
  * Creates a [PaperOuterClass.Author] from this [Author].
  */
-fun Author.toGrpcAuthor(): PaperOuterClass.Author =
-    PaperOuterClass.Author
-        .newBuilder()
-        .setFirstName(this.firstName)
-        .setLastName(this.lastName)
-        .setOrcid(this.orcid)
-        .build()
+fun Author.toGrpcAuthor(): PaperOuterClass.Author = PaperOuterClass.Author
+    .newBuilder()
+    .setFirstName(this.firstName)
+    .setLastName(this.lastName)
+    .setOrcid(this.orcid)
+    .build()

--- a/src/main/kotlin/model/dto/Criterion.kt
+++ b/src/main/kotlin/model/dto/Criterion.kt
@@ -22,12 +22,11 @@ data class Criterion(
 /**
  * Creates a [CriterionOuterClass.Criterion] from this [Criterion].
  */
-fun Criterion.toGrpcCriterion(): CriterionOuterClass.Criterion =
-    CriterionOuterClass.Criterion
-        .newBuilder()
-        .setId(this.id.toString())
-        .setTag(this.tag)
-        .setName(this.name)
-        .setDescription(this.description)
-        .setCategory(this.category)
-        .build()
+fun Criterion.toGrpcCriterion(): CriterionOuterClass.Criterion = CriterionOuterClass.Criterion
+    .newBuilder()
+    .setId(this.id.toString())
+    .setTag(this.tag)
+    .setName(this.name)
+    .setDescription(this.description)
+    .setCategory(this.category)
+    .build()

--- a/src/main/kotlin/model/dto/Paper.kt
+++ b/src/main/kotlin/model/dto/Paper.kt
@@ -27,10 +27,7 @@ data class Paper(
 /**
  * Creates a [PaperOuterClass.Paper] from this [Paper].
  */
-fun Paper.toGrpcPaper(
-    authors: List<PaperOuterClass.Author>,
-    backwardReferencedIds: List<Int>,
-): PaperOuterClass.Paper =
+fun Paper.toGrpcPaper(authors: List<PaperOuterClass.Author>, backwardReferencedIds: List<Int>,): PaperOuterClass.Paper =
     PaperOuterClass.Paper
         .newBuilder()
         .setId(this.id.toString())

--- a/src/main/kotlin/model/dto/Paper.kt
+++ b/src/main/kotlin/model/dto/Paper.kt
@@ -27,7 +27,7 @@ data class Paper(
 /**
  * Creates a [PaperOuterClass.Paper] from this [Paper].
  */
-fun Paper.toGrpcPaper(authors: List<PaperOuterClass.Author>, backwardReferencedIds: List<Int>,): PaperOuterClass.Paper =
+fun Paper.toGrpcPaper(authors: List<PaperOuterClass.Author>, backwardReferencedIds: List<Int>): PaperOuterClass.Paper =
     PaperOuterClass.Paper
         .newBuilder()
         .setId(this.id.toString())

--- a/src/main/kotlin/model/dto/User.kt
+++ b/src/main/kotlin/model/dto/User.kt
@@ -23,13 +23,12 @@ data class User(
 /**
  * Creates a [UserOuterClass.User] from this [User].
  */
-fun User.toGrpcUser(): UserOuterClass.User =
-    UserOuterClass.User
-        .newBuilder()
-        .setId(this.id.toString())
-        .setEmail(this.email)
-        .setFirstName(this.firstName)
-        .setLastName(this.lastName)
-        .setRole(this.role)
-        .setStatus(this.status)
-        .build()
+fun User.toGrpcUser(): UserOuterClass.User = UserOuterClass.User
+    .newBuilder()
+    .setId(this.id.toString())
+    .setEmail(this.email)
+    .setFirstName(this.firstName)
+    .setLastName(this.lastName)
+    .setRole(this.role)
+    .setStatus(this.status)
+    .build()

--- a/src/main/kotlin/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/repository/CriterionTableRepo.kt
@@ -20,7 +20,7 @@ import snowballr.CriterionOuterClass
  * criteria can remain decoupled from the specifics of the database layer.
  */
 interface ICriterionTableRepo {
-    suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String,): Criterion
+    suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String): Criterion
 }
 
 /**
@@ -36,7 +36,7 @@ interface ICriterionTableRepo {
 class CriterionTableRepo(
     private val db: IDatabase,
 ) : ICriterionTableRepo {
-    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String,): Criterion =
+    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String): Criterion =
         db.dbQuery {
             // Get user reference
             val userEntityId = getUserEntityId(userId)

--- a/src/main/kotlin/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/repository/CriterionTableRepo.kt
@@ -20,10 +20,7 @@ import snowballr.CriterionOuterClass
  * criteria can remain decoupled from the specifics of the database layer.
  */
 interface ICriterionTableRepo {
-    suspend fun createCriterion(
-        request: CriterionOuterClass.Criterion.Create,
-        userId: String,
-    ): Criterion
+    suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String,): Criterion
 }
 
 /**
@@ -39,10 +36,7 @@ interface ICriterionTableRepo {
 class CriterionTableRepo(
     private val db: IDatabase,
 ) : ICriterionTableRepo {
-    override suspend fun createCriterion(
-        request: CriterionOuterClass.Criterion.Create,
-        userId: String,
-    ): Criterion =
+    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: String,): Criterion =
         db.dbQuery {
             // Get user reference
             val userEntityId = getUserEntityId(userId)

--- a/src/main/kotlin/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/repository/ProjectTableRepo.kt
@@ -20,10 +20,7 @@ import snowballr.ProjectOuterClass
  * for creating and managing projects can remain decoupled from the specifics of the database layer.
  */
 interface IProjectTableRepo {
-    suspend fun createProject(
-        request: ProjectOuterClass.Project.Create,
-        userId: String,
-    ): Project
+    suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String,): Project
 }
 
 /**
@@ -38,10 +35,7 @@ interface IProjectTableRepo {
 class ProjectTableRepo(
     private val db: IDatabase,
 ) : IProjectTableRepo {
-    override suspend fun createProject(
-        request: ProjectOuterClass.Project.Create,
-        userId: String,
-    ): Project =
+    override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String,): Project =
         db.dbQuery {
             // Get user reference
             val userEntityId = getUserEntityId(userId)

--- a/src/main/kotlin/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/repository/ProjectTableRepo.kt
@@ -20,7 +20,7 @@ import snowballr.ProjectOuterClass
  * for creating and managing projects can remain decoupled from the specifics of the database layer.
  */
 interface IProjectTableRepo {
-    suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String,): Project
+    suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String): Project
 }
 
 /**
@@ -35,7 +35,7 @@ interface IProjectTableRepo {
 class ProjectTableRepo(
     private val db: IDatabase,
 ) : IProjectTableRepo {
-    override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String,): Project =
+    override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: String): Project =
         db.dbQuery {
             // Get user reference
             val userEntityId = getUserEntityId(userId)

--- a/src/main/kotlin/repository/UserTableRepo.kt
+++ b/src/main/kotlin/repository/UserTableRepo.kt
@@ -35,32 +35,29 @@ interface IUserTableRepo {
 class UserTableRepo(
     private val db: IDatabase,
 ) : IUserTableRepo {
-    override suspend fun getUserById(id: String): User =
-        db.dbQuery {
-            val uuid = parseUUID(id, "user")
+    override suspend fun getUserById(id: String): User = db.dbQuery {
+        val uuid = parseUUID(id, "user")
 
-            UserTable
-                .selectAll()
-                .where { UserTable.id eq uuid }
-                .map { it.toUser() }
-                .singleOrNull()
-                ?: throw NotFoundException.User(id)
-        }
+        UserTable
+            .selectAll()
+            .where { UserTable.id eq uuid }
+            .map { it.toUser() }
+            .singleOrNull()
+            ?: throw NotFoundException.User(id)
+    }
 
-    override suspend fun getUserByEmail(email: String): User =
-        db.dbQuery {
-            UserTable
-                .selectAll()
-                .where { UserTable.email eq email }
-                .map { it.toUser() }
-                .singleOrNull()
-                ?: throw NotFoundException.User(email, "email")
-        }
+    override suspend fun getUserByEmail(email: String): User = db.dbQuery {
+        UserTable
+            .selectAll()
+            .where { UserTable.email eq email }
+            .map { it.toUser() }
+            .singleOrNull()
+            ?: throw NotFoundException.User(email, "email")
+    }
 
-    override suspend fun getAllUsers(): List<User> =
-        db.dbQuery {
-            UserTable
-                .selectAll()
-                .map { it.toUser() }
-        }
+    override suspend fun getAllUsers(): List<User> = db.dbQuery {
+        UserTable
+            .selectAll()
+            .map { it.toUser() }
+    }
 }

--- a/src/main/kotlin/table/AuthorTable.kt
+++ b/src/main/kotlin/table/AuthorTable.kt
@@ -30,13 +30,12 @@ object AuthorTable : UUIDTable("author") {
     /**
      * Creates an [Author] from this [ResultRow].
      */
-    fun ResultRow.toAuthor() =
-        Author(
-            id = this[id].value,
-            firstName = this[firstName],
-            lastName = this[lastName],
-            orcid = this[orcid],
-            createdAt = this[createdAt],
-            modifiedAt = this[modifiedAt],
-        )
+    fun ResultRow.toAuthor() = Author(
+        id = this[id].value,
+        firstName = this[firstName],
+        lastName = this[lastName],
+        orcid = this[orcid],
+        createdAt = this[createdAt],
+        modifiedAt = this[modifiedAt],
+    )
 }

--- a/src/main/kotlin/table/ColumnHelper.kt
+++ b/src/main/kotlin/table/ColumnHelper.kt
@@ -6,11 +6,8 @@ import org.jetbrains.exposed.sql.kotlin.datetime.timestampWithTimeZone
 import java.time.OffsetDateTime
 
 /** Common column definition for a user reference */
-fun Table.userReference(
-    name: String,
-    onDelete: ReferenceOption,
-    onUpdate: ReferenceOption,
-) = reference(name, UserTable, onDelete, onUpdate)
+fun Table.userReference(name: String, onDelete: ReferenceOption, onUpdate: ReferenceOption,) =
+    reference(name, UserTable, onDelete, onUpdate)
 
 /** Common column definition for the "created at" timestamp. */
 fun Table.createdAt() = timestampWithTimeZone("created_at").clientDefault { OffsetDateTime.now() }

--- a/src/main/kotlin/table/ColumnHelper.kt
+++ b/src/main/kotlin/table/ColumnHelper.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.sql.kotlin.datetime.timestampWithTimeZone
 import java.time.OffsetDateTime
 
 /** Common column definition for a user reference */
-fun Table.userReference(name: String, onDelete: ReferenceOption, onUpdate: ReferenceOption,) =
+fun Table.userReference(name: String, onDelete: ReferenceOption, onUpdate: ReferenceOption) =
     reference(name, UserTable, onDelete, onUpdate)
 
 /** Common column definition for the "created at" timestamp. */

--- a/src/main/kotlin/table/CriterionTable.kt
+++ b/src/main/kotlin/table/CriterionTable.kt
@@ -45,15 +45,14 @@ object CriterionTable : UUIDTable("criterion") {
     /**
      * Creates a [Criterion] from this [ResultRow].
      */
-    fun ResultRow.toCriterion() =
-        Criterion(
-            id = this[id].value,
-            tag = this[tag],
-            name = this[name],
-            description = this[description],
-            category = this[category],
-            projectId = this[projectId].value,
-            createdAt = this[createdAt],
-            createdBy = this[createdBy].value,
-        )
+    fun ResultRow.toCriterion() = Criterion(
+        id = this[id].value,
+        tag = this[tag],
+        name = this[name],
+        description = this[description],
+        category = this[category],
+        projectId = this[projectId].value,
+        createdAt = this[createdAt],
+        createdBy = this[createdBy].value,
+    )
 }

--- a/src/main/kotlin/table/PaperTable.kt
+++ b/src/main/kotlin/table/PaperTable.kt
@@ -52,19 +52,18 @@ object PaperTable : UUIDTable("paper") {
     /**
      * Creates a [Paper] from this [ResultRow].
      */
-    fun ResultRow.toPaper() =
-        Paper(
-            id = this[id].value,
-            title = this[title],
-            externalId = this[externalId],
-            abstract = this[abstract],
-            publishedAt = this[publishedAt],
-            publisher = this[publisher],
-            publicationType = this[publicationType],
-            publicationName = this[publicationName],
-            pdfId = this[pdfId]?.value,
-            createdAt = this[createdAt],
-            modifiedAt = this[modifiedAt],
-            modifiedBy = this[modifiedBy]?.value,
-        )
+    fun ResultRow.toPaper() = Paper(
+        id = this[id].value,
+        title = this[title],
+        externalId = this[externalId],
+        abstract = this[abstract],
+        publishedAt = this[publishedAt],
+        publisher = this[publisher],
+        publicationType = this[publicationType],
+        publicationName = this[publicationName],
+        pdfId = this[pdfId]?.value,
+        createdAt = this[createdAt],
+        modifiedAt = this[modifiedAt],
+        modifiedBy = this[modifiedBy]?.value,
+    )
 }

--- a/src/main/kotlin/table/PdfTable.kt
+++ b/src/main/kotlin/table/PdfTable.kt
@@ -19,9 +19,8 @@ object PdfTable : UUIDTable("pdf") {
     /**
      * Creates a [Pdf] from this [ResultRow].
      */
-    fun ResultRow.toPdf() =
-        Pdf(
-            this[id].value,
-            this[data].bytes,
-        )
+    fun ResultRow.toPdf() = Pdf(
+        this[id].value,
+        this[data].bytes,
+    )
 }

--- a/src/main/kotlin/table/ProjectTable.kt
+++ b/src/main/kotlin/table/ProjectTable.kt
@@ -73,26 +73,25 @@ object ProjectTable : UUIDTable("project") {
     /**
      * Creates a [Project] from this [ResultRow].
      */
-    fun ResultRow.toProject() =
-        Project(
-            id = this[id].value,
-            name = this[name],
-            status = this[status],
-            currentStage = this[currentStage],
-            maxStage = this[maxStage],
-            similarityThreshold = this[similarityThreshold],
-            snowballingType = this[snowballingType],
-            reviewMaybeAllowed = this[reviewMaybeAllowed],
-            reviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.parseFrom(this[reviewDecisionMatrixBinary]),
-            fetcherApis = this[fetcherApis],
-            currentStageStartedAt = this[currentStageStartedAt],
-            createdAt = this[createdAt],
-            createdBy = this[createdBy].value,
-            modifiedAt = this[modifiedAt],
-            modifiedBy = this[modifiedBy]?.value,
-            deletedAt = this[deletedAt],
-            deletedBy = this[deletedBy]?.value,
-            archivedAt = this[archivedAt],
-            archivedBy = this[archivedBy]?.value,
-        )
+    fun ResultRow.toProject() = Project(
+        id = this[id].value,
+        name = this[name],
+        status = this[status],
+        currentStage = this[currentStage],
+        maxStage = this[maxStage],
+        similarityThreshold = this[similarityThreshold],
+        snowballingType = this[snowballingType],
+        reviewMaybeAllowed = this[reviewMaybeAllowed],
+        reviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.parseFrom(this[reviewDecisionMatrixBinary]),
+        fetcherApis = this[fetcherApis],
+        currentStageStartedAt = this[currentStageStartedAt],
+        createdAt = this[createdAt],
+        createdBy = this[createdBy].value,
+        modifiedAt = this[modifiedAt],
+        modifiedBy = this[modifiedBy]?.value,
+        deletedAt = this[deletedAt],
+        deletedBy = this[deletedBy]?.value,
+        archivedAt = this[archivedAt],
+        archivedBy = this[archivedBy]?.value,
+    )
 }

--- a/src/main/kotlin/table/TableHelper.kt
+++ b/src/main/kotlin/table/TableHelper.kt
@@ -20,7 +20,7 @@ import java.util.UUID
  * @return The ID of the entity as [EntityID], or null if no entity exists.
  * @throws InvalidIdException.UUID If [id] cannot be parsed to a UUID.
  */
-private fun UUIDTable.getEntityId(id: String, entityType: String,): EntityID<UUID>? {
+private fun UUIDTable.getEntityId(id: String, entityType: String): EntityID<UUID>? {
     val uuid = parseUUID(id, entityType)
 
     return this

--- a/src/main/kotlin/table/TableHelper.kt
+++ b/src/main/kotlin/table/TableHelper.kt
@@ -20,10 +20,7 @@ import java.util.UUID
  * @return The ID of the entity as [EntityID], or null if no entity exists.
  * @throws InvalidIdException.UUID If [id] cannot be parsed to a UUID.
  */
-private fun UUIDTable.getEntityId(
-    id: String,
-    entityType: String,
-): EntityID<UUID>? {
+private fun UUIDTable.getEntityId(id: String, entityType: String,): EntityID<UUID>? {
     val uuid = parseUUID(id, entityType)
 
     return this

--- a/src/main/kotlin/table/UserTable.kt
+++ b/src/main/kotlin/table/UserTable.kt
@@ -44,16 +44,15 @@ object UserTable : UUIDTable("user") {
     /**
      * Creates a [User] from this [ResultRow].
      */
-    fun ResultRow.toUser() =
-        User(
-            id = this[id].value,
-            email = this[email],
-            firstName = this[firstName],
-            lastName = this[lastName],
-            role = this[role],
-            status = this[status],
-            createdAt = this[createdAt],
-            modifiedAt = this[modifiedAt],
-            deletedAt = this[deletedAt],
-        )
+    fun ResultRow.toUser() = User(
+        id = this[id].value,
+        email = this[email],
+        firstName = this[firstName],
+        lastName = this[lastName],
+        role = this[role],
+        status = this[status],
+        createdAt = this[createdAt],
+        modifiedAt = this[modifiedAt],
+        deletedAt = this[deletedAt],
+    )
 }

--- a/src/main/kotlin/table/association/InvitationTable.kt
+++ b/src/main/kotlin/table/association/InvitationTable.kt
@@ -55,12 +55,11 @@ object InvitationTable : CompositeIdTable("invitation") {
     /**
      * Creates an [Invitation] from this [ResultRow].
      */
-    fun ResultRow.toInvitation() =
-        Invitation(
-            id = this[id].value,
-            projectId = this[projectId].value,
-            userId = this[userId].value,
-            token = this[token],
-            validUntil = this[validUntil],
-        )
+    fun ResultRow.toInvitation() = Invitation(
+        id = this[id].value,
+        projectId = this[projectId].value,
+        userId = this[userId].value,
+        token = this[token],
+        validUntil = this[validUntil],
+    )
 }

--- a/src/main/kotlin/table/association/ProjectMemberTable.kt
+++ b/src/main/kotlin/table/association/ProjectMemberTable.kt
@@ -63,13 +63,12 @@ object ProjectMemberTable : CompositeIdTable("project_member") {
     /**
      * Creates a [ProjectMember] from this [ResultRow].
      */
-    fun ResultRow.toProjectMember() =
-        ProjectMember(
-            id = this[id].value,
-            projectId = this[projectId].value,
-            userId = this[userId].value,
-            role = this[role],
-            createdAt = this[createdAt],
-            modifiedAt = this[modifiedAt],
-        )
+    fun ResultRow.toProjectMember() = ProjectMember(
+        id = this[id].value,
+        projectId = this[projectId].value,
+        userId = this[userId].value,
+        role = this[role],
+        createdAt = this[createdAt],
+        modifiedAt = this[modifiedAt],
+    )
 }

--- a/src/main/kotlin/table/association/ProjectPaperTable.kt
+++ b/src/main/kotlin/table/association/ProjectPaperTable.kt
@@ -68,17 +68,16 @@ object ProjectPaperTable : UUIDTable("project_paper") {
     /**
      * Creates a [ProjectPaper] from this [ResultRow].
      */
-    fun ResultRow.toProjectPaper() =
-        ProjectPaper(
-            id = this[id].value,
-            paperId = this[paperId].value,
-            projectId = this[projectId].value,
-            localPaperId = this[localPaperId],
-            stage = this[stage],
-            decision = this[decision],
-            createdAt = this[createdAt],
-            createdBy = this[createdBy].value,
-            modifiedAt = this[modifiedAt],
-            modifiedBy = this[modifiedBy]?.value,
-        )
+    fun ResultRow.toProjectPaper() = ProjectPaper(
+        id = this[id].value,
+        paperId = this[paperId].value,
+        projectId = this[projectId].value,
+        localPaperId = this[localPaperId],
+        stage = this[stage],
+        decision = this[decision],
+        createdAt = this[createdAt],
+        createdBy = this[createdBy].value,
+        modifiedAt = this[modifiedAt],
+        modifiedBy = this[modifiedBy]?.value,
+    )
 }

--- a/src/main/kotlin/table/association/ReviewTable.kt
+++ b/src/main/kotlin/table/association/ReviewTable.kt
@@ -54,13 +54,12 @@ object ReviewTable : UUIDTable("review") {
     /**
      * Creates a [Review] from this [ResultRow].
      */
-    fun ResultRow.toReview() =
-        Review(
-            id = this[id].value,
-            projectPaperId = this[projectPaperId].value,
-            userId = this[userId].value,
-            decision = this[decision],
-            createdAt = this[createdAt],
-            modifiedAt = this[modifiedAt],
-        )
+    fun ResultRow.toReview() = Review(
+        id = this[id].value,
+        projectPaperId = this[projectPaperId].value,
+        userId = this[userId].value,
+        decision = this[decision],
+        createdAt = this[createdAt],
+        modifiedAt = this[modifiedAt],
+    )
 }

--- a/src/main/kotlin/validation/BaseValidator.kt
+++ b/src/main/kotlin/validation/BaseValidator.kt
@@ -11,13 +11,11 @@ import snowballr.Base
  * A validator for [Base] related requests.
  */
 object BaseValidator {
-    fun validateId(request: Base.Id): EitherNel<ValidationIssue, Unit> =
-        either {
-            ensureIdValidity("id", request.id)
-        }.toEitherNel()
+    fun validateId(request: Base.Id): EitherNel<ValidationIssue, Unit> = either {
+        ensureIdValidity("id", request.id)
+    }.toEitherNel()
 
-    fun validateEmail(request: Base.Email): EitherNel<ValidationIssue, Unit> =
-        either {
-            ensure(EMAIL_REGEX.matches(request.email)) { InvalidEmail(request.email) }
-        }.toEitherNel()
+    fun validateEmail(request: Base.Email): EitherNel<ValidationIssue, Unit> = either {
+        ensure(EMAIL_REGEX.matches(request.email)) { InvalidEmail(request.email) }
+    }.toEitherNel()
 }

--- a/src/main/kotlin/validation/CriterionValidator.kt
+++ b/src/main/kotlin/validation/CriterionValidator.kt
@@ -14,25 +14,24 @@ const val CRITERION_DESCRIPTION_MAX_LENGTH = 200
  * A validator for [Criterion] related requests.
  */
 object CriterionValidator {
-    fun validateCreateRequest(request: Criterion.Create): EitherNel<ValidationIssue, Unit> =
-        either {
-            zipOrAccumulate(
-                { ensureIdValidity("project_id", request.projectId) },
-                {
-                    ensureFieldNonBlank("tag", request.tag)
-                    ensureFieldLength("tag", request.tag, CRITERION_TAG_MAX_LENGTH)
-                },
-                {
-                    ensureFieldNonBlank("name", request.name)
-                    ensureFieldLength("name", request.name, CRITERION_NAME_MAX_LENGTH)
-                },
-                {
-                    ensureFieldNonBlank("description", request.description)
-                    ensureFieldLength("description", request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
-                },
-                {
-                    ensureEnumNotUnspecified("category", request.category)
-                },
-            ) { _, _, _, _, _ -> }
-        }
+    fun validateCreateRequest(request: Criterion.Create): EitherNel<ValidationIssue, Unit> = either {
+        zipOrAccumulate(
+            { ensureIdValidity("project_id", request.projectId) },
+            {
+                ensureFieldNonBlank("tag", request.tag)
+                ensureFieldLength("tag", request.tag, CRITERION_TAG_MAX_LENGTH)
+            },
+            {
+                ensureFieldNonBlank("name", request.name)
+                ensureFieldLength("name", request.name, CRITERION_NAME_MAX_LENGTH)
+            },
+            {
+                ensureFieldNonBlank("description", request.description)
+                ensureFieldLength("description", request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
+            },
+            {
+                ensureEnumNotUnspecified("category", request.category)
+            },
+        ) { _, _, _, _, _ -> }
+    }
 }

--- a/src/main/kotlin/validation/ProjectValidator.kt
+++ b/src/main/kotlin/validation/ProjectValidator.kt
@@ -11,9 +11,8 @@ const val PROJECT_NAME_MAX_LENGTH = 100
  * A validator for [Project] related requests.
  */
 object ProjectValidator {
-    fun validateCreateRequest(request: Project.Create): EitherNel<ValidationIssue, Unit> =
-        either {
-            ensureFieldNonBlank("name", request.name)
-            ensureFieldLength("name", request.name, PROJECT_NAME_MAX_LENGTH)
-        }.toEitherNel()
+    fun validateCreateRequest(request: Project.Create): EitherNel<ValidationIssue, Unit> = either {
+        ensureFieldNonBlank("name", request.name)
+        ensureFieldLength("name", request.name, PROJECT_NAME_MAX_LENGTH)
+    }.toEitherNel()
 }

--- a/src/main/kotlin/validation/ValidationHelper.kt
+++ b/src/main/kotlin/validation/ValidationHelper.kt
@@ -16,10 +16,8 @@ import java.util.UUID
  * @param name The name of the field being validated.
  * @param value The value of the field to check for blankness.
  */
-fun Raise<ValidationIssue>.ensureFieldNonBlank(
-    name: String,
-    value: String,
-) = ensure(value.isNotBlank()) { BlankField(name) }
+fun Raise<ValidationIssue>.ensureFieldNonBlank(name: String, value: String,) =
+    ensure(value.isNotBlank()) { BlankField(name) }
 
 /**
  * Ensures that the given field value does not exceed the specified maximum length.
@@ -29,11 +27,8 @@ fun Raise<ValidationIssue>.ensureFieldNonBlank(
  * @param value The value of the field to check for its length.
  * @param maxLength The maximum allowed length for the field value.
  */
-fun Raise<ValidationIssue>.ensureFieldLength(
-    name: String,
-    value: String,
-    maxLength: Int,
-) = ensure(value.length <= maxLength) { TooLongField(name, maxLength) }
+fun Raise<ValidationIssue>.ensureFieldLength(name: String, value: String, maxLength: Int,) =
+    ensure(value.length <= maxLength) { TooLongField(name, maxLength) }
 
 /**
  * Ensures that the provided enum value is not the `UNSPECIFIED` value.
@@ -44,10 +39,8 @@ fun Raise<ValidationIssue>.ensureFieldLength(
  * @param name The name of the enum field being validated.
  * @param value The enum value to check for being `UNSPECIFIED`.
  */
-fun Raise<ValidationIssue>.ensureEnumNotUnspecified(
-    name: String,
-    value: Enum<*>,
-) = ensure(value.ordinal > 0) { EnumUnspecified(name) }
+fun Raise<ValidationIssue>.ensureEnumNotUnspecified(name: String, value: Enum<*>,) =
+    ensure(value.ordinal > 0) { EnumUnspecified(name) }
 
 /**
  * Ensures that the provided [id] of field [name] has a valid format.
@@ -55,7 +48,5 @@ fun Raise<ValidationIssue>.ensureEnumNotUnspecified(
  * @param name The name of the field being validated.
  * @param id The ID to check for validity.
  */
-fun Raise<ValidationIssue>.ensureIdValidity(
-    name: String,
-    id: String,
-) = ensure(runCatching { UUID.fromString(id) }.isSuccess) { InvalidId(name, id) }
+fun Raise<ValidationIssue>.ensureIdValidity(name: String, id: String,) =
+    ensure(runCatching { UUID.fromString(id) }.isSuccess) { InvalidId(name, id) }

--- a/src/main/kotlin/validation/ValidationHelper.kt
+++ b/src/main/kotlin/validation/ValidationHelper.kt
@@ -16,7 +16,7 @@ import java.util.UUID
  * @param name The name of the field being validated.
  * @param value The value of the field to check for blankness.
  */
-fun Raise<ValidationIssue>.ensureFieldNonBlank(name: String, value: String,) =
+fun Raise<ValidationIssue>.ensureFieldNonBlank(name: String, value: String) =
     ensure(value.isNotBlank()) { BlankField(name) }
 
 /**
@@ -27,7 +27,7 @@ fun Raise<ValidationIssue>.ensureFieldNonBlank(name: String, value: String,) =
  * @param value The value of the field to check for its length.
  * @param maxLength The maximum allowed length for the field value.
  */
-fun Raise<ValidationIssue>.ensureFieldLength(name: String, value: String, maxLength: Int,) =
+fun Raise<ValidationIssue>.ensureFieldLength(name: String, value: String, maxLength: Int) =
     ensure(value.length <= maxLength) { TooLongField(name, maxLength) }
 
 /**
@@ -39,7 +39,7 @@ fun Raise<ValidationIssue>.ensureFieldLength(name: String, value: String, maxLen
  * @param name The name of the enum field being validated.
  * @param value The enum value to check for being `UNSPECIFIED`.
  */
-fun Raise<ValidationIssue>.ensureEnumNotUnspecified(name: String, value: Enum<*>,) =
+fun Raise<ValidationIssue>.ensureEnumNotUnspecified(name: String, value: Enum<*>) =
     ensure(value.ordinal > 0) { EnumUnspecified(name) }
 
 /**
@@ -48,5 +48,5 @@ fun Raise<ValidationIssue>.ensureEnumNotUnspecified(name: String, value: Enum<*>
  * @param name The name of the field being validated.
  * @param id The ID to check for validity.
  */
-fun Raise<ValidationIssue>.ensureIdValidity(name: String, id: String,) =
+fun Raise<ValidationIssue>.ensureIdValidity(name: String, id: String) =
     ensure(runCatching { UUID.fromString(id) }.isSuccess) { InvalidId(name, id) }

--- a/src/main/kotlin/validation/Validator.kt
+++ b/src/main/kotlin/validation/Validator.kt
@@ -33,20 +33,19 @@ val EMAIL_REGEX =
  * @return An [EitherNel] containing a collection of [ValidationIssue] objects if validation issues are found,
  *         or `Unit` if the validation is successful.
  */
-fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> =
-    when (request) {
-        // Healthcheck
-        is HealthCheckRequest -> Either.Right(Unit)
-        // Project
-        is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
-        // Criterion
-        is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
-        // Base
-        is Base.Id -> BaseValidator.validateId(request)
-        is Base.Email -> BaseValidator.validateEmail(request)
-        is Base.Nothing -> Either.Right(Unit)
-        else -> Either.Left(nonEmptyListOf(UnknownRequest))
-    }
+fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (request) {
+    // Healthcheck
+    is HealthCheckRequest -> Either.Right(Unit)
+    // Project
+    is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
+    // Criterion
+    is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
+    // Base
+    is Base.Id -> BaseValidator.validateId(request)
+    is Base.Email -> BaseValidator.validateEmail(request)
+    is Base.Nothing -> Either.Right(Unit)
+    else -> Either.Left(nonEmptyListOf(UnknownRequest))
+}
 
 /**
  * Creates a [arrow.core.NonEmptyList] from this [Either].
@@ -56,8 +55,7 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> =
  * For the latter, one can use this method to create a [arrow.core.NonEmptyList] to get the same data type as the other
  * methods that accumulate the validation results.
  */
-fun Either<ValidationIssue, Unit>.toEitherNel() =
-    when (this) {
-        is Either.Left -> Either.Left(nonEmptyListOf(this.value))
-        is Either.Right -> Either.Right(Unit)
-    }
+fun Either<ValidationIssue, Unit>.toEitherNel() = when (this) {
+    is Either.Left -> Either.Left(nonEmptyListOf(this.value))
+    is Either.Right -> Either.Right(Unit)
+}

--- a/src/test/kotlin/TestUtils.kt
+++ b/src/test/kotlin/TestUtils.kt
@@ -27,7 +27,7 @@ fun testCoroutine(testFunction: suspend () -> Unit) {
  *
  * **Note:** This assumes that the validation result only contains one validation issue.
  */
-fun <T> assertInvalidResult(result: EitherNel<ValidationIssue, Unit>, issueType: Class<T>,) {
+fun <T> assertInvalidResult(result: EitherNel<ValidationIssue, Unit>, issueType: Class<T>) {
     EitherAssert.assertThat(result).isLeft()
     val value = (result as Either.Left).value
     assertThat(value.size).isEqualTo(1)

--- a/src/test/kotlin/TestUtils.kt
+++ b/src/test/kotlin/TestUtils.kt
@@ -27,10 +27,7 @@ fun testCoroutine(testFunction: suspend () -> Unit) {
  *
  * **Note:** This assumes that the validation result only contains one validation issue.
  */
-fun <T> assertInvalidResult(
-    result: EitherNel<ValidationIssue, Unit>,
-    issueType: Class<T>,
-) {
+fun <T> assertInvalidResult(result: EitherNel<ValidationIssue, Unit>, issueType: Class<T>,) {
     EitherAssert.assertThat(result).isLeft()
     val value = (result as Either.Left).value
     assertThat(value.size).isEqualTo(1)

--- a/src/test/kotlin/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/arch/LayerArchitectureTest.kt
@@ -1,3 +1,6 @@
+// Suppress the 'FunctionName' rule because it cannot detect that this is a test file.
+@file:Suppress("FunctionName")
+
 package se.uulm.snowballr.backend.arch
 
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
@@ -29,7 +32,6 @@ class LayerArchitectureTest {
     val metrics: ArchTests = ArchTests.`in`(Metrics::class.java)
 }
 
-@Suppress("ktlint:standard:function-naming")
 private class StructureRules {
     @ArchTest
     fun `When the layer architecture is violated, then this test should fail (all deps)`(classes: JavaClasses) {
@@ -141,7 +143,6 @@ private class StructureRules {
     }
 }
 
-@Suppress("ktlint:standard:function-naming")
 private class NamingConventions {
     @ArchTest
     fun `When a class is in the validation package, then it should have the 'Validator' suffix`(classes: JavaClasses) {
@@ -192,7 +193,6 @@ private class NamingConventions {
     }
 }
 
-@Suppress("ktlint:standard:function-naming")
 private class Metrics {
     @ArchTest
     fun `Print Lakos Metrics`(classes: JavaClasses) {

--- a/src/test/kotlin/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/repository/CriterionTableRepoTest.kt
@@ -73,24 +73,23 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
         }
 
         @Test
-        fun `When two criteria are created, then they have different IDs`() =
-            testCoroutine {
-                val project = createExampleProject()
+        fun `When two criteria are created, then they have different IDs`() = testCoroutine {
+            val project = createExampleProject()
 
-                val request =
-                    CriterionOuterClass.Criterion.Create
-                        .newBuilder()
-                        .setTag("Test Tag")
-                        .setName("Test Criterion")
-                        .setDescription("Test Description")
-                        .setCategory(CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
-                        .setProjectId(project.id.toString())
-                        .build()
-                val criterion1 = repo.createCriterion(request, testUserId)
-                val criterion2 = repo.createCriterion(request, testUserId)
+            val request =
+                CriterionOuterClass.Criterion.Create
+                    .newBuilder()
+                    .setTag("Test Tag")
+                    .setName("Test Criterion")
+                    .setDescription("Test Description")
+                    .setCategory(CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+                    .setProjectId(project.id.toString())
+                    .build()
+            val criterion1 = repo.createCriterion(request, testUserId)
+            val criterion2 = repo.createCriterion(request, testUserId)
 
-                Assertions.assertThat(criterion1.id).isNotEqualTo(criterion2.id)
-            }
+            Assertions.assertThat(criterion1.id).isNotEqualTo(criterion2.id)
+        }
 
         @GrpcEnumSourceTest(CriterionOuterClass.CriterionCategory::class)
         fun `When a criterion is created, but the assigned user doesn't exist, then an exception is thrown`(

--- a/src/test/kotlin/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/repository/H2DatabaseTest.kt
@@ -85,13 +85,12 @@ open class H2DatabaseTest(
      * and use the [Connection.TRANSACTION_SERIALIZABLE] isolation level to ensure data consistency.
      */
     class TestDatabase : IDatabase {
-        override suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T =
-            newSuspendedTransaction(
-                Dispatchers.IO,
-                transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
-            ) {
-                block()
-            }
+        override suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T = newSuspendedTransaction(
+            Dispatchers.IO,
+            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+        ) {
+            block()
+        }
     }
 
     @BeforeAll

--- a/src/test/kotlin/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/repository/ProjectTableRepoTest.kt
@@ -21,44 +21,42 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
     @Nested
     inner class CreateProject {
         @Test
-        fun `When a project is created, then the passed values are correctly assigned`() =
-            testCoroutine {
-                val request =
-                    ProjectOuterClass.Project.Create
-                        .newBuilder()
-                        .setName("Test Project")
-                        .build()
-                val project = repo.createProject(request, testUserId)
+        fun `When a project is created, then the passed values are correctly assigned`() = testCoroutine {
+            val request =
+                ProjectOuterClass.Project.Create
+                    .newBuilder()
+                    .setName("Test Project")
+                    .build()
+            val project = repo.createProject(request, testUserId)
 
-                assertThat(project.name).isEqualTo("Test Project")
-                assertThat(project.status).isEqualTo(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE)
-                assertThat(project.currentStage).isEqualTo(0)
-                assertThat(project.maxStage).isEqualTo(0)
-                // Assert default settings from user
-                assertThat(project.similarityThreshold).isEqualTo(0F)
-                assertThat(project.snowballingType).isEqualTo(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH)
-                assertThat(project.reviewMaybeAllowed).isTrue()
-                assertThat(
-                    project.reviewDecisionMatrix,
-                ).isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
-                FetcherApi.entries.forEach {
-                    assertThat(project.fetcherApis).contains(it)
-                }
+            assertThat(project.name).isEqualTo("Test Project")
+            assertThat(project.status).isEqualTo(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE)
+            assertThat(project.currentStage).isEqualTo(0)
+            assertThat(project.maxStage).isEqualTo(0)
+            // Assert default settings from user
+            assertThat(project.similarityThreshold).isEqualTo(0F)
+            assertThat(project.snowballingType).isEqualTo(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH)
+            assertThat(project.reviewMaybeAllowed).isTrue()
+            assertThat(
+                project.reviewDecisionMatrix,
+            ).isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
+            FetcherApi.entries.forEach {
+                assertThat(project.fetcherApis).contains(it)
             }
+        }
 
         @Test
-        fun `When two projects are created, then they have different IDs`() =
-            testCoroutine {
-                val request =
-                    ProjectOuterClass.Project.Create
-                        .newBuilder()
-                        .setName("Test Project")
-                        .build()
-                val project1 = repo.createProject(request, testUserId)
-                val project2 = repo.createProject(request, testUserId)
+        fun `When two projects are created, then they have different IDs`() = testCoroutine {
+            val request =
+                ProjectOuterClass.Project.Create
+                    .newBuilder()
+                    .setName("Test Project")
+                    .build()
+            val project1 = repo.createProject(request, testUserId)
+            val project2 = repo.createProject(request, testUserId)
 
-                assertThat(project1.id).isNotEqualTo(project2.id)
-            }
+            assertThat(project1.id).isNotEqualTo(project2.id)
+        }
 
         @Test
         fun `When a project is created, but the assigned user doesn't exist, then an exception is thrown`() =

--- a/src/test/kotlin/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/repository/UserTableRepoTest.kt
@@ -23,112 +23,106 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
     @Nested
     inner class GetUserById {
         @Test
-        fun `When a user is found, then the correct user is returned`() =
-            testCoroutine {
-                val userId =
-                    db
-                        .dbQuery {
-                            UserTable.insertAndGetId {
-                                it[email] = "test.user@example.com"
-                                it[firstName] = "Test"
-                                it[lastName] = "User"
-                                it[role] = UserRole.USER_ROLE_DEFAULT
-                                it[status] = UserStatus.USER_STATUS_ACTIVE
-                            }
-                        }.value
+        fun `When a user is found, then the correct user is returned`() = testCoroutine {
+            val userId =
+                db
+                    .dbQuery {
+                        UserTable.insertAndGetId {
+                            it[email] = "test.user@example.com"
+                            it[firstName] = "Test"
+                            it[lastName] = "User"
+                            it[role] = UserRole.USER_ROLE_DEFAULT
+                            it[status] = UserStatus.USER_STATUS_ACTIVE
+                        }
+                    }.value
 
-                val user = repo.getUserById(userId.toString())
+            val user = repo.getUserById(userId.toString())
 
-                assertThat(user.id).isEqualTo(userId)
-                assertThat(user.email).isEqualTo("test.user@example.com")
-                assertThat(user.firstName).isEqualTo("Test")
-                assertThat(user.lastName).isEqualTo("User")
-                assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
-                assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
-            }
-
-        @Test
-        fun `When a user is not found, then an exception is thrown`() =
-            testCoroutine {
-                assertThrows<NotFoundException.User> { repo.getUserById(UUID.randomUUID().toString()) }
-            }
+            assertThat(user.id).isEqualTo(userId)
+            assertThat(user.email).isEqualTo("test.user@example.com")
+            assertThat(user.firstName).isEqualTo("Test")
+            assertThat(user.lastName).isEqualTo("User")
+            assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
+            assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
+        }
 
         @Test
-        fun `When the uuid is invalid, then an exception is thrown`() =
-            testCoroutine {
-                assertThrows<InvalidIdException.UUID> { repo.getUserById("invalid uuid") }
-            }
+        fun `When a user is not found, then an exception is thrown`() = testCoroutine {
+            assertThrows<NotFoundException.User> { repo.getUserById(UUID.randomUUID().toString()) }
+        }
+
+        @Test
+        fun `When the uuid is invalid, then an exception is thrown`() = testCoroutine {
+            assertThrows<InvalidIdException.UUID> { repo.getUserById("invalid uuid") }
+        }
     }
 
     @Nested
     inner class GetUserByEmail {
         @Test
-        fun `When a user is found, then the correct user is returned`() =
-            testCoroutine {
-                val userId =
-                    db
-                        .dbQuery {
-                            UserTable.insertAndGetId {
-                                it[email] = "test.user@example.com"
-                                it[firstName] = "Test"
-                                it[lastName] = "User"
-                                it[role] = UserRole.USER_ROLE_DEFAULT
-                                it[status] = UserStatus.USER_STATUS_ACTIVE
-                            }
-                        }.value
+        fun `When a user is found, then the correct user is returned`() = testCoroutine {
+            val userId =
+                db
+                    .dbQuery {
+                        UserTable.insertAndGetId {
+                            it[email] = "test.user@example.com"
+                            it[firstName] = "Test"
+                            it[lastName] = "User"
+                            it[role] = UserRole.USER_ROLE_DEFAULT
+                            it[status] = UserStatus.USER_STATUS_ACTIVE
+                        }
+                    }.value
 
-                val user = repo.getUserByEmail("test.user@example.com")
+            val user = repo.getUserByEmail("test.user@example.com")
 
-                assertThat(user.id).isEqualTo(userId)
-                assertThat(user.email).isEqualTo("test.user@example.com")
-                assertThat(user.firstName).isEqualTo("Test")
-                assertThat(user.lastName).isEqualTo("User")
-                assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
-                assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
-            }
+            assertThat(user.id).isEqualTo(userId)
+            assertThat(user.email).isEqualTo("test.user@example.com")
+            assertThat(user.firstName).isEqualTo("Test")
+            assertThat(user.lastName).isEqualTo("User")
+            assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
+            assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
+        }
 
         @Test
-        fun `When a user is not found, then an exception is thrown`() =
-            testCoroutine {
-                assertThrows<NotFoundException.User> { repo.getUserByEmail("non-existing email") }
-            }
+        fun `When a user is not found, then an exception is thrown`() = testCoroutine {
+            assertThrows<NotFoundException.User> { repo.getUserByEmail("non-existing email") }
+        }
     }
 
     @Nested
     inner class GetAllUsers {
         @Test
-        fun `When users are found, then all users are returned`() =
-            testCoroutine {
-                val userId1 =
-                    db
-                        .dbQuery {
-                            UserTable.insertAndGetId {
-                                it[email] = "test.user1@example.com"
-                                it[firstName] = "Test"
-                                it[lastName] = "User 2"
-                                it[role] = UserRole.USER_ROLE_DEFAULT
-                                it[status] = UserStatus.USER_STATUS_ACTIVE
-                            }
-                        }.value
+        fun `When users are found, then all users are returned`() = testCoroutine {
+            val userId1 =
+                db
+                    .dbQuery {
+                        UserTable.insertAndGetId {
+                            it[email] = "test.user1@example.com"
+                            it[firstName] = "Test"
+                            it[lastName] = "User 2"
+                            it[role] = UserRole.USER_ROLE_DEFAULT
+                            it[status] = UserStatus.USER_STATUS_ACTIVE
+                        }
+                    }.value
 
-                val userId2 =
-                    db
-                        .dbQuery {
-                            UserTable.insertAndGetId {
-                                it[email] = "test.user2@example.com"
-                                it[firstName] = "Test"
-                                it[lastName] = "User 1"
-                                it[role] = UserRole.USER_ROLE_DEFAULT
-                                it[status] = UserStatus.USER_STATUS_ACTIVE
-                            }
-                        }.value
+            val userId2 =
+                db
+                    .dbQuery {
+                        UserTable.insertAndGetId {
+                            it[email] = "test.user2@example.com"
+                            it[firstName] = "Test"
+                            it[lastName] = "User 1"
+                            it[role] = UserRole.USER_ROLE_DEFAULT
+                            it[status] = UserStatus.USER_STATUS_ACTIVE
+                        }
+                    }.value
 
-                val users = repo.getAllUsers()
-                assertThat(users).hasSize(2)
-                val firstUser = users.find { it.id == userId1 }
-                assertThat(firstUser).isNotNull
-                val secondUser = users.find { it.id == userId2 }
-                assertThat(secondUser).isNotNull
-            }
+            val users = repo.getAllUsers()
+            assertThat(users).hasSize(2)
+            val firstUser = users.find { it.id == userId1 }
+            assertThat(firstUser).isNotNull
+            val secondUser = users.find { it.id == userId2 }
+            assertThat(secondUser).isNotNull
+        }
     }
 }

--- a/src/test/kotlin/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/service/criterion/CreateCriterionTest.kt
@@ -15,23 +15,21 @@ import snowballr.CriterionOuterClass
 @DelicateCoroutinesApi
 internal class CreateCriterionTest : MainServiceTest() {
     @Test
-    fun `When a criterion is correctly created, then no exception is thrown`() =
-        testCoroutine {
-            val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
-            val criterion = DataBuilder.createExampleCriterion()
+    fun `When a criterion is correctly created, then no exception is thrown`() = testCoroutine {
+        val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
+        val criterion = DataBuilder.createExampleCriterion()
 
-            coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+        coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
-            assertDoesNotThrow { mainService.createCriterion(request) }
-        }
+        assertDoesNotThrow { mainService.createCriterion(request) }
+    }
 
     @Test
-    fun `When an error occurs while a criterion is created, then an exception is thrown`() =
-        testCoroutine {
-            val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
+    fun `When an error occurs while a criterion is created, then an exception is thrown`() = testCoroutine {
+        val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
 
-            coEvery { criterionRepoMock.createCriterion(any(), any()) } throws Exception("Failed to create criterion")
+        coEvery { criterionRepoMock.createCriterion(any(), any()) } throws Exception("Failed to create criterion")
 
-            assertThrows<Exception> { mainService.createCriterion(request) }
-        }
+        assertThrows<Exception> { mainService.createCriterion(request) }
+    }
 }

--- a/src/test/kotlin/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/service/project/CreateProjectTest.kt
@@ -15,23 +15,21 @@ import snowballr.ProjectOuterClass
 @DelicateCoroutinesApi
 internal class CreateProjectTest : MainServiceTest() {
     @Test
-    fun `When a project is correctly created, then no exception is thrown`() =
-        testCoroutine {
-            val request = ProjectOuterClass.Project.Create.getDefaultInstance()
-            val project = DataBuilder.createExampleProject()
+    fun `When a project is correctly created, then no exception is thrown`() = testCoroutine {
+        val request = ProjectOuterClass.Project.Create.getDefaultInstance()
+        val project = DataBuilder.createExampleProject()
 
-            coEvery { projectRepoMock.createProject(any(), any()) } returns project
+        coEvery { projectRepoMock.createProject(any(), any()) } returns project
 
-            assertDoesNotThrow { mainService.createProject(request) }
-        }
+        assertDoesNotThrow { mainService.createProject(request) }
+    }
 
     @Test
-    fun `When an error occurs while a project is created, then an exception is thrown`() =
-        testCoroutine {
-            val request = ProjectOuterClass.Project.Create.getDefaultInstance()
+    fun `When an error occurs while a project is created, then an exception is thrown`() = testCoroutine {
+        val request = ProjectOuterClass.Project.Create.getDefaultInstance()
 
-            coEvery { projectRepoMock.createProject(any(), any()) } throws Exception("Failed to create project")
+        coEvery { projectRepoMock.createProject(any(), any()) } throws Exception("Failed to create project")
 
-            assertThrows<Exception> { mainService.createProject(request) }
-        }
+        assertThrows<Exception> { mainService.createProject(request) }
+    }
 }

--- a/src/test/kotlin/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/service/user/GetAllUsersTest.kt
@@ -17,44 +17,40 @@ import snowballr.UserOuterClass.UserRole
 @DelicateCoroutinesApi
 internal class GetAllUsersTest : MainServiceTest() {
     @Test
-    fun `When all users are retrieved by an admin, then no exception is thrown`() =
-        testCoroutine {
-            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When all users are retrieved by an admin, then no exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
-            coEvery { userRepoMock.getAllUsers() } returns emptyList()
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
-            assertDoesNotThrow { mainService.getAllUsers() }
-        }
-
-    @Test
-    fun `When retrieving the current user fails, then an exception is thrown`() =
-        testCoroutine {
-            coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
-            coEvery { userRepoMock.getAllUsers() } returns emptyList()
-
-            assertThrows<Exception> { mainService.getAllUsers() }
-        }
+        assertDoesNotThrow { mainService.getAllUsers() }
+    }
 
     @Test
-    fun `When all users are retrieved by an non-admin, then an exception is thrown`() =
-        testCoroutine {
-            val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
-            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns nonAdminUser
-            coEvery { userRepoMock.getAllUsers() } returns emptyList()
-
-            assertThrows<UnauthorizedException.All.User> { mainService.getAllUsers() }
-        }
+        assertThrows<Exception> { mainService.getAllUsers() }
+    }
 
     @Test
-    fun `When retrieving all users fails, then an exception is thrown`() =
-        testCoroutine {
-            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When all users are retrieved by an non-admin, then an exception is thrown`() = testCoroutine {
+        val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-            coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
-            coEvery { userRepoMock.getAllUsers() } throws Exception("Failed to retrieve users")
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns nonAdminUser
+        coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
-            assertThrows<Exception> { mainService.getAllUsers() }
-        }
+        assertThrows<UnauthorizedException.All.User> { mainService.getAllUsers() }
+    }
+
+    @Test
+    fun `When retrieving all users fails, then an exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        coEvery { userRepoMock.getUserById(dummyUserId!!) } returns adminUser
+        coEvery { userRepoMock.getAllUsers() } throws Exception("Failed to retrieve users")
+
+        assertThrows<Exception> { mainService.getAllUsers() }
+    }
 }

--- a/src/test/kotlin/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/service/user/GetUserByEmailTest.kt
@@ -15,23 +15,21 @@ import snowballr.Base
 @DelicateCoroutinesApi
 internal class GetUserByEmailTest : MainServiceTest() {
     @Test
-    fun `When a user is correctly retrieved, then no exception is thrown`() =
-        testCoroutine {
-            val request = Base.Email.newBuilder().build()
-            val user = DataBuilder.createExampleUser()
+    fun `When a user is correctly retrieved, then no exception is thrown`() = testCoroutine {
+        val request = Base.Email.newBuilder().build()
+        val user = DataBuilder.createExampleUser()
 
-            coEvery { userRepoMock.getUserByEmail(any()) } returns user
+        coEvery { userRepoMock.getUserByEmail(any()) } returns user
 
-            assertDoesNotThrow { mainService.getUserByEmail(request) }
-        }
+        assertDoesNotThrow { mainService.getUserByEmail(request) }
+    }
 
     @Test
-    fun `When an error occurs while a user is retrieved, then an exception is thrown`() =
-        testCoroutine {
-            val request = Base.Email.newBuilder().build()
+    fun `When an error occurs while a user is retrieved, then an exception is thrown`() = testCoroutine {
+        val request = Base.Email.newBuilder().build()
 
-            coEvery { userRepoMock.getUserByEmail(any()) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserByEmail(any()) } throws Exception("Failed to retrieve user")
 
-            assertThrows<Exception> { mainService.getUserByEmail(request) }
-        }
+        assertThrows<Exception> { mainService.getUserByEmail(request) }
+    }
 }

--- a/src/test/kotlin/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/service/user/GetUserByIdTest.kt
@@ -15,23 +15,21 @@ import snowballr.Base
 @DelicateCoroutinesApi
 internal class GetUserByIdTest : MainServiceTest() {
     @Test
-    fun `When a user is correctly retrieved, then no exception is thrown`() =
-        testCoroutine {
-            val request = Base.Id.newBuilder().build()
-            val user = DataBuilder.createExampleUser()
+    fun `When a user is correctly retrieved, then no exception is thrown`() = testCoroutine {
+        val request = Base.Id.newBuilder().build()
+        val user = DataBuilder.createExampleUser()
 
-            coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { userRepoMock.getUserById(any()) } returns user
 
-            assertDoesNotThrow { mainService.getUserById(request) }
-        }
+        assertDoesNotThrow { mainService.getUserById(request) }
+    }
 
     @Test
-    fun `When an error occurs while a user is retrieved, then an exception is thrown`() =
-        testCoroutine {
-            val request = Base.Id.newBuilder().build()
+    fun `When an error occurs while a user is retrieved, then an exception is thrown`() = testCoroutine {
+        val request = Base.Id.newBuilder().build()
 
-            coEvery { userRepoMock.getUserById(any()) } throws Exception("Failed to retrieve user")
+        coEvery { userRepoMock.getUserById(any()) } throws Exception("Failed to retrieve user")
 
-            assertThrows<Exception> { mainService.getUserById(request) }
-        }
+        assertThrows<Exception> { mainService.getUserById(request) }
+    }
 }

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -6,6 +6,7 @@ to understand the overall structure of our project.
 On this page, we explain how to contribute to the SnowballR backend project. We cover the following topics:
 
 <!-- markdownlint-disable MD007 -->
+<!-- @formatter:off -->
 <!-- TOC -->
   * [Contribution Workflow & Conventions](#contribution-workflow--conventions)
   * [Project Layout](#project-layout)
@@ -20,6 +21,7 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
     * [Linting](#linting)
   * [Teamscale Integration](#teamscale-integration)
 <!-- TOC -->
+<!-- @formatter:on -->
 <!-- markdownlint-enable MD007 -->
 
 To set up the development environment, follow the steps in

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -242,17 +242,13 @@ For information about our testing setup, see [Testing](https://github.com/SE-UUl
 ### Formatting
 
 ```bash
-# Format files
-./gradlew formatKotlin
-
-# Verify formatting
-./gradlew lintKotlin
+./gradlew format
 ```
 
 ### Linting
 
 ```bash
-./gradlew detekt
+./gradlew lint
 ```
 
 ## Teamscale Integration

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -10,6 +10,7 @@ The coverage report is located at `./build/coverageHtml/index.html` and the test
 On this page, we cover the following topics:
 
 <!-- markdownlint-disable MD007 -->
+<!-- @formatter:off -->
 <!-- TOC -->
   * [Conventions](#conventions)
   * [Testing Layers](#testing-layers)
@@ -17,6 +18,7 @@ On this page, we cover the following topics:
     * [Service](#service)
     * [Input Validation](#input-validation)
 <!-- TOC -->
+<!-- @formatter:on -->
 <!-- markdownlint-enable MD007 -->
 
 ## Conventions


### PR DESCRIPTION
Closes #61 

## What I have made

I highly recommend reviewing this commit-by-commit as the changes are according to the new formatting rules.

I also would probably wait for #59 

- Detekt has now a wrapper for ktlint so we don't need them separated anymore
- I added the rules for the formatter to the detekt config file
- I added a `format` and `lint` gradle task for easy use
- The editorconfig changes will configure IntelliJ to behave as the linter/formatter

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (not required)
- [x] (for reviewer) I have checked the implementation against the requirements
