### PR TITLE
Implement updatecriterion call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -309,7 +309,7 @@ class SnowballRServer(
             super.updateProjectMemberRole(request)
 
         override suspend fun getCriterionById(request: Base.Id): CriterionOuterClass.Criterion =
-            super.getCriterionById(request)
+            mainService.getCriterionById(request)
 
         override suspend fun getAllCriteriaForProject(request: Base.Id): CriterionOuterClass.Criterion.List =
             super.getAllCriteriaForProject(request)
@@ -320,7 +320,7 @@ class SnowballRServer(
 
         override suspend fun updateCriterion(
             request: CriterionOuterClass.Criterion.Update,
-        ): CriterionOuterClass.Criterion = super.updateCriterion(request)
+        ): CriterionOuterClass.Criterion = mainService.updateCriterion(request)
 
         override suspend fun deleteCriterion(request: Base.Id): Base.Nothing = super.deleteCriterion(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Criterion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Criterion.kt
@@ -14,9 +14,9 @@ data class Criterion(
     val name: String,
     val description: String,
     val category: CriterionOuterClass.CriterionCategory,
-    val projectId: UUID,
+    val projectId: UUID?,
     val createdAt: OffsetDateTime,
-    val createdBy: UUID?,
+    val createdBy: UUID,
 )
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -1,8 +1,13 @@
 package se.uulm.snowballr.backend.repository
 
+import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.CriterionTable
@@ -21,6 +26,11 @@ import java.util.UUID
  */
 interface ICriterionTableRepo {
     /**
+     * Returns a criterion by its ID or throws a [NotFoundException] if the criterion with the passed [id] doesn't exist.
+     */
+    suspend fun getCriterionById(id: UUID): Criterion
+
+    /**
      * Creates a new criterion in the database based on the provided request and user ID.
      *
      * @param request The creation request containing details for the new criterion.
@@ -28,6 +38,19 @@ interface ICriterionTableRepo {
      * @return The created [Criterion] object representing the newly created criterion.
      */
     suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion
+
+    /**
+     * Updates an existing criterion in the database with the provided new information.
+     * The following fields can be updated:
+     * - tag
+     * - name
+     * - description
+     * - category
+     *
+     * @param request The update request containing the new criterion details, such as the new name.
+     * @return The updated [Criterion] object reflecting the changes from the [request].
+     */
+    suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): Criterion
 }
 
 /**
@@ -43,6 +66,22 @@ interface ICriterionTableRepo {
 class CriterionTableRepo(
     private val db: IDatabase,
 ) : ICriterionTableRepo {
+    /**
+     * Requesting a criterion from the database.
+     *
+     * @param id The id of the requested criterion.
+     * @return The [Criterion] object or null, if no criterion with the given [id] was found.
+     */
+    private fun getCriterionByIdOrNull(id: UUID): Criterion? = CriterionTable
+        .selectAll()
+        .where { CriterionTable.id eq id }
+        .map { it.toCriterion() }
+        .singleOrNull()
+
+    override suspend fun getCriterionById(id: UUID): Criterion = db.dbQuery {
+        getCriterionByIdOrNull(id) ?: throw NotFoundException(EntityType.CRITERION, id.toString())
+    }
+
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =
         db.dbQuery {
             val projectUUID = parseUUID(request.projectId, EntityType.PROJECT)
@@ -62,4 +101,25 @@ class CriterionTableRepo(
                 it[createdBy] = userEntityId
             }
         }
+
+    override suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): Criterion = db.dbQuery {
+        val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
+        val fieldMask = FieldMaskUtil.normalize(request.mask)
+
+        CriterionTable.update({ CriterionTable.id eq criterionId }) {
+            for (field in fieldMask.pathsList) {
+                when (field) {
+                    "criterion.tag" -> it[tag] = request.criterion.tag
+                    "criterion.name" -> it[name] = request.criterion.name
+                    "criterion.description" -> it[description] = request.criterion.description
+                    "criterion.category" -> it[category] = request.criterion.category
+                }
+            }
+        }
+
+        // Return the updated criterion
+        getCriterionByIdOrNull(criterionId) ?: throw EntityNotPersistedException(
+            EntityType.CRITERION, criterionId.toString(),
+        )
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -82,7 +82,7 @@ class ProjectMemberTableRepo(
     /**
      * Requesting a project member from the database.
      *
-     * @param projectId The id of the requested project.
+     * @param projectId The ID of the requested project.
      * @param userId The id of the requested user.
      * @return The [ProjectMember] object or null, if no project with the given [projectId] and [userId] was found.
      */

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -2,30 +2,176 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.Criterion
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import snowballr.Base
 import snowballr.CriterionOuterClass
+import snowballr.ProjectOuterClass
 
 interface ICriterionService {
+    /**
+     * Service implementation of [SnowballRService.getCriterionById].
+     */
+    suspend fun getCriterionById(request: Base.Id): CriterionOuterClass.Criterion
+
     /**
      * Service implementation of [SnowballRService.createCriterion].
      */
     suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion
+
+    /**
+     * Service implementation of [SnowballRService.updateCriterion].
+     *
+     * @param request The update request containing the criterion details to be modified.
+     * @return The updated criterion after the changes have been applied.
+     */
+    suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): CriterionOuterClass.Criterion
 }
 
 /**
- * The [CriterionService] class handles operations for criteria by providing
- * an implementation of the [ICriterionService] interface.
+ * The [CriterionService] class handles operations related to projects by implementing the [ICriterionService] interface.
  *
- * This class serves as a layer that abstracts the responsibility of criterion CRUD operations,
- * delegating the actual persistence operations to the [ICriterionTableRepo] repository.
+ * The `CriterionService` class provides functionality for managing criteria, including
+ * creating, retrieving, and updating them. It also handles validation of access permissions,
+ * preconditions, and interactions with underlying repositories.
  *
- * @constructor Initializes the [CriterionService] with a criterion repository.
- * @param repo The repository responsible for handling persistence operations related to criteria.
+ * This service ensures that all operations related to criteria are performed
+ * in accordance with the project and user access rules.
+ *
+ * @param repo Interface for persistence and retrieval operations related to criteria.
+ * @param userRepo Interface for operations related to user management.
+ * @param projectRepo Interface for operations related to project retrieval.
+ * @param projectMemberRepo Interface for operations related to project member management.
  */
 class CriterionService(
     private val repo: ICriterionTableRepo,
+    private val userRepo: IUserTableRepo,
+    private val projectRepo: IProjectTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
 ) : ICriterionService {
+    /**
+     * Checks if the given user has the required permissions to access a project criterion.
+     *
+     * This function verifies if the user has permission to access a criterion
+     * that belongs to an active project and throws exceptions when access is unauthorized
+     * or when attempting to access a criterion of an inactive project.
+     *
+     * @param criterion The criterion for which permissions need to be checked. It may or may not
+     *                  be associated with a project.
+     * @param currentUser The user whose permissions are being validated.
+     * @param accessType The type of access being requested (e.g., READ, UPDATE).
+     *
+     * @throws SnowballRException.UnauthorizedException If the user does not have access permissions
+     *         to the criterion.
+     * @throws SnowballRException.FailedPreconditionException If attempting to access a criterion
+     *         in a project that is not active.
+     */
+    private suspend fun checkProjectCriterionPermission(
+        criterion: Criterion,
+        currentUser: User,
+        accessType: AccessType,
+    ) {
+        val criterionId = criterion.id.toString()
+        val project = projectRepo.getProjectById(criterion.projectId!!)
+        val members = when (accessType) {
+            AccessType.READ -> projectMemberRepo.getMembersOfProject(project.id)
+            AccessType.UPDATE -> projectMemberRepo.getAllProjectAdmins(project.id)
+            else -> emptyList()
+        }
+
+        if (!members.any { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.CRITERION,
+                    criterionId,
+                    AccessType.READ,
+                    currentUser.id.toString(),
+                )
+            }
+        }
+        if (accessType == AccessType.UPDATE &&
+            project.status != ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
+        ) {
+            verifyServerAdminRole(currentUser) {
+                throw SnowballRException.FailedPreconditionException(
+                    "The project is not active. Cannot update criterion with the ID: $criterionId",
+                )
+            }
+        }
+    }
+
+    /**
+     * Checks if the current user has permission to access the provided criterion.
+     *
+     * If the criterion is a user criterion but was created by another user,
+     * the method verifies whether the current user has server admin permissions. If the current user
+     * does not have such permissions, an [UnauthorizedException.Single] is thrown.
+     *
+     * @param criterion The criterion to be validated. This object may or may not have an associated project or creator.
+     * @param currentUser The user whose permissions need to be validated.
+     * @param accessType The type of access being requested (e.g., READ, UPDATE).
+     *
+     * @throws UnauthorizedException.Single If the current user does not have permissions to access the criterion.
+     */
+    private fun checkUserCriterionPermission(criterion: Criterion, currentUser: User, accessType: AccessType) {
+        if (criterion.createdBy == currentUser.id) return
+
+        verifyServerAdminRole(currentUser) {
+            throw UnauthorizedException.Single(
+                EntityType.CRITERION,
+                criterion.id.toString(),
+                accessType,
+                currentUser.id.toString(),
+            )
+        }
+    }
+
+    /**
+     * Verifies that the given user has the required permissions to access the specified criterion.
+     * Depending on whether the criterion belongs to a project or is user-specific, the appropriate permission
+     * checks are performed by delegating to either `checkProjectCriterionPermission` or `checkUserCriterionPermission`.
+     *
+     * @param criterion The criterion object whose permissions need to be validated.
+     *                  It may either belong to a project or be user-specific.
+     * @param currentUser The user whose permissions are being checked against the given criterion.
+     * @param accessType The type of access being requested on the criterion (e.g., READ, UPDATE, DELETE).
+     */
+    private suspend fun checkCriterionPermission(criterion: Criterion, currentUser: User, accessType: AccessType) {
+        if (criterion.projectId != null) {
+            checkProjectCriterionPermission(criterion, currentUser, accessType)
+        } else {
+            checkUserCriterionPermission(criterion, currentUser, accessType)
+        }
+    }
+
+    override suspend fun getCriterionById(request: Base.Id): CriterionOuterClass.Criterion {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val criterionId = parseUUID(request.id, EntityType.CRITERION)
+        val criterion = repo.getCriterionById(criterionId)
+
+        checkCriterionPermission(criterion, currentUser, AccessType.READ)
+        return criterion.toGrpcCriterion()
+    }
+
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion =
         repo.createCriterion(request, GrpcContext.getUserIdFromContext()).toGrpcCriterion()
+
+    override suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): CriterionOuterClass.Criterion {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
+        val criterion = repo.getCriterionById(criterionId)
+
+        checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
+        return repo.updateCriterion(request).toGrpcCriterion()
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -40,5 +40,5 @@ class MainService(
     private val jwtService: IJwtService,
 ) : IMainService,
     IProjectService by ProjectService(projectRepo, userRepo, projectMemberRepo),
-    ICriterionService by CriterionService(criterionRepo),
+    ICriterionService by CriterionService(criterionRepo, userRepo, projectRepo, projectMemberRepo),
     IUserService by UserService(userRepo, projectMemberRepo, jwtService)

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/CriterionTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/CriterionTable.kt
@@ -33,7 +33,7 @@ object CriterionTable : UUIDTable("criterion") {
      * - `onDelete=CASCADE` so that all criteria are deleted when the according project is deleted
      * - `onUpdate=CASCADE` so that when the project ID is updated, the foreign key ID is updated too
      */
-    val projectId = reference("project_id", ProjectTable, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
+    val projectId = optReference("project_id", ProjectTable, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
 
     // Metadata
 
@@ -50,7 +50,7 @@ fun ResultRow.toCriterion() = Criterion(
     name = this[CriterionTable.name],
     description = this[CriterionTable.description],
     category = this[CriterionTable.category],
-    projectId = this[CriterionTable.projectId].value,
+    projectId = this[CriterionTable.projectId]?.value,
     createdAt = this[CriterionTable.createdAt],
     createdBy = this[CriterionTable.createdBy].value,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.validation
 
+import arrow.core.Either
 import arrow.core.EitherNel
 import arrow.core.raise.either
 import arrow.core.raise.zipOrAccumulate
@@ -10,27 +11,83 @@ const val CRITERION_TAG_MAX_LENGTH = 10
 const val CRITERION_NAME_MAX_LENGTH = 50
 const val CRITERION_DESCRIPTION_MAX_LENGTH = 200
 
+private const val FIELD_TAG = "tag"
+private const val FIELD_NAME = "name"
+private const val FIELD_DESCRIPTION = "description"
+private const val FIELD_CATEGORY = "category"
+private const val FIELD_PROJECT_ID = "project_id"
+private const val FIELD_ID = "id"
+
+private const val MASK_TAG = "criterion.tag"
+private const val MASK_NAME = "criterion.name"
+private const val MASK_DESCRIPTION = "criterion.description"
+private const val MASK_CATEGORY = "criterion.category"
+
 /**
  * A validator for [Criterion] related requests.
  */
 object CriterionValidator {
     fun validateCreateRequest(request: Criterion.Create): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
-            { ensureIdValidity("project_id", request.projectId) },
+            { ensureIdValidity(FIELD_PROJECT_ID, request.projectId) },
             {
-                ensureFieldNonBlank("tag", request.tag)
-                ensureFieldLength("tag", request.tag, CRITERION_TAG_MAX_LENGTH)
+                ensureFieldNonBlank(FIELD_TAG, request.tag)
+                ensureFieldLength(FIELD_TAG, request.tag, CRITERION_TAG_MAX_LENGTH)
             },
             {
-                ensureFieldNonBlank("name", request.name)
-                ensureFieldLength("name", request.name, CRITERION_NAME_MAX_LENGTH)
+                ensureFieldNonBlank(FIELD_NAME, request.name)
+                ensureFieldLength(FIELD_NAME, request.name, CRITERION_NAME_MAX_LENGTH)
             },
             {
-                ensureFieldNonBlank("description", request.description)
-                ensureFieldLength("description", request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
+                ensureFieldNonBlank(FIELD_DESCRIPTION, request.description)
+                ensureFieldLength(FIELD_DESCRIPTION, request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
             },
             {
-                ensureEnumNotUnspecified("category", request.category)
+                ensureEnumNotUnspecified(FIELD_CATEGORY, request.category)
+            },
+        ) { _, _, _, _, _ -> }
+    }
+
+    fun validateUpdateRequest(request: Criterion.Update): EitherNel<ValidationIssue, Unit> = either {
+        // Validate the field mask
+        val fieldMaskResult = either {
+            ensureFieldMaskIsValid(request.mask, Criterion.Update.getDescriptor())
+        }
+
+        if (fieldMaskResult is Either.Left) {
+            fieldMaskResult.toEitherNel().bind()
+        }
+
+        val selectedFields = request.mask.pathsList.toSet()
+
+        zipOrAccumulate(
+            { ensureIdValidity(FIELD_ID, request.criterion.id) },
+            {
+                if (MASK_TAG in selectedFields) {
+                    ensureFieldNonBlank(FIELD_TAG, request.criterion.tag)
+                    ensureFieldLength(FIELD_TAG, request.criterion.tag, CRITERION_TAG_MAX_LENGTH)
+                }
+            },
+            {
+                if (MASK_NAME in selectedFields) {
+                    ensureFieldNonBlank(FIELD_NAME, request.criterion.name)
+                    ensureFieldLength(FIELD_NAME, request.criterion.name, CRITERION_NAME_MAX_LENGTH)
+                }
+            },
+            {
+                if (MASK_DESCRIPTION in selectedFields) {
+                    ensureFieldNonBlank(FIELD_DESCRIPTION, request.criterion.description)
+                    ensureFieldLength(
+                        FIELD_DESCRIPTION,
+                        request.criterion.description,
+                        CRITERION_DESCRIPTION_MAX_LENGTH,
+                    )
+                }
+            },
+            {
+                if (MASK_CATEGORY in selectedFields) {
+                    ensureEnumNotUnspecified(FIELD_CATEGORY, request.criterion.category)
+                }
             },
         ) { _, _, _, _, _ -> }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -59,6 +59,7 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is ProjectOuterClass.Project.Update -> ProjectValidator.validateUpdateRequest(request)
     // Criterion
     is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
+    is CriterionOuterClass.Criterion.Update -> CriterionValidator.validateUpdateRequest(request)
     // Base
     is Base.Id -> BaseValidator.validateId(request)
     is Base.Email -> BaseValidator.validateEmail(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -67,9 +67,9 @@ object DataBuilder {
         name: String = "Test Criterion",
         description: String = "Test Description",
         category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED,
-        projectId: UUID = UUID.randomUUID(),
+        projectId: UUID? = UUID.randomUUID(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
-        createdBy: UUID? = null,
+        createdBy: UUID = UUID.randomUUID(),
     ) = Criterion(
         id = id,
         tag = tag,

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -1,18 +1,26 @@
 package se.uulm.snowballr.backend.repository
 
+import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass
+import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import java.util.UUID
 
@@ -30,32 +38,82 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
         return projectRepo.createProject(request, testUserId)
     }
 
+    private suspend fun insertTestCriterionAndGetId(
+        tag: String = "Test Tag",
+        name: String = "Test Criterion",
+        description: String = "Test Description",
+        category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
+        projectId: UUID = UUID.randomUUID(),
+    ): UUID = db.dbQuery {
+        CriterionTable.insertAndGetId {
+            it[CriterionTable.tag] = tag
+            it[CriterionTable.name] = name
+            it[CriterionTable.description] = description
+            it[CriterionTable.category] = category
+            it[CriterionTable.projectId] = projectId
+            it[CriterionTable.createdBy] = testUserId
+        }.value
+    }
+
+    companion object {
+        @JvmStatic
+        fun validFieldMasks(): List<Arguments> = listOf(
+            Arguments.of(listOf("criterion.tag")),
+            Arguments.of(listOf("criterion.name")),
+            Arguments.of(listOf("criterion.description")),
+            Arguments.of(listOf("criterion.category")),
+        )
+    }
+
     @Nested
-    inner class CreateCriterion {
-        @GrpcEnumSourceTest(CriterionOuterClass.CriterionCategory::class)
-        fun `When a criterion is created, then the values are correctly assigned`(
-            category: CriterionOuterClass.CriterionCategory,
-        ) = runTest {
-            val project = createExampleProject()
+    inner class GetCriterionById {
+        @Test
+        fun `When a criterion is found, then the correct criterion is returned`() = runTest {
+            val projectId = createExampleProject().id
+            val criterionId = insertTestCriterionAndGetId(projectId = projectId)
+            val criterion = repo.getCriterionById(criterionId)
 
-            val request =
-                CriterionOuterClass.Criterion.Create
-                    .newBuilder()
-                    .setTag("Test Tag")
-                    .setName("Test Criterion")
-                    .setDescription("Test Description")
-                    .setCategory(category)
-                    .setProjectId(project.id.toString())
-                    .build()
-            val criterion = repo.createCriterion(request, testUserId)
-
-            Assertions.assertThat(criterion.tag).isEqualTo("Test Tag")
-            Assertions.assertThat(criterion.name).isEqualTo("Test Criterion")
-            Assertions.assertThat(criterion.description).isEqualTo("Test Description")
-            Assertions.assertThat(criterion.category).isEqualTo(category)
+            assertThat(criterion.id).isEqualTo(criterionId)
+            assertThat(criterion.tag).isEqualTo("Test Tag")
+            assertThat(criterion.name).isEqualTo("Test Criterion")
+            assertThat(criterion.description).isEqualTo("Test Description")
+            assertThat(
+                criterion.category,
+            ).isEqualTo(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+            assertThat(criterion.projectId).isEqualTo(projectId)
         }
 
-        @GrpcEnumSourceTest(CriterionOuterClass.CriterionCategory::class)
+        @Test
+        fun `When a criterion is not found, then an exception is thrown`() = runTest {
+            assertThrows<NotFoundException> { repo.getCriterionById(UUID.randomUUID()) }
+        }
+    }
+
+    @Nested
+    inner class CreateCriterion {
+        @GrpcEnumSourceTest(CriterionCategory::class)
+        fun `When a criterion is created, then the values are correctly assigned`(category: CriterionCategory) =
+            runTest {
+                val project = createExampleProject()
+
+                val request =
+                    CriterionOuterClass.Criterion.Create
+                        .newBuilder()
+                        .setTag("Test Tag")
+                        .setName("Test Criterion")
+                        .setDescription("Test Description")
+                        .setCategory(category)
+                        .setProjectId(project.id.toString())
+                        .build()
+                val criterion = repo.createCriterion(request, testUserId)
+
+                Assertions.assertThat(criterion.tag).isEqualTo("Test Tag")
+                Assertions.assertThat(criterion.name).isEqualTo("Test Criterion")
+                Assertions.assertThat(criterion.description).isEqualTo("Test Description")
+                Assertions.assertThat(criterion.category).isEqualTo(category)
+            }
+
+        @GrpcEnumSourceTest(CriterionCategory::class)
         fun `When a criterion is created, but the assigned project doesn't exist, then an exception is thrown`(
             category: CriterionOuterClass.CriterionCategory,
         ) = runTest {
@@ -82,7 +140,7 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
                     .setTag("Test Tag")
                     .setName("Test Criterion")
                     .setDescription("Test Description")
-                    .setCategory(CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+                    .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
                     .setProjectId(project.id.toString())
                     .build()
             val criterion1 = repo.createCriterion(request, testUserId)
@@ -91,9 +149,9 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
             Assertions.assertThat(criterion1.id).isNotEqualTo(criterion2.id)
         }
 
-        @GrpcEnumSourceTest(CriterionOuterClass.CriterionCategory::class)
+        @GrpcEnumSourceTest(CriterionCategory::class)
         fun `When a criterion is created, but the assigned user doesn't exist, then an exception is thrown`(
-            category: CriterionOuterClass.CriterionCategory,
+            category: CriterionCategory,
         ) = runTest {
             val request =
                 CriterionOuterClass.Criterion.Create
@@ -106,6 +164,54 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
                     .build()
 
             assertThrows<NotFoundException> { repo.createCriterion(request, UUID.randomUUID()) }
+        }
+    }
+
+    @Nested
+    inner class UpdateCriterion {
+        @ParameterizedTest(name = "Update the fields {0}")
+        @MethodSource("se.uulm.snowballr.backend.repository.CriterionTableRepoTest#validFieldMasks")
+        fun `When a criterion is updated, then only the fields specified in the field mask are updated and the updated criterion is returned`(
+            fieldMask: List<String>,
+        ) = runTest {
+            val projectId = createExampleProject().id
+            val criterionId = insertTestCriterionAndGetId(projectId = projectId)
+            val originalCriterion = repo.getCriterionById(criterionId)
+
+            val updatedCriterionDetails = originalCriterion.toGrpcCriterion().toBuilder()
+                .setTag("Updated Tag")
+                .setName("Updated Criterion")
+                .setDescription("Updated Description")
+                .setCategory(CriterionCategory.CRITERION_CATEGORY_INCLUSION)
+                .build()
+
+            val request = CriterionOuterClass.Criterion.Update.newBuilder()
+                .setCriterion(updatedCriterionDetails)
+                .setMask(FieldMaskUtil.fromStringList(fieldMask))
+                .build()
+
+            val updatedCriterion = repo.updateCriterion(request)
+
+            if ("criterion.tag" in fieldMask) {
+                assertThat(updatedCriterion.tag).isEqualTo("Updated Tag")
+            } else {
+                assertThat(updatedCriterion.tag).isEqualTo("Test Tag")
+            }
+            if ("criterion.name" in fieldMask) {
+                assertThat(updatedCriterion.name).isEqualTo("Updated Criterion")
+            } else {
+                assertThat(updatedCriterion.name).isEqualTo("Test Criterion")
+            }
+            if ("criterion.description" in fieldMask) {
+                assertThat(updatedCriterion.description).isEqualTo("Updated Description")
+            } else {
+                assertThat(updatedCriterion.description).isEqualTo("Test Description")
+            }
+            if ("criterion.category" in fieldMask) {
+                assertThat(updatedCriterion.category).isEqualTo(CriterionCategory.CRITERION_CATEGORY_INCLUSION)
+            } else {
+                assertThat(updatedCriterion.category).isEqualTo(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+            }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -1,0 +1,177 @@
+package se.uulm.snowballr.backend.service.criterion
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class GetCriterionByIdTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private val dummyUserUUID = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestId.toString())
+        .build()
+
+    @BeforeEach
+    fun setupTest() {
+        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { projectMemberRepoMock.addUserToProject(any(), any()) } throws NotImplementedError()
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
+        coEvery { criterionRepoMock.getCriterionById(any()) } throws NotImplementedError()
+    }
+
+    @Test
+    fun `When the requesting user is a server admin, then a project criterion can be retrieved`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val criterion = DataBuilder.createExampleCriterion(
+            id = requestId,
+            projectId = UUID.randomUUID(),
+            createdBy = dummyUserUUID,
+        )
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(any()) } returns project
+        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+
+        assertDoesNotThrow { mainService.getCriterionById(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a project member and wants to retrieve a project criterion, then the criterion can be retrieved`() =
+        runTest {
+            val request = getExampleRequest()
+
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val criterion = DataBuilder.createExampleCriterion(
+                id = requestId,
+                projectId = project.id,
+                createdBy = dummyUserUUID,
+            )
+            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            coEvery { projectMemberRepoMock.addUserToProject(user.id, project.id) } returns projectMember
+            coEvery { projectMemberRepoMock.getMembersOfProject(project.id) } returns listOf(projectMember)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+
+            assertDoesNotThrow { mainService.getCriterionById(request) }
+        }
+
+    @Test
+    fun `When the requesting user is not a member of the project and wants to retrieve a project criterion, then an unauthorized exception is thrown`() =
+        runTest {
+            val request = getExampleRequest()
+
+            val noAccessUser = DataBuilder.createExampleUser()
+            val criterion = DataBuilder.createExampleCriterion(
+                id = requestId,
+                projectId = UUID.randomUUID(),
+                createdBy = dummyUserUUID,
+            )
+            val project = DataBuilder.createExampleProject()
+
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+            coEvery { projectRepoMock.getProjectById(any()) } returns project
+            coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+
+            assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
+        }
+
+    @Test
+    fun `When the requesting user is a server admin, then a user criterion can be retrieved`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val criterion = DataBuilder.createExampleCriterion(
+            id = requestId,
+            projectId = null,
+            createdBy = UUID.randomUUID(),
+        )
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+
+        assertDoesNotThrow { mainService.getCriterionById(request) }
+    }
+
+    @Test
+    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he created himself, then the criterion can be retrieved`() =
+        runTest {
+            val request = getExampleRequest()
+
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val criterion = DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
+
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+
+            assertDoesNotThrow { mainService.getCriterionById(request) }
+        }
+
+    @Test
+    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he did not create himself, then an unauthorized exception is thrown`() =
+        runTest {
+            val request = getExampleRequest()
+
+            val noAccessUser = DataBuilder.createExampleUser()
+            val criterion = DataBuilder.createExampleCriterion(
+                id = requestId,
+                projectId = null,
+                createdBy = UUID.randomUUID(),
+            )
+
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+
+            assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
+        }
+
+    @Test
+    fun `When an error occurs while the criterion is retrieved, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+        val projectMember = DataBuilder.createExampleProjectMember(userId = adminUser.id, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+        coEvery { projectMemberRepoMock.getMembersOfProject(project.id) } returns listOf(projectMember)
+        coEvery { criterionRepoMock.getCriterionById(requestId) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getCriterionById(request) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -1,0 +1,223 @@
+package se.uulm.snowballr.backend.service.criterion
+
+import com.google.protobuf.util.FieldMaskUtil
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.CriterionOuterClass
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class UpdateCriterionTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private val dummyUserUUID = UUID.randomUUID()
+
+    private fun getExampleRequest(): CriterionOuterClass.Criterion.Update {
+        val updatedCriterion = DataBuilder.createExampleCriterion(
+            id = requestId,
+            tag = "Updated Tag",
+            name = "Updated Criterion",
+            description = "Updated Description",
+            category = CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_INCLUSION,
+        )
+
+        val updateFieldMask = FieldMaskUtil.fromStringList(
+            listOf("tag", "name", "description", "category"),
+        )
+
+        return CriterionOuterClass.Criterion.Update.newBuilder()
+            .setCriterion(updatedCriterion.toGrpcCriterion())
+            .setMask(updateFieldMask)
+            .build()
+    }
+
+    @BeforeEach
+    fun setUpTest() {
+        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
+        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
+        coEvery { criterionRepoMock.getCriterionById(any()) } throws NotImplementedError()
+        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } throws NotImplementedError()
+        coEvery { criterionRepoMock.updateCriterion(any()) } throws NotImplementedError()
+    }
+
+    @Test
+    fun `When a server admin updates a project criterion, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val criterion = DataBuilder.createExampleCriterion(
+            id = requestId,
+            projectId = project.id,
+            createdBy = dummyUserUUID,
+        )
+
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+        assertDoesNotThrow { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a project admin updates a project criterion, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+        val criterion = DataBuilder.createExampleCriterion(
+            id = requestId,
+            projectId = project.id,
+            createdBy = dummyUserUUID,
+        )
+
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+        assertDoesNotThrow { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a project admin updates a project criterion of a non-active project, then a failed precondition exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(
+                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+            )
+            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+            val criterion = DataBuilder.createExampleCriterion(
+                id = requestId,
+                projectId = project.id,
+                createdBy = dummyUserUUID,
+            )
+
+            val request = getExampleRequest()
+
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+            coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+            assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateCriterion(request) }
+        }
+
+    @Test
+    fun `When a project member updates a project criterion, then an unauthorized exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val criterion = DataBuilder.createExampleCriterion(
+            id = requestId,
+            projectId = project.id,
+            createdBy = dummyUserUUID,
+        )
+
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+        assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val criterion =
+            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = UUID.randomUUID())
+
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+        assertDoesNotThrow { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a user updates a user criterion, which he created himself, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val criterion =
+            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = dummyUserUUID)
+
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+        assertDoesNotThrow { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a user updates a user criterion, which he did not created himself, then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+            val criterion =
+                DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = UUID.randomUUID())
+
+            val request = getExampleRequest()
+
+            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+            assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
+        }
+
+    @Test
+    fun `When an error occurs while the criterion is updated, then an exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val criterion =
+            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = dummyUserUUID)
+
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateCriterion(request) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
@@ -1,5 +1,7 @@
 package se.uulm.snowballr.backend.validation
 
+import com.google.protobuf.FieldMask
+import com.google.protobuf.util.FieldMaskUtil
 import `in`.rcard.assertj.arrowcore.EitherAssert
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -8,9 +10,12 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.EnumUnspecified
+import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.TooLongField
+import snowballr.CriterionOuterClass.Criterion
 import snowballr.CriterionOuterClass.Criterion.Create
+import snowballr.CriterionOuterClass.Criterion.Update
 import snowballr.CriterionOuterClass.CriterionCategory
 import java.util.UUID
 
@@ -85,6 +90,171 @@ class CriterionValidatorTest {
             val result = validateRequest(request)
 
             assertInvalidResult<EnumUnspecified>(result)
+        }
+    }
+
+    @Nested
+    inner class UpdateRequest {
+        private val validUpdatedCriterion: Criterion.Builder = Criterion
+            .newBuilder()
+            .setId(UUID.randomUUID().toString())
+            .setTag("Test Tag")
+            .setName("Test Criterion")
+            .setDescription("Test Description")
+            .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+        private val validFieldMask: FieldMask = FieldMaskUtil
+            .fromStringList(
+                listOf(
+                    "criterion.tag",
+                    "criterion.name",
+                    "criterion.description",
+                    "criterion.category",
+                ),
+            )
+
+        private val validUpdateRequestBuilder: Update.Builder =
+            Update
+                .newBuilder()
+                .setCriterion(validUpdatedCriterion)
+                .setMask(validFieldMask)
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validUpdateRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a blank field mask is validated, then the 'InvalidFieldMask' issue is returned`() {
+            val inValidFieldMask = FieldMaskUtil.fromStringList(listOf())
+            val request =
+                validUpdateRequestBuilder
+                    .setMask(inValidFieldMask)
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
+        fun `When a field mask containing a non-existing field is validated, then the 'InvalidFieldMask' issue is returned`() {
+            val request =
+                validUpdateRequestBuilder
+                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existing_field")))
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
+        fun `When an invalid ID is validated, then the 'InvalidId' issue is returned`() {
+            val project = validUpdatedCriterion.setId("invalid-id").build()
+            val request = validUpdateRequestBuilder
+                .setCriterion(project)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "tag",
+                "name",
+                "description",
+            ],
+        )
+        fun `When a blank field is validated and specified in the field mask, then the 'BlankField' issue is returned`(
+            fieldName: String,
+        ) {
+            val fieldDescriptor = Criterion.getDescriptor().findFieldByName(fieldName)
+            val updatedCriterion = validUpdatedCriterion.setField(fieldDescriptor, " ").build()
+
+            val request = validUpdateRequestBuilder
+                .setCriterion(updatedCriterion)
+                .setMask(FieldMaskUtil.fromStringList(listOf("criterion.$fieldName")))
+                .build()
+
+            val result = validateRequest(request)
+            assertInvalidResult<BlankField>(result)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "tag",
+                "name",
+                "description",
+            ],
+        )
+        fun `When a blank field is validated but not specified in the field mask, then no issue is returned`(
+            fieldName: String,
+        ) {
+            val fieldDescriptor = Criterion.getDescriptor().findFieldByName(fieldName)
+            val updatedCriterion = validUpdatedCriterion.setField(fieldDescriptor, " ").build()
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("criterion.category"))
+            val request = validUpdateRequestBuilder
+                .setCriterion(updatedCriterion)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "tag:${CRITERION_TAG_MAX_LENGTH}",
+                "name:${CRITERION_NAME_MAX_LENGTH}",
+                "description:${CRITERION_DESCRIPTION_MAX_LENGTH}",
+            ],
+            delimiter = ':',
+        )
+        fun `When a too long field is validated, then the 'TooLongField' issue is returned`(
+            fieldName: String,
+            length: Int,
+        ) {
+            val fieldDescriptor = Criterion.getDescriptor().findFieldByName(fieldName)
+            val updatedCriterion = validUpdatedCriterion.setField(fieldDescriptor, "a".repeat(length + 1)).build()
+
+            val request = validUpdateRequestBuilder
+                .setCriterion(updatedCriterion)
+                .setMask(FieldMaskUtil.fromStringList(listOf("criterion.$fieldName")))
+                .build()
+
+            val result = validateRequest(request)
+            assertInvalidResult<TooLongField>(result)
+        }
+
+        @Test
+        fun `When an invalid category is provided and specified in the field mask, then the 'EnumUnspecified' issue is returned`() {
+            val criterion = validUpdatedCriterion.setCategory(CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED).build()
+
+            val request = validUpdateRequestBuilder
+                .setCriterion(criterion)
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<EnumUnspecified>(result)
+        }
+
+        @Test
+        fun `When an invalid category is provided but not specified in the field mask, then no issue is returned`() {
+            val criterion = validUpdatedCriterion.setCategory(CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED).build()
+
+            val fieldMask = FieldMaskUtil.fromStringList(listOf("criterion.tag"))
+            val request = validUpdateRequestBuilder
+                .setCriterion(criterion)
+                .setMask(fieldMask)
+                .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
         }
     }
 }


### PR DESCRIPTION
Closes #111
Closes #147 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

I implemented the `getCriterionById` and `updateCriterion` call. This includes the implementation on the following layers:
- repository layer
- service layer
- validation layer

On the service layer this call has two different functionalities, depending on the kind of criterion to update:
- If the criterion is a user criterion (created by the user as a default criterion, indicated by `createdBy != null` and `projectId == null`), then only the user, who created the criterion plus the server admin are allowed to update the criterion
- If the criterion is a project criterion (automatically created out of the default criteria of the user who created the project, indicated by `createdBy == null` and `projectId != null`), then only the project admins plus the server admin are allowed to update the criterion
 
## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
