### PR TITLE
Remove all 'internal' keywords

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -138,7 +138,7 @@ class SnowballRServer(
      * appropriate response types as defined by the respective protocol buffers.
      */
     @Suppress("TooManyFunctions")
-    internal class SnowballRService :
+    class SnowballRService :
         SnowballRGrpcKt.SnowballRCoroutineImplBase(),
         KoinComponent {
         private val mainService: IMainService by inject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -66,7 +66,7 @@ import java.util.UUID
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-internal open class MainServiceTest {
+open class MainServiceTest {
     private val threadContext = newSingleThreadContext("Test thread")
 
     val projectRepoMock = mockk<IProjectTableRepo>(relaxed = true)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-internal class CreateCriterionTest : MainServiceTest() {
+class CreateCriterionTest : MainServiceTest() {
     @Test
     fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -16,7 +16,7 @@ import snowballr.ProjectOuterClass
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-internal class CreateProjectTest : MainServiceTest() {
+class CreateProjectTest : MainServiceTest() {
     @Test
     fun `When the requesting user has an invalid ID, then an exception is thrown`() = testCoroutine {
         val request = ProjectOuterClass.Project.Create.getDefaultInstance()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-internal class GetAllUsersTest : MainServiceTest() {
+class GetAllUsersTest : MainServiceTest() {
     private var dummyUserUUID: UUID = UUID.randomUUID()
 
     @BeforeEach

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-internal class GetUserByEmailTest : MainServiceTest() {
+class GetUserByEmailTest : MainServiceTest() {
     private val requestEmail = "test.user@example.com"
     private var dummyUserUUID = UUID.randomUUID()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-internal class GetUserByIdTest : MainServiceTest() {
+class GetUserByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private var dummyUserUUID = UUID.randomUUID()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -14,7 +14,7 @@ import snowballr.Authentication
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-internal class RegisterTest : MainServiceTest() {
+class RegisterTest : MainServiceTest() {
     @Test
     fun `When a user is registered, then no exception is thrown`() = testCoroutine {
         val request = Authentication.RegisterRequest.newBuilder().build()


### PR DESCRIPTION
Closes #115 

## What I have made

- Removed all 'internal' keywords

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] (for reviewer) I have checked the implementation against the requirements
