### PR TITLE
fix: set dummy user id correctly if he already exists

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.Schema
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import se.uulm.snowballr.backend.auth.DummyUser
@@ -28,6 +29,7 @@ import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.ReadingListTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import se.uulm.snowballr.backend.table.association.ReviewTable
+import se.uulm.snowballr.backend.table.toUser
 import java.sql.Connection
 
 private val logger = KotlinLogging.logger { }
@@ -133,31 +135,23 @@ class Database(
      * The dummy user is created with predefined credentials and role, which can be used for testing purposes.
      */
     fun useDummyUser() {
-        val useDummyUser = envReader.env.miscellaneous.useDummyUser
-        if (useDummyUser && !doesDummyUserExist()) {
-            val dummyUserId =
-                UserTable.insertAndGetId {
-                    it[email] = DummyUser.email
-                    it[firstName] = DummyUser.firstName
-                    it[lastName] = DummyUser.lastName
-                    it[passwordHash] = DummyUser.passwordHash
-                    it[role] = DummyUser.role
-                    it[status] = DummyUser.status
-                }
-            DummyUser.id = dummyUserId.value
+        if (!envReader.env.miscellaneous.useDummyUser) {
+            return
         }
-    }
 
-    /**
-     * Checks if the dummy user already exists in the database.
-     *
-     * @return `true` if the dummy user exists, `false` otherwise.
-     */
-    private fun doesDummyUserExist(): Boolean {
-        return UserTable
-            .select(UserTable.id)
+        val existingId = UserTable
+            .selectAll()
             .where { UserTable.email eq DummyUser.email }
-            .empty()
-            .not()
+            .map { it.toUser().id }
+            .singleOrNull()
+
+        DummyUser.id = existingId ?: UserTable.insertAndGetId {
+            it[email] = DummyUser.email
+            it[firstName] = DummyUser.firstName
+            it[lastName] = DummyUser.lastName
+            it[passwordHash] = DummyUser.passwordHash
+            it[role] = DummyUser.role
+            it[status] = DummyUser.status
+        }.value
     }
 }


### PR DESCRIPTION
Closes #161 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

If the dummy user already exists, the `DummyUser.id` is set to the dummy user id in the database.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
