### PR TITLE
Correctly close 'getAuthenticationStatus' call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -121,13 +121,13 @@ val authenticationInterceptor: ServerInterceptor =
                                 "processing authentication status."
                         }
                         val authState = AuthRequestState(forwardingCall, headers, next)
-                        handleAuthentication(authState, true)
+                        handleAuthentication(authState, true, methodName)
                     }
 
                     else -> {
                         logger.trace { "Method $methodName requires authentication." }
                         val authState = AuthRequestState(forwardingCall, headers, next)
-                        handleAuthentication(authState, false)
+                        handleAuthentication(authState, false, methodName)
                     }
                 }
             }
@@ -148,11 +148,13 @@ val authenticationInterceptor: ServerInterceptor =
          * @param RespT The type of the response.
          * @param authState The [AuthRequestState] containing the call, headers, and next handler.
          * @param skipRefresh If true, skips the refresh token logic and only validates the access token.
+         * @param methodName The full method name being called, used to determine if the call should proceed.
          * @return A [ServerCall.Listener] that will handle the call, or an empty listener if authentication fails.
          */
         private fun <ReqT : Any?, RespT : Any?> handleAuthentication(
             authState: AuthRequestState<ReqT, RespT>,
             skipRefresh: Boolean,
+            methodName: String,
         ): ServerCall.Listener<ReqT?>? {
             val cookieHeader = authState.headers?.get(GrpcContext.COOKIE_METADATA_KEY)
             val cookies = cookieService.parseCookies(cookieHeader)
@@ -166,8 +168,12 @@ val authenticationInterceptor: ServerInterceptor =
                     context.call { authState.next?.startCall(authState.call, authState.headers) }
                 },
                 onFailure = {
-                    authState.call.close(Status.UNAUTHENTICATED.withDescription("Session is invalid"), Metadata())
-                    emptyListener()
+                    if (methodName == SnowballRGrpcKt.getAuthenticationStatusMethod.fullMethodName) {
+                        authResult.updatedContext.call { authState.next?.startCall(authState.call, authState.headers) }
+                    } else {
+                        authState.call.close(Status.UNAUTHENTICATED.withDescription("Session is invalid"), Metadata())
+                        emptyListener()
+                    }
                 },
             )
         }


### PR DESCRIPTION
Closes #159 

## What I have made

The purpose of the `getAuthenticationStatus` method is to query the authentication state of a user's session. It is expected to always succeed at the network level and return a payload describing the status (e.g., `AUTHENTICATED`, `UNAUTHENTICATED`, `ACCESS_TOKEN_EXPIRED`).

Currently, in the `handleAuthentication` function, if the `authResult.parsedJwtClaimsResult` is a failure (which is expected for a logged-out user), the interceptor immediately closes the connection with an error:
`authState.call.close(Status.UNAUTHENTICATED.withDescription("Session is invalid"), Metadata())`

This is the correct behavior for protected endpoints, but incorrect for `getAuthenticationStatus`. This call must be allowed to proceed to the service implementation, which can then read the status (`UNAUTHENTICATED`) from the gRPC context and return it in a successful response body.

The fix involves modifying the interceptor to specifically check if the method being called is `getAuthenticationStatus`. If it is, and authentication fails, it should allow the call to proceed instead of terminating it.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
