### PR TITLE
Add `getInviteCandidates` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/db/DatabaseHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/DatabaseHelper.kt
@@ -47,6 +47,7 @@ object DatabaseHelper {
      */
     fun Transaction.addExtensions() {
         exec("CREATE EXTENSION IF NOT EXISTS hstore;")
+        exec("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -249,8 +249,9 @@ class SnowballRServer(
         override suspend fun getPendingInvitationsForUser(request: Base.Id): ProjectOuterClass.Project.List =
             super.getPendingInvitationsForUser(request)
 
-        override suspend fun getInviteCandidates(request: UserOuterClass.User.SearchQuery): UserOuterClass.User.List =
-            mainService.getInviteCandidates(request)
+        override suspend fun getInviteCandidates(
+            request: ProjectOuterClass.Project.InviteCandidatesRequest,
+        ): UserOuterClass.User.List = mainService.getInviteCandidates(request)
 
         override suspend fun inviteUserToProject(request: ProjectOuterClass.Project.Member.Invite): Base.Nothing =
             super.inviteUserToProject(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -250,7 +250,7 @@ class SnowballRServer(
             super.getPendingInvitationsForUser(request)
 
         override suspend fun getInviteCandidates(request: UserOuterClass.User.SearchQuery): UserOuterClass.User.List =
-            super.getInviteCandidates(request)
+            mainService.getInviteCandidates(request)
 
         override suspend fun inviteUserToProject(request: ProjectOuterClass.Project.Member.Invite): Base.Nothing =
             super.inviteUserToProject(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/User.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/User.kt
@@ -32,3 +32,12 @@ fun User.toGrpcUser(): UserOuterClass.User = UserOuterClass.User
     .setRole(this.role)
     .setStatus(this.status)
     .build()
+
+/**
+ * Creates a list of [UserOuterClass.User]s from this list of [User]s.
+ */
+fun List<User>.toGrpcUsers(): UserOuterClass.User.List {
+    val builder = UserOuterClass.User.List.newBuilder()
+    this.forEach { builder.addUsers(it.toGrpcUser()) }
+    return builder.build()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
@@ -169,7 +168,7 @@ class UserTableRepo(
                     (UserTable.status eq UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED) or
                         (UserTable.status eq UserStatus.USER_STATUS_ACTIVE)
                 }
-                .andWhere { UserTable.id notInList excludedUsers.map { it } }
+                .andWhere { UserTable.id notInList excludedUsers.toList() }
                 .limit(MAXIMUM_NUMBER_OF_INVITE_CANDIDATES)
                 .map { it.toUser() }
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -56,14 +56,16 @@ interface IUserTableRepo {
     suspend fun getAllUsers(): List<User>
 
     /**
-     * Returns users whose names and / or emails (partially) match the [searchQuery].
+     * Retrieves a list of users whose name or email partially or fully match the [searchQuery].
      *
-     * A maximum of 10 matching users is returned. The matching users must still be active and not deleted or
-     * marked to be deleted.
+     * Only users who are active (not deleted or marked for deletion) and not present in the list of [excludedUsers]
+     * are included in the results. The number of returned users is limited to a maximum of 10.
      *
      * @param searchQuery The query against which the firstnames, lastnames, and emails of the users are checked.
+     * @param excludedUsers A list of user ids to be excluded from the results.
+     * @return A list of up to 10 matching users.
      */
-    suspend fun getUsersMatchingSearchQuery(searchQuery: String): List<User>
+    suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<UUID>): List<User>
 
     /**
      * Creates a new user in the database with the provided registration request and password hash.
@@ -154,19 +156,23 @@ class UserTableRepo(
             .map { it.toUser() }
     }
 
-    override suspend fun getUsersMatchingSearchQuery(searchQuery: String): List<User> = db.dbQuery {
-        val query = "%$searchQuery%"
+    override suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<UUID>): List<User> =
+        db.dbQuery {
+            val query = "%$searchQuery%"
 
-        UserTable
-            .selectAll()
-            .where((UserTable.firstName like query) or (UserTable.lastName like query) or (UserTable.email like query))
-            .andWhere {
-                (UserTable.status eq UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED) or
-                    (UserTable.status eq UserStatus.USER_STATUS_ACTIVE)
-            }
-            .limit(MAXIMUM_NUMBER_OF_INVITE_CANDIDATES)
-            .map { it.toUser() }
-    }
+            UserTable
+                .selectAll()
+                .where {
+                    (UserTable.firstName like query) or (UserTable.lastName like query) or (UserTable.email like query)
+                }
+                .andWhere {
+                    (UserTable.status eq UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED) or
+                        (UserTable.status eq UserStatus.USER_STATUS_ACTIVE)
+                }
+                .andWhere { UserTable.id notInList excludedUsers.map { it } }
+                .limit(MAXIMUM_NUMBER_OF_INVITE_CANDIDATES)
+                .map { it.toUser() }
+        }
 
     override suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User = db.query {
         UserTable.insertAndGet(ResultRow::toUser, EntityType.USER) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -3,9 +3,9 @@ package se.uulm.snowballr.backend.repository
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
-import org.jetbrains.exposed.sql.andWhere
-import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.TextColumnType
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
@@ -19,6 +19,7 @@ import snowballr.Authentication
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import java.sql.ResultSet
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -59,6 +60,9 @@ interface IUserTableRepo {
      *
      * Only users who are active (not deleted or marked for deletion) and not present in the list of [excludedUsers]
      * are included in the results. The number of returned users is limited to a maximum of 10.
+     * The search string is matched against the firstname, lastname, and email address of the user using
+     * the `similarity()` function from the `pg_trgm` extension. Furthermore, the matching users are sorted by
+     * their similarity to the search query.
      *
      * @param searchQuery The query against which the firstnames, lastnames, and emails of the users are checked.
      * @param excludedUsers A list of user ids to be excluded from the results.
@@ -112,11 +116,25 @@ interface IUserTableRepo {
  *
  * @param db The database abstraction used for executing queries within a transaction.
  */
+@Suppress("TooManyFunctions")
 class UserTableRepo(
     private val db: IDatabase,
 ) : IUserTableRepo {
     companion object {
         const val MAXIMUM_NUMBER_OF_INVITE_CANDIDATES = 10
+    }
+
+    private fun extractUserRows(result: ResultSet): List<User> {
+        return generateSequence {
+            if (result.next()) {
+                ResultRow.create(
+                    result,
+                    UserTable.fields.withIndex().associate { it.value to it.index },
+                )
+            } else {
+                null
+            }
+        }.map { it.toUser() }.toList()
     }
 
     /**
@@ -155,22 +173,48 @@ class UserTableRepo(
             .map { it.toUser() }
     }
 
+    @Suppress("MagicNumber")
     override suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<UUID>): List<User> =
-        db.dbQuery {
-            val query = "%$searchQuery%"
+        db.query {
+            val userTable = "\"${UserTable.tableName}\""
+            val idCol = "$userTable.${UserTable.id.name}"
+            val firstNameCol = "$userTable.${UserTable.firstName.name}"
+            val lastNameCol = "$userTable.${UserTable.lastName.name}"
+            val emailCol = "$userTable.${UserTable.email.name}"
+            val statusCol = "$userTable.${UserTable.status.name}"
 
-            UserTable
-                .selectAll()
-                .where {
-                    (UserTable.firstName like query) or (UserTable.lastName like query) or (UserTable.email like query)
-                }
-                .andWhere {
-                    (UserTable.status eq UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED) or
-                        (UserTable.status eq UserStatus.USER_STATUS_ACTIVE)
-                }
-                .andWhere { UserTable.id notInList excludedUsers.toList() }
-                .limit(MAXIMUM_NUMBER_OF_INVITE_CANDIDATES)
-                .map { it.toUser() }
+            val excludeUsersClause = if (excludedUsers.isNotEmpty()) {
+                "AND $idCol NOT IN (${excludedUsers.joinToString(",") { "'$it'" }})"
+            } else {
+                ""
+            }
+
+            val rawSqlQuery =
+                """
+                WITH users_with_similarity_scores AS (
+                    SELECT *,
+                        similarity($firstNameCol, ?) AS sim_first_name,
+                        similarity($lastNameCol, ?) AS sim_last_name,
+                        similarity($emailCol, ?) AS sim_email
+                    FROM $userTable
+                    WHERE $statusCol IN (${UserStatus.USER_STATUS_ACTIVE.ordinal}, ${UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED.ordinal})
+                      $excludeUsersClause
+                )
+                SELECT *
+                FROM users_with_similarity_scores
+                WHERE GREATEST(sim_first_name, sim_last_name, sim_email) > 0.2
+                ORDER BY GREATEST(sim_first_name, sim_last_name, sim_email) DESC
+                LIMIT $MAXIMUM_NUMBER_OF_INVITE_CANDIDATES
+                """.trimIndent()
+
+            val matchingUsers = exec(
+                stmt = rawSqlQuery,
+                args = List(3) { TextColumnType() to searchQuery },
+                explicitStatementType = StatementType.SELECT,
+                transform = ::extractUserRows,
+            )
+
+            matchingUsers.orEmpty()
         }
 
     override suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -2,7 +2,10 @@ package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
+import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
@@ -53,6 +56,16 @@ interface IUserTableRepo {
     suspend fun getAllUsers(): List<User>
 
     /**
+     * Returns users whose names and / or emails (partially) match the [searchQuery].
+     *
+     * A maximum of 10 matching users is returned. The matching users must still be active and not deleted or
+     * marked to be deleted.
+     *
+     * @param searchQuery The query against which the firstnames, lastnames, and emails of the users are checked.
+     */
+    suspend fun getUsersMatchingSearchQuery(searchQuery: String): List<User>
+
+    /**
      * Creates a new user in the database with the provided registration request and password hash.
      *
      * @param request The registration request containing user details such as email, first name, and last name.
@@ -101,6 +114,16 @@ interface IUserTableRepo {
 class UserTableRepo(
     private val db: IDatabase,
 ) : IUserTableRepo {
+    companion object {
+        const val MAXIMUM_NUMBER_OF_INVITE_CANDIDATES = 10
+    }
+
+    /**
+     * Requesting a user from the database.
+     *
+     * @param id The id of the requested user.
+     * @return The [User] object or null, if no user with the given [id] was found.
+     */
     private fun getUserByIdOrNull(id: UUID): User? = UserTable.getEntityByIdOrNull(id, ResultRow::toUser)
 
     override suspend fun getUserById(id: UUID): User = db.query {
@@ -128,6 +151,20 @@ class UserTableRepo(
         UserTable
             .selectAll()
             .where(UserTable.email neq "")
+            .map { it.toUser() }
+    }
+
+    override suspend fun getUsersMatchingSearchQuery(searchQuery: String): List<User> = db.dbQuery {
+        val query = "%$searchQuery%"
+
+        UserTable
+            .selectAll()
+            .where((UserTable.firstName like query) or (UserTable.lastName like query) or (UserTable.email like query))
+            .andWhere {
+                (UserTable.status eq UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED) or
+                    (UserTable.status eq UserStatus.USER_STATUS_ACTIVE)
+            }
+            .limit(MAXIMUM_NUMBER_OF_INVITE_CANDIDATES)
             .map { it.toUser() }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -14,6 +14,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.UnauthenticatedExcepti
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
+import se.uulm.snowballr.backend.model.dto.toGrpcUsers
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
@@ -23,6 +24,7 @@ import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
+import snowballr.UserOuterClass.User as GrpcUser
 
 interface IUserService {
     /**
@@ -39,6 +41,11 @@ interface IUserService {
      * Service implementation of [SnowballRService.getAllUsers].
      */
     suspend fun getAllUsers(): UserOuterClass.User.List
+
+    /**
+     * Service implementation of [SnowballRService.getInviteCandidates]
+     */
+    suspend fun getInviteCandidates(request: UserOuterClass.User.SearchQuery): UserOuterClass.User.List
 
     /**
      * Service implementation of [SnowballRService.register].
@@ -82,8 +89,12 @@ class UserService(
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val jwtService: IJwtService,
 ) : IUserService {
+    companion object {
+        const val MINIMUM_LENGTH_OF_SEARCH_QUERY = 3
+    }
+
     private suspend fun verifyUserAccess(currentUser: User, targetUserId: UUID, identifierType: IdentifierType) {
-        // Check whether requesting user is server admin
+        // Check whether the requesting user is server admin
         if (currentUser.role == UserRole.USER_ROLE_ADMIN) return
 
         // Check whether requesting user is requested user
@@ -106,7 +117,7 @@ class UserService(
         )
     }
 
-    override suspend fun getUserById(request: Base.Id): UserOuterClass.User {
+    override suspend fun getUserById(request: Base.Id): GrpcUser {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val targetUserId = parseUUID(request.id, EntityType.USER)
 
@@ -132,7 +143,7 @@ class UserService(
         return result.toGrpcUser()
     }
 
-    override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User {
+    override suspend fun getUserByEmail(request: Base.Email): GrpcUser {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
 
         // We have to request the user first to get the ID for the access checks
@@ -150,16 +161,26 @@ class UserService(
         return targetUser.toGrpcUser()
     }
 
-    override suspend fun getAllUsers(): UserOuterClass.User.List {
+    override suspend fun getAllUsers(): GrpcUser.List {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
 
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.USER, AccessType.READ, it) }
 
         val users = userRepo.getAllUsers()
 
-        val builder = UserOuterClass.User.List.newBuilder()
-        users.forEach { builder.addUsers(it.toGrpcUser()) }
-        return builder.build()
+        return users.toGrpcUsers()
+    }
+
+    override suspend fun getInviteCandidates(request: GrpcUser.SearchQuery): GrpcUser.List {
+        val searchQuery = request.query.trim()
+
+        // Check whether the search query is too short, i.e., 3 or fewer characters long
+        if (searchQuery.length < MINIMUM_LENGTH_OF_SEARCH_QUERY) {
+            return GrpcUser.List.newBuilder().build()
+        }
+
+        val candidates = userRepo.getUsersMatchingSearchQuery(searchQuery)
+        return candidates.toGrpcUsers()
     }
 
     override suspend fun register(request: Authentication.RegisterRequest): Base.Nothing {
@@ -212,7 +233,7 @@ class UserService(
         return Base.Nothing.getDefaultInstance()
     }
 
-    override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User {
+    override suspend fun updateUser(request: GrpcUser.Update): GrpcUser {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
 
         // Check that user to update exists in the database
@@ -241,7 +262,7 @@ class UserService(
         val targetUser = userRepo.getUserById(parseUUID(request.id, EntityType.USER))
         val isSameUser = currentUser.id == targetUser.id
 
-        // Checks, if the user tries to delete another user without being an admin
+        // Checks if the user tries to delete another user without being an admin
         if (!isSameUser) {
             verifyServerAdminRole(currentUser) {
                 UnauthorizedException.Single(EntityType.USER, targetUser.id.toString(), AccessType.DELETE, it)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -183,7 +183,7 @@ class UserService(
 
         // Check whether the search query is too short, i.e., 3 or fewer characters long
         if (searchQuery.length < MINIMUM_LENGTH_OF_SEARCH_QUERY) {
-            return GrpcUser.List.newBuilder().build()
+            return GrpcUser.List.getDefaultInstance()
         }
 
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.service
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.IJwtService
 import se.uulm.snowballr.backend.auth.PasswordUtils
@@ -7,6 +8,7 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
+import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
@@ -20,11 +22,14 @@ import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Authentication
 import snowballr.Base
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 import snowballr.UserOuterClass.User as GrpcUser
+
+val Logger = KotlinLogging.logger { }
 
 interface IUserService {
     /**
@@ -45,7 +50,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.getInviteCandidates]
      */
-    suspend fun getInviteCandidates(request: UserOuterClass.User.SearchQuery): UserOuterClass.User.List
+    suspend fun getInviteCandidates(request: ProjectOuterClass.Project.InviteCandidatesRequest): GrpcUser.List
 
     /**
      * Service implementation of [SnowballRService.register].
@@ -65,7 +70,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.updateUser].
      */
-    suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User
+    suspend fun updateUser(request: GrpcUser.Update): GrpcUser
 
     /**
      * Service implementation of [SnowballRService.softDeleteUser].
@@ -171,7 +176,9 @@ class UserService(
         return users.toGrpcUsers()
     }
 
-    override suspend fun getInviteCandidates(request: GrpcUser.SearchQuery): GrpcUser.List {
+    override suspend fun getInviteCandidates(
+        request: ProjectOuterClass.Project.InviteCandidatesRequest,
+    ): GrpcUser.List {
         val searchQuery = request.query.trim()
 
         // Check whether the search query is too short, i.e., 3 or fewer characters long
@@ -179,7 +186,17 @@ class UserService(
             return GrpcUser.List.newBuilder().build()
         }
 
-        val candidates = userRepo.getUsersMatchingSearchQuery(searchQuery)
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val excludedUsersFromSearch = mutableSetOf(currentUser.id)
+        try {
+            val projectMembers = projectMemberRepo.getMembersOfProject(parseUUID(request.projectId, EntityType.PROJECT))
+            excludedUsersFromSearch += projectMembers.map { it.userId }
+        } catch (_: SnowballRException.InvalidIdException.UUID) {
+            Logger.warn { "Invalid project ID in invite candidates request: ${request.projectId}" }
+        }
+
+        val candidates = userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
+
         return candidates.toGrpcUsers()
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -44,6 +44,7 @@ const val PROJECT_NAME_MAX_LENGTH = 100
  * @return An [EitherNel] containing a collection of [ValidationIssue] objects if validation issues are found,
  *         or `Unit` if the validation is successful.
  */
+@Suppress("CyclomaticComplexMethod")
 fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (request) {
     // Healthcheck
     is HealthCheckRequest -> Either.Right(Unit)
@@ -57,6 +58,7 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     // Project
     is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
     is ProjectOuterClass.Project.Update -> ProjectValidator.validateUpdateRequest(request)
+    is ProjectOuterClass.Project.InviteCandidatesRequest -> Either.Right(Unit)
     // Criterion
     is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
     is CriterionOuterClass.Criterion.Update -> CriterionValidator.validateUpdateRequest(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -317,20 +317,18 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             val userId2 = insertTestUserAndGetId(lastName = "John", email = "doe.john@example.com")
             val userId3 = insertTestUserAndGetId(email = "john.doe@example.com")
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf())
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 
-            assertEquals(3, matchingUsers.size)
+            assertThat(matchingUsers).hasSize(3)
 
-            assertThat(matchingUsers.find { it.id == userId1 }).isNotNull
-            assertThat(matchingUsers.find { it.id == userId2 }).isNotNull
-            assertThat(matchingUsers.find { it.id == userId3 }).isNotNull
+            assertThat(matchingUsers.map { it.id }).containsExactlyInAnyOrder(userId1, userId2, userId3)
         }
 
         @Test
         fun `When a deleted user is matching the search query, then this user is not returned`() = runTest {
             insertTestUserAndGetId(firstName = "john", lastName = "doe", status = UserStatus.USER_STATUS_DELETED)
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf())
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 
             assertEquals(0, matchingUsers.size)
         }
@@ -339,7 +337,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         fun `When no user is matching the search query, then an empty list is returned`() = runTest {
             insertTestUserAndGetId(firstName = "johnathan")
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("non-existing", setOf())
+            val matchingUsers = repo.getUsersMatchingSearchQuery("non-existing", emptySet())
 
             assertEquals(0, matchingUsers.size)
         }
@@ -351,7 +349,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
                     insertTestUserAndGetId(firstName = "John the $i-th", email = "john$i@example.com")
                 }
 
-                val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf())
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 
                 assertEquals(10, matchingUsers.size)
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -20,6 +20,7 @@ import snowballr.Authentication
 import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import snowballr.email
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -307,5 +308,53 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         fun `When a user is not found, then an exception is thrown`() = runTest {
             assertThrows<NotFoundException> { repo.getPasswordHashByEmail("non-existing email") }
         }
+    }
+
+    @Nested
+    inner class GetUsersMatchingSearchQuery {
+        @Test
+        fun `When a user is matching the search query, then this user is returned`() = runTest {
+            val userId1 = insertTestUserAndGetId(firstName = "Johnathan", email = "jonathan.doe@example.com")
+            val userId2 = insertTestUserAndGetId(lastName = "John", email = "doe.john@example.com")
+            val userId3 = insertTestUserAndGetId(email = "john.doe@example.com")
+
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john")
+
+            assertEquals(3, matchingUsers.size)
+
+            assertThat(matchingUsers.find { it.id == userId1 }).isNotNull
+            assertThat(matchingUsers.find { it.id == userId2 }).isNotNull
+            assertThat(matchingUsers.find { it.id == userId3 }).isNotNull
+        }
+
+        @Test
+        fun `When a deleted user is matching the search query, then this user is not returned`() = runTest {
+            insertTestUserAndGetId(firstName = "john", lastName = "doe", status = UserStatus.USER_STATUS_DELETED)
+
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john")
+
+            assertEquals(0, matchingUsers.size)
+        }
+
+        @Test
+        fun `When no user is matching the search query, then an empty list is returned`() = runTest {
+            insertTestUserAndGetId(firstName = "johnathan")
+
+            val matchingUsers = repo.getUsersMatchingSearchQuery("non-existing")
+
+            assertEquals(0, matchingUsers.size)
+        }
+
+        @Test
+        fun `When more than 10 users match the search query, then only the first 10 matching users are returned`() =
+            runTest {
+                for (i in 1..15) {
+                    insertTestUserAndGetId(firstName = "John the $i-th", email = "john$i@example.com")
+                }
+
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john")
+
+                assertEquals(10, matchingUsers.size)
+            }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -315,7 +315,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         fun `When a user is matching the search query, then this user is returned`() = runTest {
             val userId1 = insertTestUserAndGetId(firstName = "Johnathan", email = "jonathan.doe@example.com")
             val userId2 = insertTestUserAndGetId(lastName = "John", email = "doe.john@example.com")
-            val userId3 = insertTestUserAndGetId(email = "john.doe@example.com")
+            val userId3 = insertTestUserAndGetId(email = "john@example.com")
 
             val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -20,7 +20,6 @@ import snowballr.Authentication
 import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
-import snowballr.email
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -318,7 +317,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             val userId2 = insertTestUserAndGetId(lastName = "John", email = "doe.john@example.com")
             val userId3 = insertTestUserAndGetId(email = "john.doe@example.com")
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("john")
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf())
 
             assertEquals(3, matchingUsers.size)
 
@@ -331,7 +330,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         fun `When a deleted user is matching the search query, then this user is not returned`() = runTest {
             insertTestUserAndGetId(firstName = "john", lastName = "doe", status = UserStatus.USER_STATUS_DELETED)
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("john")
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf())
 
             assertEquals(0, matchingUsers.size)
         }
@@ -340,7 +339,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         fun `When no user is matching the search query, then an empty list is returned`() = runTest {
             insertTestUserAndGetId(firstName = "johnathan")
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("non-existing")
+            val matchingUsers = repo.getUsersMatchingSearchQuery("non-existing", setOf())
 
             assertEquals(0, matchingUsers.size)
         }
@@ -352,9 +351,19 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
                     insertTestUserAndGetId(firstName = "John the $i-th", email = "john$i@example.com")
                 }
 
-                val matchingUsers = repo.getUsersMatchingSearchQuery("john")
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf())
 
                 assertEquals(10, matchingUsers.size)
+            }
+
+        @Test
+        fun `When a user is matching the search query but should be excluded, then this user is not returned`() =
+            runTest {
+                val userId = insertTestUserAndGetId(firstName = "johnathan")
+
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf(userId))
+
+                assertEquals(0, matchingUsers.size)
             }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -32,8 +32,9 @@ class GetInviteCandidatesTest : MainServiceTest() {
 
     @Test
     fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val userId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns userId
+        coEvery { userRepoMock.getUserById(userId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getInviteCandidates(validInviteCandidatesRequest) }
     }
@@ -46,14 +47,13 @@ class GetInviteCandidatesTest : MainServiceTest() {
         ).setProjectId("invalid-uuid").build()
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
     }
 
     @Test
-    fun `When retrieving the project members fails, then only a warning is logged`() = runTest {
+    fun `When no the project members exist, then no users except for the current user are excluded`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedProjectId = UUID.randomUUID()
         val requestWithNotExistingProject = InviteCandidatesRequest.newBuilder().setQuery(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -1,38 +1,118 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.every
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass
+import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
+import java.util.UUID
+import kotlin.test.assertTrue
 
 @DelicateCoroutinesApi
 @ExperimentalCoroutinesApi
 class GetInviteCandidatesTest : MainServiceTest() {
-    private val validSearchQuery = UserOuterClass.User.SearchQuery.newBuilder().setQuery("john").build()
+    private val testProjectId = UUID.randomUUID()
+    private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder().setQuery(
+        "john",
+    ).setProjectId(testProjectId.toString()).build()
 
     @Test
     fun `When the search query is too short, then an empty list is returned`() = runTest {
-        val shortSearchQuery = UserOuterClass.User.SearchQuery.newBuilder().setQuery("ab").build()
+        val shortSearchQuery = InviteCandidatesRequest.newBuilder().setQuery("j").build()
         assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
     }
 
     @Test
-    fun `When the retrieving the invite candidates fails, then exception is thrown`() = runTest {
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(any()) } throws TestSpecificException()
+    fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { mainService.getInviteCandidates(validSearchQuery) }
+        assertThrows<TestSpecificException> { mainService.getInviteCandidates(validInviteCandidatesRequest) }
     }
 
     @Test
-    fun `When the retrieving the invite candidates is successful, then no exception is thrown`() = runTest {
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(any()) } returns emptyList()
+    fun `When parsing the project id fails, then only a warning is logged`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val requestWithInvalidProjectId = InviteCandidatesRequest.newBuilder().setQuery(
+            "john",
+        ).setProjectId("invalid-uuid").build()
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getInviteCandidates(validSearchQuery) }
+        assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
     }
+
+    @Test
+    fun `When retrieving the project members fails, then only a warning is logged`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val requestedProjectId = UUID.randomUUID()
+        val requestWithNotExistingProject = InviteCandidatesRequest.newBuilder().setQuery(
+            "john",
+        ).setProjectId(requestedProjectId.toString()).build()
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectMemberRepoMock.getMembersOfProject(requestedProjectId) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getInviteCandidates(requestWithNotExistingProject) }
+    }
+
+    @Test
+    fun `When retrieving the users matching the search query fails, then an empty list is returned`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectMemberRepoMock.getMembersOfProject(testProjectId) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
+    }
+
+    @Test
+    fun `When retrieving the invite candidates is successful, then these are returned except for the current user`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
+            val users = listOf(currentUser, DataBuilder.createExampleUser(email = "another.user@example.com"))
+            val excludedUsers = setOf(currentUser.id)
+            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { projectMemberRepoMock.getMembersOfProject(testProjectId) } returns emptyList()
+            coEvery {
+                userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id))
+            } returns users.filterNot { it.id in excludedUsers }
+
+            val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
+            assertTrue { inviteCandidates.usersList.size == 1 }
+            assertTrue { inviteCandidates.usersList.find { it.id == currentUser.id.toString() } == null }
+        }
+
+    @Test
+    fun `When retrieving the project members is successful, then these members are not returned as invite candidates`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
+            val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
+            val users = listOf(currentUser, projectMember)
+            val excludedUsers = setOf(currentUser.id, projectMember.id)
+            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery {
+                projectMemberRepoMock.getMembersOfProject(testProjectId)
+            } returns listOf(DataBuilder.createExampleProjectMember(userId = projectMember.id))
+            coEvery {
+                userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id, projectMember.id))
+            } returns users.filterNot { it.id in excludedUsers }
+
+            val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
+            assertTrue { inviteCandidates.usersList.isEmpty() }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -1,0 +1,38 @@
+package se.uulm.snowballr.backend.service.user
+
+import io.mockk.coEvery
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.UserOuterClass
+
+@DelicateCoroutinesApi
+@ExperimentalCoroutinesApi
+class GetInviteCandidatesTest : MainServiceTest() {
+    private val validSearchQuery = UserOuterClass.User.SearchQuery.newBuilder().setQuery("john").build()
+
+    @Test
+    fun `When the search query is too short, then an empty list is returned`() = runTest {
+        val shortSearchQuery = UserOuterClass.User.SearchQuery.newBuilder().setQuery("ab").build()
+        assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
+    }
+
+    @Test
+    fun `When the retrieving the invite candidates fails, then exception is thrown`() = runTest {
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getInviteCandidates(validSearchQuery) }
+    }
+
+    @Test
+    fun `When the retrieving the invite candidates is successful, then no exception is thrown`() = runTest {
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(any()) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getInviteCandidates(validSearchQuery) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -246,4 +246,15 @@ class ProjectValidatorTest {
             EitherAssert.assertThat(result).isRight()
         }
     }
+
+    @Nested
+    inner class InviteCandidatesRequest {
+        @Test
+        fun `When an invite candidate request is validated, it is always valid`() {
+            val request = Project.InviteCandidatesRequest.getDefaultInstance()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+    }
 }


### PR DESCRIPTION
Closes #75 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I bumped the api version to v0.5.1
- I added the implementation for the following call
  - `GetInviteCandidates`

**Note:** I manually tested the call and using the frontend you can clearly see that the user currently logged in is excluded. However, I do not really now how to manually test the process with the exclusion of project members, as a lot of stuff is missing to test this in the frontend and testing it with grpc requests is really time consuming.

And another question for the reviewer: At the moment I implemented a very simple matching algorithm that is neither robust against spelling mistakes nor ranks the results based on some kind of "relevance". 
Theoretically there exist a Postgres sql extension `pg_trgm` that could be used to introduce a similarity function that would allows some kind of fuzzing matching. Now my question: is this necessary to solve now or should be go on and create an issue for the next team describing how the search for candidates could be improved. Furthermore, what do you think of the limiting of the results to 10 users? Especially since only the first 10 are taken and not the 10 best matching. Should I remove this again or should we keep it as discussed?

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
