### PR TITLE
fix: getAllUsers only returns existing users

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
@@ -17,6 +18,7 @@ import snowballr.Authentication
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import snowballr.email
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -129,6 +131,7 @@ class UserTableRepo(
     override suspend fun getAllUsers(): List<User> = db.dbQuery {
         UserTable
             .selectAll()
+            .where(UserTable.email neq "")
             .map { it.toUser() }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -127,6 +127,19 @@ class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
             val secondUser = users.find { it.id == userId2 }
             assertThat(secondUser).isNotNull
         }
+
+        @Test
+        fun `When permanently deleted users exist, then only the existing users are returned`() = testCoroutine {
+            val userId1 = insertTestUserAndGetId(email = "test.user1@example.com", lastName = "User 1")
+            val userId2 = insertTestUserAndGetId(email = "", firstName = "", lastName = "")
+
+            val users = repo.getAllUsers()
+            assertThat(users).hasSize(1)
+            val firstUser = users.find { it.id == userId1 }
+            assertThat(firstUser).isNotNull
+            val secondUser = users.find { it.id == userId2 }
+            assertThat(secondUser).isNull()
+        }
     }
 
     @Nested


### PR DESCRIPTION
Closes #113 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

I added a check for an empty email in the `getAllUsers` method to only return the still existing users. To only check the email should be enough, because only the server itself can set an empty email on permanent delete of an user.
Additionally, I added one test for the bug fix. 

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
