### PR TITLE
Feat/122 lua plugin system for fetchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ bin/
 
 ### Database ###
 db-data
+
+### Local Lua Fetcher Plugins ###
+fetcher-plugins

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,8 @@ dependencies {
     runtimeOnly(libs.grpc.netty)
 
     detektPlugins(libs.detekt.formatting)
+
+    implementation(libs.luaj)
 }
 
 kotlin {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     backend-local:
         build:
             context: .
+        volumes:
+            - ./fetcher-plugins:/fetcher-plugins
         environment:
             PORT: ${PORT:-8080}
             LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
@@ -28,6 +30,7 @@ services:
             DATABASE_HOST: db # use db service as db host
             JWT_PRIVATE_KEY_BASE64: ${JWT_PRIVATE_KEY_BASE64}
             JWT_PUBLIC_KEY_BASE64: ${JWT_PUBLIC_KEY_BASE64}
+            FETCHER_PLUGIN_DIRECTORY: "/fetcher-plugins"
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         depends_on:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ shadow-jar-version = "8.3.6"
 archunit-version = "1.4.1"
 password4j-version = "1.8.3"
 jjwt-version = "0.12.6"
+luaj = "3.0.1"
 
 [libraries]
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-version" }
@@ -76,6 +77,8 @@ archunit = { module = "com.tngtech.archunit:archunit", version.ref = "archunit-v
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit-version" }
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-version" }
+
+luaj = { module = "org.luaj:luaj-jse", version.ref = "luaj" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -38,7 +38,7 @@ val snowballRModule =
         singleOf(::CriterionTableRepo) { bind<ICriterionTableRepo>() }
         singleOf(::UserTableRepo) { bind<IUserTableRepo>() }
         singleOf(::ProjectMemberTableRepo) { bind<IProjectMemberTableRepo>() }
-        singleOf(::FetcherService) { bind<IFetcherService>() }
+        single<IFetcherService>(createdAtStart = true) { FetcherService(Env().fetcher) }
         // The main service comes last
         singleOf(::MainService) { bind<IMainService>() }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -14,6 +14,8 @@ import se.uulm.snowballr.backend.repository.ProjectTableRepo
 import se.uulm.snowballr.backend.repository.UserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectMemberTableRepo
+import se.uulm.snowballr.backend.service.FetcherService
+import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IMainService
 import se.uulm.snowballr.backend.service.MainService
 
@@ -36,6 +38,7 @@ val snowballRModule =
         singleOf(::CriterionTableRepo) { bind<ICriterionTableRepo>() }
         singleOf(::UserTableRepo) { bind<IUserTableRepo>() }
         singleOf(::ProjectMemberTableRepo) { bind<IProjectMemberTableRepo>() }
+        singleOf(::FetcherService) { bind<IFetcherService>() }
         // The main service comes last
         singleOf(::MainService) { bind<IMainService>() }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.env
 
 import io.github.cdimascio.dotenv.dotenv
+import java.nio.file.Path
 
 // Default values
 const val DEFAULT_LOG_LEVEL = "DEBUG"
@@ -20,6 +21,9 @@ private const val DATABASE_HOST = "DATABASE_HOST"
 private const val JWT_PRIVATE_KEY_BASE64 = "JWT_PRIVATE_KEY_BASE64"
 private const val JWT_PUBLIC_KEY_BASE64 = "JWT_PUBLIC_KEY_BASE64"
 
+// Fetcher
+private const val FETCHER_PLUGIN_DIRECTORY = "FETCHER_PLUGIN_DIRECTORY"
+
 private val envService = EnvService()
 
 /**
@@ -29,12 +33,14 @@ private val envService = EnvService()
  * @property miscellaneous Miscellaneous configuration, such as the logging level.
  * @property database Configuration related to the database connection, including user credentials.
  * @property encryption Configuration for encryption keys used in the application, such as JWT keys.
+ * @property fetcher Configuration for fetcher plugin loading.
  */
 data class Env(
     val http: Http = Http(),
     val miscellaneous: Miscellaneous = Miscellaneous(),
     val database: Database = Database(),
     val encryption: Encryption = Encryption(),
+    val fetcher: Fetcher = Fetcher(),
 ) {
     data class Http(
         val port: Int = envService[PORT].toInt(),
@@ -52,6 +58,10 @@ data class Env(
     data class Encryption(
         val jwtPrivateKeyBase64: String = envService[JWT_PRIVATE_KEY_BASE64],
         val jwtPublicKeyBase64: String = envService[JWT_PUBLIC_KEY_BASE64],
+    )
+
+    data class Fetcher(
+        val pluginDirectory: Path = Path.of(envService.getOrDefault(FETCHER_PLUGIN_DIRECTORY, "./plugins/fetchers/")),
     )
 }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcher.kt
@@ -1,0 +1,59 @@
+package se.uulm.snowballr.backend.fetcher
+
+import se.uulm.snowballr.backend.model.dto.Paper
+
+/**
+ * An [IFetcher] abstracts away the API used to acquire new papers during the
+ * crawl process.
+ *
+ * Each fetcher is instanciated once and will be reused between projects. The
+ * behavior of the fetcher can be configured using a set of string-to-string
+ * key-value pairs. These options reside in the project settings and are thus
+ * project specific. An example use-case are bring-your-own access-tokens for
+ * public (potentially rate-limited) APIs.
+ */
+interface IFetcher {
+    /**
+     * Get a set of all option keys this fetcher can be configured with.
+     * The values remain shapeless and ought to be validated in the fetcher
+     * implementation.
+     */
+    suspend fun getAvailableOptions(): Set<String>
+
+    /**
+     * Search for papers using a search query.
+     *
+     * @param searchQuery A text to search for.
+     * @param options The set of options to be used for this invocation.
+     * @return A set of papers best matching the provided searchQuery.
+     */
+    suspend fun searchPapers(searchQuery: String, options: Map<String, String>): Set<Paper>
+
+    /**
+     * Get the papers which are references of the specified paper.
+     * Paper A is a reference of Paper B if it is referred to in B:
+     *
+     *  Paper A <-referring-- Paper B <-referring-- Paper C
+     * reference                                    citation
+     *  (past)               (present)              (future)
+     *
+     * @param paper The paper of which the references should be fetched.
+     * @param options The set of options to be used for this invocation.
+     * @return A set of papers believed to be references of the provided paper.
+     */
+    suspend fun fetchReferences(paper: Paper, options: Map<String, String>): Set<Paper>
+
+    /**
+     * Get the papers which are citations of the specified paper.
+     * Paper C is a citation of Paper B if it is referring to B:
+     *
+     *  Paper A <-referring-- Paper B <-referring-- Paper C
+     * reference                                    citation
+     *  (past)               (present)              (future)
+     *
+     * @param paper The paper of which the citations should be fetched.
+     * @param options The set of options to be used for this invocation.
+     * @return A set of papers believed to be citations of the provided paper.
+     */
+    suspend fun fetchCitations(paper: Paper, options: Map<String, String>): Set<Paper>
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/LuaPluginFetcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/LuaPluginFetcher.kt
@@ -1,0 +1,174 @@
+package se.uulm.snowballr.backend.fetcher
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.datetime.Instant
+import org.luaj.vm2.Globals
+import org.luaj.vm2.LuaTable
+import org.luaj.vm2.LuaValue
+import org.luaj.vm2.lib.jse.JsePlatform
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.Paper
+import java.nio.file.Path
+import java.time.OffsetDateTime
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+@Suppress("StringLiteralDuplication")
+class LuaPluginFetcher : IFetcher {
+    private val globals: Globals
+
+    private constructor(globals: Globals) {
+        this.globals = globals
+        ensureApiContract()
+    }
+
+    companion object {
+        private val VALID_KEYS: Set<String> = setOf(
+            "name",
+            "title",
+            "externalId",
+            "abstract",
+            "publishedAt",
+            "publisher",
+            "publicationType",
+            "publicationName",
+        )
+
+        private fun newGlobals(): Globals = JsePlatform.standardGlobals()
+
+        fun fromFile(path: Path): LuaPluginFetcher {
+            val globals = newGlobals()
+            val chunk = globals.loadfile(path.toString())
+            chunk.call()
+            return LuaPluginFetcher(globals)
+        }
+
+        fun fromSource(source: String): LuaPluginFetcher {
+            val globals = newGlobals()
+            val chunk = globals.load(source)
+            chunk.call()
+            return LuaPluginFetcher(globals)
+        }
+    }
+
+    private fun ensureApiContract() {
+        globals.get("availableOptions").checktable()
+        globals.get("searchPapers").checkfunction()
+        globals.get("fetchReferences").checkfunction()
+        globals.get("fetchCitations").checkfunction()
+    }
+
+    override suspend fun getAvailableOptions(): Set<String> {
+        val value = globals.get("availableOptions")
+
+        if (!value.istable()) {
+            throw SnowballRException.FetcherException.LuaInternal("Lua fetcher specified invalid 'availableOptions'")
+        }
+
+        val table = value as LuaTable
+        return table
+            .keys()
+            .map { table.get(it) }
+            .map { it.tojstring() }
+            .toSet()
+    }
+
+    override suspend fun searchPapers(searchQuery: String, options: Map<String, String>): Set<Paper> {
+        val value = globals
+            .get("searchPapers")
+            .call(LuaValue.valueOf(searchQuery), options.toLuaTable())
+        return value.toPaperSet()
+    }
+
+    override suspend fun fetchReferences(paper: Paper, options: Map<String, String>): Set<Paper> {
+        val value = globals
+            .get("fetchReferences")
+            .call(paper.toLuaTable(), options.toLuaTable())
+        return value.toPaperSet()
+    }
+
+    override suspend fun fetchCitations(paper: Paper, options: Map<String, String>): Set<Paper> {
+        val value = globals
+            .get("fetchCitations")
+            .call(paper.toLuaTable(), options.toLuaTable())
+        return value.toPaperSet()
+    }
+
+    fun LuaValue.toPaper(): Paper {
+        if (!this.istable()) {
+            throw SnowballRException.FetcherException.LuaInternal("Lua fetcher return value was not a table")
+        }
+
+        val table = this as LuaTable
+
+        if (table.keys().any {
+                logger.info { "Key: $it" }
+                !LuaPluginFetcher.VALID_KEYS.contains(it.toString())
+            }
+        ) {
+            throw SnowballRException.FetcherException.LuaInternal("Lua fetcher return table contains unexpected key")
+        }
+
+        // Sets some keys to `null` as these ideally shouldn't be settable by a fetcher
+        return Paper(
+            id = UUID.randomUUID(),
+            title = table.get("title").tojstring(),
+            externalId = table.get("externalId").tojstring(),
+            abstract = table.get("abstract").tojstring(),
+            publishedAt = Instant.fromEpochSeconds(table.get("publishedAt").tolong()),
+            publisher = table.get("publisher").tojstring(),
+            publicationType = table.get("publicationType").tojstring(),
+            publicationName = table.get("publicationName").tojstring(),
+            pdfId = null,
+            createdAt = OffsetDateTime.now(),
+            modifiedAt = null,
+            modifiedBy = null,
+        )
+    }
+
+    fun LuaValue.toPaperSet(): Set<Paper> {
+        if (!this.istable()) {
+            throw SnowballRException.FetcherException.LuaInternal("Lua fetcher return value was not an array")
+        }
+        val table = this as LuaTable
+        val papers = table
+            .keys()
+            .map { table.get(it) }
+            .map { it.toPaper() }
+            .toSet()
+        return papers
+    }
+
+    fun Map<String, String>.toLuaTable(): LuaValue = LuaValue.tableOf(
+        this.entries
+            .flatMap { listOf(it.key, it.value) }
+            .map { LuaValue.valueOf(it) }.toTypedArray(),
+    )
+
+    fun Paper.toLuaTable(): LuaValue {
+        val entries = ArrayList<String>()
+
+        fun <T> addEntry(key: String, value: T?) {
+            if (value != null) {
+                entries.add(key)
+                entries.add(value.toString())
+            }
+        }
+
+        addEntry("id", this.id)
+        addEntry("title", this.title)
+        addEntry("externalId", this.externalId)
+        addEntry("abstract", this.abstract)
+        addEntry("publishedAt", this.publishedAt?.epochSeconds)
+        addEntry("publisher", this.publisher)
+        addEntry("publicationType", this.publicationType)
+        addEntry("publicationName", this.publicationName)
+        addEntry("pdfId", this.pdfId)
+        addEntry("createdAt", this.createdAt.toEpochSecond())
+        addEntry("modifiedAt", this.modifiedAt?.toEpochSecond())
+        addEntry("modifiedBy", this.modifiedBy)
+
+        return LuaValue.tableOf(entries.map { LuaValue.valueOf(it) }.toTypedArray())
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -144,7 +144,10 @@ class SnowballRServer(
         private val mainService: IMainService by inject()
 
         override suspend fun getAvailableFetcherApis(request: Base.Nothing): Main.AvailableFetcherApis =
-            super.getAvailableFetcherApis(request)
+            Main.AvailableFetcherApis
+                .newBuilder()
+                .addAllFetcherApis(mainService.getAvailableFetchers())
+                .build()
 
         override suspend fun register(request: Authentication.RegisterRequest): Base.Nothing {
             val (accessToken, refreshToken) = mainService.register(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -82,6 +82,7 @@ private class ExceptionCall<ReqT, RespT>(
                 is SnowballRException.UnauthorizedException -> Status.PERMISSION_DENIED
                 is SnowballRException.InvalidIdException -> Status.INVALID_ARGUMENT
                 is SnowballRException.MissingContextException -> Status.INTERNAL
+                is SnowballRException.FetcherException -> Status.INVALID_ARGUMENT
             }.withDescription(e.message).withCause(e.cause)
 
         logger.debug {

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -180,5 +180,8 @@ sealed class SnowballRException(
     ) : SnowballRException(description) {
         class UnknownFetcher(fetcher: String) : FetcherException("The fetcher '$fetcher' is not known.")
         class AlreadyRegistered(fetcher: String) : FetcherException("The fetcher '$fetcher' is already registered.")
+        class LuaInternal(reason: String) : FetcherException(
+            "A lua fetcher plugin experienced an interanl issue: $reason",
+        )
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -165,4 +165,20 @@ sealed class SnowballRException(
 
         class MissingCookiesMap : MissingContextException("Cookie map")
     }
+
+    /**
+     * Represents an exception that occurs when there is an issue with fetchers.
+     *
+     * This could indicate invalid project settings, missing/changed fetcher
+     * implementations, or a misconfiguration of the backend.
+     *
+     * @constructor Creates a [FetcherException] with a specific description.
+     * @param description A human-readable description of the specific issue.
+     */
+    sealed class FetcherException(
+        description: String,
+    ) : SnowballRException(description) {
+        class UnknownFetcher(fetcher: String) : FetcherException("The fetcher '$fetcher' is not known.")
+        class AlreadyRegistered(fetcher: String) : FetcherException("The fetcher '$fetcher' is already registered.")
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -1,0 +1,115 @@
+package se.uulm.snowballr.backend.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import se.uulm.snowballr.backend.fetcher.IFetcher
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.Paper
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Keeps track of and delegates requests to multiple [IFetcher] instances.
+ */
+interface IFetcherService {
+    /**
+     * Get a list of the names of all registered fetchers.
+     */
+    suspend fun getAvailableFetchers(): Set<String>
+
+    /**
+     * Register a fetcher.
+     * @param name The name under which a fetcher should be accessible.
+     * @param impl An implementation of a fetcher.
+     */
+    suspend fun registerFetcher(name: String, impl: IFetcher)
+
+    /**
+     * Get a set of all option keys the specified fetcher can be configured
+     * with. The values remain shapeless and ought to be validated in the
+     * fetcher implementation.
+     */
+    suspend fun getAvailableOptions(fetcher: String): Set<String>
+
+    /**
+     * Search for papers using a search query.
+     *
+     * @param fetcher The name of the fether to be used for this request.
+     * @param searchQuery A text to search for.
+     * @param options The set of options to be used for this invocation.
+     * @return A set of papers best matching the provided searchQuery.
+     */
+    suspend fun searchPapers(fetcher: String, searchQuery: String, options: Map<String, String>): Set<Paper>
+
+    /**
+     * Get the papers which are references of the specified paper.
+     * Paper A is a reference of Paper B if it is referred to in B:
+     *
+     *  Paper A <-referring-- Paper B <-referring-- Paper C
+     * reference                                    citation
+     *  (past)               (present)              (future)
+     *
+     * @param fetcher The name of the fether to be used for this request.
+     * @param paper The paper of which the references should be fetched.
+     * @param options The set of options to be used for this invocation.
+     * @return A set of papers believed to be references of the provided paper.
+     */
+    suspend fun fetchReferences(fetcher: String, paper: Paper, options: Map<String, String>): Set<Paper>
+
+    /**
+     * Get the papers which are citations of the specified paper.
+     * Paper C is a citation of Paper B if it is referring to B:
+     *
+     *  Paper A <-referring-- Paper B <-referring-- Paper C
+     * reference                                    citation
+     *  (past)               (present)              (future)
+     *
+     * @param fetcher The name of the fether to be used for this request.
+     * @param paper The paper of which the citations should be fetched.
+     * @param options The set of options to be used for this invocation.
+     * @return A set of papers believed to be citations of the provided paper.
+     */
+    suspend fun fetchCitations(fetcher: String, paper: Paper, options: Map<String, String>): Set<Paper>
+}
+
+class FetcherService : IFetcherService {
+    private val fetchers: HashMap<String, IFetcher> = HashMap()
+
+    private fun ensureFetcher(name: String) {
+        if (!fetchers.containsKey(name)) {
+            throw SnowballRException.FetcherException.UnknownFetcher(name)
+        }
+    }
+
+    override suspend fun getAvailableFetchers(): Set<String> = fetchers.keys.toSet()
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun registerFetcher(name: String, impl: IFetcher) {
+        if (fetchers.containsKey(name)) {
+            throw SnowballRException.FetcherException.AlreadyRegistered("Fetcher with name '$name' already registered")
+        }
+
+        logger.info { "Successfully registered a fetcher: $name" }
+
+        fetchers.put(name, impl)
+    }
+
+    override suspend fun getAvailableOptions(fetcher: String): Set<String> {
+        ensureFetcher(fetcher)
+        return fetchers.get(fetcher)!!.getAvailableOptions()
+    }
+
+    override suspend fun searchPapers(fetcher: String, searchQuery: String, options: Map<String, String>): Set<Paper> {
+        ensureFetcher(fetcher)
+        return fetchers.get(fetcher)!!.searchPapers(searchQuery, options)
+    }
+
+    override suspend fun fetchReferences(fetcher: String, paper: Paper, options: Map<String, String>): Set<Paper> {
+        ensureFetcher(fetcher)
+        return fetchers.get(fetcher)!!.fetchReferences(paper, options)
+    }
+
+    override suspend fun fetchCitations(fetcher: String, paper: Paper, options: Map<String, String>): Set<Paper> {
+        ensureFetcher(fetcher)
+        return fetchers.get(fetcher)!!.fetchCitations(paper, options)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -1,9 +1,17 @@
 package se.uulm.snowballr.backend.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import se.uulm.snowballr.backend.env.Env
 import se.uulm.snowballr.backend.fetcher.IFetcher
+import se.uulm.snowballr.backend.fetcher.LuaPluginFetcher
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.dto.Paper
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 
 private val logger = KotlinLogging.logger {}
 
@@ -71,8 +79,14 @@ interface IFetcherService {
     suspend fun fetchCitations(fetcher: String, paper: Paper, options: Map<String, String>): Set<Paper>
 }
 
-class FetcherService : IFetcherService {
+class FetcherService(
+    private val data: Env.Fetcher,
+) : IFetcherService {
     private val fetchers: HashMap<String, IFetcher> = HashMap()
+
+    init {
+        loadLuaFetcherPlugins()
+    }
 
     private fun ensureFetcher(name: String) {
         if (!fetchers.containsKey(name)) {
@@ -82,8 +96,7 @@ class FetcherService : IFetcherService {
 
     override suspend fun getAvailableFetchers(): Set<String> = fetchers.keys.toSet()
 
-    @Suppress("TooGenericExceptionCaught")
-    override suspend fun registerFetcher(name: String, impl: IFetcher) {
+    fun registerFetcherSync(name: String, impl: IFetcher) {
         if (fetchers.containsKey(name)) {
             throw SnowballRException.FetcherException.AlreadyRegistered("Fetcher with name '$name' already registered")
         }
@@ -92,6 +105,8 @@ class FetcherService : IFetcherService {
 
         fetchers.put(name, impl)
     }
+
+    override suspend fun registerFetcher(name: String, impl: IFetcher) = registerFetcherSync(name, impl)
 
     override suspend fun getAvailableOptions(fetcher: String): Set<String> {
         ensureFetcher(fetcher)
@@ -111,5 +126,55 @@ class FetcherService : IFetcherService {
     override suspend fun fetchCitations(fetcher: String, paper: Paper, options: Map<String, String>): Set<Paper> {
         ensureFetcher(fetcher)
         return fetchers.get(fetcher)!!.fetchCitations(paper, options)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun loadLuaFetcherPlugins() {
+        val pluginFiles = discoverLuaFetcherPluginFiles()
+        logger.info { "Trying to load ${pluginFiles.size} lua fetcher plugins" }
+        var successfulCount = 0
+        pluginFiles.forEach { path ->
+            val basename = path.name
+                .subSequence(0, path.name.length - ".lua".length)
+                .toString()
+
+            try {
+                registerFetcherSync(basename, LuaPluginFetcher.fromFile(path))
+                successfulCount += 1
+            } catch (e: Exception) {
+                logger.atError {
+                    message = "A lua fetcher plugin could not be loaded: ${path.name}"
+                    cause = e
+                }
+            }
+        }
+        logger.info { "Successfully loaded ${pluginFiles.size} lua fetcher plugins" }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun discoverLuaFetcherPluginFiles(): List<Path> {
+        if (!data.pluginDirectory.isDirectory()) {
+            logger.warn { "Fetcher plugin directory could not be found" }
+
+            try {
+                data.pluginDirectory.createDirectories()
+                logger.info { "Created fetcher plugin directory" }
+                return data.pluginDirectory.listDirectoryEntries()
+            } catch (e: Exception) {
+                logger.error { "Could not create fetcher plugin directory. Continuing without fetchers" }
+            }
+        }
+
+        return data
+            .pluginDirectory
+            .listDirectoryEntries()
+            .filter {
+                if (it.extension == "lua") {
+                    true
+                } else {
+                    logger.warn { "Ignoring unknown file in lua fetcher plugins directory: $it" }
+                    false
+                }
+            }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -17,7 +17,8 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 interface IMainService :
     IProjectService,
     ICriterionService,
-    IUserService
+    IUserService,
+    IFetcherService
 
 /**
  * The [MainService] class serves as the primary service implementation layer that aggregates multiple sub-services.
@@ -29,13 +30,16 @@ interface IMainService :
  * @param criterionRepo The repository responsible for handling persistence operations related to criteria.
  * @param userRepo The repository responsible for handling persistence operations related to users.
  * @param projectMemberRepo The repository responsible for handling persistence operations related to project members.
+ * @param fetcherService The service responsible for managing and providing fetchers.
  */
 class MainService(
     private val projectRepo: IProjectTableRepo,
     private val criterionRepo: ICriterionTableRepo,
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
+    private val fetcherService: IFetcherService,
 ) : IMainService,
     IProjectService by ProjectService(projectRepo),
     ICriterionService by CriterionService(criterionRepo),
-    IUserService by UserService(userRepo, projectMemberRepo)
+    IUserService by UserService(userRepo, projectMemberRepo),
+    IFetcherService by fetcherService

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/LuaPluginFetcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/LuaPluginFetcherTest.kt
@@ -1,0 +1,447 @@
+package se.uulm.snowballr.backend.fetcher
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+@Suppress("StringTemplateIndent", "Indentation")
+internal class LuaPluginFetcherTest : MainServiceTest() {
+    @Test
+    fun `When a plugin function is missing, then an exception is thrown`() = testCoroutine {
+        assertThrows<Exception> { PluginBuilder().withNoOptions().build() }
+        assertThrows<Exception> { PluginBuilder().withNoSearchPapers().build() }
+        assertThrows<Exception> { PluginBuilder().withNoFetchCitations().build() }
+        assertThrows<Exception> { PluginBuilder().withNoFetchReferences().build() }
+    }
+
+    @Test
+    fun `When all plugin functions are defined, then no exception is thrown`() = testCoroutine {
+        assertDoesNotThrow { PluginBuilder().build() }
+    }
+
+    @Test
+    fun `When there are an incorrect number of function parameters, then an exception is thrown`() = testCoroutine {
+        assertThrows<Exception> {
+            PluginBuilder().withRawSearchPapers(
+                """
+                function searchPapers ()
+                end
+                """.trimIndent(),
+            ).build().searchPapers("", mapOf())
+        }
+        assertThrows<Exception> {
+            PluginBuilder().withRawSearchPapers(
+                """
+                function searchPapers (a, b, c)
+                end
+                """.trimIndent(),
+            ).build().searchPapers("", mapOf())
+        }
+    }
+
+    @Test
+    fun `When the option table has the wrong type in lua, then an exception is thrown`() = testCoroutine {
+        assertThrows<Exception> {
+            PluginBuilder()
+                .withRawOptions("availableOptions = \"test\"")
+                .build()
+                .getAvailableOptions()
+        }
+    }
+
+    @Test
+    fun `When an option is specified in lua, then it is returned`() = testCoroutine {
+        val option = "test"
+        val options = PluginBuilder().withOptions(option).build().getAvailableOptions()
+        assertEquals(1, options.size)
+        assertEquals(option, options.iterator().next())
+    }
+
+    @Test
+    fun `When no lua table is returned, then an exception is thrown`() = testCoroutine {
+        assertThrows<Exception> {
+            PluginBuilder()
+                .withSearchPapers("return \"test\"")
+                .build()
+                .searchPapers("", mapOf())
+        }
+    }
+
+    @Test
+    fun `When a returned paper has unknown keys, then an exception is thrown`() = testCoroutine {
+        assertThrows<Exception> {
+            PluginBuilder()
+                .withSearchPapers("return { unknown = \"Unknown\" }")
+                .build()
+                .searchPapers("", mapOf())
+        }
+    }
+
+    @Test
+    fun `When searchPapers returns a singular full paper, then it is correctly transferred`() = testCoroutine {
+        PluginBuilder()
+            .withSearchPapers(singleFullPaperImpl)
+            .build()
+            .searchPapers("", mapOf())
+            .verifySingleFullPaper()
+    }
+
+    @Test
+    fun `When searchPapers returns a partial paper, then it is correctly transferred`() = testCoroutine {
+        PluginBuilder()
+            .withSearchPapers(singlePartialPaperImpl)
+            .build()
+            .searchPapers("", mapOf())
+            .verifySinglePartialPaper()
+    }
+
+    @Test
+    fun `When fetchReferences returns a singular full paper, then it is correctly transferred`() = testCoroutine {
+        PluginBuilder()
+            .withFetchReferences(singleFullPaperImpl)
+            .build()
+            .fetchReferences(emptyPaper, mapOf())
+            .verifySingleFullPaper()
+    }
+
+    @Test
+    fun `When fetchReferences returns a partial paper, then it is correctly transferred`() = testCoroutine {
+        PluginBuilder()
+            .withFetchReferences(singlePartialPaperImpl)
+            .build()
+            .fetchReferences(emptyPaper, mapOf())
+            .verifySinglePartialPaper()
+    }
+
+    @Test
+    fun `When fetchCitations returns a singular full paper, then it is correctly transferred`() = testCoroutine {
+        PluginBuilder()
+            .withFetchCitations(singleFullPaperImpl)
+            .build()
+            .fetchCitations(emptyPaper, mapOf())
+            .verifySingleFullPaper()
+    }
+
+    @Test
+    fun `When fetchCitations returns a partial paper, then it is correctly transferred`() = testCoroutine {
+        PluginBuilder()
+            .withFetchCitations(singlePartialPaperImpl)
+            .build()
+            .fetchCitations(emptyPaper, mapOf())
+            .verifySinglePartialPaper()
+    }
+
+    @Test
+    fun `When searchPapers returns multiple papers, then multiple papers are transferred`() = testCoroutine {
+        PluginBuilder()
+            .withSearchPapers(multiplePapersImpl)
+            .build()
+            .searchPapers("", mapOf())
+            .verifyMultiplePapers()
+    }
+
+    @Test
+    fun `When fetchReferences returns multiple papers, then multiple papers are transferred`() = testCoroutine {
+        PluginBuilder()
+            .withFetchReferences(multiplePapersImpl)
+            .build()
+            .fetchReferences(emptyPaper, mapOf())
+            .verifyMultiplePapers()
+    }
+
+    @Test
+    fun `When fetchCitations returns multiple papers, then multiple papers are transferred`() = testCoroutine {
+        PluginBuilder()
+            .withFetchCitations(multiplePapersImpl)
+            .build()
+            .fetchCitations(emptyPaper, mapOf())
+            .verifyMultiplePapers()
+    }
+
+    @Test
+    fun `When searchPapers is provdided with options, then the lua function can access them`() = testCoroutine {
+        val testPair = "test" to "test"
+        PluginBuilder()
+            .withSearchPapers(optionBasedPaperImpl(testPair.first))
+            .build()
+            .searchPapers("", mapOf(testPair))
+            .verifyOptionBasedPaper(testPair.second)
+    }
+
+    @Test
+    fun `When fetchReferences is provdided with options, then the lua function can access them`() = testCoroutine {
+        val testPair = "test" to "test"
+        PluginBuilder()
+            .withFetchReferences(optionBasedPaperImpl(testPair.first))
+            .build()
+            .fetchReferences(emptyPaper, mapOf(testPair))
+            .verifyOptionBasedPaper(testPair.second)
+    }
+
+    @Test
+    fun `When fetchCitations is provdided with options, then the lua function can access them`() = testCoroutine {
+        val testPair = "test" to "test"
+        PluginBuilder()
+            .withFetchCitations(optionBasedPaperImpl(testPair.first))
+            .build()
+            .fetchCitations(emptyPaper, mapOf(testPair))
+            .verifyOptionBasedPaper(testPair.second)
+    }
+
+    @Test
+    fun `When a search query is provided, then the searchPapers lua function can access it`() = testCoroutine {
+        val searchQuery = "test"
+        val papers = PluginBuilder().withSearchPapers(
+            """
+            return {
+                { title = searchQuery },
+            }
+            """.trimIndent(),
+        ).build().searchPapers(searchQuery, mapOf())
+
+        assertEquals(1, papers.size)
+        assertEquals(searchQuery, papers.iterator().next().title)
+    }
+
+    @Test
+    fun `When a paper is provided, then the fetchReferences lua function can access it`() = testCoroutine {
+        val papers = PluginBuilder().withFetchReferences(
+            """
+            return {
+                { title = paper.title },
+            }
+            """.trimIndent(),
+        ).build().fetchReferences(emptyPaper, mapOf())
+
+        assertEquals(1, papers.size)
+        assertEquals(emptyPaper.title, papers.iterator().next().title)
+    }
+
+    @Test
+    fun `When a paper is provided, then the fetchCitations lua function can access it`() = testCoroutine {
+        val papers = PluginBuilder().withFetchCitations(
+            """
+            return {
+                { title = paper.title },
+            }
+            """.trimIndent(),
+        ).build().fetchCitations(emptyPaper, mapOf())
+
+        assertEquals(1, papers.size)
+        assertEquals(emptyPaper.title, papers.iterator().next().title)
+    }
+
+    class PluginBuilder {
+        private var optionsImpl: String? = null
+        private var searchPapersImpl: String? = null
+        private var fetchReferencesImpl: String? = null
+        private var fetchCitationsImpl: String? = null
+
+        init {
+            this
+                .withDefaultOptions()
+                .withDefaultSearchPapers()
+                .withDefaultFetchCitations()
+                .withDefaultFetchReferences()
+        }
+
+        fun build(): LuaPluginFetcher = LuaPluginFetcher.fromSource(
+            arrayOf(
+                optionsImpl,
+                searchPapersImpl,
+                fetchReferencesImpl,
+                fetchCitationsImpl,
+            ).filterNotNull()
+                .joinToString("\n"),
+        )
+
+        fun clone(): PluginBuilder {
+            val builder = PluginBuilder()
+            builder.optionsImpl = this.optionsImpl
+            builder.searchPapersImpl = this.searchPapersImpl
+            builder.fetchReferencesImpl = this.fetchReferencesImpl
+            builder.fetchCitationsImpl = this.fetchCitationsImpl
+            return builder
+        }
+
+        fun withNoDefaults(): PluginBuilder = this
+            .withNoOptions()
+            .withNoSearchPapers()
+            .withNoFetchCitations()
+            .withNoFetchReferences()
+
+        fun withOptions(vararg options: String): PluginBuilder = withRawOptions(
+            options.map { "\"${it}\"" }.joinToString(
+                ", ",
+                "availableOptions = { ",
+                " }",
+            ),
+        )
+
+        fun withSearchPapers(impl: String): PluginBuilder =
+            withRawSearchPapers(function("searchPapers", impl, "searchQuery", "options"))
+
+        fun withFetchReferences(impl: String): PluginBuilder =
+            withRawFetchReferences(function("fetchReferences", impl, "paper", "options"))
+
+        fun withFetchCitations(impl: String): PluginBuilder =
+            withRawFetchCitations(function("fetchCitations", impl, "paper", "options"))
+
+        fun withRawOptions(impl: String?): PluginBuilder {
+            this.optionsImpl = impl
+            return this
+        }
+
+        fun withRawSearchPapers(impl: String?): PluginBuilder {
+            this.searchPapersImpl = impl
+            return this
+        }
+
+        fun withRawFetchReferences(impl: String?): PluginBuilder {
+            this.fetchReferencesImpl = impl
+            return this
+        }
+
+        fun withRawFetchCitations(impl: String?): PluginBuilder {
+            this.fetchCitationsImpl = impl
+            return this
+        }
+
+        fun withDefaultOptions(): PluginBuilder {
+            this.optionsImpl = "availableOptions = {}"
+            return this
+        }
+
+        fun withDefaultSearchPapers(): PluginBuilder =
+            withRawSearchPapers(emptyFunction("searchPapers", "searchQuery", "options"))
+
+        fun withDefaultFetchReferences(): PluginBuilder =
+            withRawFetchReferences(emptyFunction("fetchReferences", "paper", "options"))
+
+        fun withDefaultFetchCitations(): PluginBuilder =
+            withRawFetchCitations(emptyFunction("fetchCitations", "paper", "options"))
+
+        fun withNoOptions(): PluginBuilder = withRawOptions(null)
+
+        fun withNoSearchPapers(): PluginBuilder = withRawSearchPapers(null)
+
+        fun withNoFetchReferences(): PluginBuilder = withRawFetchReferences(null)
+
+        fun withNoFetchCitations(): PluginBuilder = withRawFetchCitations(null)
+
+        private fun function(name: String, body: String, vararg params: String): String = """
+            function $name(${params.joinToString(", ")})
+                $body
+            end
+        """.trimIndent()
+
+        private fun emptyFunction(name: String, vararg params: String): String = function(name, "return {}", *params)
+    }
+
+    private val singleFullPaperImpl =
+        """
+        return {
+            {
+                title = "Title",
+                externalId = "ExternalId",
+                abstract = "Abstract",
+                publishedAt = 0,
+                publisher = "Publisher",
+                publicationType = "PublicationType",
+                publicationName = "PublicationName",
+            },
+        }
+        """.trimIndent()
+
+    private fun Set<Paper>.verifySingleFullPaper() {
+        assertEquals(1, this.size)
+        val paper = this.iterator().next()
+
+        with(paper) {
+            assertEquals(title, "Title")
+            assertEquals(externalId, "ExternalId")
+            assertEquals(abstract, "Abstract")
+            assertEquals(publishedAt, Instant.fromEpochSeconds(0))
+            assertEquals(publisher, "Publisher")
+            assertEquals(publicationType, "PublicationType")
+            assertEquals(publicationName, "PublicationName")
+        }
+    }
+
+    private val singlePartialPaperImpl =
+        """
+        return {
+            {
+                title = "Title",
+                externalId = "ExternalId",
+                abstract = "Abstract",
+            },
+        }
+        """.trimIndent()
+
+    private fun Set<Paper>.verifySinglePartialPaper() {
+        assertEquals(1, this.size)
+        val paper = this.iterator().next()
+
+        with(paper) {
+            assertEquals(title, "Title")
+            assertEquals(externalId, "ExternalId")
+            assertEquals(abstract, "Abstract")
+        }
+    }
+
+    private val multiplePapersImpl =
+        """
+        return {
+            { title = "Title1" },
+            { title = "Title2" },
+        }
+        """.trimIndent()
+
+    private fun Set<Paper>.verifyMultiplePapers() {
+        assertEquals(2, this.size)
+
+        val iter = this.iterator()
+        val paper1 = iter.next()
+        val paper2 = iter.next()
+        assertEquals("Title1", paper1.title)
+        assertEquals("Title2", paper2.title)
+    }
+
+    private fun optionBasedPaperImpl(option: String) = """
+        return {
+            { title = options["$option"] },
+        }
+    """.trimIndent()
+
+    private fun Set<Paper>.verifyOptionBasedPaper(optionValue: String) {
+        assertEquals(1, this.size)
+        assertEquals(optionValue, this.iterator().next().title)
+    }
+
+    private val emptyPaper = Paper(
+        UUID.randomUUID(),
+        "Title",
+        null,
+        "Abstract",
+        null,
+        null,
+        null,
+        null,
+        null,
+        OffsetDateTime.now(),
+        null,
+        null,
+    )
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -73,12 +73,14 @@ internal open class MainServiceTest {
     val criterionRepoMock = mockk<ICriterionTableRepo>(relaxed = true)
     val userRepoMock = mockk<IUserTableRepo>(relaxed = true)
     val projectMemberRepoMock = mockk<IProjectMemberTableRepo>(relaxed = true)
+    val fetcherServiceMock = mockk<IFetcherService>(relaxed = true)
     val mainService =
         MainService(
             projectRepoMock,
             criterionRepoMock,
             userRepoMock,
             projectMemberRepoMock,
+            fetcherServiceMock,
         )
 
     @BeforeAll


### PR DESCRIPTION
Closes #122 

## What I have made

- LuaPluginFetcher class
- New `Env().fetcher` for configuring plugin path

Example Lua Fetcher Plugin:
```lua
local examplePaper = {
    title = "Title",
    externalId = "ExternalId",
    abstract = "Abstract",
    publishedAt = os.time(),
    publisher = "Publisher",
    publicationType = "PublicationType",
    publicationName = "PublicationName",
}

availableOptions = {
    "test"
}

function searchPapers(searchQuery, options)
    return { examplePaper }
end

function fetchReferences(paper, options)
    return { examplePaper }
end

function fetchCitations(paper, options)
    return { examplePaper }
end

```

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
