### PR TITLE
Added getAllProjects call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -242,7 +242,7 @@ class SnowballRServer(
             super.removeProjectMember(request)
 
         override suspend fun getAllProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
-            super.getAllProjects(request)
+            mainService.getAllProjects()
 
         override suspend fun getAllDeletedProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
             super.getAllDeletedProjects(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -127,6 +127,10 @@ sealed class SnowballRException(
             class User(
                 currentUserId: String,
             ) : All(currentUserId, "users")
+
+            class Project(
+                currentUserId: String,
+            ) : All(currentUserId, "projects")
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.FetcherApi
@@ -11,6 +12,9 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.ProjectTable.toProject
 import se.uulm.snowballr.backend.table.getUserEntityId
 import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
+import snowballr.ProjectOuterClass.SnowballingType
 import java.util.UUID
 
 /**
@@ -29,6 +33,11 @@ interface IProjectTableRepo {
      * @return The created [Project] object representing the newly created project.
      */
     suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: UUID): Project
+
+    /**
+     * Returns all active projects stored in the database.
+     */
+    suspend fun getAllProjects(): List<Project>
 }
 
 /**
@@ -52,15 +61,14 @@ class ProjectTableRepo(
             ProjectTable
                 .insertAndGetId {
                     it[name] = request.name
-                    it[status] = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
+                    it[status] = ProjectStatus.PROJECT_STATUS_ACTIVE
                     it[currentStage] = 0
                     it[maxStage] = 0
                     // TODO: Fetch default settings from user
                     it[similarityThreshold] = 0F
-                    it[snowballingType] = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+                    it[snowballingType] = SnowballingType.SNOWBALLING_TYPE_BOTH
                     it[reviewMaybeAllowed] = true
-                    it[reviewDecisionMatrixBinary] =
-                        ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+                    it[reviewDecisionMatrixBinary] = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
                     it[fetcherApis] = FetcherApi.entries.toList()
                     it[createdBy] = userEntityId
                 }.value
@@ -72,5 +80,15 @@ class ProjectTableRepo(
             .map { it.toProject() }
             .singleOrNull()
             ?: throw EntityNotPersistedException.Project(projectId.toString())
+    }
+
+    override suspend fun getAllProjects(): List<Project> = db.dbQuery {
+        ProjectTable
+            .selectAll()
+            .where {
+                (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE) or
+                    (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            }
+            .map { it.toProject() }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -36,6 +36,6 @@ class MainService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IMainService,
-    IProjectService by ProjectService(projectRepo),
+    IProjectService by ProjectService(projectRepo, userRepo),
     ICriterionService by CriterionService(criterionRepo),
     IUserService by UserService(userRepo, projectMemberRepo)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -8,7 +8,6 @@ import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import snowballr.ProjectOuterClass
-import snowballr.UserOuterClass.UserRole
 
 interface IProjectService {
     /**
@@ -45,11 +44,8 @@ class ProjectService(
     override suspend fun getAllProjects(): ProjectOuterClass.Project.List {
         val requestingUserId = parseUUID(dummyUserId!!, "user")
         val currentUser = userRepo.getUserById(requestingUserId)
-        // Check whether the current user has access to retrieve all projects
-        // TODO: remove dummy user when user management is implemented
-        if (currentUser.role != UserRole.USER_ROLE_ADMIN) {
-            throw UnauthorizedException.All.Project(dummyUserId!!)
-        }
+
+        verifyServerAdminRole(currentUser) { UnauthorizedException.All.Project(it) }
 
         val projects = repo.getAllProjects()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -2,16 +2,24 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IUserTableRepo
 import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass.UserRole
 
 interface IProjectService {
     /**
      * Service implementation of [SnowballRService.createProject].
      */
     suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project
+
+    /**
+     * Service implementation of [SnowballRService.getAllProjects].
+     */
+    suspend fun getAllProjects(): ProjectOuterClass.Project.List
 }
 
 /**
@@ -22,13 +30,31 @@ interface IProjectService {
  *
  * @constructor Initializes the [ProjectService] with a project repository.
  * @param repo The repository responsible for managing persistence operations for projects.
+ * @param userRepo The repository responsible for managing persistence operations for users.
  */
 class ProjectService(
     private val repo: IProjectTableRepo,
+    private val userRepo: IUserTableRepo,
 ) : IProjectService {
     override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project {
         // TODO: remove dummy user when user management is implemented
         val requestingUserId = parseUUID(dummyUserId!!, "user")
         return repo.createProject(request, requestingUserId).toGrpcProject()
+    }
+
+    override suspend fun getAllProjects(): ProjectOuterClass.Project.List {
+        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val currentUser = userRepo.getUserById(requestingUserId)
+        // Check whether the current user has access to retrieve all projects
+        // TODO: remove dummy user when user management is implemented
+        if (currentUser.role != UserRole.USER_ROLE_ADMIN) {
+            throw UnauthorizedException.All.Project(dummyUserId!!)
+        }
+
+        val projects = repo.getAllProjects()
+
+        val builder = ProjectOuterClass.Project.List.newBuilder()
+        projects.forEach { builder.addProjects(it.toGrpcProject()) }
+        return builder.build()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -1,0 +1,20 @@
+package se.uulm.snowballr.backend.service
+
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.User
+import snowballr.UserOuterClass.UserRole
+
+/**
+ * Verifies that the [user] has the role [UserRole.USER_ROLE_ADMIN].
+ *
+ * If the user is not a server admin, a [SnowballRException.UnauthorizedException.All] is thrown.
+ *
+ * @param user The user to verify
+ * @param getException Getter method for the subtype of [SnowballRException.UnauthorizedException.All], which is thrown
+ * when the user is not a server admin.
+ */
+fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRException.UnauthorizedException.All) {
+    if (user.role != UserRole.USER_ROLE_ADMIN) {
+        throw getException(user.id.toString())
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -124,11 +124,7 @@ class UserService(
         val requestingUserId = parseUUID(dummyUserId!!, "user")
         val currentUser = userRepo.getUserById(requestingUserId)
 
-        // Check whether the current user has access to retrieve all users
-        // TODO: remove dummy user when user management is implemented
-        if (currentUser.role != UserRole.USER_ROLE_ADMIN) {
-            throw UnauthorizedException.All.User(dummyUserId!!)
-        }
+        verifyServerAdminRole(currentUser) { UnauthorizedException.All.User(it) }
 
         val users = userRepo.getAllUsers()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.repository
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -10,7 +11,10 @@ import se.uulm.snowballr.backend.model.FetcherApi
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.testCoroutine
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.Project
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
+import snowballr.ProjectOuterClass.SnowballingType
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
@@ -18,28 +22,38 @@ import java.util.UUID
 class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
     private val repo = ProjectTableRepo(db)
 
+    private suspend fun createExampleProject(name: String, status: ProjectStatus): UUID = db.dbQuery {
+        ProjectTable
+            .insertAndGetId {
+                it[ProjectTable.name] = name
+                it[ProjectTable.status] = status
+                it[currentStage] = 0
+                it[maxStage] = 0
+                it[similarityThreshold] = 0F
+                it[snowballingType] = SnowballingType.SNOWBALLING_TYPE_BOTH
+                it[reviewMaybeAllowed] = true
+                it[reviewDecisionMatrixBinary] = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+                it[fetcherApis] = FetcherApi.entries.toList()
+                it[createdBy] = testUserId
+            }.value
+    }
+
     @Nested
     inner class CreateProject {
         @Test
         fun `When a project is created, then the passed values are correctly assigned`() = testCoroutine {
-            val request =
-                ProjectOuterClass.Project.Create
-                    .newBuilder()
-                    .setName("Test Project")
-                    .build()
+            val request = Project.Create.newBuilder().setName("Test Project").build()
             val project = repo.createProject(request, testUserId)
 
             assertThat(project.name).isEqualTo("Test Project")
-            assertThat(project.status).isEqualTo(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE)
+            assertThat(project.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE)
             assertThat(project.currentStage).isEqualTo(0)
             assertThat(project.maxStage).isEqualTo(0)
             // Assert default settings from user
             assertThat(project.similarityThreshold).isEqualTo(0F)
-            assertThat(project.snowballingType).isEqualTo(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH)
+            assertThat(project.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_BOTH)
             assertThat(project.reviewMaybeAllowed).isTrue()
-            assertThat(
-                project.reviewDecisionMatrix,
-            ).isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
+            assertThat(project.reviewDecisionMatrix).isEqualTo(ReviewDecisionMatrix.getDefaultInstance())
             FetcherApi.entries.forEach {
                 assertThat(project.fetcherApis).contains(it)
             }
@@ -47,11 +61,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
 
         @Test
         fun `When two projects are created, then they have different IDs`() = testCoroutine {
-            val request =
-                ProjectOuterClass.Project.Create
-                    .newBuilder()
-                    .setName("Test Project")
-                    .build()
+            val request = Project.Create.newBuilder().setName("Test Project").build()
             val project1 = repo.createProject(request, testUserId)
             val project2 = repo.createProject(request, testUserId)
 
@@ -61,13 +71,40 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
         @Test
         fun `When a project is created, but the assigned user doesn't exist, then an exception is thrown`() =
             testCoroutine {
-                val request =
-                    ProjectOuterClass.Project.Create
-                        .newBuilder()
-                        .setName("Test Project")
-                        .build()
-
+                val request = Project.Create.newBuilder().setName("Test Project").build()
                 assertThrows<NotFoundException.User> { repo.createProject(request, UUID.randomUUID()) }
             }
+    }
+
+    @Nested
+    inner class GetAllProjects {
+        @Test
+        fun `When projects are found, then all projects are returned`() = testCoroutine {
+            val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+
+            val projects = repo.getAllProjects()
+            assertThat(projects).hasSize(2)
+            val firstProject = projects.find { it.id == project1Id }
+            assertThat(firstProject).isNotNull
+            val secondProject = projects.find { it.id == project2Id }
+            assertThat(secondProject).isNotNull
+        }
+
+        @Test
+        fun `When archived and deleted projects exist, then they are not returned`() = testCoroutine {
+            val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
+
+            val projects = repo.getAllProjects()
+            assertThat(projects).hasSize(1)
+            val firstProject = projects.find { it.id == project1Id }
+            assertThat(firstProject).isNotNull
+            val secondProject = projects.find { it.id == project2Id }
+            assertThat(secondProject).isNull()
+            val thirdProject = projects.find { it.id == project3Id }
+            assertThat(thirdProject).isNull()
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
@@ -1,0 +1,33 @@
+package se.uulm.snowballr.backend.service
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
+import snowballr.UserOuterClass.UserRole
+
+class ServiceChecksTest {
+    @Nested
+    inner class VerifyServerAdminRole {
+        @ParameterizedTest
+        @GrpcEnumSourceTest(UserRole::class, excludes = ["USER_ROLE_ADMIN"])
+        fun `When the user is not a server admin, then an exception is thrown`(role: UserRole) {
+            val user = DataBuilder.createExampleUser(role = role)
+            assertThrows<UnauthorizedException.All.User> {
+                verifyServerAdminRole(user) { UnauthorizedException.All.User(it) }
+            }
+        }
+
+        @Test
+        fun `When the user is a server admin, then no exception is thrown`() {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            assertDoesNotThrow {
+                verifyServerAdminRole(user) { UnauthorizedException.All.User(it) }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -1,0 +1,56 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.UserOuterClass.UserRole
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+internal class GetAllProjectsTest : MainServiceTest() {
+    @Test
+    fun `When all projects are retrieved by an admin, then no exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery { projectRepoMock.getAllProjects() } returns emptyList()
+
+        assertDoesNotThrow { mainService.getAllProjects() }
+    }
+
+    @Test
+    fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        coEvery { projectRepoMock.getAllProjects() } returns emptyList()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjects() }
+    }
+
+    @Test
+    fun `When all projects are retrieved by a non-admin, then an exception is thrown`() = testCoroutine {
+        val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+
+        coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
+        coEvery { projectRepoMock.getAllProjects() } returns emptyList()
+
+        assertThrows<UnauthorizedException.All.Project> { mainService.getAllProjects() }
+    }
+
+    @Test
+    fun `When retrieving all projects fails, then an exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery { projectRepoMock.getAllProjects() } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjects() }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/utils/GrpcEnumSourceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/utils/GrpcEnumSourceTest.kt
@@ -1,10 +1,12 @@
 package se.uulm.snowballr.backend.utils
 
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.jupiter.params.support.ParameterDeclarations
 import java.util.Objects.requireNonNull
 import java.util.stream.Stream
 import kotlin.jvm.optionals.getOrNull
@@ -32,6 +34,7 @@ import kotlin.reflect.KClass
  * ```
  *
  * @property value The enum class to be tested. This must be a class that extends [Enum].
+ * @property excludes A list of enum names that are also excluded from parameterization.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
@@ -39,11 +42,15 @@ import kotlin.reflect.KClass
 @ArgumentsSource(GenericEnumProvider::class)
 annotation class GrpcEnumSourceTest(
     val value: KClass<out Enum<*>>,
+    val excludes: Array<String> = [],
 )
 
 class GenericEnumProvider : ArgumentsProvider {
-    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
-        val method = checkNotNull(context.testMethod.getOrNull()) { "No test method found." }
+    override fun provideArguments(
+        parameters: ParameterDeclarations,
+        context: ExtensionContext?,
+    ): Stream<out Arguments> {
+        val method = checkNotNull(context?.testMethod?.getOrNull()) { "No test method found." }
 
         val annotation = method.getAnnotation(GrpcEnumSourceTest::class.java)
         requireNonNull(annotation, "Missing @GrpcEnumSourceTest annotation.")
@@ -51,9 +58,17 @@ class GenericEnumProvider : ArgumentsProvider {
         val enumClass = annotation.value.java
         require(enumClass.isEnum) { "Provided class ${enumClass.name} is not an enum." }
 
+        // Assert that all exclude values are valid enum values
+        annotation.excludes.forEach { excludeValue ->
+            assertNotNull(enumClass.enumConstants.find { it.toString() == excludeValue })
+        }
+
+        val excludes = annotation.excludes.toSet() + "UNRECOGNIZED"
+
         @Suppress("UNCHECKED_CAST")
         val values = enumClass.enumConstants as Array<Enum<*>>
         // Filter out UNRECOGNIZED, since it is not a valid value for the enum
-        return values.filter { it.toString() !== "UNRECOGNIZED" }.map { Arguments.of(it) }.stream()
+        // Also exclude any other value in the excludes parameter.
+        return values.filter { excludes.contains(it.toString()).not() }.map { Arguments.of(it) }.stream()
     }
 }


### PR DESCRIPTION
Closes #63 

## What I have made

I added the `getAllProjects` call, which retrieves all active projects for an admin user.
This was pretty straightforward as it is very similar to `getAllUsers`.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
