### PR TITLE
Feat/64 updateproject

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -285,10 +285,12 @@ class SnowballRServer(
         override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project =
             mainService.createProject(request)
 
-        override suspend fun getProjectById(request: Base.Id): ProjectOuterClass.Project = super.getProjectById(request)
+        override suspend fun getProjectById(request: Base.Id): ProjectOuterClass.Project = mainService.getProjectById(
+            request,
+        )
 
         override suspend fun updateProject(request: ProjectOuterClass.Project.Update): ProjectOuterClass.Project =
-            super.updateProject(request)
+            mainService.updateProject(request)
 
         override suspend fun exportProject(request: Export.ExportRequest): Base.Blob = super.exportProject(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -77,8 +77,10 @@ private class ExceptionCall<ReqT, RespT>(
         val status =
             when (e) {
                 is SnowballRException.NotFoundException -> Status.NOT_FOUND
+                is SnowballRException.NotFoundException.ComposedId -> Status.NOT_FOUND
                 is SnowballRException.DuplicateEntityException -> Status.ALREADY_EXISTS
                 is SnowballRException.EntityNotPersistedException -> Status.INTERNAL
+                is SnowballRException.EntityNotPersistedException.ComposedId -> Status.INTERNAL
                 is SnowballRException.UnauthorizedException -> Status.PERMISSION_DENIED
                 is SnowballRException.InvalidIdException -> Status.INVALID_ARGUMENT
                 is SnowballRException.MissingContextException -> Status.INTERNAL

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -79,7 +79,6 @@ private class ExceptionCall<ReqT, RespT>(
                 is SnowballRException.NotFoundException -> Status.NOT_FOUND
                 is SnowballRException.DuplicateEntityException -> Status.ALREADY_EXISTS
                 is SnowballRException.EntityNotPersistedException -> Status.INTERNAL
-                is SnowballRException.EntityNotPersistedException.ComposedId -> Status.INTERNAL
                 is SnowballRException.UnauthorizedException -> Status.PERMISSION_DENIED
                 is SnowballRException.InvalidIdException -> Status.INVALID_ARGUMENT
                 is SnowballRException.MissingContextException -> Status.INTERNAL

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -77,7 +77,6 @@ private class ExceptionCall<ReqT, RespT>(
         val status =
             when (e) {
                 is SnowballRException.NotFoundException -> Status.NOT_FOUND
-                is SnowballRException.NotFoundException.ComposedId -> Status.NOT_FOUND
                 is SnowballRException.DuplicateEntityException -> Status.ALREADY_EXISTS
                 is SnowballRException.EntityNotPersistedException -> Status.INTERNAL
                 is SnowballRException.EntityNotPersistedException.ComposedId -> Status.INTERNAL

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ExceptionHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ExceptionHelper.kt
@@ -1,0 +1,20 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Constructs a formatted string representation of the provided entity IDs, incorporating
+ * an optional identifier type for contextualizing the IDs.
+ *
+ * @param entityIds A list of entity IDs to be displayed in the resulting string.
+ * @param identifierType The type of identifier associated with the entity IDs. Defaults to [IdentifierType.ID].
+ * @return A string containing the formatted representation of the entity IDs prefixed with the specified identifier type.
+ */
+fun displayEntityIds(entityIds: List<String>, identifierType: IdentifierType = IdentifierType.ID): String {
+    var idString = entityIds.dropLast(1).joinToString(
+        separator = ", ",
+    ) { "'$it'" }
+
+    if (entityIds.isNotEmpty()) {
+        idString += " and '${entityIds.last()}'"
+    }
+    return "with ${identifierType.displayName} $idString"
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ExceptionHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ExceptionHelper.kt
@@ -9,12 +9,10 @@ package se.uulm.snowballr.backend.model
  * @return A string containing the formatted representation of the entity IDs prefixed with the specified identifier type.
  */
 fun displayEntityIds(entityIds: List<String>, identifierType: IdentifierType = IdentifierType.ID): String {
-    var idString = entityIds.dropLast(1).joinToString(
-        separator = ", ",
-    ) { "'$it'" }
-
-    if (entityIds.isNotEmpty()) {
-        idString += " and '${entityIds.last()}'"
+    require(entityIds.isNotEmpty()) { "Cannot display empty list of entity IDs." }
+    if (entityIds.size == 1) {
+        return "with ${identifierType.displayName} '${entityIds[0]}'"
     }
-    return "with ${identifierType.displayName} $idString"
+    val idString = entityIds.dropLast(1).joinToString(separator = ", ") { "'$it'" }
+    return "with ${identifierType.displayName} $idString and '${entityIds.last()}'"
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -17,24 +17,16 @@ sealed class SnowballRException(
      * Represents an exception that occurs when an entity cannot be found by its identifier.
      *
      * @param entityType The type of the entity that could not be found.
-     * @param entityId The unique identifier of the missing entity.
+     * @param entityIds The list missing entity IDs.
      * @param identifierType The type of the [identifierType] field. Default to [IdentifierType.ID].
      */
     open class NotFoundException(
         entityType: EntityType,
-        entityId: String,
+        vararg entityIds: String,
         identifierType: IdentifierType = IdentifierType.ID,
-    ) : SnowballRException("${entityType.singularUpper()} with ${identifierType.displayName} '$entityId' not found.") {
-        class ComposedId(
-            entityType: EntityType,
-            firstEntityId: String,
-            secondEntityId: String,
-            identifierType: IdentifierType = IdentifierType.ID,
-        ) : SnowballRException(
-            "${entityType.singularUpper()} with ${identifierType.displayName} '$firstEntityId' and " +
-                "'$secondEntityId' not found.",
-        )
-    }
+    ) : SnowballRException(
+        "${entityType.singularUpper()} ${displayEntityIds(entityIds.toList(), identifierType)} not found.",
+    )
 
     /**
      * Represents an exception that occurs when an entity already exists in the system

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -17,8 +17,8 @@ sealed class SnowballRException(
      * Represents an exception that occurs when an entity cannot be found by its identifier.
      *
      * @param entityType The type of the entity that could not be found.
-     * @param entityIds The list missing entity IDs.
-     * @param identifierType The type of the [identifierType] field. Default to [IdentifierType.ID].
+     * @param entityIds The missing entity's ID(s).
+     * @param identifierType The type of the entity's identifier. Defaults to [IdentifierType.ID].
      */
     open class NotFoundException(
         entityType: EntityType,
@@ -33,15 +33,16 @@ sealed class SnowballRException(
      * and creation is not allowed.
      *
      * @param entityType The type of the duplicated entity.
-     * @param identifier The identifying value (e.g., email, username).
-     * @param identifierType The type of the [identifier] field. Default to [IdentifierType.ID].
+     * @param entityIds The missing entity's ID(s).
+     * @param identifierType The type of the entity's identifier. Defaults to [IdentifierType.ID].
      */
     class DuplicateEntityException(
         entityType: EntityType,
-        identifier: String,
+        vararg entityIds: String,
         identifierType: IdentifierType = IdentifierType.ID,
     ) : SnowballRException(
-        "${entityType.singularUpper()} with ${identifierType.displayName} '$identifier' already exists.",
+        "${entityType.singularUpper()} ${displayEntityIds(entityIds.toList(), identifierType)}" +
+            " already exists.",
     )
 
     /**
@@ -53,16 +54,7 @@ sealed class SnowballRException(
     class EntityNotPersistedException(
         entityType: EntityType,
         entityId: String,
-    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.") {
-        class ComposedId(
-            entityType: EntityType,
-            firstEntityId: String,
-            secondEntityId: String,
-        ) : SnowballRException(
-            "${entityType.singularUpper()} with the composed ID '$firstEntityId' and '$secondEntityId' " +
-                "was not persisted.",
-        )
-    }
+    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.")
 
     /**
      * Represents an exception that occurs when the current user accesses one or more entities without permission.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -24,7 +24,17 @@ sealed class SnowballRException(
         entityType: EntityType,
         entityId: String,
         identifierType: IdentifierType = IdentifierType.ID,
-    ) : SnowballRException("${entityType.singularUpper()} with ${identifierType.displayName} '$entityId' not found.")
+    ) : SnowballRException("${entityType.singularUpper()} with ${identifierType.displayName} '$entityId' not found.") {
+        class ComposedId(
+            entityType: EntityType,
+            firstEntityId: String,
+            secondEntityId: String,
+            identifierType: IdentifierType = IdentifierType.ID,
+        ) : SnowballRException(
+            "${entityType.singularUpper()} with ${identifierType.displayName} '$firstEntityId' and " +
+                "'$secondEntityId' not found.",
+        )
+    }
 
     /**
      * Represents an exception that occurs when an entity already exists in the system
@@ -51,7 +61,16 @@ sealed class SnowballRException(
     class EntityNotPersistedException(
         entityType: EntityType,
         entityId: String,
-    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.")
+    ) : SnowballRException("${entityType.singularUpper()} with ID '$entityId' was not persisted.") {
+        class ComposedId(
+            entityType: EntityType,
+            firstEntityId: String,
+            secondEntityId: String,
+        ) : SnowballRException(
+            "${entityType.singularUpper()} with the composed ID '$firstEntityId' and '$secondEntityId' " +
+                "was not persisted.",
+        )
+    }
 
     /**
      * Represents an exception that occurs when the current user accesses one or more entities without permission.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -91,8 +91,11 @@ data class InvalidId(
 data class InvalidThreshold(
     val name: String,
     val threshold: Float,
+    val from: Float,
+    val to: Float,
 ) : ValidationIssue {
-    override fun toString(): String = "The threshold '$threshold' is invalid for the field '$name'."
+    override fun toString(): String =
+        "The value '$threshold' is not in the allowed range [$from-$to] for the field '$name'."
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -88,14 +88,14 @@ data class InvalidId(
     override fun toString(): String = "The ID '$id' is invalid for the field '$name'."
 }
 
-data class InvalidThreshold(
+data class OutOfRangeValue(
     val name: String,
-    val threshold: Float,
+    val value: Float,
     val from: Float,
     val to: Float,
 ) : ValidationIssue {
     override fun toString(): String =
-        "The value '$threshold' is not in the allowed range [$from-$to] for the field '$name'."
+        "The value '$value' is not in the allowed range [$from-$to] for the field '$name'."
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -88,6 +88,13 @@ data class InvalidId(
     override fun toString(): String = "The ID '$id' is invalid for the field '$name'."
 }
 
+data class InvalidThreshold(
+    val name: String,
+    val threshold: Float,
+) : ValidationIssue {
+    override fun toString(): String = "The threshold '$threshold' is invalid for the field '$name'."
+}
+
 /**
  * Represents a validation issue where a password does not meet the required criteria.
  *

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -1,13 +1,19 @@
 package se.uulm.snowballr.backend.repository
 
+import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.statements.UpdateStatement
+import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.getUserEntityId
@@ -16,6 +22,7 @@ import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
+import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
@@ -26,6 +33,11 @@ import java.util.UUID
  * for creating and managing projects can remain decoupled from the specifics of the database layer.
  */
 interface IProjectTableRepo {
+    /**
+     * Returns a project by its ID or throws a [NotFoundException] if the project with the passed [id] doesn't exist.
+     */
+    suspend fun getProjectById(id: UUID): Project
+
     /**
      * Creates a new project in the database with the provided project creation request and user ID.
      *
@@ -62,6 +74,21 @@ interface IProjectTableRepo {
             ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
         ),
     ): List<Project>
+
+    /**
+     * Updates an existing project in the database with the provided new information.
+     * The following fields can be updated:
+     * - name
+     * - status
+     * - similarity_threshold
+     * - snowballing_type
+     * - review_maybe_allowed
+     *
+     * @param request The update request containing the new project details, such as the new name.
+     * @param isActiveLocked True, if the project is of status [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED] (only the name and status can be updated then).
+     * @return The updated [Project] object reflecting the changes from the [request].
+     */
+    suspend fun updateProject(request: ProjectOuterClass.Project.Update, isActiveLocked: Boolean): Project
 }
 
 /**
@@ -76,6 +103,22 @@ interface IProjectTableRepo {
 class ProjectTableRepo(
     private val db: IDatabase,
 ) : IProjectTableRepo {
+    /**
+     * Requesting a project from the database.
+     *
+     * @param id The ID of the requested project.
+     * @return The [Project] object or null, if no project with the given [id] was found.
+     */
+    private fun getProjectByIdOrNull(id: UUID): Project? = ProjectTable
+        .selectAll()
+        .where { ProjectTable.id eq id }
+        .map { it.toProject() }
+        .singleOrNull()
+
+    override suspend fun getProjectById(id: UUID): Project = db.dbQuery {
+        getProjectByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT, id.toString())
+    }
+
     override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: UUID): Project = db.dbQuery {
         // Get user reference
         val userEntityId = getUserEntityId(userId)
@@ -121,5 +164,47 @@ class ProjectTableRepo(
             .where { ProjectMemberTable.userId eq userId }
             .andWhere { projectFilter }
             .map { it.toProject() }
+    }
+
+    override suspend fun updateProject(request: ProjectOuterClass.Project.Update, isActiveLocked: Boolean): Project =
+        db.dbQuery {
+            val projectId = parseUUID(request.project.id, EntityType.PROJECT)
+            val fieldMaskPaths = FieldMaskUtil.normalize(request.mask).pathsList.toSet()
+
+            ProjectTable.update({ ProjectTable.id eq projectId }) {
+                it.applyBasicProjectUpdates(request.project, fieldMaskPaths)
+                if (!isActiveLocked) {
+                    it.applySlrProjectUpdates(request.project.settings, fieldMaskPaths)
+                }
+                it[modifiedAt] = OffsetDateTime.now()
+            }
+
+            // Return updated project
+            getProjectByIdOrNull(projectId)
+                ?: throw EntityNotPersistedException(EntityType.PROJECT, projectId.toString())
+        }
+
+    private fun UpdateStatement.applyBasicProjectUpdates(project: ProjectOuterClass.Project, paths: Set<String>) {
+        if ("project.name" in paths) {
+            this[ProjectTable.name] = project.name
+        }
+        if ("project.status" in paths) {
+            this[ProjectTable.status] = project.status
+        }
+    }
+
+    private fun UpdateStatement.applySlrProjectUpdates(
+        settings: ProjectOuterClass.Project.Settings,
+        paths: Set<String>,
+    ) {
+        if ("project.settings.similarity_threshold" in paths) {
+            this[ProjectTable.similarityThreshold] = settings.similarityThreshold
+        }
+        if ("project.settings.snowballing_type" in paths) {
+            this[ProjectTable.snowballingType] = settings.snowballingType
+        }
+        if ("project.settings.review_maybe_allowed" in paths) {
+            this[ProjectTable.reviewMaybeAllowed] = settings.reviewMaybeAllowed
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -85,7 +85,8 @@ interface IProjectTableRepo {
      * - review_maybe_allowed
      *
      * @param request The update request containing the new project details, such as the new name.
-     * @param isActiveLocked True, if the project is of status [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED] (only the name and status can be updated then).
+     * @param isActiveLocked True, if the project is of status [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED] (only the
+     * name and status can be updated then).
      * @return The updated [Project] object reflecting the changes from the [request].
      */
     suspend fun updateProject(request: ProjectOuterClass.Project.Update, isActiveLocked: Boolean): Project

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -117,7 +117,7 @@ class UserTableRepo(
             .where { UserTable.email eq email }
             .map { it.toUser() }
             .singleOrNull()
-            ?: throw NotFoundException(EntityType.USER, email, IdentifierType.EMAIL)
+            ?: throw NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL)
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.dbQuery {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -167,10 +167,9 @@ class ProjectMemberTableRepo(
             it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
         }
 
-        getProjectMemberByComposedIdOrNull(projectId, userId) ?: throw EntityNotPersistedException.ComposedId(
+        getProjectMemberByComposedIdOrNull(projectId, userId) ?: throw EntityNotPersistedException(
             EntityType.PROJECT_MEMBER,
             projectId.toString(),
-            userId.toString(),
         )
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -3,9 +3,13 @@ package se.uulm.snowballr.backend.repository.association
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.alias
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
@@ -24,6 +28,11 @@ import java.util.UUID
  */
 interface IProjectMemberTableRepo {
     /**
+     * Returns a project member by its composed ID or throws a [NotFoundException] if the project with the passed [projectId] and [userId] doesn't exist.
+     */
+    suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): ProjectMember
+
+    /**
      * Adds a user with the passed [userId] as member to the project with the passed [projectId].
      *
      * @return The added [ProjectMember].
@@ -41,6 +50,20 @@ interface IProjectMemberTableRepo {
      * The user itself is not part of the resulting list.
      */
     suspend fun getMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember>
+
+    /**
+     * Returns the [List] of all [ProjectMember] with the role admin.
+     */
+    suspend fun getAllProjectAdmins(projectId: UUID): List<ProjectMember>
+
+    /**
+     * Promotes a project member to an admin role in the specified project.
+     *
+     * @param projectId The unique identifier of the project to which the member belongs.
+     * @param userId The unique identifier of the user to be promoted to admin.
+     * @return The updated [ProjectMember] including the new role as an admin.
+     */
+    suspend fun promoteProjectMemberToAdmin(projectId: UUID, userId: UUID): ProjectMember
 }
 
 /**
@@ -56,6 +79,27 @@ interface IProjectMemberTableRepo {
 class ProjectMemberTableRepo(
     private val db: IDatabase,
 ) : IProjectMemberTableRepo {
+    /**
+     * Requesting a project member from the database.
+     *
+     * @param projectId The id of the requested project.
+     * @param userId The id of the requested user.
+     * @return The [ProjectMember] object or null, if no project with the given [projectId] and [userId] was found.
+     */
+    private fun getProjectMemberByComposedIdOrNull(projectId: UUID, userId: UUID): ProjectMember? = ProjectMemberTable
+        .selectAll()
+        .where {
+            (ProjectMemberTable.projectId eq projectId) and
+                (ProjectMemberTable.userId eq userId)
+        }
+        .map { it.toProjectMember() }
+        .singleOrNull()
+
+    override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): ProjectMember = db.dbQuery {
+        getProjectMemberByComposedIdOrNull(projectId, userId)
+            ?: throw NotFoundException(EntityType.PROJECT_MEMBER, projectId.toString(), userId.toString())
+    }
+
     override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.dbQuery {
         // Get user reference
         val userEntityId = getUserEntityId(userId)
@@ -101,5 +145,32 @@ class ProjectMemberTableRepo(
             // Filter out the calling user
             .where { ProjectMemberTable.userId neq userId }
             .map { it.toProjectMember() }
+    }
+
+    override suspend fun getAllProjectAdmins(projectId: UUID): List<ProjectMember> = db.dbQuery {
+        ProjectMemberTable
+            .selectAll()
+            .where {
+                (ProjectMemberTable.projectId eq projectId) and
+                    (ProjectMemberTable.role eq ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN)
+            }
+            .map { it.toProjectMember() }
+    }
+
+    override suspend fun promoteProjectMemberToAdmin(projectId: UUID, userId: UUID): ProjectMember = db.dbQuery {
+        ProjectMemberTable.update(
+            {
+                (ProjectMemberTable.projectId eq projectId) and
+                    (ProjectMemberTable.userId eq userId)
+            },
+        ) {
+            it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
+        }
+
+        getProjectMemberByComposedIdOrNull(projectId, userId) ?: throw EntityNotPersistedException.ComposedId(
+            EntityType.PROJECT_MEMBER,
+            projectId.toString(),
+            userId.toString(),
+        )
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -39,6 +39,6 @@ class MainService(
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val jwtService: IJwtService,
 ) : IMainService,
-    IProjectService by ProjectService(projectRepo, userRepo),
+    IProjectService by ProjectService(projectRepo, userRepo, projectMemberRepo),
     ICriterionService by CriterionService(criterionRepo),
     IUserService by UserService(userRepo, projectMemberRepo, jwtService)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -4,17 +4,24 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.toGrpcProjects
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 interface IProjectService {
+    /**
+     * Service implementation of [SnowballRService.getProjectById].
+     */
+    suspend fun getProjectById(projectId: Base.Id): GrpcProject
+
     /**
      * Service implementation of [SnowballRService.createProject].
      */
@@ -39,6 +46,14 @@ interface IProjectService {
      * Service implementation of [SnowballRService.getAllDeletedProjectsForUser].
      */
     suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List
+
+    /**
+     * Service implementation of [SnowballRService.updateProject].
+     *
+     * @param request The update request containing the project details to be modified.
+     * @return The updated project after the changes have been applied.
+     */
+    suspend fun updateProject(request: GrpcProject.Update): GrpcProject
 }
 
 /**
@@ -50,11 +65,32 @@ interface IProjectService {
  * @constructor Initializes the [ProjectService] with a project repository.
  * @param repo The repository responsible for managing persistence operations for projects.
  * @param userRepo The repository responsible for managing persistence operations for users.
+ * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
  */
 class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IProjectService {
+    override suspend fun getProjectById(projectId: Base.Id): GrpcProject {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectId = parseUUID(projectId.id, EntityType.PROJECT)
+        val isInProject = projectMemberRepo.getMembersOfProject(projectId)
+            .any { it.userId == currentUser.id }
+
+        if (!isInProject) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+        return repo.getProjectById(projectId).toGrpcProject()
+    }
+
     override suspend fun createProject(request: GrpcProject.Create): GrpcProject =
         repo.createProject(request, GrpcContext.getUserIdFromContext()).toGrpcProject()
 
@@ -89,5 +125,31 @@ class ProjectService(
 
         val deletedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_DELETED))
         return deletedUserProjects.toGrpcProjects()
+    }
+
+    override suspend fun updateProject(request: GrpcProject.Update): GrpcProject {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectId = parseUUID(request.project.id, EntityType.PROJECT)
+        val project = repo.getProjectById(projectId)
+        val isProjectAdmin = projectMemberRepo.getAllProjectAdmins(projectId).any { it.userId == currentUser.id }
+        val isProjectActiveLocked = project.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+
+        if (!isProjectAdmin) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    request.project.id,
+                    AccessType.UPDATE,
+                    it,
+                )
+            }
+        }
+        if (project.status != ProjectStatus.PROJECT_STATUS_ACTIVE && !isProjectActiveLocked) {
+            throw SnowballRException.FailedPreconditionException(
+                "The project with the id ${request.project.id} is not active.",
+            )
+        }
+
+        return repo.updateProject(request, isProjectActiveLocked).toGrpcProject()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -159,7 +159,7 @@ class UserService(
     override suspend fun register(request: Authentication.RegisterRequest): Base.Nothing {
         // Check whether a user with the given email already exists
         if (userRepo.doesUserExistByEmail(request.email)) {
-            throw DuplicateEntityException(EntityType.USER, request.email, IdentifierType.EMAIL)
+            throw DuplicateEntityException(EntityType.USER, request.email, identifierType = IdentifierType.EMAIL)
         }
 
         // Hash the password and create the user
@@ -196,7 +196,7 @@ class UserService(
 
         // Check whether a user with the given email already exists if the email should be changed
         if (request.mask.pathsList.contains("email") && userRepo.doesUserExistByEmail(request.user.email)) {
-            throw DuplicateEntityException(EntityType.USER, request.user.email, IdentifierType.EMAIL)
+            throw DuplicateEntityException(EntityType.USER, request.user.email, identifierType = IdentifierType.EMAIL)
         }
 
         val updatedUser = userRepo.updateUser(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -138,7 +138,7 @@ class UserService(
         if (targetUser.status != UserStatus.USER_STATUS_ACTIVE &&
             targetUser.status != UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
         ) {
-            throw NotFoundException(EntityType.USER, request.email, IdentifierType.EMAIL)
+            throw NotFoundException(EntityType.USER, request.email, identifierType = IdentifierType.EMAIL)
         }
 
         return targetUser.toGrpcUser()

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -1,18 +1,77 @@
 package se.uulm.snowballr.backend.validation
 
+import arrow.core.Either
 import arrow.core.EitherNel
+import arrow.core.raise.Raise
 import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.InvalidThreshold
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.ProjectOuterClass.Project
-
-const val PROJECT_NAME_MAX_LENGTH = 100
+import snowballr.ProjectOuterClass.Project.Create
 
 /**
  * A validator for [Project] related requests.
  */
 object ProjectValidator {
-    fun validateCreateRequest(request: Project.Create): EitherNel<ValidationIssue, Unit> = either {
-        ensureFieldNonBlank("name", request.name)
-        ensureFieldLength("name", request.name, PROJECT_NAME_MAX_LENGTH)
+    fun validateCreateRequest(request: Create): EitherNel<ValidationIssue, Unit> = either {
+        ensureProjectNameValidity(request.name)
     }.toEitherNel()
+
+    fun validateUpdateRequest(request: Project.Update): EitherNel<ValidationIssue, Unit> = either {
+        // Validate the field mask
+        val fieldMaskResult = either {
+            ensureFieldMaskIsValid(request.mask, Project.Update.getDescriptor())
+        }
+
+        // If field mask validation fails, return early
+        if (fieldMaskResult is Either.Left) {
+            fieldMaskResult.toEitherNel().bind()
+        }
+
+        // Only proceed with field validation if the mask is valid
+        val selectedFields = request.mask.pathsList.toSet()
+
+        zipOrAccumulate(
+            { ensureIdValidity("id", request.project.id) },
+            {
+                if ("project.name" in selectedFields) {
+                    ensureProjectNameValidity(request.project.name)
+                }
+            },
+            {
+                if ("project.status" in selectedFields) {
+                    ensureEnumNotUnspecified("status", request.project.status)
+                }
+            },
+            {
+                if ("project.settings.snowballing_type" in selectedFields) {
+                    ensureEnumNotUnspecified("snowballing_type", request.project.settings.snowballingType)
+                }
+            },
+            {
+                if ("project.settings.similarity_threshold" in selectedFields) {
+                    ensureSimilarityThresholdValidity(request.project.settings.similarityThreshold)
+                }
+            },
+        ) { _, _, _, _, _ -> }
+    }
+
+    /**
+     * Ensures that the provided project name is valid.
+     * It checks that the project name is not blank and does not exceed the maximum length defined by [PROJECT_NAME_MAX_LENGTH].
+     *
+     * @param name The project name to validate.
+     */
+    fun Raise<ValidationIssue>.ensureProjectNameValidity(name: String) {
+        ensureFieldNonBlank("name", name)
+        ensureFieldLength("name", name, PROJECT_NAME_MAX_LENGTH)
+    }
+
+    fun Raise<ValidationIssue>.ensureSimilarityThresholdValidity(threshold: Float) {
+        ensure(threshold in 0.0f..1.0f) {
+            InvalidThreshold("similarity_threshold", threshold, 0.0f, 1.0f)
+        }
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -6,7 +6,7 @@ import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.zipOrAccumulate
-import se.uulm.snowballr.backend.model.InvalidThreshold
+import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
@@ -71,7 +71,7 @@ object ProjectValidator {
 
     fun Raise<ValidationIssue>.ensureSimilarityThresholdValidity(threshold: Float) {
         ensure(threshold in 0.0f..1.0f) {
-            InvalidThreshold("similarity_threshold", threshold, 0.0f, 1.0f)
+            OutOfRangeValue("similarity_threshold", threshold, 0.0f, 1.0f)
         }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -30,6 +30,7 @@ const val PASSWORD_MIN_NUMBER_SPECIAL_CHARS = 2
 const val PASSWORD_MIN_LENGTH = 8
 const val FIRST_NAME_MAX_LENGTH = 100
 const val LAST_NAME_MAX_LENGTH = 100
+const val PROJECT_NAME_MAX_LENGTH = 100
 
 /**
  * Validates a given request object and returns either a collection of validation issues
@@ -54,6 +55,7 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is UserOuterClass.User.Update -> UserValidator.validateUpdateRequest(request)
     // Project
     is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
+    is ProjectOuterClass.Project.Update -> ProjectValidator.validateUpdateRequest(request)
     // Criterion
     is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
     // Base

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
+import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
@@ -7,7 +8,11 @@ import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.table.ProjectTable
@@ -24,7 +29,7 @@ import java.util.UUID
 class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectTableRepo(db)
 
-    private suspend fun createExampleProject(name: String, status: ProjectStatus): UUID = db.dbQuery {
+    private suspend fun insertTestProjectAndGetId(name: String, status: ProjectStatus): UUID = db.dbQuery {
         ProjectTable
             .insertAndGetId {
                 it[ProjectTable.name] = name
@@ -40,12 +45,48 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
             }.value
     }
 
+    companion object {
+        @JvmStatic
+        fun validFieldMasks(): List<Arguments> = listOf(
+            Arguments.of(listOf("project.name")),
+            Arguments.of(listOf("project.status")),
+            Arguments.of(listOf("project.settings.similarity_threshold")),
+            Arguments.of(listOf("project.settings.snowballing_type")),
+            Arguments.of(listOf("project.settings.review_maybe_allowed")),
+        )
+    }
+
+    @Nested
+    inner class GetProjectById {
+        @Test
+        fun `When a project is found, then the correct project is returned`() = testCoroutine {
+            val projectId = insertTestProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val project = repo.getProjectById(projectId)
+
+            assertThat(project.id).isEqualTo(projectId)
+            assertThat(project.name).isEqualTo("Test Project")
+            assertThat(project.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE)
+            assertThat(project.currentStage).isEqualTo(0)
+            assertThat(project.maxStage).isEqualTo(0)
+            assertThat(project.similarityThreshold).isEqualTo(0F)
+            assertThat(project.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_BOTH)
+            assertThat(project.reviewMaybeAllowed).isEqualTo(true)
+            assertThat(project.reviewDecisionMatrix).isEqualTo(ReviewDecisionMatrix.getDefaultInstance())
+            assertThat(project.createdBy).isEqualTo(testUserId)
+        }
+
+        @Test
+        fun `When a project is not found, then an exception is thrown`() = testCoroutine {
+            assertThrows<NotFoundException> { repo.getProjectById(UUID.randomUUID()) }
+        }
+    }
+
     @Nested
     inner class CreateProject {
         @Test
         fun `When a project is created, then the passed values are correctly assigned`() = testCoroutine {
-            val request = Project.Create.newBuilder().setName("Test Project").build()
-            val project = repo.createProject(request, testUserId)
+            val projectId = insertTestProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val project = repo.getProjectById(projectId)
 
             assertThat(project.name).isEqualTo("Test Project")
             assertThat(project.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE)
@@ -61,11 +102,9 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
 
         @Test
         fun `When two projects are created, then they have different IDs`() = testCoroutine {
-            val request = Project.Create.newBuilder().setName("Test Project").build()
-            val project1 = repo.createProject(request, testUserId)
-            val project2 = repo.createProject(request, testUserId)
-
-            assertThat(project1.id).isNotEqualTo(project2.id)
+            val projectId1 = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val projectId2 = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            assertThat(projectId1).isNotEqualTo(projectId2)
         }
 
         @Test
@@ -80,8 +119,8 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
     inner class GetAllProjects {
         @Test
         fun `When projects are found, then all projects are returned`() = testCoroutine {
-            val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
 
             val projects = repo.getAllProjects()
             assertThat(projects).hasSize(2)
@@ -93,9 +132,9 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
 
         @Test
         fun `When archived and deleted projects exist, then they are not returned`() = testCoroutine {
-            val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
+            val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
 
             val projects = repo.getAllProjects()
             assertThat(projects).hasSize(1)
@@ -109,14 +148,115 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
     }
 
     @Nested
+    inner class UpdateProject {
+        @ParameterizedTest(name = "Update the fields {0}")
+        @MethodSource("se.uulm.snowballr.backend.repository.ProjectTableRepoTest#validFieldMasks")
+        fun `When a project is active and updated, then only the fields specified in the field mask are updated and the updated project is returned`(
+            fieldMask: List<String>,
+        ) = testCoroutine {
+            val projectId =
+                insertTestProjectAndGetId(name = "Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val originalProject = repo.getProjectById(projectId)
+
+            val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
+                .setName("Updated Project")
+                .setStatus(ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                .setSettings(
+                    Project.Settings.newBuilder()
+                        .setSimilarityThreshold(1F)
+                        .setSnowballingType(SnowballingType.SNOWBALLING_TYPE_FORWARD)
+                        .setReviewMaybeAllowed(false)
+                        .build(),
+                )
+                .build()
+
+            val request = Project.Update.newBuilder()
+                .setProject(updatedProjectDetails)
+                .setMask(FieldMaskUtil.fromStringList(fieldMask))
+                .build()
+
+            val updatedProject = repo.updateProject(request, false)
+
+            if ("project.name" in fieldMask) {
+                assertThat(updatedProject.name).isEqualTo("Updated Project")
+            } else {
+                assertThat(updatedProject.name).isEqualTo("Test Project")
+            }
+            if ("project.status" in fieldMask) {
+                assertThat(updatedProject.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            } else {
+                assertThat(updatedProject.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE)
+            }
+            if ("project.settings.similarity_threshold" in fieldMask) {
+                assertThat(updatedProject.similarityThreshold).isEqualTo(1F)
+            } else {
+                assertThat(updatedProject.similarityThreshold).isEqualTo(0F)
+            }
+            if ("project.settings.snowballing_type" in fieldMask) {
+                assertThat(updatedProject.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_FORWARD)
+            } else {
+                assertThat(updatedProject.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_BOTH)
+            }
+            if ("project.settings.review_maybe_allowed" in fieldMask) {
+                assertThat(updatedProject.reviewMaybeAllowed).isEqualTo(false)
+            } else {
+                assertThat(updatedProject.reviewMaybeAllowed).isEqualTo(true)
+            }
+        }
+
+        @ParameterizedTest(name = "Update the fields {0}")
+        @MethodSource("se.uulm.snowballr.backend.repository.ProjectTableRepoTest#validFieldMasks")
+        fun `When a project is active locked and updated, then only the project name and status are updated and the updated project is returned`(
+            fieldMask: List<String>,
+        ) = testCoroutine {
+            val projectId =
+                insertTestProjectAndGetId(name = "Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            val originalProject = repo.getProjectById(projectId)
+
+            val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
+                .setName("Updated Project")
+                .setStatus(ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                .setSettings(
+                    Project.Settings.newBuilder()
+                        .setSimilarityThreshold(1F)
+                        .setSnowballingType(SnowballingType.SNOWBALLING_TYPE_FORWARD)
+                        .setReviewMaybeAllowed(false)
+                        .build(),
+                )
+                .build()
+
+            val request = Project.Update.newBuilder()
+                .setProject(updatedProjectDetails)
+                .setMask(FieldMaskUtil.fromStringList(fieldMask))
+                .build()
+
+            val updatedProject = repo.updateProject(request, true)
+
+            if ("project.name" in fieldMask) {
+                assertThat(updatedProject.name).isEqualTo("Updated Project")
+            } else {
+                assertThat(updatedProject.name).isEqualTo("Test Project")
+            }
+            if ("project.status" in fieldMask) {
+                assertThat(updatedProject.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            } else {
+                assertThat(updatedProject.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            }
+            assertThat(updatedProject.similarityThreshold).isEqualTo(0F)
+            assertThat(updatedProject.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_BOTH)
+            assertThat(updatedProject.reviewMaybeAllowed).isEqualTo(true)
+        }
+    }
+
+    @Nested
     inner class GetUserProjects {
         @Test
         fun `When active projects are found where the user is member of, then all (and only these) active projects are returned`() =
             testCoroutine {
-                val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-                val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-                val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-                val project4Id = createExampleProject("Test Project 4", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+                val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val project4Id = insertTestProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_ACTIVE)
 
                 val userId = createExampleUser("userWithActiveProjects@example.com")
 
@@ -136,10 +276,10 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
         @Test
         fun `When archived projects are found where the user is member of, then all (and only these) archived projects are returned`() =
             testCoroutine {
-                val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-                val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-                val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-                val project4Id = createExampleProject("Test Project 4", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+                val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val project4Id = insertTestProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_ARCHIVED)
 
                 val userId = createExampleUser("userWithActiveProjects@example.com")
 
@@ -159,10 +299,10 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
         @Test
         fun `When deleted projects are found where the user is member of, then all (and only these) deleted projects are returned`() =
             testCoroutine {
-                val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-                val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-                val project3Id = createExampleProject("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
-                val project4Id = createExampleProject("Test Project 4", ProjectStatus.PROJECT_STATUS_DELETED)
+                val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+                val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
+                val project4Id = insertTestProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_DELETED)
 
                 val userId = createExampleUser("userWithActiveProjects@example.com")
 
@@ -181,8 +321,8 @@ class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberT
 
         @Test
         fun `When no projects are found where the user is member of, then no projects are returned`() = testCoroutine {
-            val project1Id = createExampleProject("Test Project 1", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val project2Id = createExampleProject("Test Project 2", ProjectStatus.PROJECT_STATUS_DELETED)
+            val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_DELETED)
 
             val userId = createExampleUser("userWithActiveProjects@example.com")
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -53,6 +53,29 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
     }
 
     @Nested
+    inner class GetProjectMemberByComposedId {
+        @Test
+        fun `When a project member is found, then the correct project member is returned`() = testCoroutine {
+            val (project, members) = setupProject()
+            val projectMember = repo.getProjectMemberByComposedId(project.id, members[0].userId)
+
+            assertThat(projectMember.projectId).isEqualTo(project.id)
+            assertThat(projectMember.userId).isEqualTo(testUserId)
+            assertThat(projectMember.role).isEqualTo(members[0].role)
+        }
+
+        @Test
+        fun `When a project member is not found, then an exception is thrown`() = testCoroutine {
+            assertThrows<NotFoundException> {
+                repo.getProjectMemberByComposedId(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                )
+            }
+        }
+    }
+
+    @Nested
     inner class AddUserToProject {
         @Test
         fun `When a user is added to a project, then they can be retrieved as project member`() = testCoroutine {
@@ -167,6 +190,78 @@ class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectM
 
             assertThat(result).hasSize(3)
             assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
+        }
+    }
+
+    @Nested
+    inner class GetAllProjectAdmins {
+        @Test
+        fun `When all project members are project admins, then the correct list of project admins is returned`() =
+            testCoroutine {
+                val (project, members) = setupProject(1)
+                val firstMember = repo.getProjectMemberByComposedId(project.id, testUserId)
+                val secondMember = repo.getProjectMemberByComposedId(project.id, members[1].userId)
+                assertThat(firstMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
+                assertThat(secondMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
+
+                repo.promoteProjectMemberToAdmin(project.id, firstMember.userId)
+                repo.promoteProjectMemberToAdmin(project.id, secondMember.userId)
+
+                val projectAdmins = repo.getAllProjectAdmins(project.id)
+
+                projectAdmins.forEachIndexed { index, admin ->
+                    assertThat(admin.projectId).isEqualTo(project.id)
+                    assertThat(admin.userId).isEqualTo(members[index].userId)
+                    assertThat(admin.role).isEqualTo(MemberRole.MEMBER_ROLE_ADMIN)
+                }
+            }
+
+        @Test
+        fun `When not all project members are project admins, then the correct list of project admins is returned`() =
+            testCoroutine {
+                val (project, members) = setupProject(1)
+                val firstMember = repo.getProjectMemberByComposedId(project.id, testUserId)
+                val secondMember = repo.getProjectMemberByComposedId(project.id, members[1].userId)
+                assertThat(firstMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
+                assertThat(secondMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
+
+                repo.promoteProjectMemberToAdmin(project.id, firstMember.userId)
+
+                val projectAdmins = repo.getAllProjectAdmins(project.id)
+
+                assertThat(projectAdmins).hasSize(1)
+                assertThat(projectAdmins).anyMatch { it.userId == firstMember.userId }
+                assertThat(projectAdmins).noneMatch { it.userId == secondMember.userId }
+            }
+    }
+
+    @Nested
+    inner class PromoteProjectMemberToAdmin {
+        @Test
+        fun `When a project member is promoted to admin, then the role of the project member is correctly updated`() =
+            testCoroutine {
+                val (project, _) = setupProject()
+                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId)
+                assertThat(normalMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
+
+                val promotedMember = repo.promoteProjectMemberToAdmin(project.id, testUserId)
+
+                assertThat(promotedMember.projectId).isEqualTo(project.id)
+                assertThat(promotedMember.userId).isEqualTo(testUserId)
+                assertThat(promotedMember.role).isEqualTo(MemberRole.MEMBER_ROLE_ADMIN)
+            }
+
+        @Test
+        fun `When a project admin is promoted, then the role of the project admin does not change`() = testCoroutine {
+            val (project, _) = setupProject()
+            var promotedMember = repo.promoteProjectMemberToAdmin(project.id, testUserId)
+            assertThat(promotedMember.role).isEqualTo(MemberRole.MEMBER_ROLE_ADMIN)
+
+            promotedMember = repo.promoteProjectMemberToAdmin(project.id, testUserId)
+
+            assertThat(promotedMember.projectId).isEqualTo(project.id)
+            assertThat(promotedMember.userId).isEqualTo(testUserId)
+            assertThat(promotedMember.role).isEqualTo(MemberRole.MEMBER_ROLE_ADMIN)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.every
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.BeforeEach
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
@@ -21,7 +22,7 @@ import java.util.UUID
 @DelicateCoroutinesApi
 class GetProjectByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
-    private var dummyUserUUID = UUID.randomUUID()
+    private val dummyUserUUID = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
@@ -29,8 +30,12 @@ class GetProjectByIdTest : MainServiceTest() {
         .build()
 
     @BeforeEach
-    fun setup() {
-        dummyUserUUID = UUID.fromString(dummyUserId!!)
+    fun setupTest() {
+        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
+        coEvery { projectMemberRepoMock.addUserToProject(any(), any()) } throws NotImplementedError()
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } throws NotImplementedError()
     }
 
     @Test
@@ -40,7 +45,9 @@ class GetProjectByIdTest : MainServiceTest() {
         val noAccessUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(id = requestId)
 
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
         assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
@@ -53,7 +60,9 @@ class GetProjectByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = requestId)
 
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
         assertDoesNotThrow { mainService.getProjectById(request) }
@@ -67,6 +76,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = requestId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = requestId)
 
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { projectMemberRepoMock.addUserToProject(user.id, requestId) } returns projectMember
         coEvery { projectMemberRepoMock.getMembersOfProject(requestId) } returns listOf(projectMember)
@@ -80,7 +90,10 @@ class GetProjectByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getProjectById(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -1,0 +1,88 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.Base
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class GetProjectByIdTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private var dummyUserUUID = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestId.toString())
+        .build()
+
+    @BeforeEach
+    fun setup() {
+        dummyUserUUID = UUID.fromString(dummyUserId!!)
+    }
+
+    @Test
+    fun `When the requesting user is not a member of the project, then an exception is thrown`() = testCoroutine {
+        val request = getExampleRequest()
+
+        val noAccessUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+
+        assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a server admin, then the project can be retrieved`() = testCoroutine {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+
+        assertDoesNotThrow { mainService.getProjectById(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a project member, then the project can be retrieved`() = testCoroutine {
+        val request = getExampleRequest()
+
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = requestId)
+
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { projectMemberRepoMock.addUserToProject(user.id, requestId) } returns projectMember
+        coEvery { projectMemberRepoMock.getMembersOfProject(requestId) } returns listOf(projectMember)
+        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+
+        assertDoesNotThrow { mainService.getProjectById(request) }
+    }
+
+    @Test
+    fun `When an error occurs while the project is retrieved, then an exception is thrown`() = testCoroutine {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectById(request) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.project
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
+import io.mockk.every
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.BeforeEach
@@ -10,29 +11,39 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.db.dummyUserId
-import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.testCoroutine
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
+import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 class UpdateProjectTest : MainServiceTest() {
+    private val dummyUserUUID = UUID.randomUUID()
+
     @BeforeEach
-    override fun setUpTest() {
-        super.setUpTest()
+    fun setupTest() {
+        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
+        coEvery {
+            projectMemberRepoMock.addUserToProject(any(), any())
+        } throws NotImplementedError()
+        coEvery {
+            projectMemberRepoMock.promoteProjectMemberToAdmin(any(), any())
+        } throws NotImplementedError()
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.updateProject(any(), any()) } throws NotImplementedError()
     }
 
     @Test
     fun `When a server admin updates the project information successfully, then no exception is thrown`() =
         testCoroutine {
-            val userId = parseUUID(dummyUserId!!, EntityType.USER)
-            val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_ADMIN)
+            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject(
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
             )
@@ -53,7 +64,8 @@ class UpdateProjectTest : MainServiceTest() {
                 updatedProject.toGrpcProject(),
             ).setMask(updateFieldMask).build()
 
-            coEvery { userRepoMock.getUserById(userId) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
             coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
@@ -63,8 +75,7 @@ class UpdateProjectTest : MainServiceTest() {
 
     @Test
     fun `When a project admin updates an ACITVE project, then no exception is thrown`() = testCoroutine {
-        val userId = parseUUID(dummyUserId!!, EntityType.USER)
-        val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
@@ -86,10 +97,11 @@ class UpdateProjectTest : MainServiceTest() {
             updatedProject.toGrpcProject(),
         ).setMask(updateFieldMask).build()
 
-        coEvery { userRepoMock.getUserById(userId) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
-        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, userId) } returns projectMember
+        coEvery { projectMemberRepoMock.addUserToProject(dummyUserUUID, project.id) } returns projectMember
+        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, dummyUserUUID) } returns projectMember
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
 
@@ -98,8 +110,7 @@ class UpdateProjectTest : MainServiceTest() {
 
     @Test
     fun `When a project member updates an ACTIVE project, then an unauthorized exception is thrown`() = testCoroutine {
-        val userId = parseUUID(dummyUserId!!, EntityType.USER)
-        val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
@@ -115,9 +126,11 @@ class UpdateProjectTest : MainServiceTest() {
             updatedProject.toGrpcProject(),
         ).setMask(updateFieldMask).build()
 
-        coEvery { userRepoMock.getUserById(userId) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+        coEvery { projectMemberRepoMock.addUserToProject(dummyUserUUID, project.id) } returns
+            projectMember
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
 
@@ -125,9 +138,8 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a project admin updates an ACTIVE_LOCKED project, then no exception is thrown`() = testCoroutine {
-        val userId = parseUUID(dummyUserId!!, EntityType.USER)
-        val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+    fun `When a project admin updates an ACITVE_LOCKED project, then no exception is thrown`() = testCoroutine {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
         )
@@ -137,6 +149,9 @@ class UpdateProjectTest : MainServiceTest() {
             id = project.id,
             name = "Updated Project",
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+            similarityThreshold = 1F,
+            snowballingType = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD,
+            reviewMaybeAllowed = false,
         )
 
         val updateFieldMask = FieldMaskUtil.fromStringList(
@@ -146,12 +161,16 @@ class UpdateProjectTest : MainServiceTest() {
             updatedProject.toGrpcProject(),
         ).setMask(updateFieldMask).build()
 
-        coEvery { userRepoMock.getUserById(userId) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
-        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, userId) } returns projectMember
+        coEvery { projectMemberRepoMock.addUserToProject(dummyUserUUID, project.id) } returns
+            projectMember
+        coEvery {
+            projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, dummyUserUUID)
+        } returns projectMember
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+        coEvery { projectRepoMock.updateProject(request, true) } returns updatedProject
 
         assertDoesNotThrow { mainService.updateProject(request) }
     }
@@ -159,8 +178,7 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When a project member updates an ACTIVE_LOCKED project, then an unauthorized exception is thrown`() =
         testCoroutine {
-            val userId = parseUUID(dummyUserId!!, EntityType.USER)
-            val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
             )
@@ -176,9 +194,11 @@ class UpdateProjectTest : MainServiceTest() {
                 updatedProject.toGrpcProject(),
             ).setMask(updateFieldMask).build()
 
-            coEvery { userRepoMock.getUserById(userId) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
-            coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+            coEvery { projectMemberRepoMock.addUserToProject(dummyUserUUID, project.id) } returns
+                projectMember
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
             coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
 
@@ -188,8 +208,7 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When a project admin updates an archived project, then a failed precondition exception is thrown`() =
         testCoroutine {
-            val userId = parseUUID(dummyUserId!!, EntityType.USER)
-            val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
             )
@@ -205,10 +224,14 @@ class UpdateProjectTest : MainServiceTest() {
                 updatedProject.toGrpcProject(),
             ).setMask(updateFieldMask).build()
 
-            coEvery { userRepoMock.getUserById(userId) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
-            coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
-            coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, userId) } returns projectMember
+            coEvery { projectMemberRepoMock.addUserToProject(dummyUserUUID, project.id) } returns
+                projectMember
+            coEvery {
+                projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, dummyUserUUID)
+            } returns projectMember
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
 
@@ -223,8 +246,10 @@ class UpdateProjectTest : MainServiceTest() {
         )
         val request = ProjectOuterClass.Project.Update.newBuilder().setProject(updatedProject.toGrpcProject()).build()
 
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(any()) } returns user
         coEvery { projectRepoMock.getProjectById(updatedProject.id) } returns updatedProject
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
         coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -1,0 +1,232 @@
+package se.uulm.snowballr.backend.service.project
+
+import com.google.protobuf.util.FieldMaskUtil
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.db.dummyUserId
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.toGrpcProject
+import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.testCoroutine
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass.UserRole
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class UpdateProjectTest : MainServiceTest() {
+    @BeforeEach
+    override fun setUpTest() {
+        super.setUpTest()
+    }
+
+    @Test
+    fun `When a server admin updates the project information successfully, then no exception is thrown`() =
+        testCoroutine {
+            val userId = parseUUID(dummyUserId!!, EntityType.USER)
+            val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(
+                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+            )
+
+            val updatedProject = DataBuilder.createExampleProject(
+                id = project.id,
+                name = "Updated Project",
+                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+                similarityThreshold = 1F,
+                snowballingType = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD,
+                reviewMaybeAllowed = false,
+            )
+
+            val updateFieldMask = FieldMaskUtil.fromStringList(
+                listOf("name", "status", "similarityThreshold", "snowballingType", "reviewMaybeAllowed"),
+            )
+            val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
+                updatedProject.toGrpcProject(),
+            ).setMask(updateFieldMask).build()
+
+            coEvery { userRepoMock.getUserById(userId) } returns user
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+
+            assertDoesNotThrow { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When a project admin updates an ACITVE project, then no exception is thrown`() = testCoroutine {
+        val userId = parseUUID(dummyUserId!!, EntityType.USER)
+        val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+        val updatedProject = DataBuilder.createExampleProject(
+            id = project.id,
+            name = "Updated Project",
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+            similarityThreshold = 1F,
+            snowballingType = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD,
+            reviewMaybeAllowed = false,
+        )
+
+        val updateFieldMask = FieldMaskUtil.fromStringList(
+            listOf("name", "status", "similarityThreshold", "snowballingType", "reviewMaybeAllowed"),
+        )
+        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
+            updatedProject.toGrpcProject(),
+        ).setMask(updateFieldMask).build()
+
+        coEvery { userRepoMock.getUserById(userId) } returns user
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, userId) } returns projectMember
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+        coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+
+        assertDoesNotThrow { mainService.updateProject(request) }
+    }
+
+    @Test
+    fun `When a project member updates an ACTIVE project, then an unauthorized exception is thrown`() = testCoroutine {
+        val userId = parseUUID(dummyUserId!!, EntityType.USER)
+        val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+        val updatedProject = DataBuilder.createExampleProject(
+            id = project.id,
+            name = "Updated Project",
+        )
+
+        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
+        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
+            updatedProject.toGrpcProject(),
+        ).setMask(updateFieldMask).build()
+
+        coEvery { userRepoMock.getUserById(userId) } returns user
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+
+        assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateProject(request) }
+    }
+
+    @Test
+    fun `When a project admin updates an ACTIVE_LOCKED project, then no exception is thrown`() = testCoroutine {
+        val userId = parseUUID(dummyUserId!!, EntityType.USER)
+        val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+        val updatedProject = DataBuilder.createExampleProject(
+            id = project.id,
+            name = "Updated Project",
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+        )
+
+        val updateFieldMask = FieldMaskUtil.fromStringList(
+            listOf("name", "status"),
+        )
+        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
+            updatedProject.toGrpcProject(),
+        ).setMask(updateFieldMask).build()
+
+        coEvery { userRepoMock.getUserById(userId) } returns user
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, userId) } returns projectMember
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+        coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+
+        assertDoesNotThrow { mainService.updateProject(request) }
+    }
+
+    @Test
+    fun `When a project member updates an ACTIVE_LOCKED project, then an unauthorized exception is thrown`() =
+        testCoroutine {
+            val userId = parseUUID(dummyUserId!!, EntityType.USER)
+            val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(
+                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+            )
+            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+            val updatedProject = DataBuilder.createExampleProject(
+                id = project.id,
+                name = "Updated Project",
+            )
+
+            val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
+            val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
+                updatedProject.toGrpcProject(),
+            ).setMask(updateFieldMask).build()
+
+            coEvery { userRepoMock.getUserById(userId) } returns user
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+
+            assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When a project admin updates an archived project, then a failed precondition exception is thrown`() =
+        testCoroutine {
+            val userId = parseUUID(dummyUserId!!, EntityType.USER)
+            val user = DataBuilder.createExampleUser(id = userId, role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(
+                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+            )
+            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+            val updatedProject = DataBuilder.createExampleProject(
+                id = project.id,
+                name = "Updated Project",
+            )
+
+            val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
+            val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
+                updatedProject.toGrpcProject(),
+            ).setMask(updateFieldMask).build()
+
+            coEvery { userRepoMock.getUserById(userId) } returns user
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.addUserToProject(userId, project.id) } returns projectMember
+            coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, userId) } returns projectMember
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+            coEvery { projectRepoMock.updateProject(request, false) } returns updatedProject
+
+            assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When an error occurs while updating a project, then an exception is thrown`() = testCoroutine {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val updatedProject = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(updatedProject.toGrpcProject()).build()
+
+        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { projectRepoMock.getProjectById(updatedProject.id) } returns updatedProject
+        coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateProject(request) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -9,8 +9,8 @@ import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.EnumUnspecified
 import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
+import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.TooLongField
-import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
 import snowballr.ProjectOuterClass.Project.Update
@@ -129,7 +129,7 @@ class ProjectValidatorTest {
         }
 
         @Test
-        fun `When an invalid project name is provided and specified in the field mask, then an 'BlankField' issue is returned`() {
+        fun `When an invalid project name is provided and specified in the field mask, then the 'BlankField' issue is returned`() {
             val project = validUpdatedProject.setName("  ").build()
             val request = validUpdateRequestBuilder
                 .setProject(project)
@@ -206,7 +206,7 @@ class ProjectValidatorTest {
         }
 
         @Test
-        fun `When a too low similarity threshold is provided and specified in the field mask, then the 'ValidationIssue' issue is returned`() {
+        fun `When a too low similarity threshold is provided and specified in the field mask, then the 'OutOfRangeValue' issue is returned`() {
             val project = validUpdatedProject.setSettings(
                 Project.Settings.newBuilder().setSimilarityThreshold(-1f).build(),
             ).build()
@@ -215,11 +215,11 @@ class ProjectValidatorTest {
                 .build()
             val result = validateRequest(request)
 
-            assertInvalidResult<ValidationIssue>(result)
+            assertInvalidResult<OutOfRangeValue>(result)
         }
 
         @Test
-        fun `When a too high similarity threshold is provided and specified in the field mask, then the 'ValidationIssue' issue is returned`() {
+        fun `When a too high similarity threshold is provided and specified in the field mask, then the 'OutOfRangeValue' issue is returned`() {
             val project = validUpdatedProject.setSettings(
                 Project.Settings.newBuilder().setSimilarityThreshold(2f).build(),
             ).build()
@@ -228,7 +228,7 @@ class ProjectValidatorTest {
                 .build()
             val result = validateRequest(request)
 
-            assertInvalidResult<ValidationIssue>(result)
+            assertInvalidResult<OutOfRangeValue>(result)
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -1,11 +1,22 @@
 package se.uulm.snowballr.backend.validation
 
+import com.google.protobuf.FieldMask
+import com.google.protobuf.util.FieldMaskUtil
 import `in`.rcard.assertj.arrowcore.EitherAssert
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.EnumUnspecified
+import se.uulm.snowballr.backend.model.InvalidFieldMask
+import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.TooLongField
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
+import snowballr.ProjectOuterClass.Project.Update
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ProjectOuterClass.SnowballingType
+import java.util.UUID
 
 class ProjectValidatorTest {
     @Nested
@@ -43,6 +54,196 @@ class ProjectValidatorTest {
             val result = validateRequest(request)
 
             assertInvalidResult<TooLongField>(result)
+        }
+    }
+
+    @Nested
+    inner class UpdateRequest {
+        private val validUpdatedProject: Project.Builder = Project.newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setName("Test Project")
+            .setStatus(ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            .setSettings(
+                Project.Settings.newBuilder()
+                    .setSimilarityThreshold(1F)
+                    .setSnowballingType(SnowballingType.SNOWBALLING_TYPE_FORWARD)
+                    .setReviewMaybeAllowed(false),
+            )
+        private val validFieldMask: FieldMask = FieldMaskUtil
+            .fromStringList(
+                listOf(
+                    "project.name",
+                    "project.status",
+                    "project.settings.similarity_threshold",
+                    "project.settings.snowballing_type",
+                    "project.settings.review_maybe_allowed",
+                ),
+            )
+
+        private val validUpdateRequestBuilder: Update.Builder =
+            Update
+                .newBuilder()
+                .setProject(validUpdatedProject)
+                .setMask(validFieldMask)
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validUpdateRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a blank field mask is validated, then the 'InvalidFieldMask' issue is returned`() {
+            val inValidFieldMask = FieldMaskUtil.fromStringList(listOf())
+            val request =
+                validUpdateRequestBuilder
+                    .setMask(inValidFieldMask)
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
+        fun `When a field mask containing a non-existing field is validated, then the 'InvalidFieldMask' issue is returned`() {
+            val request =
+                validUpdateRequestBuilder
+                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existing_field")))
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
+        fun `When an invalid ID is validated, then the 'InvalidId' issue is returned`() {
+            val project = validUpdatedProject.setId("invalid-id").build()
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When an invalid project name is provided and specified in the field mask, then an 'BlankField' issue is returned`() {
+            val project = validUpdatedProject.setName("  ").build()
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .setMask(validFieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<BlankField>(result)
+        }
+
+        @Test
+        fun `When an invalid project name is provided but not specified in the field mask, then no issue is returned`() {
+            val project = validUpdatedProject.setName("  ").build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("project.status"))
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid project status is provided and specified in the field mask, then the 'EnumUnspecified' issue is returned`() {
+            val project = validUpdatedProject.setStatus(ProjectStatus.PROJECT_STATUS_UNSPECIFIED).build()
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<EnumUnspecified>(result)
+        }
+
+        @Test
+        fun `When an invalid role is provided but not specified in the field mask, then no issue is returned`() {
+            val project = validUpdatedProject.setStatus(ProjectStatus.PROJECT_STATUS_UNSPECIFIED).build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("project.name"))
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid snowballing type is provided and specified in the field mask, then the 'EnumUnspecified' issue is returned`() {
+            val project = validUpdatedProject.setSettings(
+                Project.Settings.newBuilder().setSnowballingType(SnowballingType.SNOWBALLING_TYPE_UNSPECIFIED).build(),
+            ).build()
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<EnumUnspecified>(result)
+        }
+
+        @Test
+        fun `When an invalid snowballing type is provided but not specified in the field mask, then no issue is returned`() {
+            val project = validUpdatedProject.setSettings(
+                Project.Settings.newBuilder().setSnowballingType(SnowballingType.SNOWBALLING_TYPE_UNSPECIFIED).build(),
+            ).build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("project.name"))
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a too low similarity threshold is provided and specified in the field mask, then the 'ValidationIssue' issue is returned`() {
+            val project = validUpdatedProject.setSettings(
+                Project.Settings.newBuilder().setSimilarityThreshold(-1f).build(),
+            ).build()
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<ValidationIssue>(result)
+        }
+
+        @Test
+        fun `When a too high similarity threshold is provided and specified in the field mask, then the 'ValidationIssue' issue is returned`() {
+            val project = validUpdatedProject.setSettings(
+                Project.Settings.newBuilder().setSimilarityThreshold(2f).build(),
+            ).build()
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<ValidationIssue>(result)
+        }
+
+        @Test
+        fun `When an invalid similarity threshold is provided but not specified in the field mask, then no issue is returned`() {
+            val project = validUpdatedProject.setSettings(
+                Project.Settings.newBuilder().setSimilarityThreshold(2f).build(),
+            ).build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("project.name"))
+            val request = validUpdateRequestBuilder
+                .setProject(project)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
         }
     }
 }


### PR DESCRIPTION
Closes #64
Closes #86 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I added the implementation for the following calls
  - `updateProject`
  - `getProjectById` (#86)
- This includes the implementation of the repository layer, i.e., an update function for a project, the service layer and the validation for an update request.
- I also added a few calls in the repository layer to be able to update the project properly. This includes:
  - `getProjectMemberByComposedId`
  - `getAllProjectAdmins`
  - `promoteProjectMemberToAdmin`

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
