### PR TITLE
Refactor error types to be parameterized

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
@@ -2,6 +2,9 @@ package se.uulm.snowballr.backend.model
 
 /**
  * Enum that represents the different entities in our server and their names for logging.
+ *
+ * @property singular The singular form of the entity's name.
+ * @property plural The plural form of the entity's name.
  */
 enum class EntityType(val singular: String, val plural: String) {
     USER("user", "users"),

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
@@ -1,0 +1,17 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Enum that represents the different entities in our server and their names for logging.
+ */
+enum class EntityType(val singular: String, val plural: String) {
+    USER("user", "users"),
+    PROJECT("project", "projects"),
+    CRITERION("criterion", "criteria"),
+    PROJECT_MEMBER("project member", "project members"),
+    ;
+
+    /**
+     * Converts the [singular] value to have the first char in upper case.
+     */
+    fun singularUpper(): String = this.singular.replaceFirstChar { it.uppercase() }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/IdentifierType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/IdentifierType.kt
@@ -2,6 +2,8 @@ package se.uulm.snowballr.backend.model
 
 /**
  * Enum that represents different identifiers for entities.
+ *
+ * @property displayName The displayable name of the identifier, which can be used in logs or user messages.
  */
 enum class IdentifierType(val displayName: String) {
     ID("ID"),

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/IdentifierType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/IdentifierType.kt
@@ -1,0 +1,9 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Enum that represents different identifiers for entities.
+ */
+enum class IdentifierType(val displayName: String) {
+    ID("ID"),
+    EMAIL("email"),
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/Parser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/Parser.kt
@@ -6,5 +6,5 @@ import java.util.UUID
 /**
  * Parses the passed [uuid] string to a UUID. If the parsing fails an [InvalidIdException.UUID] is thrown.
  */
-fun parseUUID(uuid: String, entityType: String): UUID =
+fun parseUUID(uuid: String, entityType: EntityType): UUID =
     runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(uuid, entityType)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/Parser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/Parser.kt
@@ -5,6 +5,10 @@ import java.util.UUID
 
 /**
  * Parses the passed [uuid] string to a UUID. If the parsing fails an [InvalidIdException.UUID] is thrown.
+ *
+ * @param uuid The UUID string to parse.
+ * @param entityType The type of the entity represented by the [uuid].
+ * @throws [InvalidIdException.UUID] If the [uuid] has not the UUID format.
  */
 fun parseUUID(uuid: String, entityType: EntityType): UUID =
     runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(uuid, entityType)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/Parser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/Parser.kt
@@ -11,4 +11,4 @@ import java.util.UUID
  * @throws [InvalidIdException.UUID] If the [uuid] has not the UUID format.
  */
 fun parseUUID(uuid: String, entityType: EntityType): UUID =
-    runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(uuid, entityType)
+    runCatching { UUID.fromString(uuid) }.getOrNull() ?: throw InvalidIdException.UUID(entityType, uuid)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -60,7 +60,8 @@ sealed class SnowballRException(
     ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.")
 
     /**
-     * Represents an exception that occurs when an entity is accessed by the current user, but they are not authorized.
+     * Represents an exception that occurs when the current user accesses one or more entities, but they don't have the
+     * required permission.
      *
      * @constructor Creates an [UnauthorizedException] with the current user's ID, the type and ID of the accessed
      * entity.
@@ -81,18 +82,10 @@ sealed class SnowballRException(
             "${accessedEntityType.singular} with $identifier '$accessedEntityId'.",
         )
 
-        sealed class All(
+        class All(
             currentUserId: String,
             accessedEntityType: EntityType,
-        ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.") {
-            class User(
-                currentUserId: String,
-            ) : All(currentUserId, EntityType.USER)
-
-            class Project(
-                currentUserId: String,
-            ) : All(currentUserId, EntityType.PROJECT)
-        }
+        ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.")
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -20,13 +20,13 @@ sealed class SnowballRException(
      * @constructor Creates a [NotFoundException] with the type and ID of the missing entity.
      * @param entityType The type of the entity that could not be found.
      * @param entityId The unique identifier of the missing entity.
-     * @param identifier The name of the identifier. Defaults to 'ID'.
+     * @param identifierType The type of the [identifierType] field. Default to [IdentifierType.ID].
      */
     open class NotFoundException(
         entityType: EntityType,
         entityId: String,
-        identifier: String? = "ID",
-    ) : SnowballRException("${entityType.singularUpper()} with $identifier '$entityId' not found.")
+        identifierType: IdentifierType = IdentifierType.ID,
+    ) : SnowballRException("${entityType.singularUpper()} with ${identifierType.displayName} '$entityId' not found.")
 
     /**
      * Represents an exception that occurs when an entity already exists in the system
@@ -35,16 +35,18 @@ sealed class SnowballRException(
      * @constructor Creates a [DuplicateEntityException] with a message about the entity.
      * @param entityType The type of the duplicated entity.
      * @param identifier The identifying value (e.g., email, username).
-     * @param identifierName The name of the identifier field (defaults to "ID").
+     * @param identifierType The type of the [identifier] field. Default to [IdentifierType.ID].
      */
     sealed class DuplicateEntityException(
         entityType: EntityType,
         identifier: String,
-        identifierName: String = "ID",
-    ) : SnowballRException("${entityType.singularUpper()} with $identifierName '$identifier' already exists.") {
+        identifierType: IdentifierType = IdentifierType.ID,
+    ) : SnowballRException(
+        "${entityType.singularUpper()} with ${identifierType.displayName} '$identifier' already exists.",
+    ) {
         class UserEmail(
             email: String,
-        ) : DuplicateEntityException(EntityType.USER, email, "email")
+        ) : DuplicateEntityException(EntityType.USER, email, IdentifierType.EMAIL)
     }
 
     /**
@@ -76,10 +78,10 @@ sealed class SnowballRException(
             currentUserId: String,
             accessedEntityType: EntityType,
             accessedEntityId: String,
-            identifier: String? = "ID",
+            identifierType: IdentifierType = IdentifierType.ID,
         ) : UnauthorizedException(
             currentUserId,
-            "${accessedEntityType.singular} with $identifier '$accessedEntityId'.",
+            "${accessedEntityType.singular} with ${identifierType.displayName} '$accessedEntityId'.",
         )
 
         class All(

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -37,17 +37,13 @@ sealed class SnowballRException(
      * @param identifier The identifying value (e.g., email, username).
      * @param identifierType The type of the [identifier] field. Default to [IdentifierType.ID].
      */
-    sealed class DuplicateEntityException(
+    class DuplicateEntityException(
         entityType: EntityType,
         identifier: String,
         identifierType: IdentifierType = IdentifierType.ID,
     ) : SnowballRException(
         "${entityType.singularUpper()} with ${identifierType.displayName} '$identifier' already exists.",
-    ) {
-        class UserEmail(
-            email: String,
-        ) : DuplicateEntityException(EntityType.USER, email, IdentifierType.EMAIL)
-    }
+    )
 
     /**
      * Represents an exception that occurs when an entity creation was triggered, but it couldn't be fetched afterward.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -6,7 +6,6 @@ package se.uulm.snowballr.backend.model
  * Used to encapsulate specific error details and provide a consistent exception structure.
  * Can be extended to create more detailed exceptions specific to various error scenarios.
  *
- * @constructor Creates an instance of [SnowballRException] with an optional message and cause.
  * @param message Detailed message describing the reason for the exception, or null if not provided.
  * @param cause The cause of the exception, which can be another exception, or null if not provided.
  */
@@ -17,7 +16,6 @@ sealed class SnowballRException(
     /**
      * Represents an exception that occurs when an entity cannot be found by its identifier.
      *
-     * @constructor Creates a [NotFoundException] with the type and ID of the missing entity.
      * @param entityType The type of the entity that could not be found.
      * @param entityId The unique identifier of the missing entity.
      * @param identifierType The type of the [identifierType] field. Default to [IdentifierType.ID].
@@ -32,7 +30,6 @@ sealed class SnowballRException(
      * Represents an exception that occurs when an entity already exists in the system
      * and creation is not allowed.
      *
-     * @constructor Creates a [DuplicateEntityException] with a message about the entity.
      * @param entityType The type of the duplicated entity.
      * @param identifier The identifying value (e.g., email, username).
      * @param identifierType The type of the [identifier] field. Default to [IdentifierType.ID].
@@ -48,7 +45,6 @@ sealed class SnowballRException(
     /**
      * Represents an exception that occurs when an entity creation was triggered, but it couldn't be fetched afterward.
      *
-     * @constructor Creates a [EntityNotPersistedException] with the type and ID of the not persisted entity.
      * @param entityType The type of the entity that was not persisted.
      * @param entityId The unique identifier of the not persisted entity.
      */
@@ -58,18 +54,24 @@ sealed class SnowballRException(
     ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.")
 
     /**
-     * Represents an exception that occurs when the current user accesses one or more entities, but they don't have the
-     * required permission.
+     * Represents an exception that occurs when the current user accesses one or more entities without permission.
      *
-     * @constructor Creates an [UnauthorizedException] with the current user's ID, the type and ID of the accessed
-     * entity.
-     * @param currentUserId The ID of the user that is accessing the entity.
+     * @param currentUserId The ID of the user that is accessing the entity/entities.
      * @param accessedEntityMessage The message of what is accessed.
      */
     sealed class UnauthorizedException(
         currentUserId: String,
         accessedEntityMessage: String,
     ) : SnowballRException("User with ID '$currentUserId' is not authorized to access $accessedEntityMessage") {
+        /**
+         * Represents an [UnauthorizedException] that occurs when the current user accesses a single entity without
+         * permission.
+         *
+         * @param currentUserId The ID of the user that is accessing the entity.
+         * @param accessedEntityType The type of the entity that was accessed without permission.
+         * @param accessedEntityId The ID of the entity that was accessed without permission.
+         * @param identifierType The type of the identifier used to access the entity.
+         */
         class Single(
             currentUserId: String,
             accessedEntityType: EntityType,
@@ -80,6 +82,13 @@ sealed class SnowballRException(
             "${accessedEntityType.singular} with ${identifierType.displayName} '$accessedEntityId'.",
         )
 
+        /**
+         * Represents an [UnauthorizedException] that occurs when the current user accesses several entities without
+         * permission.
+         *
+         * @param currentUserId The ID of the user that is accessing the entities.
+         * @param accessedEntityType The type of the entities that were accessed without permission.
+         */
         class All(
             currentUserId: String,
             accessedEntityType: EntityType,
@@ -87,9 +96,8 @@ sealed class SnowballRException(
     }
 
     /**
-     * Represents a specific type of exception that occurs when an ID is in an invalid format.
+     * Represents an exception that occurs when an ID is in an invalid format.
      *
-     * @constructor Creates an [InvalidIdException] with the value and format of the invalid ID.
      * @param id The value of the invalid ID.
      * @param entityType The type of the entity to which the ID belongs to.
      * @param format The format that the ID should've had.
@@ -99,6 +107,12 @@ sealed class SnowballRException(
         entityType: EntityType,
         format: String,
     ) : SnowballRException("The ID '$id' of the ${entityType.singular} is not a valid $format.") {
+        /**
+         * Represents an [InvalidIdException] that occurs when a [UUID] is in an invalid format.
+         *
+         * @param id The value of the invalid [UUID].
+         * @param entityType The type of the entity to which the [UUID] belongs to.
+         */
         class UUID(
             id: String,
             entityType: EntityType,
@@ -111,14 +125,19 @@ sealed class SnowballRException(
      * This may indicate a misconfigured interceptor, a bug in the server flow,
      * or a misuse of context propagation.
      *
-     * @constructor Creates a [MissingContextException] with a description of the missing value.
      * @param keyDescription A human-readable description of the missing key or context value.
      */
     sealed class MissingContextException(
         keyDescription: String,
     ) : SnowballRException("Missing context value: $keyDescription") {
+        /**
+         * Represents a [MissingContextException] that occurs when the user ID is missing in the context.
+         */
         class MissingUserId : MissingContextException("Authenticated user ID")
 
+        /**
+         * Represents a [MissingContextException] that occurs when the cookies map is missing in the context.
+         */
         class MissingCookiesMap : MissingContextException("Cookie map")
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -27,18 +27,18 @@ sealed class SnowballRException(
      * @param identifier The name of the identifier. Defaults to 'ID'.
      */
     sealed class NotFoundException(
-        entityType: String,
+        entityType: EntityType,
         entityId: String,
         identifier: String? = "ID",
-    ) : SnowballRException("$entityType with $identifier '$entityId' not found.") {
+    ) : SnowballRException("${entityType.singularUpper()} with $identifier '$entityId' not found.") {
         class Project(
             projectId: String,
-        ) : NotFoundException("Project", projectId)
+        ) : NotFoundException(EntityType.PROJECT, projectId)
 
         class User(
             userId: String,
             identifier: String? = "ID",
-        ) : NotFoundException("User", userId, identifier)
+        ) : NotFoundException(EntityType.USER, userId, identifier)
     }
 
     /**
@@ -51,13 +51,13 @@ sealed class SnowballRException(
      * @param identifierName The name of the identifier field (defaults to "ID").
      */
     sealed class DuplicateEntityException(
-        entityType: String,
+        entityType: EntityType,
         identifier: String,
         identifierName: String = "ID",
-    ) : SnowballRException("$entityType with $identifierName '$identifier' already exists.") {
+    ) : SnowballRException("${entityType.singularUpper()} with $identifierName '$identifier' already exists.") {
         class UserEmail(
             email: String,
-        ) : DuplicateEntityException("User", email, "email")
+        ) : DuplicateEntityException(EntityType.USER, email, "email")
     }
 
     /**
@@ -69,24 +69,24 @@ sealed class SnowballRException(
      * @param entityId The unique identifier of the not persisted entity.
      */
     sealed class EntityNotPersistedException(
-        entityType: String,
+        entityType: EntityType,
         entityId: String,
-    ) : SnowballRException("$entityType with ID '$entityId' was not persisted.") {
+    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.") {
         class Project(
             projectId: String,
-        ) : EntityNotPersistedException("Project", projectId)
+        ) : EntityNotPersistedException(EntityType.PROJECT, projectId)
 
         class Criterion(
             criterionId: String,
-        ) : EntityNotPersistedException("Criterion", criterionId)
+        ) : EntityNotPersistedException(EntityType.CRITERION, criterionId)
 
         class ProjectMember(
             projectMemberId: String,
-        ) : EntityNotPersistedException("ProjectMember", projectMemberId)
+        ) : EntityNotPersistedException(EntityType.PROJECT_MEMBER, projectMemberId)
 
         class User(
             userId: String,
-        ) : EntityNotPersistedException("User", userId)
+        ) : EntityNotPersistedException(EntityType.USER, userId)
     }
 
     /**
@@ -109,28 +109,31 @@ sealed class SnowballRException(
     ) : SnowballRException("User with ID '$currentUserId' is not authorized to access $accessedEntityMessage") {
         sealed class Single(
             currentUserId: String,
-            accessedEntityType: String,
+            accessedEntityType: EntityType,
             accessedEntityId: String,
             identifier: String? = "ID",
-        ) : UnauthorizedException(currentUserId, "$accessedEntityType with $identifier '$accessedEntityId'.") {
+        ) : UnauthorizedException(
+            currentUserId,
+            "${accessedEntityType.singular} with $identifier '$accessedEntityId'.",
+        ) {
             class User(
                 currentUserId: String,
                 identifier: String? = "ID",
                 accessedUserId: String,
-            ) : Single(currentUserId, "user", accessedUserId, identifier)
+            ) : Single(currentUserId, EntityType.USER, accessedUserId, identifier)
         }
 
         sealed class All(
             currentUserId: String,
-            accessedEntityType: String,
-        ) : UnauthorizedException(currentUserId, "all $accessedEntityType.") {
+            accessedEntityType: EntityType,
+        ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.") {
             class User(
                 currentUserId: String,
-            ) : All(currentUserId, "users")
+            ) : All(currentUserId, EntityType.USER)
 
             class Project(
                 currentUserId: String,
-            ) : All(currentUserId, "projects")
+            ) : All(currentUserId, EntityType.PROJECT)
         }
     }
 
@@ -144,12 +147,12 @@ sealed class SnowballRException(
      */
     sealed class InvalidIdException(
         id: String,
-        entityType: String,
+        entityType: EntityType,
         format: String,
-    ) : SnowballRException("The ID '$id' of the $entityType is not a valid $format.") {
+    ) : SnowballRException("The ID '$id' of the ${entityType.singular} is not a valid $format.") {
         class UUID(
             id: String,
-            entityType: String,
+            entityType: EntityType,
         ) : InvalidIdException(id, entityType, "UUID")
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -60,16 +60,10 @@ sealed class SnowballRException(
     ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.")
 
     /**
-     * Represents a specific type of exception that occurs when an entity is accessed by
-     * the current user, but they are not authorized.
+     * Represents an exception that occurs when an entity is accessed by the current user, but they are not authorized.
      *
-     * This exception is intended to provide a clear and structured way to handle
-     * scenarios where a particular entity is accessed without permission.
-     * It serves as a base class to define more specific "unauthorized" exceptions for
-     * various entities.
-     *
-     * @constructor Creates an [UnauthorizedException] with the current user's ID, the
-     * type and ID of the accessed entity.
+     * @constructor Creates an [UnauthorizedException] with the current user's ID, the type and ID of the accessed
+     * entity.
      * @param currentUserId The ID of the user that is accessing the entity.
      * @param accessedEntityMessage The message of what is accessed.
      */
@@ -77,7 +71,7 @@ sealed class SnowballRException(
         currentUserId: String,
         accessedEntityMessage: String,
     ) : SnowballRException("User with ID '$currentUserId' is not authorized to access $accessedEntityMessage") {
-        sealed class Single(
+        class Single(
             currentUserId: String,
             accessedEntityType: EntityType,
             accessedEntityId: String,
@@ -85,13 +79,7 @@ sealed class SnowballRException(
         ) : UnauthorizedException(
             currentUserId,
             "${accessedEntityType.singular} with $identifier '$accessedEntityId'.",
-        ) {
-            class User(
-                currentUserId: String,
-                identifier: String? = "ID",
-                accessedUserId: String,
-            ) : Single(currentUserId, EntityType.USER, accessedUserId, identifier)
-        }
+        )
 
         sealed class All(
             currentUserId: String,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -48,33 +48,16 @@ sealed class SnowballRException(
     }
 
     /**
-     * Represents a specific type of exception that occurs when an entity creation was triggered, but it couldn't be
-     * fetched afterward.
+     * Represents an exception that occurs when an entity creation was triggered, but it couldn't be fetched afterward.
      *
      * @constructor Creates a [EntityNotPersistedException] with the type and ID of the not persisted entity.
      * @param entityType The type of the entity that was not persisted.
      * @param entityId The unique identifier of the not persisted entity.
      */
-    sealed class EntityNotPersistedException(
+    class EntityNotPersistedException(
         entityType: EntityType,
         entityId: String,
-    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.") {
-        class Project(
-            projectId: String,
-        ) : EntityNotPersistedException(EntityType.PROJECT, projectId)
-
-        class Criterion(
-            criterionId: String,
-        ) : EntityNotPersistedException(EntityType.CRITERION, criterionId)
-
-        class ProjectMember(
-            projectMemberId: String,
-        ) : EntityNotPersistedException(EntityType.PROJECT_MEMBER, projectMemberId)
-
-        class User(
-            userId: String,
-        ) : EntityNotPersistedException(EntityType.USER, userId)
-    }
+    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.")
 
     /**
      * Represents a specific type of exception that occurs when an entity is accessed by

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -67,15 +67,15 @@ sealed class SnowballRException(
          * Represents an [UnauthorizedException] that occurs when the current user accesses a single entity without
          * permission.
          *
-         * @param currentUserId The ID of the user that is accessing the entity.
          * @param accessedEntityType The type of the entity that was accessed without permission.
          * @param accessedEntityId The ID of the entity that was accessed without permission.
+         * @param currentUserId The ID of the user that is accessing the entity.
          * @param identifierType The type of the identifier used to access the entity.
          */
         class Single(
-            currentUserId: String,
             accessedEntityType: EntityType,
             accessedEntityId: String,
+            currentUserId: String,
             identifierType: IdentifierType = IdentifierType.ID,
         ) : UnauthorizedException(
             currentUserId,
@@ -86,37 +86,37 @@ sealed class SnowballRException(
          * Represents an [UnauthorizedException] that occurs when the current user accesses several entities without
          * permission.
          *
-         * @param currentUserId The ID of the user that is accessing the entities.
          * @param accessedEntityType The type of the entities that were accessed without permission.
+         * @param currentUserId The ID of the user that is accessing the entities.
          */
         class All(
-            currentUserId: String,
             accessedEntityType: EntityType,
+            currentUserId: String,
         ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.")
     }
 
     /**
      * Represents an exception that occurs when an ID is in an invalid format.
      *
-     * @param id The value of the invalid ID.
      * @param entityType The type of the entity to which the ID belongs to.
+     * @param entityId The value of the invalid ID.
      * @param format The format that the ID should've had.
      */
     sealed class InvalidIdException(
-        id: String,
         entityType: EntityType,
+        entityId: String,
         format: String,
-    ) : SnowballRException("The ID '$id' of the ${entityType.singular} is not a valid $format.") {
+    ) : SnowballRException("The ID '$entityId' of the ${entityType.singular} is not a valid $format.") {
         /**
          * Represents an [InvalidIdException] that occurs when a [UUID] is in an invalid format.
          *
-         * @param id The value of the invalid [UUID].
          * @param entityType The type of the entity to which the [UUID] belongs to.
+         * @param id The value of the invalid [UUID].
          */
         class UUID(
-            id: String,
             entityType: EntityType,
-        ) : InvalidIdException(id, entityType, "UUID")
+            id: String,
+        ) : InvalidIdException(entityType, id, "UUID")
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -15,31 +15,18 @@ sealed class SnowballRException(
     cause: Throwable? = null,
 ) : RuntimeException(message, cause) {
     /**
-     * Represents a specific type of exception that occurs when an entity cannot be found.
-     *
-     * This exception is intended to provide a clear and structured way to handle
-     * scenarios where a particular entity, identified by its type and ID, is not found.
-     * It serves as a base class to define more specific "not found" exceptions for various entities.
+     * Represents an exception that occurs when an entity cannot be found by its identifier.
      *
      * @constructor Creates a [NotFoundException] with the type and ID of the missing entity.
      * @param entityType The type of the entity that could not be found.
      * @param entityId The unique identifier of the missing entity.
      * @param identifier The name of the identifier. Defaults to 'ID'.
      */
-    sealed class NotFoundException(
+    open class NotFoundException(
         entityType: EntityType,
         entityId: String,
         identifier: String? = "ID",
-    ) : SnowballRException("${entityType.singularUpper()} with $identifier '$entityId' not found.") {
-        class Project(
-            projectId: String,
-        ) : NotFoundException(EntityType.PROJECT, projectId)
-
-        class User(
-            userId: String,
-            identifier: String? = "ID",
-        ) : NotFoundException(EntityType.USER, userId, identifier)
-    }
+    ) : SnowballRException("${entityType.singularUpper()} with $identifier '$entityId' not found.")
 
     /**
      * Represents an exception that occurs when an entity already exists in the system

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.parseUUID
@@ -45,7 +46,7 @@ class CriterionTableRepo(
 ) : ICriterionTableRepo {
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =
         db.dbQuery {
-            val projectUUID = parseUUID(request.projectId, "project")
+            val projectUUID = parseUUID(request.projectId, EntityType.PROJECT)
 
             // Get user reference
             val userEntityId = getUserEntityId(userId)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.repository
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.CriterionTable
@@ -54,7 +53,7 @@ class CriterionTableRepo(
             // Get project reference
             val projectEntityId = getProjectEntityId(projectUUID)
 
-            CriterionTable.insertAndGet(ResultRow::toCriterion, { EntityNotPersistedException.Criterion(it) }) {
+            CriterionTable.insertAndGet(ResultRow::toCriterion, EntityType.CRITERION) {
                 it[tag] = request.tag
                 it[name] = request.name
                 it[description] = request.description

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -4,8 +4,8 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.FetcherApi
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.getUserEntityId
@@ -55,7 +55,7 @@ class ProjectTableRepo(
         // Get user reference
         val userEntityId = getUserEntityId(userId)
 
-        ProjectTable.insertAndGet(ResultRow::toProject, { EntityNotPersistedException.Project(it) }) {
+        ProjectTable.insertAndGet(ResultRow::toProject, EntityType.PROJECT) {
             it[name] = request.name
             it[status] = ProjectStatus.PROJECT_STATUS_ACTIVE
             it[currentStage] = 0

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -17,7 +17,8 @@ import java.util.UUID
  * @param T The table type as a subtype of [IdTable].
  * @param EntT The result entity type.
  * @param mapper Mapping function of the [ResultRow] to the entity type [EntT].
- * @param entityType The [EntityNotPersistedException], which is thrown when the entity cannot be retrieved by its ID.
+ * @param entityType The entity type used for the [EntityNotPersistedException], which is thrown when the entity cannot
+ * be retrieved by its ID.
  * @param body The body that is passed to [insertAndGetId].
  */
 inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.insertAndGet(

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.statements.InsertStatement
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import java.util.UUID
 
@@ -16,13 +17,12 @@ import java.util.UUID
  * @param T The table type as a subtype of [IdTable].
  * @param EntT The result entity type.
  * @param mapper Mapping function of the [ResultRow] to the entity type [EntT].
- * @param getException Getter method for the subtype of [EntityNotPersistedException], which is thrown when the entity
- * cannot be retrieved by its ID.
+ * @param entityType The [EntityNotPersistedException], which is thrown when the entity cannot be retrieved by its ID.
  * @param body The body that is passed to [insertAndGetId].
  */
 inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.insertAndGet(
     mapper: (ResultRow) -> EntT,
-    getException: (String) -> EntityNotPersistedException,
+    entityType: EntityType,
     crossinline body: T.(InsertStatement<EntityID<Key>>) -> Unit,
 ): EntT {
     val id = this.insertAndGetId(body).value
@@ -31,5 +31,5 @@ inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.insertAndGet(
         .where { this@insertAndGet.id eq id }
         .map { mapper.invoke(it) }
         .singleOrNull()
-        ?: throw getException(id.toString())
+        ?: throw EntityNotPersistedException(entityType, id.toString())
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -4,7 +4,6 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.table.UserTable
@@ -101,7 +100,7 @@ class UserTableRepo(
     }
 
     override suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User = db.dbQuery {
-        UserTable.insertAndGet(ResultRow::toUser, { EntityNotPersistedException.User(it) }) {
+        UserTable.insertAndGet(ResultRow::toUser, EntityType.USER) {
             it[email] = request.email
             it[firstName] = request.firstName
             it[lastName] = request.lastName

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.repository
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
@@ -22,12 +23,12 @@ import java.util.UUID
  */
 interface IUserTableRepo {
     /**
-     * Returns a user by its id or throws a [NotFoundException.User] if the user with the passed [id] doesn't exist.
+     * Returns a user by its id or throws a [NotFoundException] if the user with the passed [id] doesn't exist.
      */
     suspend fun getUserById(id: UUID): User
 
     /**
-     * Returns a user by its email or throws a [NotFoundException.User] if the user with the passed [email] doesn't
+     * Returns a user by its email or throws a [NotFoundException] if the user with the passed [email] doesn't
      * exist.
      */
     suspend fun getUserByEmail(email: String): User
@@ -73,7 +74,7 @@ class UserTableRepo(
             .where { UserTable.id eq id }
             .map { it.toUser() }
             .singleOrNull()
-            ?: throw NotFoundException.User(id.toString())
+            ?: throw NotFoundException(EntityType.USER, id.toString())
     }
 
     override suspend fun getUserByEmail(email: String): User = db.dbQuery {
@@ -82,7 +83,7 @@ class UserTableRepo(
             .where { UserTable.email eq email }
             .map { it.toUser() }
             .singleOrNull()
-            ?: throw NotFoundException.User(email, "email")
+            ?: throw NotFoundException(EntityType.USER, email, "email")
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.dbQuery {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.table.UserTable
@@ -82,7 +83,7 @@ class UserTableRepo(
             .where { UserTable.email eq email }
             .map { it.toUser() }
             .singleOrNull()
-            ?: throw NotFoundException(EntityType.USER, email, "email")
+            ?: throw NotFoundException(EntityType.USER, email, IdentifierType.EMAIL)
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.dbQuery {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
@@ -70,7 +70,7 @@ class ProjectMemberTableRepo(
             return@dbQuery existingMember
         }
 
-        ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, { EntityNotPersistedException.ProjectMember(it) }) {
+        ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, EntityType.PROJECT_MEMBER) {
             it[this.userId] = userEntityId
             it[this.projectId] = projectEntityId
             it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
@@ -29,7 +30,7 @@ class CriterionService(
 ) : ICriterionService {
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion {
         // TODO: remove dummy user when user management is implemented
-        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         return repo.createCriterion(request, requestingUserId).toGrpcCriterion()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -46,7 +45,7 @@ class ProjectService(
         val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
-        verifyServerAdminRole(currentUser) { UnauthorizedException.All.Project(it) }
+        verifyServerAdminRole(currentUser, EntityType.PROJECT)
 
         val projects = repo.getAllProjects()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.parseUUID
@@ -37,12 +38,12 @@ class ProjectService(
 ) : IProjectService {
     override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project {
         // TODO: remove dummy user when user management is implemented
-        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         return repo.createProject(request, requestingUserId).toGrpcProject()
     }
 
     override suspend fun getAllProjects(): ProjectOuterClass.Project.List {
-        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
         verifyServerAdminRole(currentUser) { UnauthorizedException.All.Project(it) }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.service
 
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.dto.User
 import snowballr.UserOuterClass.UserRole
@@ -10,11 +11,10 @@ import snowballr.UserOuterClass.UserRole
  * If the user is not a server admin, a [SnowballRException.UnauthorizedException.All] is thrown.
  *
  * @param user The user to verify
- * @param getException Getter method for the subtype of [SnowballRException.UnauthorizedException.All], which is thrown
- * when the user is not a server admin.
+ * @param entityType The entity type of the accessed entity.
  */
-fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRException.UnauthorizedException.All) {
+fun verifyServerAdminRole(user: User, entityType: EntityType) {
     if (user.role != UserRole.USER_ROLE_ADMIN) {
-        throw getException(user.id.toString())
+        throw SnowballRException.UnauthorizedException.All(user.id.toString(), entityType)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -15,6 +15,6 @@ import snowballr.UserOuterClass.UserRole
  */
 fun verifyServerAdminRole(user: User, entityType: EntityType) {
     if (user.role != UserRole.USER_ROLE_ADMIN) {
-        throw SnowballRException.UnauthorizedException.All(user.id.toString(), entityType)
+        throw SnowballRException.UnauthorizedException.All(entityType, user.id.toString())
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -57,7 +58,7 @@ class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IUserService {
-    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: UUID, identifier: String) {
+    private suspend fun verifyUserAccess(currentUser: User, requestedUserId: UUID, identifierType: IdentifierType) {
         // Check whether requesting user is server admin
         if (currentUser.role == UserRole.USER_ROLE_ADMIN) return
 
@@ -75,8 +76,8 @@ class UserService(
         throw UnauthorizedException.Single(
             currentUser.id.toString(),
             EntityType.USER,
-            identifier,
             requestedUserId.toString(),
+            identifierType,
         )
     }
 
@@ -85,7 +86,7 @@ class UserService(
         val requestedUserId = parseUUID(request.id, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
-        verifyUserAccess(currentUser, requestingUserId, "ID")
+        verifyUserAccess(currentUser, requestingUserId, IdentifierType.ID)
 
         val isRequestedUser = requestingUserId == currentUser.id
 
@@ -114,13 +115,13 @@ class UserService(
         // We have to request the user first to get the ID for the access checks
         val requestedUser = userRepo.getUserByEmail(request.email)
 
-        verifyUserAccess(currentUser, requestingUserId, "email")
+        verifyUserAccess(currentUser, requestingUserId, IdentifierType.EMAIL)
 
         // Only active or active unconfirmed users can be retrieved
         if (requestedUser.status != UserStatus.USER_STATUS_ACTIVE &&
             requestedUser.status != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
         ) {
-            throw NotFoundException(EntityType.USER, request.email, "email")
+            throw NotFoundException(EntityType.USER, request.email, IdentifierType.EMAIL)
         }
 
         return requestedUser.toGrpcUser()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -74,9 +74,9 @@ class UserService(
 
         // Requesting user is not authorized
         throw UnauthorizedException.Single(
-            currentUser.id.toString(),
             EntityType.USER,
             requestedUserId.toString(),
+            currentUser.id.toString(),
             identifierType,
         )
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -143,7 +143,7 @@ class UserService(
     override suspend fun register(request: Authentication.RegisterRequest): JwtTokens {
         // Check whether a user with the given email already exists
         if (userRepo.doesUserExistByEmail(request.email)) {
-            throw DuplicateEntityException.UserEmail(request.email)
+            throw DuplicateEntityException(EntityType.USER, request.email, IdentifierType.EMAIL)
         }
 
         // Hash the password and create the user

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -130,7 +130,7 @@ class UserService(
         val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
-        verifyServerAdminRole(currentUser) { UnauthorizedException.All.User(it) }
+        verifyServerAdminRole(currentUser, EntityType.USER)
 
         val users = userRepo.getAllUsers()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -96,7 +96,7 @@ class UserService(
         if (result.status != UserStatus.USER_STATUS_ACTIVE &&
             result.status != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
         ) {
-            throw NotFoundException.User(request.id)
+            throw NotFoundException(EntityType.USER, request.id)
         }
 
         return result.toGrpcUser()
@@ -115,7 +115,7 @@ class UserService(
         if (requestedUser.status != UserStatus.USER_STATUS_ACTIVE &&
             requestedUser.status != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
         ) {
-            throw NotFoundException.User(request.email, "email")
+            throw NotFoundException(EntityType.USER, request.email, "email")
         }
 
         return requestedUser.toGrpcUser()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -4,6 +4,7 @@ import se.uulm.snowballr.backend.auth.JwtUtils
 import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -75,8 +76,8 @@ class UserService(
     }
 
     override suspend fun getUserById(request: Base.Id): UserOuterClass.User {
-        val requestingUserId = parseUUID(dummyUserId!!, "user")
-        val requestedUserId = parseUUID(request.id, "user")
+        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
+        val requestedUserId = parseUUID(request.id, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
         verifyUserAccess(currentUser, requestingUserId, "ID")
@@ -102,7 +103,7 @@ class UserService(
     }
 
     override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User {
-        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
         // We have to request the user first to get the ID for the access checks
@@ -121,7 +122,7 @@ class UserService(
     }
 
     override suspend fun getAllUsers(): UserOuterClass.User.List {
-        val requestingUserId = parseUUID(dummyUserId!!, "user")
+        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         val currentUser = userRepo.getUserById(requestingUserId)
 
         verifyServerAdminRole(currentUser) { UnauthorizedException.All.User(it) }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -72,7 +72,12 @@ class UserService(
         if (isInSameProject) return
 
         // Requesting user is not authorized
-        throw UnauthorizedException.Single.User(currentUser.id.toString(), identifier, requestedUserId.toString())
+        throw UnauthorizedException.Single(
+            currentUser.id.toString(),
+            EntityType.USER,
+            identifier,
+            requestedUserId.toString(),
+        )
     }
 
     override suspend fun getUserById(request: Base.Id): UserOuterClass.User {

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/TableHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/TableHelper.kt
@@ -2,11 +2,12 @@ package se.uulm.snowballr.backend.table
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import java.util.UUID
 
 /**
- * Returns the entity ID of the entity with the given [id] or `null` if no such entity exists.
+ * Returns the entity ID of the entity with the given [id] or throws a [NotFoundException] if no such entity exists.
  * This can be used to reference the entity in other table rows.
  *
  * Example:
@@ -14,27 +15,28 @@ import java.util.UUID
  * to get the [EntityID] and then pass it to the `entity_id` column of table A.
  *
  * @param id The ID of the entity as [String].
- * @return The ID of the entity as [EntityID], or null if no entity exists.
+ * @param entityType The type of the entity.
+ * @return The ID of the entity as [EntityID].
  */
-fun UUIDTable.getEntityId(id: UUID): EntityID<UUID>? = this
+private fun UUIDTable.getEntityId(id: UUID, entityType: EntityType): EntityID<UUID> = this
     .select(this.id)
     .where { this@getEntityId.id eq id }
     .map { it[this.id] }
     .singleOrNull()
+    ?: throw NotFoundException(entityType, id.toString())
 
 /**
- * Returns the entity ID of the user with the passed [id] or throws a [NotFoundException.User] if the user doesn't
+ * Returns the entity ID of the user with the passed [id] or throws a [NotFoundException] if the user doesn't
  * exist.
  *
  * @see getEntityId
  */
-fun getUserEntityId(id: UUID): EntityID<UUID> = UserTable.getEntityId(id) ?: throw NotFoundException.User(id.toString())
+fun getUserEntityId(id: UUID): EntityID<UUID> = UserTable.getEntityId(id, EntityType.USER)
 
 /**
- * Returns the entity ID of the project with the passed [id] or throws a [NotFoundException.Project] if the project
+ * Returns the entity ID of the project with the passed [id] or throws a [NotFoundException] if the project
  * doesn't exist.
  *
  * @see getEntityId
  */
-fun getProjectEntityId(id: UUID): EntityID<UUID> =
-    ProjectTable.getEntityId(id) ?: throw NotFoundException.Project(id.toString())
+fun getProjectEntityId(id: UUID): EntityID<UUID> = ProjectTable.getEntityId(id, EntityType.PROJECT)

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/ParserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/ParserTest.kt
@@ -11,13 +11,13 @@ class ParserTest {
         @Test
         fun `When a valid UUID is passed, then it is correctly parsed`() {
             val uuid = "123e4567-e89b-12d3-a456-426614174000"
-            assertDoesNotThrow { parseUUID(uuid, "test") }
+            assertDoesNotThrow { parseUUID(uuid, EntityType.USER) }
         }
 
         @Test
         fun `When an invalid UUID is passed, then an exception is thrown`() {
             val uuid = "invalid-uuid"
-            assertThrows<SnowballRException.InvalidIdException.UUID> { parseUUID(uuid, "test") }
+            assertThrows<SnowballRException.InvalidIdException.UUID> { parseUUID(uuid, EntityType.USER) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -69,7 +69,7 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
                     .setProjectId(UUID.randomUUID().toString())
                     .build()
 
-            assertThrows<NotFoundException.Project> { repo.createCriterion(request, testUserId) }
+            assertThrows<NotFoundException> { repo.createCriterion(request, testUserId) }
         }
 
         @Test
@@ -105,7 +105,7 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
                     .setProjectId(UUID.randomUUID().toString())
                     .build()
 
-            assertThrows<NotFoundException.User> { repo.createCriterion(request, UUID.randomUUID()) }
+            assertThrows<NotFoundException> { repo.createCriterion(request, UUID.randomUUID()) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -72,7 +72,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
         fun `When a project is created, but the assigned user doesn't exist, then an exception is thrown`() =
             testCoroutine {
                 val request = Project.Create.newBuilder().setName("Test Project").build()
-                assertThrows<NotFoundException.User> { repo.createProject(request, UUID.randomUUID()) }
+                assertThrows<NotFoundException> { repo.createProject(request, UUID.randomUUID()) }
             }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -52,7 +52,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
 
         @Test
         fun `When a user is not found, then an exception is thrown`() = testCoroutine {
-            assertThrows<NotFoundException.User> { repo.getUserById(UUID.randomUUID()) }
+            assertThrows<NotFoundException> { repo.getUserById(UUID.randomUUID()) }
         }
     }
 
@@ -85,7 +85,7 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
 
         @Test
         fun `When a user is not found, then an exception is thrown`() = testCoroutine {
-            assertThrows<NotFoundException.User> { repo.getUserByEmail("non-existing email") }
+            assertThrows<NotFoundException> { repo.getUserByEmail("non-existing email") }
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -101,7 +101,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
 
         @Test
         fun `When a user is added to a non-existing project, then an exception is thrown`() = testCoroutine {
-            assertThrows<NotFoundException.Project> {
+            assertThrows<NotFoundException> {
                 repo.addUserToProject(testUserId, UUID.randomUUID())
             }
         }
@@ -110,7 +110,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         fun `When a non-existing user is added to a project, then an exception is thrown`() = testCoroutine {
             val project = createExampleProject()
 
-            assertThrows<NotFoundException.User> {
+            assertThrows<NotFoundException> {
                 repo.addUserToProject(UUID.randomUUID(), project.id)
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.UserOuterClass.UserRole
@@ -17,17 +18,13 @@ class ServiceChecksTest {
         @GrpcEnumSourceTest(UserRole::class, excludes = ["USER_ROLE_ADMIN"])
         fun `When the user is not a server admin, then an exception is thrown`(role: UserRole) {
             val user = DataBuilder.createExampleUser(role = role)
-            assertThrows<UnauthorizedException.All.User> {
-                verifyServerAdminRole(user) { UnauthorizedException.All.User(it) }
-            }
+            assertThrows<UnauthorizedException.All> { verifyServerAdminRole(user, EntityType.PROJECT) }
         }
 
         @Test
         fun `When the user is a server admin, then no exception is thrown`() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            assertDoesNotThrow {
-                verifyServerAdminRole(user) { UnauthorizedException.All.User(it) }
-            }
+            assertDoesNotThrow { verifyServerAdminRole(user, EntityType.PROJECT) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -41,7 +41,7 @@ internal class GetAllProjectsTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
         coEvery { projectRepoMock.getAllProjects() } returns emptyList()
 
-        assertThrows<UnauthorizedException.All.Project> { mainService.getAllProjects() }
+        assertThrows<UnauthorizedException.All> { mainService.getAllProjects() }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -59,7 +59,7 @@ class GetAllUsersTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns nonAdminUser
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
-        assertThrows<UnauthorizedException.All.User> { mainService.getAllUsers() }
+        assertThrows<UnauthorizedException.All> { mainService.getAllUsers() }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -63,7 +63,7 @@ class GetUserByEmailTest : MainServiceTest() {
         coEvery { userRepoMock.getUserByEmail(requestEmail) } returns DataBuilder.createExampleUser()
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
-        assertThrows<UnauthorizedException.Single.User> { mainService.getUserByEmail(request) }
+        assertThrows<UnauthorizedException.Single> { mainService.getUserByEmail(request) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -153,7 +153,7 @@ class GetUserByEmailTest : MainServiceTest() {
             coEvery { userRepoMock.getUserByEmail(requestEmail) } returns user
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
-            assertThrows<NotFoundException.User> { mainService.getUserByEmail(request) }
+            assertThrows<NotFoundException> { mainService.getUserByEmail(request) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -73,7 +73,7 @@ class GetUserByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } returns listOf()
 
-        assertThrows<UnauthorizedException.Single.User> { mainService.getUserById(request) }
+        assertThrows<UnauthorizedException.Single> { mainService.getUserById(request) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -187,7 +187,7 @@ class GetUserByIdTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(status = status)
             coEvery { userRepoMock.getUserById(requestId) } returns user
 
-            assertThrows<NotFoundException.User> { mainService.getUserById(request) }
+            assertThrows<NotFoundException> { mainService.getUserById(request) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -71,7 +71,7 @@ class RegisterTest : MainServiceTest(), KoinTest {
 
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
 
-        assertThrows<SnowballRException.DuplicateEntityException.UserEmail> { mainService.register(request) }
+        assertThrows<SnowballRException.DuplicateEntityException> { mainService.register(request) }
     }
 
     @Test


### PR DESCRIPTION
Closes #129

## What I have made

Instead of having entity subtypes for each entity, we now can parameterize the exception type.
This especially benefits us when writing helper methods that throw such exceptions. See the `verifyServerAdminRole` method, which doesn't have to accept a getter method anymore, but can just use the entity type to create an exception itself. The `insertAndGet` method in #68 will benefit from this too.

This also has the advantage that we cannot pass any string as an entity type, but now have constant enum values for this.

The minor disadvantage that comes with this, is that we don't check for a specific exception type in the tests anymore. I think this is fine, as the use case exception type, i.e., the direct child classes of `SnowballRException`, e.g. `NotFoundException`, are most important to test.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only type refactoring)
- [x] (for reviewer) I have checked the implementation against the requirements
