### PR TITLE
Added updateUser call

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.grpc.protobuf)
     implementation(libs.grpc.services)
     implementation(libs.protobuf.kotlin)
+    implementation(libs.protobuf.java.util)
 
     runtimeOnly(libs.grpc.netty)
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -95,6 +95,8 @@ complexity:
     CognitiveComplexMethod:
         active: true
         threshold: 15
+        excludes:
+            - '**/test/**'
     ComplexCondition:
         active: true
         threshold: 4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc-version"
 grpc-services = { module = "io.grpc:grpc-services", version.ref = "grpc-version" }
 grpc-netty = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc-version" }
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf-kotlin-version" }
+protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf-kotlin-version" }
 
 archunit = { module = "com.tngtech.archunit:archunit", version.ref = "archunit-version" }
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit-version" }

--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/CookieUtils.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/CookieUtils.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.auth
 
-import se.uulm.snowballr.backend.grpc.GrpcContext
 import se.uulm.snowballr.backend.model.auth.CookieConfig
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/GrpcContext.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/GrpcContext.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.grpc
+package se.uulm.snowballr.backend.auth
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.Context

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -8,6 +8,7 @@ import io.grpc.protobuf.services.HealthStatusManager
 import io.grpc.protobuf.services.ProtoReflectionService
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.interceptor.authenticationInterceptor
 import se.uulm.snowballr.backend.grpc.interceptor.exceptionInterceptor
 import se.uulm.snowballr.backend.grpc.interceptor.loggingInterceptor

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -197,7 +197,7 @@ class SnowballRServer(
             mainService.getUserByEmail(request)
 
         override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User =
-            super.updateUser(request)
+            mainService.updateUser(request)
 
         override suspend fun softDeleteUser(request: Base.Id): Base.Nothing = super.softDeleteUser(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -13,8 +13,8 @@ import io.grpc.reflection.v1alpha.ServerReflectionGrpc
 import io.jsonwebtoken.JwtException
 import se.uulm.snowballr.backend.auth.CookieUtils
 import se.uulm.snowballr.backend.auth.CookieUtils.parseCookies
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.JwtUtils
-import se.uulm.snowballr.backend.grpc.GrpcContext
 import se.uulm.snowballr.backend.model.auth.AuthRequestState
 import se.uulm.snowballr.backend.model.jwt.ParsedJwtClaims
 import snowballr.SnowballRGrpcKt

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/AccessType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/AccessType.kt
@@ -1,0 +1,21 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Represents the type of access being attempted on an entity.
+ */
+enum class AccessType(val description: String) {
+    /** Attempt to read or access an entity */
+    READ("read"),
+
+    /** Attempt to create a new entity */
+    CREATE("create"),
+
+    /** Attempt to update an existing entity */
+    UPDATE("update"),
+
+    /** Attempt to delete an entity */
+    DELETE("delete"),
+    ;
+
+    override fun toString(): String = description
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -58,28 +58,33 @@ sealed class SnowballRException(
      *
      * @param currentUserId The ID of the user that is accessing the entity/entities.
      * @param accessedEntityMessage The message of what is accessed.
+     * @param accessType The type of access, i.e., an update, read access, ...
      */
     sealed class UnauthorizedException(
         currentUserId: String,
         accessedEntityMessage: String,
-    ) : SnowballRException("User with ID '$currentUserId' is not authorized to access $accessedEntityMessage") {
+        accessType: AccessType,
+    ) : SnowballRException("User with ID '$currentUserId' is not authorized to $accessType $accessedEntityMessage") {
         /**
          * Represents an [UnauthorizedException] that occurs when the current user accesses a single entity without
          * permission.
          *
          * @param accessedEntityType The type of the entity that was accessed without permission.
          * @param accessedEntityId The ID of the entity that was accessed without permission.
+         * @param accessType The type of access (@see [AccessType] for possible types).
          * @param currentUserId The ID of the user that is accessing the entity.
          * @param identifierType The type of the identifier used to access the entity.
          */
         class Single(
             accessedEntityType: EntityType,
             accessedEntityId: String,
+            accessType: AccessType = AccessType.READ,
             currentUserId: String,
             identifierType: IdentifierType = IdentifierType.ID,
         ) : UnauthorizedException(
             currentUserId,
             "${accessedEntityType.singular} with ${identifierType.displayName} '$accessedEntityId'.",
+            accessType,
         )
 
         /**
@@ -87,12 +92,14 @@ sealed class SnowballRException(
          * permission.
          *
          * @param accessedEntityType The type of the entities that were accessed without permission.
+         * @param accessType The type of access (@see [AccessType] for possible types).
          * @param currentUserId The ID of the user that is accessing the entities.
          */
         class All(
             accessedEntityType: EntityType,
+            accessType: AccessType = AccessType.READ,
             currentUserId: String,
-        ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.")
+        ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.", accessType)
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -71,7 +71,7 @@ sealed class SnowballRException(
          *
          * @param accessedEntityType The type of the entity that was accessed without permission.
          * @param accessedEntityId The ID of the entity that was accessed without permission.
-         * @param accessType The type of access (@see [AccessType] for possible types).
+         * @param accessType The type of access (see [AccessType] for possible types).
          * @param currentUserId The ID of the user that is accessing the entity.
          * @param identifierType The type of the identifier used to access the entity.
          */
@@ -92,7 +92,7 @@ sealed class SnowballRException(
          * permission.
          *
          * @param accessedEntityType The type of the entities that were accessed without permission.
-         * @param accessType The type of access (@see [AccessType] for possible types).
+         * @param accessType The type of access (see [AccessType] for possible types).
          * @param currentUserId The ID of the user that is accessing the entities.
          */
         class All(

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -117,7 +117,7 @@ data class InvalidPassword(
 }
 
 /**
- * Represents an issue where a provided field mask contains invalid fields or is blank.
+ * Represents a validation issue where a provided field mask contains invalid fields or is blank.
  *
  * This class is utilized to indicate that some fields in the provided field mask
  * are not valid, i.e., do not exist in the generated gRPC class or the field mask is blank

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -115,3 +115,21 @@ data class InvalidPassword(
         NOT_ENOUGH_SPECIAL_CHARS("Password contains less than $PASSWORD_MIN_NUMBER_SPECIAL_CHARS special characters"),
     }
 }
+
+/**
+ * Represents an issue where a provided field mask contains invalid fields or is blank.
+ *
+ * This class is utilized to indicate that some fields in the provided field mask
+ * are not valid, i.e., do not exist in the generated gRPC class or the field mask is blank
+ * and the entire object would be overwritten. If this is intended, every field should be specified
+ * instead of leaving the field mask blank.
+ *
+ * @property fieldMask The invalid field mask causing the issue.
+ */
+data class InvalidFieldMask(val fieldMask: String?) : ValidationIssue {
+    override fun toString(): String = if (fieldMask.isNullOrBlank()) {
+        "Field mask must be not blank."
+    } else {
+        "Field mask contains invalid fields: $fieldMask."
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -143,7 +143,7 @@ class UserTableRepo(
         val fieldMask = FieldMaskUtil.normalize(request.mask)
 
         // Update user
-        val updatedRowCount = UserTable.update({ UserTable.id eq uuid }) {
+        UserTable.update({ UserTable.id eq uuid }) {
             for (field in fieldMask.pathsList) {
                 when (field) {
                     "user.email" -> it[email] = request.user.email
@@ -156,10 +156,6 @@ class UserTableRepo(
             it[modifiedAt] = OffsetDateTime.now()
         }
 
-        if (updatedRowCount == 0) {
-            // If no row was updated, then the user with the given id does not exist
-            throw NotFoundException(EntityType.USER, uuid.toString())
-        }
         // Return updated user
         getUserByIdOrNull(uuid) ?: throw EntityNotPersistedException(EntityType.USER, uuid.toString())
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -68,7 +68,6 @@ interface IUserTableRepo {
      * - last name
      * - email
      * - role
-     * - password hash
      *
      * @param request The update request containing the new user details, such as the new first name.
      * @return The updated [User] object reflecting the changes from the [request].

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -1,17 +1,23 @@
 package se.uulm.snowballr.backend.repository
 
+import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
+import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.toUser
 import snowballr.Authentication
+import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
@@ -54,6 +60,20 @@ interface IUserTableRepo {
      * @return The created [User] object representing the newly registered user.
      */
     suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User
+
+    /**
+     * Updates an existing user in the database with the provided new information.
+     * The following fields can be updated:
+     * - first name
+     * - last name
+     * - email
+     * - role
+     * - password hash
+     *
+     * @param request The update request containing the new user details, such as the new first name.
+     * @return The updated [User] object reflecting the changes from the [request].
+     */
+    suspend fun updateUser(request: UserOuterClass.User.Update): User
 }
 
 /**
@@ -68,13 +88,20 @@ interface IUserTableRepo {
 class UserTableRepo(
     private val db: IDatabase,
 ) : IUserTableRepo {
+    /**
+     * Requesting a user from the database.
+     *
+     * @param id The id of the requested user.
+     * @return The [User] object or null, if no user with the given [id] was found.
+     */
+    private fun getUserByIdOrNull(id: UUID): User? = UserTable
+        .selectAll()
+        .where { UserTable.id eq id }
+        .map { it.toUser() }
+        .singleOrNull()
+
     override suspend fun getUserById(id: UUID): User = db.dbQuery {
-        UserTable
-            .selectAll()
-            .where { UserTable.id eq id }
-            .map { it.toUser() }
-            .singleOrNull()
-            ?: throw NotFoundException(EntityType.USER, id.toString())
+        getUserByIdOrNull(id) ?: throw NotFoundException(EntityType.USER, id.toString())
     }
 
     override suspend fun getUserByEmail(email: String): User = db.dbQuery {
@@ -109,5 +136,31 @@ class UserTableRepo(
             it[role] = UserRole.USER_ROLE_DEFAULT
             it[status] = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
         }
+    }
+
+    override suspend fun updateUser(request: UserOuterClass.User.Update): User = db.dbQuery {
+        val uuid = parseUUID(request.user.id, EntityType.USER)
+        val fieldMask = FieldMaskUtil.normalize(request.mask)
+
+        // Update user
+        val updatedRowCount = UserTable.update({ UserTable.id eq uuid }) {
+            for (field in fieldMask.pathsList) {
+                when (field) {
+                    "user.email" -> it[email] = request.user.email
+                    "user.first_name" -> it[firstName] = request.user.firstName
+                    "user.last_name" -> it[lastName] = request.user.lastName
+                    "user.role" -> it[role] = request.user.role
+                }
+            }
+
+            it[modifiedAt] = OffsetDateTime.now()
+        }
+
+        if (updatedRowCount == 0) {
+            // If no row was updated, then the user with the given id does not exist
+            throw NotFoundException(EntityType.USER, uuid.toString())
+        }
+        // Return updated user
+        getUserByIdOrNull(uuid) ?: throw EntityNotPersistedException(EntityType.USER, uuid.toString())
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -2,7 +2,9 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -45,7 +47,7 @@ class ProjectService(
         val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
-        verifyServerAdminRole(currentUser, EntityType.PROJECT)
+        verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, it) }
 
         val projects = repo.getAllProjects()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.dto.User
 import snowballr.UserOuterClass.UserRole
@@ -8,13 +7,14 @@ import snowballr.UserOuterClass.UserRole
 /**
  * Verifies that the [user] has the role [UserRole.USER_ROLE_ADMIN].
  *
- * If the user is not a server admin, a [SnowballRException.UnauthorizedException.All] is thrown.
+ * If the user is not a server admin, a [SnowballRException.UnauthorizedException] is thrown.
  *
  * @param user The user to verify
- * @param entityType The entity type of the accessed entity.
+ * @param getException Getter method for the subtype of [SnowballRException.UnauthorizedException], which is thrown
+ * when the user is not a server admin.
  */
-fun verifyServerAdminRole(user: User, entityType: EntityType) {
+fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRException.UnauthorizedException) {
     if (user.role != UserRole.USER_ROLE_ADMIN) {
-        throw SnowballRException.UnauthorizedException.All(entityType, currentUserId = user.id.toString())
+        throw getException(user.id.toString())
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -15,6 +15,6 @@ import snowballr.UserOuterClass.UserRole
  */
 fun verifyServerAdminRole(user: User, entityType: EntityType) {
     if (user.role != UserRole.USER_ROLE_ADMIN) {
-        throw SnowballRException.UnauthorizedException.All(entityType, user.id.toString())
+        throw SnowballRException.UnauthorizedException.All(entityType, currentUserId = user.id.toString())
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.service
 
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.JwtUtils
 import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.db.dummyUserId
-import se.uulm.snowballr.backend.grpc.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
@@ -167,20 +167,29 @@ class UserService(
 
     override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        val currentUserId = currentUser.id.toString()
-        val updatedUserId = request.user.id
+
+        // Check that user to update exists in the database
+        val requestedUserId = parseUUID(request.user.id, EntityType.USER)
+        val requestedUser = userRepo.getUserById(requestedUserId)
+
+        // Check whether the current user is a server admin if the role is changed or the requested user is different
+        // from the current user
+        if (request.mask.pathsList.contains("role") || currentUser.id != requestedUser.id) {
+            verifyServerAdminRole(
+                currentUser,
+            ) {
+                UnauthorizedException.Single(
+                    EntityType.USER,
+                    requestedUser.id.toString(),
+                    AccessType.UPDATE,
+                    currentUser.id.toString(),
+                )
+            }
+        }
 
         // Check whether a user with the given email already exists if the email should be changed
         if (request.mask.pathsList.contains("email") && userRepo.doesUserExistByEmail(request.user.email)) {
             throw DuplicateEntityException(EntityType.USER, request.user.email, IdentifierType.EMAIL)
-        }
-
-        // Check whether the current user is a server admin if the role is changed or the requested user is different
-        // from the current user
-        if (request.mask.pathsList.contains("role") || currentUserId != updatedUserId) {
-            verifyServerAdminRole(
-                currentUser,
-            ) { UnauthorizedException.Single(EntityType.USER, updatedUserId, AccessType.UPDATE, currentUserId) }
         }
 
         val updatedUser = userRepo.updateUser(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.auth.JwtUtils
 import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.grpc.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
@@ -43,6 +44,11 @@ interface IUserService {
      * Service implementation of [SnowballRService.register].
      */
     suspend fun register(request: Authentication.RegisterRequest): JwtTokens
+
+    /**
+     * Service implementation of [SnowballRService.updateUser].
+     */
+    suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User
 }
 
 /**
@@ -117,6 +123,7 @@ class UserService(
         // We have to request the user first to get the ID for the access checks
         val requestedUser = userRepo.getUserByEmail(request.email)
 
+        @Suppress("StringLiteralDuplication")
         verifyUserAccess(currentUser, requestingUserId, IdentifierType.EMAIL)
 
         // Only active or active unconfirmed users can be retrieved
@@ -133,7 +140,7 @@ class UserService(
         val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
-        verifyServerAdminRole(currentUser, EntityType.USER)
+        verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.USER, AccessType.READ, it) }
 
         val users = userRepo.getAllUsers()
 
@@ -156,5 +163,27 @@ class UserService(
         val tokens = JwtUtils.generateTokens(user.id)
 
         return tokens
+    }
+
+    override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUserId = currentUser.id.toString()
+        val updatedUserId = request.user.id
+
+        // Check whether a user with the given email already exists if the email should be changed
+        if (request.mask.pathsList.contains("email") && userRepo.doesUserExistByEmail(request.user.email)) {
+            throw DuplicateEntityException(EntityType.USER, request.user.email, IdentifierType.EMAIL)
+        }
+
+        // Check whether the current user is a server admin if the role is changed or the requested user is different
+        // from the current user
+        if (request.mask.pathsList.contains("role") || currentUserId != updatedUserId) {
+            verifyServerAdminRole(
+                currentUser,
+            ) { UnauthorizedException.Single(EntityType.USER, updatedUserId, AccessType.UPDATE, currentUserId) }
+        }
+
+        val updatedUser = userRepo.updateUser(request)
+        return updatedUser.toGrpcUser()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -123,7 +123,6 @@ class UserService(
         // We have to request the user first to get the ID for the access checks
         val requestedUser = userRepo.getUserByEmail(request.email)
 
-        @Suppress("StringLiteralDuplication")
         verifyUserAccess(currentUser, requestingUserId, IdentifierType.EMAIL)
 
         // Only active or active unconfirmed users can be retrieved
@@ -175,15 +174,8 @@ class UserService(
         // Check whether the current user is a server admin if the role is changed or the requested user is different
         // from the current user
         if (request.mask.pathsList.contains("role") || currentUser.id != requestedUser.id) {
-            verifyServerAdminRole(
-                currentUser,
-            ) {
-                UnauthorizedException.Single(
-                    EntityType.USER,
-                    requestedUser.id.toString(),
-                    AccessType.UPDATE,
-                    currentUser.id.toString(),
-                )
+            verifyServerAdminRole(currentUser) {
+                UnauthorizedException.Single(EntityType.USER, requestedUser.id.toString(), AccessType.UPDATE, it)
             }
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -4,6 +4,7 @@ import se.uulm.snowballr.backend.auth.JwtUtils
 import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
@@ -76,6 +77,7 @@ class UserService(
         throw UnauthorizedException.Single(
             EntityType.USER,
             requestedUserId.toString(),
+            AccessType.READ,
             currentUser.id.toString(),
             identifierType,
         )

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
@@ -14,7 +14,7 @@ import snowballr.UserOuterClass.User
  */
 object UserValidator {
     fun validateUpdateRequest(request: User.Update): EitherNel<ValidationIssue, Unit> = either {
-        // validate the field mask
+        // Validate the field mask
         val fieldMaskResult = either {
             ensureFieldMaskIsValid(request.mask, User.Update.getDescriptor())
         }
@@ -46,7 +46,7 @@ object UserValidator {
             },
             {
                 if ("user.role" in selectedFields) {
-                    ensureEnumNotUnspecified("userRole", request.user.role)
+                    ensureEnumNotUnspecified("role", request.user.role)
                 }
             },
         ) { _, _, _, _, _ -> }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
@@ -1,0 +1,54 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.Either
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.UserOuterClass.User
+
+/**
+ * A validator for [User] related requests.
+ *
+ * @see AuthenticationValidator for more validation functions regarding the [User]
+ */
+object UserValidator {
+    fun validateUpdateRequest(request: User.Update): EitherNel<ValidationIssue, Unit> = either {
+        // validate the field mask
+        val fieldMaskResult = either {
+            ensureFieldMaskIsValid(request.mask, User.Update.getDescriptor())
+        }
+
+        // If field mask validation fails, return early
+        if (fieldMaskResult is Either.Left) {
+            fieldMaskResult.toEitherNel().bind()
+        }
+
+        // Only proceed with field validation if the mask is valid
+        val selectedFields = request.mask.pathsList.toSet()
+
+        zipOrAccumulate(
+            { ensureIdValidity("id", request.user.id) },
+            {
+                if ("user.email" in selectedFields) {
+                    ensureEmailValidity(request.user.email)
+                }
+            },
+            {
+                if ("user.first_name" in selectedFields) {
+                    ensureFirstNameValidity(request.user.firstName)
+                }
+            },
+            {
+                if ("user.last_name" in selectedFields) {
+                    ensureLastNameValidity(request.user.lastName)
+                }
+            },
+            {
+                if ("user.role" in selectedFields) {
+                    ensureEnumNotUnspecified("userRole", request.user.role)
+                }
+            },
+        ) { _, _, _, _, _ -> }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -150,9 +150,8 @@ fun Raise<ValidationIssue>.ensureLastNameValidity(lastName: String) {
  * Ensures that the provided field mask contains only valid fields for the given object type and
  * is non-blank.
  *
- * @param fieldMask The FieldMask to validate.
+ * @param fieldMask The [FieldMask] to validate.
  * @param descriptor The object descriptor to validate against.
- * @throws ValidationIssue if the field mask contains invalid or blank fields.
  */
 fun Raise<ValidationIssue>.ensureFieldMaskIsValid(fieldMask: FieldMask, descriptor: Descriptor) {
     ensure(fieldMask.pathsList.isNotEmpty()) { InvalidFieldMask(null) }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -4,9 +4,13 @@ import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.zipOrAccumulate
+import com.google.protobuf.Descriptors.Descriptor
+import com.google.protobuf.FieldMask
+import com.google.protobuf.util.FieldMaskUtil
 import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.EnumUnspecified
 import se.uulm.snowballr.backend.model.InvalidEmail
+import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.InvalidPassword
 import se.uulm.snowballr.backend.model.InvalidPassword.Reason
@@ -140,4 +144,19 @@ fun Raise<ValidationIssue>.ensureFirstNameValidity(firstName: String) {
 fun Raise<ValidationIssue>.ensureLastNameValidity(lastName: String) {
     ensureFieldNonBlank("last_name", lastName)
     ensureFieldLength("last_name", lastName, LAST_NAME_MAX_LENGTH)
+}
+
+/**
+ * Ensures that the provided field mask contains only valid fields for the given object type and
+ * is non-blank.
+ *
+ * @param fieldMask The FieldMask to validate.
+ * @param descriptor The object descriptor to validate against.
+ * @throws ValidationIssue if the field mask contains invalid or blank fields.
+ */
+fun Raise<ValidationIssue>.ensureFieldMaskIsValid(fieldMask: FieldMask, descriptor: Descriptor) {
+    ensure(fieldMask.pathsList.isNotEmpty()) { InvalidFieldMask(null) }
+    ensure(FieldMaskUtil.isValid(descriptor, fieldMask)) {
+        InvalidFieldMask(fieldMask.toString())
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -10,6 +10,7 @@ import snowballr.Authentication
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass
 
 /**
  * Email regex.
@@ -49,6 +50,8 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is io.grpc.reflection.v1.ServerReflectionRequest -> Either.Right(Unit)
     // Authentication
     is Authentication.RegisterRequest -> AuthenticationValidator.validateRegisterRequest(request)
+    // User
+    is UserOuterClass.User.Update -> UserValidator.validateUpdateRequest(request)
     // Project
     is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
     // Criterion

--- a/src/test/kotlin/se/uulm/snowballr/backend/grpc/GrpcContextTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/grpc/GrpcContextTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.MissingContextException
 import java.util.UUID
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import se.uulm.snowballr.backend.DataBuilder.createExampleUser
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.table.UserTable
@@ -257,17 +256,5 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
                     repo.updateUser(updateRequest)
                 }
             }
-
-        @Test
-        fun `When the user that should be updated does not exist, then an exception is thrown`() = testCoroutine {
-            val request =
-                User.Update
-                    .newBuilder()
-                    .setUser(createExampleUser().toGrpcUser())
-                    .setMask(FieldMaskUtil.fromString("user.email"))
-                    .build()
-
-            assertThrows<NotFoundException> { repo.updateUser(request) }
-        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
+import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -10,10 +11,16 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder.createExampleUser
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.Authentication
+import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
@@ -23,23 +30,37 @@ import java.util.UUID
 class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
     private val repo = UserTableRepo(db)
 
+    private suspend fun insertTestUserAndGetId(
+        email: String = "test.user@example.com",
+        firstName: String = "Test",
+        lastName: String = "User",
+        role: UserRole = UserRole.USER_ROLE_DEFAULT,
+        status: UserStatus = UserStatus.USER_STATUS_ACTIVE,
+    ): UUID = db.dbQuery {
+        UserTable.insertAndGetId {
+            it[UserTable.email] = email
+            it[UserTable.firstName] = firstName
+            it[UserTable.lastName] = lastName
+            it[UserTable.passwordHash] = "hashedPassword"
+            it[UserTable.role] = role
+            it[UserTable.status] = status
+        }.value
+    }
+
+    companion object {
+        @JvmStatic
+        fun validFieldMasks(): List<Arguments> = listOf(
+            Arguments.of(listOf("user.email")),
+            Arguments.of(listOf("user.first_name", "user.last_name")),
+            Arguments.of(listOf("user.role")),
+        )
+    }
+
     @Nested
     inner class GetUserById {
         @Test
         fun `When a user is found, then the correct user is returned`() = testCoroutine {
-            val userId =
-                db
-                    .dbQuery {
-                        UserTable.insertAndGetId {
-                            it[email] = "test.user@example.com"
-                            it[firstName] = "Test"
-                            it[lastName] = "User"
-                            it[passwordHash] = "hashedPassword"
-                            it[role] = UserRole.USER_ROLE_DEFAULT
-                            it[status] = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
-                        }
-                    }.value
-
+            val userId = insertTestUserAndGetId()
             val user = repo.getUserById(userId)
 
             assertThat(user.id).isEqualTo(userId)
@@ -47,7 +68,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
             assertThat(user.firstName).isEqualTo("Test")
             assertThat(user.lastName).isEqualTo("User")
             assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
-            assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
+            assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
         }
 
         @Test
@@ -60,19 +81,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
     inner class GetUserByEmail {
         @Test
         fun `When a user is found, then the correct user is returned`() = testCoroutine {
-            val userId =
-                db
-                    .dbQuery {
-                        UserTable.insertAndGetId {
-                            it[email] = "test.user@example.com"
-                            it[firstName] = "Test"
-                            it[lastName] = "User"
-                            it[passwordHash] = "hashedPassword"
-                            it[role] = UserRole.USER_ROLE_DEFAULT
-                            it[status] = UserStatus.USER_STATUS_ACTIVE
-                        }
-                    }.value
-
+            val userId = insertTestUserAndGetId()
             val user = repo.getUserByEmail("test.user@example.com")
 
             assertThat(user.id).isEqualTo(userId)
@@ -93,16 +102,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
     inner class DoesUserExistByEmail {
         @Test
         fun `When a user with the given email exists, then true is returned`() = testCoroutine {
-            db.dbQuery {
-                UserTable.insertAndGetId {
-                    it[email] = "test.user@example.com"
-                    it[firstName] = "Test"
-                    it[lastName] = "User"
-                    it[passwordHash] = "hashedPassword"
-                    it[role] = UserRole.USER_ROLE_DEFAULT
-                    it[status] = UserStatus.USER_STATUS_ACTIVE
-                }
-            }
+            insertTestUserAndGetId()
 
             assertTrue(repo.doesUserExistByEmail("test.user@example.com"))
         }
@@ -117,31 +117,8 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
     inner class GetAllUsers {
         @Test
         fun `When users are found, then all users are returned`() = testCoroutine {
-            val userId1 =
-                db
-                    .dbQuery {
-                        UserTable.insertAndGetId {
-                            it[email] = "test.user1@example.com"
-                            it[firstName] = "Test"
-                            it[lastName] = "User 2"
-                            it[passwordHash] = "hashedPassword"
-                            it[role] = UserRole.USER_ROLE_DEFAULT
-                            it[status] = UserStatus.USER_STATUS_ACTIVE
-                        }
-                    }.value
-
-            val userId2 =
-                db
-                    .dbQuery {
-                        UserTable.insertAndGetId {
-                            it[email] = "test.user2@example.com"
-                            it[firstName] = "Test"
-                            it[lastName] = "User 1"
-                            it[passwordHash] = "hashedPassword"
-                            it[role] = UserRole.USER_ROLE_DEFAULT
-                            it[status] = UserStatus.USER_STATUS_ACTIVE
-                        }
-                    }.value
+            val userId1 = insertTestUserAndGetId(email = "test.user1@example.com", lastName = "User 2")
+            val userId2 = insertTestUserAndGetId(email = "test.user2@example.com", lastName = "User 1")
 
             val users = repo.getAllUsers()
             assertThat(users).hasSize(2)
@@ -212,6 +189,85 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
             val user2 = repo.createUser(request2, "hashedPassword2")
 
             assertThat(user1.id).isNotEqualTo(user2.id)
+        }
+    }
+
+    @Nested
+    inner class UpdateUser {
+        @ParameterizedTest(name = "Update the fields {0}")
+        @MethodSource("se.uulm.snowballr.backend.repository.UserTableRepoTest#validFieldMasks")
+        fun `When a user is updated, then only the fields specified in the field mask are updated and the updated user is returned`(
+            fieldMask: List<String>,
+        ) = testCoroutine {
+            val userId = insertTestUserAndGetId(email = "test.user@example.com")
+            val originalUser = repo.getUserById(userId)
+
+            val updatedUserDetails = originalUser.toGrpcUser().toBuilder()
+                .setEmail("updated.user@example.com")
+                .setFirstName("John")
+                .setLastName("Doe")
+                .setRole(UserRole.USER_ROLE_ADMIN)
+                .build()
+
+            val request = User.Update.newBuilder()
+                .setUser(updatedUserDetails)
+                .setMask(FieldMaskUtil.fromStringList(fieldMask))
+                .build()
+
+            val updatedUser = repo.updateUser(request)
+
+            if ("user.email" in fieldMask) {
+                assertThat(updatedUser.email).isEqualTo("updated.user@example.com")
+            } else {
+                assertThat(updatedUser.email).isEqualTo("test.user@example.com")
+            }
+            if ("user.first_name" in fieldMask) {
+                assertThat(updatedUser.firstName).isEqualTo("John")
+            } else {
+                assertThat(updatedUser.firstName).isEqualTo("Test")
+            }
+            if ("user.last_name" in fieldMask) {
+                assertThat(updatedUser.lastName).isEqualTo("Doe")
+            } else {
+                assertThat(updatedUser.lastName).isEqualTo("User")
+            }
+            if ("user.role" in fieldMask) {
+                assertThat(updatedUser.role).isEqualTo(UserRole.USER_ROLE_ADMIN)
+            } else {
+                assertThat(updatedUser.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
+            }
+        }
+
+        @Test
+        fun `When a user's email should be updated to an existing email, then an exception is thrown`() =
+            testCoroutine {
+                insertTestUserAndGetId(email = "alice.smith@example.com")
+
+                val user2Id = insertTestUserAndGetId(email = "bob.smith@example.com")
+                val user2Builder = repo.getUserById(user2Id).toGrpcUser().toBuilder()
+
+                val updateRequest =
+                    User.Update
+                        .newBuilder()
+                        .setUser(user2Builder.setEmail("alice.smith@example.com").build())
+                        .setMask(FieldMaskUtil.fromString("user.email"))
+                        .build()
+
+                assertThrows<ExposedSQLException> {
+                    repo.updateUser(updateRequest)
+                }
+            }
+
+        @Test
+        fun `When the user that should be updated does not exist, then an exception is thrown`() = testCoroutine {
+            val request =
+                User.Update
+                    .newBuilder()
+                    .setUser(createExampleUser().toGrpcUser())
+                    .setMask(FieldMaskUtil.fromString("user.email"))
+                    .build()
+
+            assertThrows<NotFoundException> { repo.updateUser(request) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -1,7 +1,10 @@
 package se.uulm.snowballr.backend.service
 
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.grpc.GrpcContext
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -84,12 +88,15 @@ open class MainServiceTest {
     @BeforeAll
     fun setUp() {
         Dispatchers.setMain(threadContext)
+        mockkObject(GrpcContext)
     }
 
     @BeforeEach
     open fun setUpTest() {
+        val userId = UUID.randomUUID()
+        coEvery { GrpcContext.getUserIdFromContext() } returns userId
         // TODO: remove when user management is implemented
-        dummyUserId = UUID.randomUUID().toString()
+        dummyUserId = userId.toString()
     }
 
     @AfterEach
@@ -101,5 +108,6 @@ open class MainServiceTest {
     fun tearDown() {
         Dispatchers.resetMain()
         threadContext.close()
+        unmockkObject(GrpcContext)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.db.dummyUserId
-import se.uulm.snowballr.backend.grpc.GrpcContext
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
@@ -18,13 +19,21 @@ class ServiceChecksTest {
         @GrpcEnumSourceTest(UserRole::class, excludes = ["USER_ROLE_ADMIN"])
         fun `When the user is not a server admin, then an exception is thrown`(role: UserRole) {
             val user = DataBuilder.createExampleUser(role = role)
-            assertThrows<UnauthorizedException.All> { verifyServerAdminRole(user, EntityType.PROJECT) }
+            assertThrows<UnauthorizedException.All> {
+                verifyServerAdminRole(
+                    user,
+                ) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, user.id.toString()) }
+            }
         }
 
         @Test
         fun `When the user is a server admin, then no exception is thrown`() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            assertDoesNotThrow { verifyServerAdminRole(user, EntityType.PROJECT) }
+            assertDoesNotThrow {
+                verifyServerAdminRole(
+                    user,
+                ) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, user.id.toString()) }
+            }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -53,8 +53,12 @@ class UpdateUserTest : MainServiceTest() {
 
     @Test
     fun `When a user wants to change their email to an existing email, then an exception is thrown`() = testCoroutine {
-        val request = User.Update.newBuilder().setMask(FieldMaskUtil.fromString("email")).build()
+        val user = DataBuilder.createExampleUser()
+        val request = User.Update.newBuilder().setUser(
+            user.toGrpcUser(),
+        ).setMask(FieldMaskUtil.fromString("email")).build()
 
+        coEvery { userRepoMock.getUserById(any()) } returns user
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
 
         assertThrows<SnowballRException.DuplicateEntityException> { mainService.updateUser(request) }
@@ -63,7 +67,8 @@ class UpdateUserTest : MainServiceTest() {
     @Test
     fun `When a non-admin user wants to change the user role, then an exception is thrown`() = testCoroutine {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val request = User.Update.newBuilder().setMask(FieldMaskUtil.fromString("role")).build()
+        val updatedUser = DataBuilder.createExampleUser().toGrpcUser()
+        val request = User.Update.newBuilder().setUser(updatedUser).setMask(FieldMaskUtil.fromString("role")).build()
 
         coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
 
@@ -74,11 +79,12 @@ class UpdateUserTest : MainServiceTest() {
     fun `When a non-admin user wants to change the user information from another user, then an exception is thrown`() =
         testCoroutine {
             val anotherUser = DataBuilder.createExampleUser()
-            val updatedUser = DataBuilder.createExampleUser().toGrpcUser()
+            val updatedUser = DataBuilder.createExampleUser()
             val updateFieldMask = FieldMaskUtil.fromString("first_name")
-            val request = User.Update.newBuilder().setUser(updatedUser).setMask(updateFieldMask).build()
+            val request = User.Update.newBuilder().setUser(updatedUser.toGrpcUser()).setMask(updateFieldMask).build()
 
-            coEvery { userRepoMock.getUserById(any()) } returns anotherUser
+            coEvery { userRepoMock.getUserById(anotherUser.id) } returns anotherUser
+            coEvery { userRepoMock.getUserById(updatedUser.id) } returns updatedUser
 
             assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateUser(request) }
         }
@@ -86,7 +92,8 @@ class UpdateUserTest : MainServiceTest() {
     @Test
     fun `When an error occurs while updating a user, then an exception is thrown`() = testCoroutine {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val request = User.Update.newBuilder().build()
+        val updatedUser = DataBuilder.createExampleUser().toGrpcUser()
+        val request = User.Update.newBuilder().setUser(updatedUser).build()
 
         coEvery { userRepoMock.getUserById(any()) } returns adminUser
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -4,21 +4,33 @@ import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
+import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 class UpdateUserTest : MainServiceTest() {
+    @BeforeEach
+    override fun setUpTest() {
+        super.setUpTest()
+
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { userRepoMock.doesUserExistByEmail(any()) } throws NotImplementedError()
+        coEvery { userRepoMock.updateUser(any()) } throws NotImplementedError()
+    }
+
     @Test
     fun `When a user updates their own information successfully, then no exception is thrown`() = testCoroutine {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
@@ -26,11 +38,13 @@ class UpdateUserTest : MainServiceTest() {
             id = nonAdminUser.id,
             firstName = "John",
             lastName = "Doe",
-        ).toGrpcUser()
+        )
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("first_name", "last_name"))
-        val request = User.Update.newBuilder().setUser(updatedUser).setMask(updateFieldMask).build()
+        val request = User.Update.newBuilder().setUser(updatedUser.toGrpcUser()).setMask(updateFieldMask).build()
 
         coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
+        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
+        coEvery { userRepoMock.updateUser(request) } returns updatedUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
     }
@@ -42,11 +56,13 @@ class UpdateUserTest : MainServiceTest() {
             email = "john@doe.com",
             firstName = "John",
             lastName = "Doe",
-        ).toGrpcUser()
+        )
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("email", "first_name", "last_name"))
-        val request = User.Update.newBuilder().setUser(updatedUser).setMask(updateFieldMask).build()
+        val request = User.Update.newBuilder().setUser(updatedUser.toGrpcUser()).setMask(updateFieldMask).build()
 
         coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
+        coEvery { userRepoMock.updateUser(request) } returns updatedUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
     }
@@ -78,12 +94,12 @@ class UpdateUserTest : MainServiceTest() {
     @Test
     fun `When a non-admin user wants to change the user information from another user, then an exception is thrown`() =
         testCoroutine {
-            val anotherUser = DataBuilder.createExampleUser()
+            val anotherUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
             val updatedUser = DataBuilder.createExampleUser()
             val updateFieldMask = FieldMaskUtil.fromString("first_name")
             val request = User.Update.newBuilder().setUser(updatedUser.toGrpcUser()).setMask(updateFieldMask).build()
 
-            coEvery { userRepoMock.getUserById(anotherUser.id) } returns anotherUser
+            coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns anotherUser
             coEvery { userRepoMock.getUserById(updatedUser.id) } returns updatedUser
 
             assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateUser(request) }
@@ -96,6 +112,7 @@ class UpdateUserTest : MainServiceTest() {
         val request = User.Update.newBuilder().setUser(updatedUser).build()
 
         coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -1,0 +1,96 @@
+package se.uulm.snowballr.backend.service.user
+
+import com.google.protobuf.util.FieldMaskUtil
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.toGrpcUser
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.UserOuterClass.User
+import snowballr.UserOuterClass.UserRole
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class UpdateUserTest : MainServiceTest() {
+    @Test
+    fun `When a user updates its own information successfully, then no exception is thrown`() = testCoroutine {
+        val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val updatedUser = DataBuilder.createExampleUser(
+            id = nonAdminUser.id,
+            firstName = "John",
+            lastName = "Doe",
+        ).toGrpcUser()
+        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("first_name", "last_name"))
+        val request = User.Update.newBuilder().setUser(updatedUser).setMask(updateFieldMask).build()
+
+        coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
+
+        assertDoesNotThrow { mainService.updateUser(request) }
+    }
+
+    @Test
+    fun `When an admin updates a user's information successfully, then no exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val updatedUser = DataBuilder.createExampleUser(
+            email = "john@doe.com",
+            firstName = "John",
+            lastName = "Doe",
+        ).toGrpcUser()
+        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("email", "first_name", "last_name"))
+        val request = User.Update.newBuilder().setUser(updatedUser).setMask(updateFieldMask).build()
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+
+        assertDoesNotThrow { mainService.updateUser(request) }
+    }
+
+    @Test
+    fun `When a user wants to change its email to an existing email, then an exception is thrown`() = testCoroutine {
+        val request = User.Update.newBuilder().setMask(FieldMaskUtil.fromString("email")).build()
+
+        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
+
+        assertThrows<SnowballRException.DuplicateEntityException> { mainService.updateUser(request) }
+    }
+
+    @Test
+    fun `When a non-admin user wants to change the user role, then an exception is thrown`() = testCoroutine {
+        val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val request = User.Update.newBuilder().setMask(FieldMaskUtil.fromString("role")).build()
+
+        coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
+
+        assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateUser(request) }
+    }
+
+    @Test
+    fun `When a non-admin user wants to change the user information from another user, then an exception is thrown`() =
+        testCoroutine {
+            val anotherUser = DataBuilder.createExampleUser()
+            val updatedUser = DataBuilder.createExampleUser().toGrpcUser()
+            val updateFieldMask = FieldMaskUtil.fromString("first_name")
+            val request = User.Update.newBuilder().setUser(updatedUser).setMask(updateFieldMask).build()
+
+            coEvery { userRepoMock.getUserById(any()) } returns anotherUser
+
+            assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateUser(request) }
+        }
+
+    @Test
+    fun `When an error occurs while updating a user, then an exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val request = User.Update.newBuilder().build()
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateUser(request) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -56,8 +56,9 @@ class UpdateUserTest : MainServiceTest() {
             email = "john@doe.com",
             firstName = "John",
             lastName = "Doe",
+            role = UserRole.USER_ROLE_ADMIN,
         )
-        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("email", "first_name", "last_name"))
+        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("email", "first_name", "last_name", "role"))
         val request = User.Update.newBuilder().setUser(updatedUser.toGrpcUser()).setMask(updateFieldMask).build()
 
         coEvery { userRepoMock.getUserById(any()) } returns adminUser

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -20,7 +20,7 @@ import snowballr.UserOuterClass.UserRole
 @DelicateCoroutinesApi
 class UpdateUserTest : MainServiceTest() {
     @Test
-    fun `When a user updates its own information successfully, then no exception is thrown`() = testCoroutine {
+    fun `When a user updates their own information successfully, then no exception is thrown`() = testCoroutine {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val updatedUser = DataBuilder.createExampleUser(
             id = nonAdminUser.id,
@@ -52,7 +52,7 @@ class UpdateUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a user wants to change its email to an existing email, then an exception is thrown`() = testCoroutine {
+    fun `When a user wants to change their email to an existing email, then an exception is thrown`() = testCoroutine {
         val request = User.Update.newBuilder().setMask(FieldMaskUtil.fromString("email")).build()
 
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
@@ -66,7 +66,7 @@ class UserValidatorTest {
         }
 
         @Test
-        fun `When an invalid id is validated, then the 'InvalidId' issue is returned`() {
+        fun `When an invalid ID is validated, then the 'InvalidId' issue is returned`() {
             val user = validUpdatedUser.setId("invalid-id").build()
             val request = validUpdateRequestBuilder
                 .setUser(user)
@@ -150,7 +150,7 @@ class UserValidatorTest {
         }
 
         @Test
-        fun `When an invalid role is provided and specified in the field mask, then the 'InvalidEmail' issue is returned`() {
+        fun `When an invalid role is provided and specified in the field mask, then the 'EnumUnspecified' issue is returned`() {
             val user = validUpdatedUser.setRole(UserRole.USER_ROLE_UNSPECIFIED).build()
             val request = validUpdateRequestBuilder
                 .setUser(user)

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
@@ -1,0 +1,176 @@
+package se.uulm.snowballr.backend.validation
+
+import com.google.protobuf.FieldMask
+import com.google.protobuf.util.FieldMaskUtil
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.EnumUnspecified
+import se.uulm.snowballr.backend.model.InvalidEmail
+import se.uulm.snowballr.backend.model.InvalidFieldMask
+import se.uulm.snowballr.backend.model.InvalidId
+import se.uulm.snowballr.backend.model.TooLongField
+import snowballr.UserOuterClass.User
+import snowballr.UserOuterClass.User.Update
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+class UserValidatorTest {
+    @Nested
+    inner class UpdateRequest {
+        private val validUpdatedUser: User.Builder = User.newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setEmail("test.user@example.com")
+            .setFirstName("test")
+            .setLastName("user")
+            .setRole(UserRole.USER_ROLE_DEFAULT)
+        private val validFieldMask: FieldMask = FieldMaskUtil
+            .fromStringList(listOf("user.email", "user.first_name", "user.last_name", "user.role"))
+
+        private val validUpdateRequestBuilder: Update.Builder =
+            Update
+                .newBuilder()
+                .setUser(validUpdatedUser)
+                .setMask(validFieldMask)
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validUpdateRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a blank field mask is validated, then the 'InvalidFieldMask' issue is returned`() {
+            val inValidFieldMask = FieldMaskUtil.fromStringList(listOf())
+            val request =
+                validUpdateRequestBuilder
+                    .setMask(inValidFieldMask)
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
+        fun `When a field mask containing a non-existing field is validated, then the 'InvalidFieldMask' issue is returned`() {
+            val request =
+                validUpdateRequestBuilder
+                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existing_field")))
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
+        fun `When an invalid id is validated, then the 'InvalidId' issue is returned`() {
+            val user = validUpdatedUser.setId("invalid-id").build()
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When an invalid email is provided and specified in the field mask, then the 'InvalidEmail' issue is returned`() {
+            val user = validUpdatedUser.setEmail("wrong-email").build()
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidEmail>(result)
+        }
+
+        @Test
+        fun `When an invalid email is provided but not specified in the field mask, then no issue is returned`() {
+            val user = validUpdatedUser.setEmail("wrong-email").build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("user.first_name"))
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid firstname is provided and specified in the field mask, then an issue is returned`() {
+            val user = validUpdatedUser.setFirstName("  ").build()
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .setMask(validFieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<BlankField>(result)
+        }
+
+        @Test
+        fun `When an invalid firstname is provided but not specified in the field mask, then no issue is returned`() {
+            val user = validUpdatedUser.setFirstName("  ").build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("user.last_name"))
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid lastname is provided and specified in the field mask, then an issue is returned`() {
+            val user = validUpdatedUser.setLastName("user".repeat(26)).build()
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<TooLongField>(result)
+        }
+
+        @Test
+        fun `When an invalid lastname is provided but not specified in the field mask, then no issue is returned`() {
+            val user = validUpdatedUser.setLastName("user".repeat(26)).build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("user.first_name"))
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid role is provided and specified in the field mask, then the 'InvalidEmail' issue is returned`() {
+            val user = validUpdatedUser.setRole(UserRole.USER_ROLE_UNSPECIFIED).build()
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<EnumUnspecified>(result)
+        }
+
+        @Test
+        fun `When an invalid role is provided but not specified in the field mask, then no issue is returned`() {
+            val user = validUpdatedUser.setRole(UserRole.USER_ROLE_UNSPECIFIED).build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("user.first_name"))
+            val request = validUpdateRequestBuilder
+                .setUser(user)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+    }
+}


### PR DESCRIPTION
Closes #31 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I added the implementation for the following call
  - updateUser
- This includes the implementation of the repository layer, i.e., an update function for a user (probably need to be generalized when introducing #93), the service layer and the validation for an update request.
- The validation especially includes a check, whether a field mask is valid
- Furthermore I figured out how to manually test this call in IntelliJ: 
![Bildschirmfoto 2025-07-03 um 19 46 09](https://github.com/user-attachments/assets/addd9bd3-39b9-4cd4-8573-baa404c05768)
but this doesn't work as long as you cannot login using manual requests
- Regarding to the issue #31 this PR should also implement the `ChangePassword` call, however the overlap of these calls is not as large as expected, so this call should be implemented separately (see #93).

>**Note**: I do not understand why the coverage reporter does not recognize the coverage for the `UserTableRepo`. When I run the tests locally and check the coverage, my new implementation is completely covered. I am glad for suggestions and ideas for improvement as this is my first PR for the backend.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
