### PR TITLE
Add user projects retrieval

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -263,16 +263,16 @@ class SnowballRServer(
             super.getAllDeletedProjects(request)
 
         override suspend fun getAllDeletedProjectsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            super.getAllDeletedProjectsForUser(request)
+            mainService.getAllDeletedProjectsForUser(request)
 
         override suspend fun getAllArchivedProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
             super.getAllArchivedProjects(request)
 
         override suspend fun getAllProjectsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            super.getAllProjectsForUser(request)
+            mainService.getAllProjectsForUser(request)
 
         override suspend fun getAllArchivedProjectsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            super.getAllArchivedProjectsForUser(request)
+            mainService.getAllArchivedProjectsForUser(request)
 
         override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project =
             mainService.createProject(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
@@ -57,3 +57,12 @@ fun Project.toGrpcProject(): ProjectOuterClass.Project {
         .setSettings(settings)
         .build()
 }
+
+/**
+ * Creates a list of [ProjectOuterClass.Project]s from this list of [Project]s.
+ */
+fun List<Project>.toGrpcProjects(): ProjectOuterClass.Project.List {
+    val builder = ProjectOuterClass.Project.List.newBuilder()
+    this.forEach { builder.addProjects(it.toGrpcProject()) }
+    return builder.build()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
@@ -8,6 +9,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.FetcherApi
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.getUserEntityId
 import se.uulm.snowballr.backend.table.toProject
 import snowballr.ProjectOuterClass
@@ -37,6 +39,23 @@ interface IProjectTableRepo {
      * Returns all active projects stored in the database.
      */
     suspend fun getAllProjects(): List<Project>
+
+    /**
+     * Retrieves a list of projects from the database in which the user with the specified [userId] is a member.
+     *
+     * @param userId The unique identifier of the user whose associated projects are to be fetched.
+     * @param statusFilter (optional) Filter to specify which project status the fetched projects should have.
+     *        By default, [ProjectStatus.PROJECT_STATUS_ACTIVE] is used, which includes both active
+     *        and active-locked projects.
+     *        If set to another value (e.g., [ProjectStatus.PROJECT_STATUS_DELETED]), only projects
+     *        matching that (e.g., deleted) status will be returned.
+     *
+     * @return A list of [Project] objects matching the specified filter where the given user is member of.
+     */
+    suspend fun getUserProjects(
+        userId: UUID,
+        statusFilter: ProjectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE,
+    ): List<Project>
 }
 
 /**
@@ -76,6 +95,29 @@ class ProjectTableRepo(
             .where {
                 (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE) or
                     (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            }
+            .map { it.toProject() }
+    }
+
+    override suspend fun getUserProjects(userId: UUID, statusFilter: ProjectStatus): List<Project> = db.dbQuery {
+        // TODO (question for reviewer too): Check whether library automatically optimize this and first filter ProjectTable and afterwards joins
+        (ProjectTable innerJoin ProjectMemberTable)
+            .select(ProjectTable.columns)
+            .where { ProjectMemberTable.userId eq userId }
+            .andWhere {
+                when (statusFilter) {
+                    ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED ->
+                        (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE) or
+                            (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+
+                    ProjectStatus.PROJECT_STATUS_ARCHIVED ->
+                        ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ARCHIVED
+
+                    ProjectStatus.PROJECT_STATUS_DELETED ->
+                        ProjectTable.status eq ProjectStatus.PROJECT_STATUS_DELETED
+
+                    else -> throw IllegalArgumentException("Unsupported status: $statusFilter")
+                }
             }
             .map { it.toProject() }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
@@ -43,18 +44,24 @@ interface IProjectTableRepo {
     /**
      * Retrieves a list of projects from the database in which the user with the specified [userId] is a member.
      *
-     * @param userId The unique identifier of the user whose associated projects are to be fetched.
-     * @param statusFilter (optional) Filter to specify which project status the fetched projects should have.
-     *        By default, [ProjectStatus.PROJECT_STATUS_ACTIVE] is used, which includes both active
-     *        and active-locked projects.
-     *        If set to another value (e.g., [ProjectStatus.PROJECT_STATUS_DELETED]), only projects
-     *        matching that (e.g., deleted) status will be returned.
+     * These projects can be filtered by their status, e.g., this function can be used to retrieve all archived
+     * and deleted projects of a user.
      *
-     * @return A list of [Project] objects matching the specified filter where the given user is member of.
+     * @param userId The unique identifier of the user whose associated projects are to be fetched.
+     * @param statusFilters (optional) Set of filters to specify which project status the fetched projects should have.
+     * By default, [ProjectStatus.PROJECT_STATUS_ACTIVE] and [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED] are used,
+     * which includes both active and active-locked projects, i.e., projects where settings cannot be changed anymore.
+     * If set to another value (e.g., [ProjectStatus.PROJECT_STATUS_DELETED]), only projects
+     * matching one of the statuses (e.g., deleted) will be returned.
+     *
+     * @return A list of [Project] objects matching the specified filters where the given user is member of.
      */
     suspend fun getUserProjects(
         userId: UUID,
-        statusFilter: ProjectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE,
+        statusFilters: Set<ProjectStatus> = setOf(
+            ProjectStatus.PROJECT_STATUS_ACTIVE,
+            ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+        ),
     ): List<Project>
 }
 
@@ -99,26 +106,21 @@ class ProjectTableRepo(
             .map { it.toProject() }
     }
 
-    override suspend fun getUserProjects(userId: UUID, statusFilter: ProjectStatus): List<Project> = db.dbQuery {
-        // TODO (question for reviewer too): Check whether library automatically optimize this and first filter ProjectTable and afterwards joins
+    override suspend fun getUserProjects(userId: UUID, statusFilters: Set<ProjectStatus>): List<Project> = db.dbQuery {
+        val excludedStatuses = listOf(ProjectStatus.PROJECT_STATUS_UNSPECIFIED)
+        val projectFilter = statusFilters
+            .filterNot { it in excludedStatuses }
+            .map { ProjectTable.status eq it }
+            .reduceOrNull { acc, filter -> acc or filter }
+
+        require(
+            projectFilter != null,
+        ) { "Unsupported filter statuses: ${statusFilters.joinToString(", ") { it.name }}." }
+
         (ProjectTable innerJoin ProjectMemberTable)
             .select(ProjectTable.columns)
             .where { ProjectMemberTable.userId eq userId }
-            .andWhere {
-                when (statusFilter) {
-                    ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED ->
-                        (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE) or
-                            (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-
-                    ProjectStatus.PROJECT_STATUS_ARCHIVED ->
-                        ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ARCHIVED
-
-                    ProjectStatus.PROJECT_STATUS_DELETED ->
-                        ProjectTable.status eq ProjectStatus.PROJECT_STATUS_DELETED
-
-                    else -> throw IllegalArgumentException("Unsupported status: $statusFilter")
-                }
-            }
+            .andWhere { projectFilter }
             .map { it.toProject() }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -6,8 +6,8 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
-import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
+import se.uulm.snowballr.backend.model.dto.toGrpcProjects
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -56,12 +56,6 @@ class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
 ) : IProjectService {
-    private fun toGrpcProjects(projects: List<Project>): GrpcProject.List {
-        val builder = GrpcProject.List.newBuilder()
-        projects.forEach { builder.addProjects(it.toGrpcProject()) }
-        return builder.build()
-    }
-
     override suspend fun createProject(request: GrpcProject.Create): GrpcProject {
         // TODO: remove dummy user when user management is implemented
         val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
@@ -74,7 +68,7 @@ class ProjectService(
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, it) }
 
         val projects = repo.getAllProjects()
-        return toGrpcProjects(projects)
+        return projects.toGrpcProjects()
     }
 
     override suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List {
@@ -82,7 +76,7 @@ class ProjectService(
         authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
 
         val userProjects = repo.getUserProjects(requestedUserId)
-        return toGrpcProjects(userProjects)
+        return userProjects.toGrpcProjects()
     }
 
     override suspend fun getAllArchivedProjectsForUser(request: Base.Id): GrpcProject.List {
@@ -90,7 +84,7 @@ class ProjectService(
         authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
 
         val archivedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
-        return toGrpcProjects(archivedUserProjects)
+        return archivedUserProjects.toGrpcProjects()
     }
 
     override suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List {
@@ -98,6 +92,6 @@ class ProjectService(
         authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
 
         val deletedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_DELETED))
-        return toGrpcProjects(deletedUserProjects)
+        return deletedUserProjects.toGrpcProjects()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -27,17 +27,17 @@ interface IProjectService {
     suspend fun getAllProjects(): GrpcProject.List
 
     /**
-     * Service implementation of [SnowballRService.getAllProjectsForUser]
+     * Service implementation of [SnowballRService.getAllProjectsForUser].
      */
     suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List
 
     /**
-     * Service implementation of [SnowballRService.getAllArchivedProjectsForUser]
+     * Service implementation of [SnowballRService.getAllArchivedProjectsForUser].
      */
     suspend fun getAllArchivedProjectsForUser(request: Base.Id): GrpcProject.List
 
     /**
-     * Service implementation of [SnowballRService.getAllDeletedProjectsForUser]
+     * Service implementation of [SnowballRService.getAllDeletedProjectsForUser].
      */
     suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -89,7 +89,7 @@ class ProjectService(
         val requestedUserId = parseUUID(request.id, EntityType.USER)
         authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
 
-        val archivedUserProjects = repo.getUserProjects(requestedUserId, ProjectStatus.PROJECT_STATUS_ARCHIVED)
+        val archivedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
         return toGrpcProjects(archivedUserProjects)
     }
 
@@ -97,7 +97,7 @@ class ProjectService(
         val requestedUserId = parseUUID(request.id, EntityType.USER)
         authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
 
-        val deletedUserProjects = repo.getUserProjects(requestedUserId, ProjectStatus.PROJECT_STATUS_DELETED)
+        val deletedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_DELETED))
         return toGrpcProjects(deletedUserProjects)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -1,26 +1,45 @@
 package se.uulm.snowballr.backend.service
 
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.db.dummyUserId
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
-import snowballr.ProjectOuterClass
+import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 interface IProjectService {
     /**
      * Service implementation of [SnowballRService.createProject].
      */
-    suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project
+    suspend fun createProject(request: GrpcProject.Create): GrpcProject
 
     /**
      * Service implementation of [SnowballRService.getAllProjects].
      */
-    suspend fun getAllProjects(): ProjectOuterClass.Project.List
+    suspend fun getAllProjects(): GrpcProject.List
+
+    /**
+     * Service implementation of [SnowballRService.getAllProjectsForUser]
+     */
+    suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List
+
+    /**
+     * Service implementation of [SnowballRService.getAllArchivedProjectsForUser]
+     */
+    suspend fun getAllArchivedProjectsForUser(request: Base.Id): GrpcProject.List
+
+    /**
+     * Service implementation of [SnowballRService.getAllDeletedProjectsForUser]
+     */
+    suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List
 }
 
 /**
@@ -37,22 +56,48 @@ class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
 ) : IProjectService {
-    override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project {
+    private fun toGrpcProjects(projects: List<Project>): GrpcProject.List {
+        val builder = GrpcProject.List.newBuilder()
+        projects.forEach { builder.addProjects(it.toGrpcProject()) }
+        return builder.build()
+    }
+
+    override suspend fun createProject(request: GrpcProject.Create): GrpcProject {
         // TODO: remove dummy user when user management is implemented
         val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
         return repo.createProject(request, requestingUserId).toGrpcProject()
     }
 
-    override suspend fun getAllProjects(): ProjectOuterClass.Project.List {
-        val requestingUserId = parseUUID(dummyUserId!!, EntityType.USER)
-        val currentUser = userRepo.getUserById(requestingUserId)
+    override suspend fun getAllProjects(): GrpcProject.List {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
 
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, it) }
 
         val projects = repo.getAllProjects()
+        return toGrpcProjects(projects)
+    }
 
-        val builder = ProjectOuterClass.Project.List.newBuilder()
-        projects.forEach { builder.addProjects(it.toGrpcProject()) }
-        return builder.build()
+    override suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List {
+        val requestedUserId = parseUUID(request.id, EntityType.USER)
+        authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
+
+        val userProjects = repo.getUserProjects(requestedUserId)
+        return toGrpcProjects(userProjects)
+    }
+
+    override suspend fun getAllArchivedProjectsForUser(request: Base.Id): GrpcProject.List {
+        val requestedUserId = parseUUID(request.id, EntityType.USER)
+        authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
+
+        val archivedUserProjects = repo.getUserProjects(requestedUserId, ProjectStatus.PROJECT_STATUS_ARCHIVED)
+        return toGrpcProjects(archivedUserProjects)
+    }
+
+    override suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List {
+        val requestedUserId = parseUUID(request.id, EntityType.USER)
+        authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
+
+        val deletedUserProjects = repo.getUserProjects(requestedUserId, ProjectStatus.PROJECT_STATUS_DELETED)
+        return toGrpcProjects(deletedUserProjects)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -1,8 +1,13 @@
 package se.uulm.snowballr.backend.service
 
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.repository.IUserTableRepo
 import snowballr.UserOuterClass.UserRole
+import java.util.UUID
 
 /**
  * Verifies that the [user] has the role [UserRole.USER_ROLE_ADMIN].
@@ -16,5 +21,33 @@ import snowballr.UserOuterClass.UserRole
 fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRException.UnauthorizedException) {
     if (user.role != UserRole.USER_ROLE_ADMIN) {
         throw getException(user.id.toString())
+    }
+}
+
+/**
+ * Authorizes access to a user's resources based on the requesting user's identity and role.
+ *
+ * This method checks whether the requesting user is the same as the
+ * target user identified by [requestedUserId]. If the users differ, the method verifies that the
+ * requesting user has the server admin role. If neither condition is met, an
+ * [SnowballRException.UnauthorizedException] is thrown.
+ *
+ * @param requestedUserId The ID of the user whose resource is being accessed.
+ * @param userRepo The user repository used to retrieve user data.
+ * @param accessType The type of access being attempted, used to construct the exception if unauthorized.
+ */
+suspend fun authorizeAccessTo(requestedUserId: UUID, userRepo: IUserTableRepo, accessType: AccessType) {
+    val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+    val requestedUser = userRepo.getUserById(requestedUserId)
+
+    if (currentUser.id != requestedUser.id) {
+        verifyServerAdminRole(currentUser) {
+            SnowballRException.UnauthorizedException.Single(
+                EntityType.USER,
+                requestedUserId.toString(),
+                accessType,
+                it,
+            )
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
@@ -97,6 +97,7 @@ open class H2DatabaseTest(
     @BeforeAll
     fun setUp() {
         Dispatchers.setMain(threadContext)
+        RepositoryHelper.db = db
     }
 
     @BeforeEach

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -3,28 +3,26 @@ package se.uulm.snowballr.backend.repository
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.FetcherApi
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
+import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.table.ProjectTable
-import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.testCoroutine
-import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
-import snowballr.UserOuterClass
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable, UserTable), true) {
+class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectTableRepo(db)
 
     private suspend fun createExampleProject(name: String, status: ProjectStatus): UUID = db.dbQuery {
@@ -41,26 +39,6 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
                 it[fetcherApis] = FetcherApi.entries.toList()
                 it[createdBy] = testUserId
             }.value
-    }
-
-    private suspend fun createExampleUser(email: String) = db.dbQuery {
-        UserTable
-            .insertAndGetId {
-                it[UserTable.email] = email
-                it[firstName] = "Test"
-                it[lastName] = "User"
-                it[passwordHash] = "1234"
-                it[role] = UserOuterClass.UserRole.USER_ROLE_DEFAULT
-                it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
-            }.value
-    }
-
-    private suspend fun assignUserToProject(userId: UUID, projectId: UUID) = db.dbQuery {
-        ProjectMemberTable.insert {
-            it[ProjectMemberTable.userId] = userId
-            it[ProjectMemberTable.projectId] = projectId
-            it[role] = MemberRole.MEMBER_ROLE_DEFAULT
-        }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -172,7 +172,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
                 assignUserToProject(userId, project2Id)
                 assignUserToProject(userId, project3Id)
 
-                val archivedUserProjects = repo.getUserProjects(userId, ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val archivedUserProjects = repo.getUserProjects(userId, setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
                 assertThat(archivedUserProjects).hasSize(1)
 
                 assertThat(archivedUserProjects.find { it.id == project1Id }).isNull()
@@ -195,7 +195,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
                 assignUserToProject(userId, project2Id)
                 assignUserToProject(userId, project3Id)
 
-                val deletedUserProjects = repo.getUserProjects(userId, ProjectStatus.PROJECT_STATUS_DELETED)
+                val deletedUserProjects = repo.getUserProjects(userId, setOf(ProjectStatus.PROJECT_STATUS_DELETED))
                 assertThat(deletedUserProjects).hasSize(1)
 
                 assertThat(deletedUserProjects.find { it.id == project1Id }).isNull()
@@ -214,7 +214,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
             assignUserToProject(userId, project1Id)
             assignUserToProject(userId, project2Id)
 
-            val activeUserProjects = repo.getUserProjects(userId, ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val activeUserProjects = repo.getUserProjects(userId, setOf(ProjectStatus.PROJECT_STATUS_ACTIVE))
             assertThat(activeUserProjects).hasSize(0)
 
             assertThat(activeUserProjects.find { it.id == project1Id }).isNull()
@@ -229,7 +229,7 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
                 assertThrows<IllegalArgumentException> {
                     repo.getUserProjects(
                         userId,
-                        ProjectStatus.PROJECT_STATUS_UNSPECIFIED,
+                        setOf(ProjectStatus.PROJECT_STATUS_UNSPECIFIED),
                     )
                 }
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.repository
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -10,16 +11,20 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.FetcherApi
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.UserTable
+import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.testCoroutine
+import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
+import snowballr.UserOuterClass
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
+class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable, UserTable), true) {
     private val repo = ProjectTableRepo(db)
 
     private suspend fun createExampleProject(name: String, status: ProjectStatus): UUID = db.dbQuery {
@@ -36,6 +41,26 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
                 it[fetcherApis] = FetcherApi.entries.toList()
                 it[createdBy] = testUserId
             }.value
+    }
+
+    private suspend fun createExampleUser(email: String) = db.dbQuery {
+        UserTable
+            .insertAndGetId {
+                it[UserTable.email] = email
+                it[firstName] = "Test"
+                it[lastName] = "User"
+                it[passwordHash] = "1234"
+                it[role] = UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+            }.value
+    }
+
+    private suspend fun assignUserToProject(userId: UUID, projectId: UUID) = db.dbQuery {
+        ProjectMemberTable.insert {
+            it[ProjectMemberTable.userId] = userId
+            it[ProjectMemberTable.projectId] = projectId
+            it[role] = MemberRole.MEMBER_ROLE_DEFAULT
+        }
     }
 
     @Nested
@@ -106,5 +131,107 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable), true) {
             val thirdProject = projects.find { it.id == project3Id }
             assertThat(thirdProject).isNull()
         }
+    }
+
+    @Nested
+    inner class GetUserProjects {
+        @Test
+        fun `When active projects are found where the user is member of, then all (and only these) active projects are returned`() =
+            testCoroutine {
+                val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+                val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val project4Id = createExampleProject("Test Project 4", ProjectStatus.PROJECT_STATUS_ACTIVE)
+
+                val userId = createExampleUser("userWithActiveProjects@example.com")
+
+                assignUserToProject(userId, project1Id)
+                assignUserToProject(userId, project2Id)
+                assignUserToProject(userId, project3Id)
+
+                val activeUserProjects = repo.getUserProjects(userId)
+                assertThat(activeUserProjects).hasSize(2)
+
+                assertThat(activeUserProjects.find { it.id == project1Id }).isNotNull
+                assertThat(activeUserProjects.find { it.id == project2Id }).isNotNull
+                assertThat(activeUserProjects.find { it.id == project3Id }).isNull()
+                assertThat(activeUserProjects.find { it.id == project4Id }).isNull()
+            }
+
+        @Test
+        fun `When archived projects are found where the user is member of, then all (and only these) archived projects are returned`() =
+            testCoroutine {
+                val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+                val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val project4Id = createExampleProject("Test Project 4", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+
+                val userId = createExampleUser("userWithActiveProjects@example.com")
+
+                assignUserToProject(userId, project1Id)
+                assignUserToProject(userId, project2Id)
+                assignUserToProject(userId, project3Id)
+
+                val archivedUserProjects = repo.getUserProjects(userId, ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                assertThat(archivedUserProjects).hasSize(1)
+
+                assertThat(archivedUserProjects.find { it.id == project1Id }).isNull()
+                assertThat(archivedUserProjects.find { it.id == project2Id }).isNull()
+                assertThat(archivedUserProjects.find { it.id == project3Id }).isNotNull
+                assertThat(archivedUserProjects.find { it.id == project4Id }).isNull()
+            }
+
+        @Test
+        fun `When deleted projects are found where the user is member of, then all (and only these) deleted projects are returned`() =
+            testCoroutine {
+                val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+                val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
+                val project4Id = createExampleProject("Test Project 4", ProjectStatus.PROJECT_STATUS_DELETED)
+
+                val userId = createExampleUser("userWithActiveProjects@example.com")
+
+                assignUserToProject(userId, project1Id)
+                assignUserToProject(userId, project2Id)
+                assignUserToProject(userId, project3Id)
+
+                val deletedUserProjects = repo.getUserProjects(userId, ProjectStatus.PROJECT_STATUS_DELETED)
+                assertThat(deletedUserProjects).hasSize(1)
+
+                assertThat(deletedUserProjects.find { it.id == project1Id }).isNull()
+                assertThat(deletedUserProjects.find { it.id == project2Id }).isNull()
+                assertThat(deletedUserProjects.find { it.id == project3Id }).isNotNull
+                assertThat(deletedUserProjects.find { it.id == project4Id }).isNull()
+            }
+
+        @Test
+        fun `When no projects are found where the user is member of, then no projects are returned`() = testCoroutine {
+            val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_DELETED)
+
+            val userId = createExampleUser("userWithActiveProjects@example.com")
+
+            assignUserToProject(userId, project1Id)
+            assignUserToProject(userId, project2Id)
+
+            val activeUserProjects = repo.getUserProjects(userId, ProjectStatus.PROJECT_STATUS_ACTIVE)
+            assertThat(activeUserProjects).hasSize(0)
+
+            assertThat(activeUserProjects.find { it.id == project1Id }).isNull()
+            assertThat(activeUserProjects.find { it.id == project2Id }).isNull()
+        }
+
+        @Test
+        fun `When an invalid project status is used to filter user projects, then an exception is thrown`() =
+            testCoroutine {
+                val userId = createExampleUser("userWithActiveProjects@example.com")
+
+                assertThrows<IllegalArgumentException> {
+                    repo.getUserProjects(
+                        userId,
+                        ProjectStatus.PROJECT_STATUS_UNSPECIFIED,
+                    )
+                }
+            }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -1,0 +1,66 @@
+package se.uulm.snowballr.backend.repository
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.insertAndGetId
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.table.UserTable
+import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.table.association.toProjectMember
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass
+import java.util.UUID
+
+/**
+ * This class acts as a collection of create methods to create database entries for testing purposes.
+ */
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+object RepositoryHelper {
+    lateinit var db: H2DatabaseTest.TestDatabase
+
+    /**
+     * Creates an example user in the database with the specified email and fake user details
+     *
+     * @param email The email address for the example user to be created.
+     * @return The uuid of the created user
+     */
+    suspend fun createExampleUser(email: String) = db.dbQuery {
+        UserTable
+            .insertAndGetId {
+                it[UserTable.email] = email
+                it[firstName] = "Test"
+                it[lastName] = "User"
+                it[passwordHash] = "1234"
+                it[role] = UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+            }.value
+    }
+
+    /**
+     * Assigns a user to a project by inserting an entry into the ProjectMemberTable with the default member role.
+     *
+     * @param userId The unique identifier of the user to be assigned to the project.
+     * @param projectId The unique identifier of the project to which the user is being assigned.
+     * @return The created project member instance
+     */
+    suspend fun assignUserToProject(userId: UUID, projectId: UUID) = db.dbQuery {
+        ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, EntityType.PROJECT_MEMBER) {
+            it[ProjectMemberTable.userId] = userId
+            it[ProjectMemberTable.projectId] = projectId
+            it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
+        }
+    }
+
+    /**
+     * Creates a user with the specified email and assigns the user to a project.
+     *
+     * @param email The email address of the user to be created.
+     * @param projectId The unique identifier of the project to which the user will be assigned.
+     */
+    suspend fun createAndAssignUserToProject(email: String, projectId: UUID) = db.dbQuery {
+        val userId = createExampleUser(email)
+        assignUserToProject(userId, projectId)
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.repository.association
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -12,13 +11,12 @@ import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.repository.H2DatabaseTest
 import se.uulm.snowballr.backend.repository.ProjectTableRepo
+import se.uulm.snowballr.backend.repository.RepositoryHelper.createAndAssignUserToProject
 import se.uulm.snowballr.backend.table.ProjectTable
-import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
-import snowballr.UserOuterClass
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
@@ -36,22 +34,6 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         return projectRepo.createProject(request, testUserId)
     }
 
-    private suspend fun addTestMember(index: Int, projectId: UUID): ProjectMember {
-        val userId =
-            db.dbQuery {
-                UserTable
-                    .insertAndGetId {
-                        it[email] = "test.user.$index@example.com"
-                        it[firstName] = "Test"
-                        it[lastName] = "User"
-                        it[passwordHash] = "hashedPassword"
-                        it[role] = UserOuterClass.UserRole.USER_ROLE_DEFAULT
-                        it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
-                    }.value
-            }
-        return repo.addUserToProject(userId, projectId)
-    }
-
     private suspend fun setupProject(
         numberOfTestMembers: Int = 0,
         addTestUser: Boolean = true,
@@ -64,7 +46,7 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
         }
 
         for (i in 1..numberOfTestMembers) {
-            addTestMember(i, project.id).also { members.add(it) }
+            createAndAssignUserToProject("test.user$i@example.com", project.id).also { members.add(it) }
         }
 
         return project to members
@@ -177,9 +159,9 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
             val project2 = setupProject().first
             val project3 = setupProject().first
 
-            val member1 = addTestMember(1, project1.id)
-            val member2 = addTestMember(2, project2.id)
-            val member3 = addTestMember(3, project3.id)
+            val member1 = createAndAssignUserToProject("test.user1@example.com", project1.id)
+            val member2 = createAndAssignUserToProject("test.user2@example.com", project2.id)
+            val member3 = createAndAssignUserToProject("test.user3@example.com", project3.id)
 
             val result = repo.getMembersInSameProjectsAsUser(testUserId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -44,7 +44,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns anotherUser
             coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
             coEvery {
-                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
             } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> {
@@ -61,7 +61,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects
             coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
             coEvery {
-                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
             } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
@@ -74,7 +74,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
 
             coEvery { userRepoMock.getUserById(any()) } returns adminUser
             coEvery {
-                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
             } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
@@ -93,7 +93,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
 
         coEvery { userRepoMock.getUserById(any()) } returns adminUser
         coEvery {
-            projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
         } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -54,7 +54,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
             }
         }
 
-    fun `When a user retrieve its own archived projects, then all projects are returned successfully`() =
+    fun `When a user retrieves its own archived projects, then all projects are returned successfully`() =
         testCoroutine {
             val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -1,0 +1,101 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class GetAllArchivedProjectsForUserTest : MainServiceTest() {
+    @BeforeEach
+    override fun setUpTest() {
+        super.setUpTest()
+
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getUserProjects(any()) } throws NotImplementedError()
+    }
+
+    private val requestedUserId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestedUserId.toString())
+        .build()
+
+    @Test
+    fun `When all archived user projects are retrieved by another non-admin user, then an exception is thrown`() =
+        testCoroutine {
+            val anotherUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+            val userWithProjects = DataBuilder.createExampleUser(id = requestedUserId)
+
+            coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns anotherUser
+            coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+            coEvery {
+                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            } returns emptyList()
+
+            assertThrows<UnauthorizedException.Single> {
+                mainService.getAllArchivedProjectsForUser(
+                    getExampleRequest(),
+                )
+            }
+        }
+
+    fun `When a user retrieve its own archived projects, then all projects are returned successfully`() =
+        testCoroutine {
+            val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+
+            coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects
+            coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+            coEvery {
+                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            } returns emptyList()
+
+            assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When the user's archived projects are retrieved by an admin, then all user projects are returned successfully`() =
+        testCoroutine {
+            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+            coEvery { userRepoMock.getUserById(any()) } returns adminUser
+            coEvery {
+                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            } returns emptyList()
+
+            assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving all user's archived projects fails, then an exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery {
+            projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_ARCHIVED)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -1,0 +1,96 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class GetAllDeletedProjectsForUserTest : MainServiceTest() {
+    @BeforeEach
+    override fun setUpTest() {
+        super.setUpTest()
+
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getUserProjects(any()) } throws NotImplementedError()
+    }
+
+    private val requestedUserId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestedUserId.toString())
+        .build()
+
+    @Test
+    fun `When all deleted user projects are retrieved by another non-admin user, then an exception is thrown`() =
+        testCoroutine {
+            val anotherUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+            val userWithProjects = DataBuilder.createExampleUser(id = requestedUserId)
+
+            coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns anotherUser
+            coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+            coEvery {
+                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+            } returns emptyList()
+
+            assertThrows<UnauthorizedException.Single> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+        }
+
+    fun `When a user retrieve its own deleted projects, then all projects are returned successfully`() = testCoroutine {
+        val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+
+        coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects
+        coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+        coEvery {
+            projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+        } returns emptyList()
+
+        assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When the user's deleted projects are retrieved by an admin, then all user projects are returned successfully`() =
+        testCoroutine {
+            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+            coEvery { userRepoMock.getUserById(any()) } returns adminUser
+            coEvery {
+                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+            } returns emptyList()
+
+            assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving all user's deleted projects fails, then an exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery {
+            projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -44,23 +44,24 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns anotherUser
             coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
             coEvery {
-                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+                projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_DELETED))
             } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
         }
 
-    fun `When a user retrieves its own deleted projects, then all projects are returned successfully`() = testCoroutine {
-        val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+    fun `When a user retrieves its own deleted projects, then all projects are returned successfully`() =
+        testCoroutine {
+            val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
 
-        coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects
-        coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
-        coEvery {
-            projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
-        } returns emptyList()
+            coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects
+            coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+            coEvery {
+                projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_DELETED))
+            } returns emptyList()
 
-        assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
-    }
+            assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+        }
 
     @Test
     fun `When the user's deleted projects are retrieved by an admin, then all user projects are returned successfully`() =
@@ -69,7 +70,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
 
             coEvery { userRepoMock.getUserById(any()) } returns adminUser
             coEvery {
-                projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+                projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_DELETED))
             } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
@@ -88,7 +89,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
 
         coEvery { userRepoMock.getUserById(any()) } returns adminUser
         coEvery {
-            projectRepoMock.getUserProjects(any(), ProjectStatus.PROJECT_STATUS_DELETED)
+            projectRepoMock.getUserProjects(any(), setOf(ProjectStatus.PROJECT_STATUS_DELETED))
         } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -50,7 +50,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
             assertThrows<UnauthorizedException.Single> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
         }
 
-    fun `When a user retrieve its own deleted projects, then all projects are returned successfully`() = testCoroutine {
+    fun `When a user retrieves its own deleted projects, then all projects are returned successfully`() = testCoroutine {
         val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
 
         coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -47,7 +47,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
             assertThrows<UnauthorizedException.Single> { mainService.getAllProjectsForUser(getExampleRequest()) }
         }
 
-    fun `When a user retrieve its own projects, then all projects are returned successfully`() = testCoroutine {
+    fun `When a user retrieves its own projects, then all projects are returned successfully`() = testCoroutine {
         val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
 
         coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -1,0 +1,87 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.Base
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class GetAllProjectsForUserTest : MainServiceTest() {
+    @BeforeEach
+    override fun setUpTest() {
+        super.setUpTest()
+
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getUserProjects(any()) } throws NotImplementedError()
+    }
+
+    private val requestedUserId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestedUserId.toString())
+        .build()
+
+    @Test
+    fun `When all user projects are retrieved by another non-admin user, then an exception is thrown`() =
+        testCoroutine {
+            val anotherUser = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+            val userWithProjects = DataBuilder.createExampleUser(id = requestedUserId)
+
+            coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns anotherUser
+            coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+            coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+
+            assertThrows<UnauthorizedException.Single> { mainService.getAllProjectsForUser(getExampleRequest()) }
+        }
+
+    fun `When a user retrieve its own projects, then all projects are returned successfully`() = testCoroutine {
+        val userWithProjects = DataBuilder.createExampleUser(id = UUID.fromString(dummyUserId))
+
+        coEvery { userRepoMock.getUserById(UUID.fromString(dummyUserId)) } returns userWithProjects
+        coEvery { userRepoMock.getUserById(userWithProjects.id) } returns userWithProjects
+        coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getAllProjectsForUser(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When the user projects are retrieved by an admin, then all user projects are returned successfully`() =
+        testCoroutine {
+            val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+            coEvery { userRepoMock.getUserById(any()) } returns adminUser
+            coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+
+            assertDoesNotThrow { mainService.getAllProjectsForUser(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When retrieving the current user fails, then an exception is thrown`() = testCoroutine {
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving all projects fails, then an exception is thrown`() = testCoroutine {
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        coEvery { projectRepoMock.getUserProjects(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+    }
+}


### PR DESCRIPTION
Closes #84, Closes #85, Closes #82

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

I added the implementation for the following calls
- `GetAllProjectsForUser`
- `GetAllArchivedProjectsForUser`
- `GetAllDeletedProjectsForUser`

I implemented these calls together as `GetAllArchivedProjectsForUser` and `GetAllDeletedProjectsForUser` are only special / filtered versions of the general `GetAllProjectsForUser`. That's why their implementation is quite similar and can be combined. 

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
