### PR TITLE
Implement `createCriterion` and `getUserSettings` calls

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.auth
 
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import java.util.UUID
 
@@ -20,4 +21,14 @@ object DummyUser {
     var passwordHash: String = PasswordUtils.hashPassword(password)
     var role: UserOuterClass.UserRole = UserOuterClass.UserRole.USER_ROLE_ADMIN
     var status: UserOuterClass.UserStatus = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+
+    // user settings
+    var areHotkeysShown: Boolean = true
+    var isReviewModeEnabled: Boolean = false
+    var criteriaIds: List<UUID> = emptyList()
+    var similarityThreshold: Float = 0F
+    var decisionMatrix: ByteArray = ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+    var fetcherApis: List<String> = emptyList()
+    var snowballingType: ProjectOuterClass.SnowballingType = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+    var reviewMaybeAllowed: Boolean = true
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -228,7 +228,7 @@ class SnowballRServer(
             super.getPreviousPaper(request)
 
         override suspend fun getUserSettings(request: Base.Nothing): UserSettingsOuterClass.UserSettings =
-            super.getUserSettings(request)
+            mainService.getUserSettings()
 
         override suspend fun updateUserSettings(
             request: UserSettingsOuterClass.UserSettings.Update,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
@@ -1,0 +1,42 @@
+package se.uulm.snowballr.backend.model.dto
+
+import snowballr.CriterionOuterClass
+import snowballr.ProjectOuterClass
+import snowballr.UserSettingsOuterClass
+import java.util.UUID
+
+data class UserSettings(
+    val areHotkeysShown: Boolean,
+    val isReviewModeEnabled: Boolean,
+    val criteriaIds: List<UUID>,
+    val similarityThreshold: Float,
+    val decisionMatrix: ProjectOuterClass.ReviewDecisionMatrix,
+    val fetcherApis: List<String>,
+    val snowballingType: ProjectOuterClass.SnowballingType,
+    val reviewMaybeAllowed: Boolean,
+)
+
+/**
+ * Creates a [UserSettingsOuterClass.UserSettings] from this [UserSettings].
+ */
+fun UserSettings.toGrpcUserSettings(
+    criteria: List<CriterionOuterClass.Criterion>,
+): UserSettingsOuterClass.UserSettings = UserSettingsOuterClass.UserSettings
+    .newBuilder()
+    .setShowHotkeys(this.areHotkeysShown)
+    .setReviewMode(this.isReviewModeEnabled)
+    .setDefaultCriteria(
+        CriterionOuterClass.Criterion.List.newBuilder()
+            .addAllCriteria(criteria)
+            .build(),
+    )
+    .setDefaultProjectSettings(
+        ProjectOuterClass.Project.Settings.newBuilder()
+            .setSimilarityThreshold(this.similarityThreshold)
+            .setDecisionMatrix(this.decisionMatrix)
+            .addAllFetcherApis(this.fetcherApis)
+            .setSnowballingType(this.snowballingType)
+            .setReviewMaybeAllowed(this.reviewMaybeAllowed)
+            .build(),
+    )
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -124,10 +124,7 @@ class CriterionTableRepo(
     }
 
     override suspend fun getCriteriaByIds(ids: List<UUID>): List<Criterion> = db.query {
-        CriterionTable
-            .selectAll()
-            .where { CriterionTable.id inList ids }
-            .map { it.toCriterion() }
+        CriterionTable.getEntitiesByIds(ids, ResultRow::toCriterion)
     }
 
     override suspend fun getAllUserCriteria(userId: UUID): List<Criterion> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -1,7 +1,10 @@
 package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
@@ -35,6 +38,14 @@ interface ICriterionTableRepo {
     suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion
 
     /**
+     * Retrieves all criteria associated with a specific user.
+     *
+     * @param userId The unique identifier of the user for whom the criteria are being retrieved.
+     * @return A list of [Criterion] objects associated with the given user.
+     */
+    suspend fun getAllUserCriteria(userId: UUID): List<Criterion>
+
+    /**
      * Updates an existing criterion in the database with the provided new information.
      * The following fields can be updated:
      * - tag
@@ -46,6 +57,15 @@ interface ICriterionTableRepo {
      * @return The updated [Criterion] object reflecting the changes from the [request].
      */
     suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): Criterion
+
+    /**
+     * Retrieves a list of criteria based on their unique identifiers.
+     *
+     * @param ids A list of unique identifiers (UUIDs) for the criteria to be fetched.
+     * @return A list of [Criterion] objects corresponding to the provided IDs.
+     *         If no criteria are found for certain IDs, they may be excluded from the result.
+     */
+    suspend fun getCriteriaByIds(ids: List<UUID>): List<Criterion>
 }
 
 /**
@@ -70,13 +90,12 @@ class CriterionTableRepo(
 
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =
         db.query {
-            val projectUUID = parseUUID(request.projectId, EntityType.PROJECT)
-
-            // Get user reference
             val userEntityId = getUserEntityId(userId)
-
-            // Get project reference
-            val projectEntityId = getProjectEntityId(projectUUID)
+            var projectEntityId: EntityID<UUID>? = null
+            if (request.projectId.isNotEmpty()) {
+                val projectUUID = parseUUID(request.projectId, EntityType.PROJECT)
+                projectEntityId = getProjectEntityId(projectUUID)
+            }
 
             CriterionTable.insertAndGet(ResultRow::toCriterion, EntityType.CRITERION) {
                 it[tag] = request.tag
@@ -102,5 +121,19 @@ class CriterionTableRepo(
                 }
             }
         }
+    }
+
+    override suspend fun getCriteriaByIds(ids: List<UUID>): List<Criterion> = db.query {
+        CriterionTable
+            .selectAll()
+            .where { CriterionTable.id inList ids }
+            .map { it.toCriterion() }
+    }
+
+    override suspend fun getAllUserCriteria(userId: UUID): List<Criterion> = db.query {
+        CriterionTable
+            .selectAll()
+            .where { CriterionTable.createdBy eq userId and CriterionTable.projectId.isNull() }
+            .map { it.toCriterion() }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -11,14 +11,13 @@ import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.toProject
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.ProjectOuterClass.ReviewDecisionMatrix
-import snowballr.ProjectOuterClass.SnowballingType
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -40,9 +39,14 @@ interface IProjectTableRepo {
      *
      * @param request The project creation request containing project details
      * @param userId The ID of the user creating the project.
+     * @param userSettings The user's current settings, such as default criteria IDs, similarity threshold, and other relevant preferences.
      * @return The created [Project] object representing the newly created project.
      */
-    suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: UUID): Project
+    suspend fun createProject(
+        request: ProjectOuterClass.Project.Create,
+        userId: UUID,
+        userSettings: UserSettings,
+    ): Project
 
     /**
      * Returns all active projects stored in the database.
@@ -108,8 +112,11 @@ class ProjectTableRepo(
         getProjectByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT, id.toString())
     }
 
-    override suspend fun createProject(request: ProjectOuterClass.Project.Create, userId: UUID): Project = db.query {
-        // Get user reference
+    override suspend fun createProject(
+        request: ProjectOuterClass.Project.Create,
+        userId: UUID,
+        userSettings: UserSettings,
+    ): Project = db.query {
         val userEntityId = getUserEntityId(userId)
 
         ProjectTable.insertAndGet(ResultRow::toProject, EntityType.PROJECT) {
@@ -117,11 +124,10 @@ class ProjectTableRepo(
             it[status] = ProjectStatus.PROJECT_STATUS_ACTIVE
             it[currentStage] = 0
             it[maxStage] = 0
-            // TODO: Fetch default settings from user
-            it[similarityThreshold] = 0F
-            it[snowballingType] = SnowballingType.SNOWBALLING_TYPE_BOTH
-            it[reviewMaybeAllowed] = true
-            it[reviewDecisionMatrixBinary] = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+            it[similarityThreshold] = userSettings.similarityThreshold
+            it[snowballingType] = userSettings.snowballingType
+            it[reviewMaybeAllowed] = userSettings.reviewMaybeAllowed
+            it[reviewDecisionMatrixBinary] = userSettings.decisionMatrix.toByteArray()
             it[fetcherApis] = emptyList()
             it[createdBy] = userEntityId
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -12,9 +12,11 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.toUser
+import se.uulm.snowballr.backend.table.toUserSettings
 import snowballr.Authentication
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
@@ -105,6 +107,14 @@ interface IUserTableRepo {
      * @return The password hash as a [String] for the user with the specified email.
      */
     suspend fun getPasswordHashByEmail(email: String): String
+
+    /**
+     * Retrieves the user settings associated with a specific user ID.
+     *
+     * @param id The unique identifier of the user whose settings are to be fetched.
+     * @return The [UserSettings] object containing the settings for the specified user.
+     */
+    suspend fun getUserSettings(id: UUID): UserSettings
 }
 
 /**
@@ -262,5 +272,13 @@ class UserTableRepo(
             .map { it[UserTable.passwordHash] }
             .singleOrNull()
             ?: throw NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL)
+    }
+
+    override suspend fun getUserSettings(id: UUID): UserSettings = db.dbQuery {
+        UserTable.selectAll()
+            .where { UserTable.id eq id }
+            .map { it.toUserSettings() }
+            .singleOrNull()
+            ?: throw NotFoundException(EntityType.USER, id.toString(), identifierType = IdentifierType.ID)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -32,6 +32,7 @@ import java.util.UUID
  * abstraction over the underlying database implementation. By using this interface, the logic
  * for creating and managing users can remain decoupled from the specifics of the database layer.
  */
+@Suppress("ComplexInterface")
 interface IUserTableRepo {
     /**
      * Returns a user by its id or throws a [NotFoundException] if the user with the passed [id] doesn't exist.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -274,7 +274,7 @@ class UserTableRepo(
             ?: throw NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL)
     }
 
-    override suspend fun getUserSettings(id: UUID): UserSettings = db.dbQuery {
+    override suspend fun getUserSettings(id: UUID): UserSettings = db.query {
         UserTable.selectAll()
             .where { UserTable.id eq id }
             .map { it.toUserSettings() }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -67,8 +67,8 @@ class CriterionService(
      * that belongs to an active project and throws exceptions when access is unauthorized
      * or when attempting to access a criterion of an inactive project.
      *
-     * @param criterion The criterion for which permissions need to be checked. It may or may not
-     *                  be associated with a project.
+     * @param criterion The [CriterionOuterClass.Criterion] to check the permission for or null, if it does not already exists
+     * @param projectId The projectId of the [ProjectOuterClass.Project] to check the permission for.
      * @param currentUser The user whose permissions are being validated.
      * @param accessType The type of access being requested (e.g., READ, UPDATE).
      *
@@ -78,38 +78,38 @@ class CriterionService(
      *         in a project that is not active.
      */
     private suspend fun checkProjectCriterionPermission(
-        criterion: Criterion,
+        criterion: Criterion?,
+        projectId: UUID,
         currentUser: User,
         accessType: AccessType,
     ) {
-        val criterionId = criterion.id.toString()
-        val project = projectRepo.getProjectById(
-            // TODO: This will be refactored in #163
-            criterion.projectId ?: UUID.fromString("00000000-0000-0000-0000-000000000000"),
-        )
+        val project = projectRepo.getProjectById(projectId)
         val members = when (accessType) {
             AccessType.READ -> projectMemberRepo.getProjectMembers(project.id)
-            AccessType.UPDATE -> projectMemberRepo.getAllProjectAdmins(project.id)
-            AccessType.CREATE, AccessType.DELETE -> emptyList()
+            AccessType.CREATE, AccessType.UPDATE -> projectMemberRepo.getAllProjectAdmins(project.id)
+            AccessType.DELETE -> emptyList()
         }
 
         if (!members.any { it.userId == currentUser.id }) {
             verifyServerAdminRole(currentUser) {
                 throw UnauthorizedException.Single(
-                    EntityType.CRITERION,
-                    criterionId,
+                    EntityType.PROJECT,
+                    projectId.toString(),
                     AccessType.READ,
-                    currentUser.id.toString(),
+                    it,
                 )
             }
         }
-        if (accessType == AccessType.UPDATE &&
+        if ((accessType == AccessType.UPDATE || accessType == AccessType.CREATE) &&
             project.status != ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
         ) {
             verifyServerAdminRole(currentUser) {
-                throw SnowballRException.FailedPreconditionException(
-                    "The project is not active. Cannot update criterion with the ID: $criterionId",
-                )
+                val message = if (accessType == AccessType.CREATE) {
+                    "Cannot create a criterion for the project with the id: $projectId."
+                } else {
+                    "Cannot update criterion with the ID: ${criterion?.id ?: "<unknown>"}"
+                }
+                throw SnowballRException.FailedPreconditionException("The project is not active. $message")
             }
         }
     }
@@ -135,7 +135,7 @@ class CriterionService(
                 EntityType.CRITERION,
                 criterion.id.toString(),
                 accessType,
-                currentUser.id.toString(),
+                it,
             )
         }
     }
@@ -147,12 +147,18 @@ class CriterionService(
      *
      * @param criterion The criterion object whose permissions need to be validated.
      *                  It may either belong to a project or be user-specific.
+     * @param projectId The projectId of the [ProjectOuterClass.Project] to check the permission for.
      * @param currentUser The user whose permissions are being checked against the given criterion.
      * @param accessType The type of access being requested on the criterion (e.g., READ, UPDATE, DELETE).
      */
-    private suspend fun checkCriterionPermission(criterion: Criterion, currentUser: User, accessType: AccessType) {
+    private suspend fun checkCriterionPermission(
+        criterion: Criterion,
+        projectId: UUID,
+        currentUser: User,
+        accessType: AccessType,
+    ) {
         if (criterion.projectId != null) {
-            checkProjectCriterionPermission(criterion, currentUser, accessType)
+            checkProjectCriterionPermission(criterion, projectId, currentUser, accessType)
         } else {
             checkUserCriterionPermission(criterion, currentUser, accessType)
         }
@@ -163,19 +169,29 @@ class CriterionService(
         val criterionId = parseUUID(request.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId)
 
-        checkCriterionPermission(criterion, currentUser, AccessType.READ)
+        checkCriterionPermission(criterion, criterionId, currentUser, AccessType.READ)
         return criterion.toGrpcCriterion()
     }
 
-    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion =
-        repo.createCriterion(request, GrpcContext.getUserIdFromContext()).toGrpcCriterion()
+    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create): CriterionOuterClass.Criterion {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        if (request.projectId.isNotEmpty()) {
+            checkProjectCriterionPermission(
+                null,
+                parseUUID(request.projectId, EntityType.PROJECT),
+                currentUser,
+                AccessType.CREATE,
+            )
+        }
+        return repo.createCriterion(request, currentUser.id).toGrpcCriterion()
+    }
 
     override suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): CriterionOuterClass.Criterion {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId)
 
-        checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
+        checkCriterionPermission(criterion, criterionId, currentUser, AccessType.UPDATE)
         return repo.updateCriterion(request).toGrpcCriterion()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -147,18 +147,12 @@ class CriterionService(
      *
      * @param criterion The criterion object whose permissions need to be validated.
      *                  It may either belong to a project or be user-specific.
-     * @param projectId The projectId of the [ProjectOuterClass.Project] to check the permission for.
      * @param currentUser The user whose permissions are being checked against the given criterion.
      * @param accessType The type of access being requested on the criterion (e.g., READ, UPDATE, DELETE).
      */
-    private suspend fun checkCriterionPermission(
-        criterion: Criterion,
-        projectId: UUID,
-        currentUser: User,
-        accessType: AccessType,
-    ) {
+    private suspend fun checkCriterionPermission(criterion: Criterion, currentUser: User, accessType: AccessType) {
         if (criterion.projectId != null) {
-            checkProjectCriterionPermission(criterion, projectId, currentUser, accessType)
+            checkProjectCriterionPermission(criterion, criterion.projectId, currentUser, accessType)
         } else {
             checkUserCriterionPermission(criterion, currentUser, accessType)
         }
@@ -169,7 +163,7 @@ class CriterionService(
         val criterionId = parseUUID(request.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId)
 
-        checkCriterionPermission(criterion, criterionId, currentUser, AccessType.READ)
+        checkCriterionPermission(criterion, currentUser, AccessType.READ)
         return criterion.toGrpcCriterion()
     }
 
@@ -191,7 +185,7 @@ class CriterionService(
         val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId)
 
-        checkCriterionPermission(criterion, criterionId, currentUser, AccessType.UPDATE)
+        checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
         return repo.updateCriterion(request).toGrpcCriterion()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -1,12 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.IJwtService
-import se.uulm.snowballr.backend.fetcher.FetcherManager
-import se.uulm.snowballr.backend.repository.ICriterionTableRepo
-import se.uulm.snowballr.backend.repository.IProjectTableRepo
-import se.uulm.snowballr.backend.repository.IUserTableRepo
-import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-
 /**
  * The [IMainService] interface provides a unified contract that combines the responsibilities of all sub-services. It
  * inherits functionality from their interfaces, making it possible to handle CRUD operations related to various
@@ -27,23 +20,19 @@ interface IMainService :
  * This class implements the [IMainService] interface and delegates the execution of specific functionality to the
  * sub-service implementations, e.g. [ProjectService].
  *
- * @constructor Initializes the [MainService] with the required repositories.
- * @param projectRepo The repository responsible for handling persistence operations related to projects.
- * @param criterionRepo The repository responsible for handling persistence operations related to criteria.
- * @param userRepo The repository responsible for handling persistence operations related to users.
- * @param projectMemberRepo The repository responsible for handling persistence operations related to project members.
- * @param jwtService The utility for handling JWT operations, such as token parsing and validation.
- * @param fetcherManager The manager responsible for making fetchers available for use.
+ * @constructor Initializes the [MainService] with the required services.
+ * @param projectService The service responsible for handling business logic related to projects.
+ * @param criterionService The service responsible for handling business logic related to criteria.
+ * @param userService The service responsible for handling business logic related to users.
+ * @param fetcherService The service responsible for handling business logic related to fetchers.
  */
 class MainService(
-    private val projectRepo: IProjectTableRepo,
-    private val criterionRepo: ICriterionTableRepo,
-    private val userRepo: IUserTableRepo,
-    private val projectMemberRepo: IProjectMemberTableRepo,
-    private val jwtService: IJwtService,
-    private val fetcherManager: FetcherManager,
+    private val projectService: IProjectService,
+    private val criterionService: ICriterionService,
+    private val userService: IUserService,
+    private val fetcherService: IFetcherService,
 ) : IMainService,
-    IProjectService by ProjectService(projectRepo, userRepo, projectMemberRepo),
-    ICriterionService by CriterionService(criterionRepo, userRepo, projectRepo, projectMemberRepo),
-    IUserService by UserService(userRepo, projectMemberRepo, criterionRepo, jwtService),
-    IFetcherService by FetcherService(fetcherManager)
+    IProjectService by projectService,
+    ICriterionService by criterionService,
+    IUserService by userService,
+    IFetcherService by fetcherService

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -1,5 +1,12 @@
 package se.uulm.snowballr.backend.service
 
+import se.uulm.snowballr.backend.auth.IJwtService
+import se.uulm.snowballr.backend.fetcher.FetcherManager
+import se.uulm.snowballr.backend.repository.ICriterionTableRepo
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+
 /**
  * The [IMainService] interface provides a unified contract that combines the responsibilities of all sub-services. It
  * inherits functionality from their interfaces, making it possible to handle CRUD operations related to various
@@ -20,19 +27,23 @@ interface IMainService :
  * This class implements the [IMainService] interface and delegates the execution of specific functionality to the
  * sub-service implementations, e.g. [ProjectService].
  *
- * @constructor Initializes the [MainService] with the required services.
- * @param projectService The service responsible for handling business logic related to projects.
- * @param criterionService The service responsible for handling business logic related to criteria.
- * @param userService The service responsible for handling business logic related to users.
- * @param fetcherService The service responsible for handling business logic related to fetchers.
+ * @constructor Initializes the [MainService] with the required repositories.
+ * @param projectRepo The repository responsible for handling persistence operations related to projects.
+ * @param criterionRepo The repository responsible for handling persistence operations related to criteria.
+ * @param userRepo The repository responsible for handling persistence operations related to users.
+ * @param projectMemberRepo The repository responsible for handling persistence operations related to project members.
+ * @param jwtService The utility for handling JWT operations, such as token parsing and validation.
+ * @param fetcherManager The manager responsible for making fetchers available for use.
  */
 class MainService(
-    private val projectService: IProjectService,
-    private val criterionService: ICriterionService,
-    private val userService: IUserService,
-    private val fetcherService: IFetcherService,
+    private val projectRepo: IProjectTableRepo,
+    private val criterionRepo: ICriterionTableRepo,
+    private val userRepo: IUserTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
+    private val jwtService: IJwtService,
+    private val fetcherManager: FetcherManager,
 ) : IMainService,
-    IProjectService by projectService,
-    ICriterionService by criterionService,
-    IUserService by userService,
-    IFetcherService by fetcherService
+    IProjectService by ProjectService(projectRepo, userRepo, projectMemberRepo),
+    ICriterionService by CriterionService(criterionRepo, userRepo, projectRepo, projectMemberRepo),
+    IUserService by UserService(userRepo, projectMemberRepo, criterionRepo, jwtService),
+    IFetcherService by FetcherService(fetcherManager)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -10,10 +10,12 @@ import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.dto.toGrpcProjects
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
+import snowballr.CriterionOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
@@ -72,11 +74,13 @@ interface IProjectService {
  * @param repo The repository responsible for managing persistence operations for projects.
  * @param userRepo The repository responsible for managing persistence operations for users.
  * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
+ * @param criterionRepo The repository responsible for managing persistence operations for criteria.
  */
 class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
+    private val criterionRepo: ICriterionTableRepo,
 ) : IProjectService {
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
@@ -97,8 +101,27 @@ class ProjectService(
         return repo.getProjectById(projectId).toGrpcProject()
     }
 
-    override suspend fun createProject(request: GrpcProject.Create): GrpcProject =
-        repo.createProject(request, GrpcContext.getUserIdFromContext()).toGrpcProject()
+    override suspend fun createProject(request: GrpcProject.Create): GrpcProject {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val userSettings = userRepo.getUserSettings(currentUser.id)
+        val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
+
+        val project = repo.createProject(request, GrpcContext.getUserIdFromContext(), userSettings).toGrpcProject()
+
+        for (criterion in userDefaultCriteria) {
+            val criterionRequest = CriterionOuterClass.Criterion.Create
+                .newBuilder()
+                .setTag(criterion.tag)
+                .setName(criterion.name)
+                .setDescription(criterion.description)
+                .setCategory(criterion.category)
+                .setProjectId(project.id ?: "")
+                .build()
+
+            criterionRepo.createCriterion(criterionRequest, currentUser.id)
+        }
+        return project
+    }
 
     override suspend fun getAllProjects(): GrpcProject.List {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -106,7 +106,7 @@ class ProjectService(
         val userSettings = userRepo.getUserSettings(currentUser.id)
         val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        val project = repo.createProject(request, GrpcContext.getUserIdFromContext(), userSettings).toGrpcProject()
+        val project = repo.createProject(request, GrpcContext.getUserIdFromContext(), userSettings)
 
         for (criterion in userDefaultCriteria) {
             val criterionRequest = CriterionOuterClass.Criterion.Create
@@ -115,12 +115,12 @@ class ProjectService(
                 .setName(criterion.name)
                 .setDescription(criterion.description)
                 .setCategory(criterion.category)
-                .setProjectId(project.id ?: "")
+                .setProjectId(project.id.toString())
                 .build()
 
             criterionRepo.createCriterion(criterionRequest, currentUser.id)
         }
-        return project
+        return project.toGrpcProject()
     }
 
     override suspend fun getAllProjects(): GrpcProject.List {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -16,16 +16,16 @@ import se.uulm.snowballr.backend.model.SnowballRException.UnauthenticatedExcepti
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
-import se.uulm.snowballr.backend.model.dto.toGrpcUsers
 import se.uulm.snowballr.backend.model.dto.toGrpcUserSettings
+import se.uulm.snowballr.backend.model.dto.toGrpcUsers
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Authentication
 import snowballr.Base
-import snowballr.ProjectOuterClass
 import snowballr.CriterionOuterClass
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
@@ -35,6 +35,7 @@ import snowballr.UserOuterClass.User as GrpcUser
 
 val Logger = KotlinLogging.logger { }
 
+@Suppress("ComplexInterface")
 interface IUserService {
     /**
      * Service implementation of [SnowballRService.getUserById].
@@ -99,6 +100,7 @@ interface IUserService {
  * @param criterionRepo The repository responsible for managing persistence operations for criteria.
  * @param jwtService The utility for handling JWT operations, such as token parsing and validation.
  */
+@Suppress("TooManyFunctions")
 class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -17,15 +17,19 @@ import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.toGrpcUsers
+import se.uulm.snowballr.backend.model.dto.toGrpcUserSettings
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Authentication
 import snowballr.Base
 import snowballr.ProjectOuterClass
+import snowballr.CriterionOuterClass
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import snowballr.UserSettingsOuterClass
 import java.util.UUID
 import snowballr.UserOuterClass.User as GrpcUser
 
@@ -76,6 +80,11 @@ interface IUserService {
      * Service implementation of [SnowballRService.softDeleteUser].
      */
     suspend fun softDeleteUser(request: Base.Id): Base.Nothing
+
+    /**
+     * Service implementation of [SnowballRService.getUserSettings].
+     */
+    suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings
 }
 
 /**
@@ -87,11 +96,13 @@ interface IUserService {
  * @constructor Initializes the [UserService] with a user repository.
  * @param userRepo The repository responsible for managing persistence operations for users.
  * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
+ * @param criterionRepo The repository responsible for managing persistence operations for criteria.
  * @param jwtService The utility for handling JWT operations, such as token parsing and validation.
  */
 class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
+    private val criterionRepo: ICriterionTableRepo,
     private val jwtService: IJwtService,
 ) : IUserService {
     companion object {
@@ -296,5 +307,26 @@ class UserService(
 
         userRepo.softDeleteUser(targetUser.id)
         return Base.Nothing.getDefaultInstance()
+    }
+
+    override suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val userSettings = userRepo.getUserSettings(currentUser.id)
+        val userCriteria = criterionRepo.getAllUserCriteria(currentUser.id)
+        val defaultUserCriteria = userCriteria.filter { userSettings.criteriaIds.contains(it.id) }
+
+        val criteria = mutableListOf<CriterionOuterClass.Criterion>()
+        for (criterion in defaultUserCriteria) {
+            criteria.add(
+                CriterionOuterClass.Criterion
+                    .newBuilder()
+                    .setTag(criterion.tag)
+                    .setName(criterion.name)
+                    .setDescription(criterion.description)
+                    .setCategory(criterion.category)
+                    .build(),
+            )
+        }
+        return userSettings.toGrpcUserSettings(criteria)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -312,8 +312,7 @@ class UserService(
     override suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val userSettings = userRepo.getUserSettings(currentUser.id)
-        val userCriteria = criterionRepo.getAllUserCriteria(currentUser.id)
-        val defaultUserCriteria = userCriteria.filter { userSettings.criteriaIds.contains(it.id) }
+        val defaultUserCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
         val criteria = mutableListOf<CriterionOuterClass.Criterion>()
         for (criterion in defaultUserCriteria) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -1,10 +1,24 @@
 package se.uulm.snowballr.backend.table
 
 import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.UserSettings
+import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.UserOuterClass
 import java.time.OffsetDateTime
+import java.util.UUID
+
+private const val ARE_HOTKEYS_SHOWN_DEFAULT = true
+private const val IS_REVIEW_MODE_ENABLED_DEFAULT = false
+private val CRITERIA_IDS_DEFAULT = emptyList<UUID>()
+private const val SIMILARITY_THRESHOLD_DEFAULT = 0F
+private val DECISION_MATRIX_DEFAULT: ByteArray = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+private val FETCHER_APIS_DEFAULT = emptyList<String>()
+private val SNOWBALLING_TYPE_DEFAULT = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+private const val REVIEW_MAYBE_ALLOWED_DEFAULT = true
 
 /**
  * Represents the database table "user" and provides a mapping for managing user-related entities in the database.
@@ -16,6 +30,15 @@ import java.time.OffsetDateTime
  * - [passwordHash]: Represents the hashed password of the user as a [String].
  * - [role]: Represents the role of the user as an enumeration value from [UserOuterClass.UserRole].
  * - [status]: Represents the status of the user as an enumeration value from [UserOuterClass.UserStatus].
+ * - [areHotkeysShown]: Represents whether the user has hotkeys displayed as a [Boolean].
+ * - [reviewModeEnabled]: Represents whether the user is in review mode as a [Boolean].
+ * - [criteriaIds]: Represents a list of criteria IDs associated with the user as a [List] of [UUID].
+ * - [similarityThreshold]: Represents the user's similarity threshold as a [Float].
+ * - [decisionMatrix]: Represents the review decision matrix of the user as a binary value.
+ * - [fetcherApis]: Represents a list of fetcher API identifiers associated with the user, stored as a [List] of [String].
+ * - [snowballingType]: Represents the snowballing type associated with the user, stored as an enumeration value of
+ * [ProjectOuterClass.SnowballingType].
+ * - [reviewMaybeAllowed]: Indicates whether "maybe" is allowed in reviews, stored as a [Boolean].
  * - [createdAt]: Represents the timestamp of when the user was created as an [OffsetDateTime].
  * - [modifiedAt]: Represents the timestamp of when the user was last modified as an [OffsetDateTime].
  * - [deletedAt]: Represents the timestamp of when the user was last deleted as an [OffsetDateTime].
@@ -28,8 +51,20 @@ object UserTable : UUIDTable("user") {
     val role = enumeration<UserOuterClass.UserRole>("role")
     val status = enumeration<UserOuterClass.UserStatus>("status")
 
-    // Metadata
+    // User settings
+    val areHotkeysShown = bool("show_hotkeys").clientDefault { ARE_HOTKEYS_SHOWN_DEFAULT }
+    val reviewModeEnabled = bool("review_mode").clientDefault { IS_REVIEW_MODE_ENABLED_DEFAULT }
+    val criteriaIds: Column<List<UUID>> = array<UUID>("criteria_ids").clientDefault { CRITERIA_IDS_DEFAULT }
 
+    // Project settings defaults
+    val similarityThreshold = float("similarity_threshold").clientDefault { SIMILARITY_THRESHOLD_DEFAULT }
+    val decisionMatrix = binary("review_decision_matrix").clientDefault { DECISION_MATRIX_DEFAULT }
+    val fetcherApis = array<String>("fetcher_apis").clientDefault { FETCHER_APIS_DEFAULT }
+    val snowballingType =
+        enumeration<ProjectOuterClass.SnowballingType>("snowballing_type").clientDefault { SNOWBALLING_TYPE_DEFAULT }
+    val reviewMaybeAllowed = bool("review_maybe_allowed").clientDefault { REVIEW_MAYBE_ALLOWED_DEFAULT }
+
+    // Metadata
     val createdAt = createdAt()
     val modifiedAt = modifiedAt()
     val deletedAt = deletedAt()
@@ -48,4 +83,18 @@ fun ResultRow.toUser() = User(
     createdAt = this[UserTable.createdAt],
     modifiedAt = this[UserTable.modifiedAt],
     deletedAt = this[UserTable.deletedAt],
+)
+
+/**
+ * Creates [UserSettings] from this [ResultRow].
+ */
+fun ResultRow.toUserSettings() = UserSettings(
+    areHotkeysShown = this[UserTable.areHotkeysShown],
+    isReviewModeEnabled = this[UserTable.reviewModeEnabled],
+    criteriaIds = this[UserTable.criteriaIds],
+    similarityThreshold = this[UserTable.similarityThreshold],
+    decisionMatrix = ReviewDecisionMatrix.parseFrom(this[UserTable.decisionMatrix]),
+    fetcherApis = this[UserTable.fetcherApis],
+    snowballingType = this[UserTable.snowballingType],
+    reviewMaybeAllowed = this[UserTable.reviewMaybeAllowed],
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
@@ -29,7 +29,11 @@ private const val MASK_CATEGORY = "criterion.category"
 object CriterionValidator {
     fun validateCreateRequest(request: Criterion.Create): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
-            { ensureIdValidity(FIELD_PROJECT_ID, request.projectId) },
+            {
+                if (request.projectId.isNotEmpty()) {
+                    ensureIdValidity(FIELD_PROJECT_ID, request.projectId)
+                }
+            },
             {
                 ensureFieldNonBlank(FIELD_TAG, request.tag)
                 ensureFieldLength(FIELD_TAG, request.tag, CRITERION_TAG_MAX_LENGTH)

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -6,6 +6,7 @@ import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.UserSettings
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.ProjectStatus
@@ -117,6 +118,26 @@ object DataBuilder {
         role = role,
         createdAt = createdAt,
         modifiedAt = modifiedAt,
+    )
+
+    fun createExampleUserSettings(
+        showHotkeys: Boolean = true,
+        reviewMode: Boolean = false,
+        criteriaIds: List<UUID> = emptyList(),
+        similarityThreshold: Float = 0.5f,
+        decisionMatrix: ReviewDecisionMatrix = ReviewDecisionMatrix.getDefaultInstance(),
+        fetcherApis: List<String> = emptyList(),
+        snowballingType: SnowballingType = SnowballingType.SNOWBALLING_TYPE_BOTH,
+        reviewMaybeAllowed: Boolean = false,
+    ) = UserSettings(
+        areHotkeysShown = showHotkeys,
+        isReviewModeEnabled = reviewMode,
+        criteriaIds = criteriaIds,
+        similarityThreshold = similarityThreshold,
+        decisionMatrix = decisionMatrix,
+        fetcherApis = fetcherApis,
+        snowballingType = snowballingType,
+        reviewMaybeAllowed = reviewMaybeAllowed,
     )
 
     fun createExamplePaper(

--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/DummyUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/DummyUserTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.auth
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
@@ -15,6 +16,19 @@ class DummyUserTest {
         assertEquals("Alice", DummyUser.firstName)
         assertEquals("Smith", DummyUser.lastName)
         assertEquals("VALIDPassword__1234", DummyUser.password)
+        // User Settings
+        assertEquals(true, DummyUser.areHotkeysShown)
+        assertEquals(false, DummyUser.isReviewModeEnabled)
+        assertEquals(emptyList<UUID>(), DummyUser.criteriaIds)
+        assertEquals(0F, DummyUser.similarityThreshold)
+        assertTrue(
+            ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray().contentEquals(
+                DummyUser.decisionMatrix,
+            ),
+        )
+        assertEquals(emptyList<String>(), DummyUser.fetcherApis)
+        assertEquals(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH, DummyUser.snowballingType)
+        assertEquals(true, DummyUser.reviewMaybeAllowed)
 
         assertTrue(
             PasswordUtils.verifyPassword(DummyUser.password, DummyUser.passwordHash),

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -11,13 +11,16 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
+import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass
+import snowballr.CriterionOuterClass.Criterion
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import java.util.UUID
@@ -31,7 +34,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             ProjectOuterClass.Project.Create
                 .newBuilder()
                 .build()
-        return projectRepo.createProject(request, testUserId)
+        return projectRepo.createProject(request, testUserId, DataBuilder.createExampleUserSettings())
     }
 
     private suspend fun insertTestCriterionAndGetId(
@@ -88,12 +91,12 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
     @Nested
     inner class CreateCriterion {
         @GrpcEnumSourceTest(CriterionCategory::class)
-        fun `When a criterion is created, then the values are correctly assigned`(category: CriterionCategory) =
+        fun `When a project criterion is created, then the values are correctly assigned`(category: CriterionCategory) =
             runTest {
                 val project = createExampleProject()
 
                 val request =
-                    CriterionOuterClass.Criterion.Create
+                    Criterion.Create
                         .newBuilder()
                         .setTag("Test Tag")
                         .setName("Test Criterion")
@@ -107,31 +110,53 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 Assertions.assertThat(criterion.name).isEqualTo("Test Criterion")
                 Assertions.assertThat(criterion.description).isEqualTo("Test Description")
                 Assertions.assertThat(criterion.category).isEqualTo(category)
+                Assertions.assertThat(criterion.projectId).isEqualTo(project.id)
+                Assertions.assertThat(criterion.createdBy).isEqualTo(testUserId)
             }
 
         @GrpcEnumSourceTest(CriterionCategory::class)
-        fun `When a criterion is created, but the assigned project doesn't exist, then an exception is thrown`(
-            category: CriterionCategory,
-        ) = runTest {
-            val request =
-                CriterionOuterClass.Criterion.Create
-                    .newBuilder()
-                    .setTag("Test Tag")
-                    .setName("Test Criterion")
-                    .setDescription("Test Description")
-                    .setCategory(category)
-                    .setProjectId(UUID.randomUUID().toString())
-                    .build()
+        fun `When a user criterion is created, then the values are correctly assigned`(category: CriterionCategory) =
+            runTest {
+                val request =
+                    Criterion.Create
+                        .newBuilder()
+                        .setTag("Test Tag")
+                        .setName("Test Criterion")
+                        .setDescription("Test Description")
+                        .setCategory(category)
+                        .build()
+                val criterion = repo.createCriterion(request, testUserId)
 
-            assertThrows<NotFoundException> { repo.createCriterion(request, testUserId) }
-        }
+                Assertions.assertThat(criterion.tag).isEqualTo("Test Tag")
+                Assertions.assertThat(criterion.name).isEqualTo("Test Criterion")
+                Assertions.assertThat(criterion.description).isEqualTo("Test Description")
+                Assertions.assertThat(criterion.category).isEqualTo(category)
+                Assertions.assertThat(criterion.projectId).isNull()
+                Assertions.assertThat(criterion.createdBy).isEqualTo(testUserId)
+            }
+
+        @Test
+        fun `When a project criterion is created, but the assigned project doesn't exist, then an exception is thrown`() =
+            runTest {
+                val request =
+                    Criterion.Create
+                        .newBuilder()
+                        .setTag("Test Tag")
+                        .setName("Test Criterion")
+                        .setDescription("Test Description")
+                        .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+                        .setProjectId(UUID.randomUUID().toString())
+                        .build()
+
+                assertThrows<NotFoundException> { repo.createCriterion(request, testUserId) }
+            }
 
         @Test
         fun `When two criteria are created, then they have different IDs`() = runTest {
             val project = createExampleProject()
 
             val request =
-                CriterionOuterClass.Criterion.Create
+                Criterion.Create
                     .newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
@@ -150,7 +175,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             category: CriterionCategory,
         ) = runTest {
             val request =
-                CriterionOuterClass.Criterion.Create
+                Criterion.Create
                     .newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
@@ -160,6 +185,115 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                     .build()
 
             assertThrows<NotFoundException> { repo.createCriterion(request, UUID.randomUUID()) }
+        }
+    }
+
+    @Nested
+    inner class GetAllUserCriteria {
+        @Test
+        fun `When all criteria of a specific user are requested, then the only criteria created by the according user are returned`() =
+            runTest {
+                val userId = createExampleUser("test@email.com")
+                val projectId = createExampleProject().id
+
+                val baseRequestBuilder = Criterion.Create.newBuilder()
+                    .setTag("Test Tag")
+                    .setName("Test Criterion")
+                    .setDescription("Test Description")
+                    .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+
+                val userCriterionRequest = baseRequestBuilder.build()
+                val projectCriterionRequest = baseRequestBuilder
+                    .setProjectId(projectId.toString())
+                    .build()
+
+                val userCriterion1 = repo.createCriterion(userCriterionRequest, testUserId)
+                val userCriterion2 = repo.createCriterion(userCriterionRequest, userId)
+                val projectCriterion = repo.createCriterion(projectCriterionRequest, testUserId)
+
+                val userCriteria = repo.getAllUserCriteria(testUserId)
+
+                Assertions.assertThat(userCriteria).hasSize(1)
+                Assertions.assertThat(userCriteria).containsExactly(userCriterion1)
+                Assertions.assertThat(userCriteria).doesNotContain(userCriterion2)
+                Assertions.assertThat(userCriteria).doesNotContain(projectCriterion)
+            }
+    }
+
+    @Nested
+    inner class GetCriteriaByIds {
+        @Test
+        fun `When all criteria of the given ids are requested and exist, then all those criteria are returned`() =
+            runTest {
+                val projectId = createExampleProject().id
+
+                val baseRequestBuilder = Criterion.Create.newBuilder()
+                    .setTag("Test Tag")
+                    .setName("Test Criterion")
+                    .setDescription("Test Description")
+                    .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+
+                val userCriterionRequest = baseRequestBuilder.build()
+                val projectCriterionRequest = baseRequestBuilder
+                    .setProjectId(projectId.toString())
+                    .build()
+
+                val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
+                val projectCriterion = repo.createCriterion(projectCriterionRequest, testUserId)
+
+                val userCriteria = repo.getCriteriaByIds(listOf(userCriterion.id, projectCriterion.id))
+
+                assertThat(userCriteria).hasSize(2)
+                assertThat(userCriteria).containsExactlyInAnyOrder(userCriterion, projectCriterion)
+            }
+
+        @Test
+        fun `When all criteria of the given ids are requested but not all criteria exist, then only the existing criteria are returned`() =
+            runTest {
+                val baseRequestBuilder = Criterion.Create.newBuilder()
+                    .setTag("Test Tag")
+                    .setName("Test Criterion")
+                    .setDescription("Test Description")
+                    .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+
+                val userCriterionRequest = baseRequestBuilder.build()
+
+                val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
+
+                val userCriteria = repo.getCriteriaByIds(listOf(userCriterion.id, UUID.randomUUID()))
+
+                assertThat(userCriteria).hasSize(1)
+                assertThat(userCriteria).containsExactlyInAnyOrder(userCriterion)
+            }
+
+        @Test
+        fun `When all the input list is empty, then an empty list is returned`() = runTest {
+            val userCriteria = repo.getCriteriaByIds(emptyList())
+            assertThat(userCriteria).isEmpty()
+        }
+
+        @Test
+        fun `When no criteria of the input list exist, then an empty list is returned`() = runTest {
+            val userCriteria = repo.getCriteriaByIds(listOf(UUID.randomUUID()))
+            assertThat(userCriteria).isEmpty()
+        }
+
+        @Test
+        fun `When the input list contains duplicated ids, then every criterion is returned only once`() = runTest {
+            val baseRequestBuilder = Criterion.Create.newBuilder()
+                .setTag("Test Tag")
+                .setName("Test Criterion")
+                .setDescription("Test Description")
+                .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+
+            val userCriterionRequest = baseRequestBuilder.build()
+
+            val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
+
+            val userCriteria = repo.getCriteriaByIds(listOf(userCriterion.id, userCriterion.id))
+
+            assertThat(userCriteria).hasSize(1)
+            assertThat(userCriteria).containsExactlyInAnyOrder(userCriterion)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
@@ -81,32 +82,36 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
     inner class CreateProject {
         @Test
         fun `When a project is created, then the passed values are correctly assigned`() = runTest {
-            val projectId = insertTestProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val project = repo.getProjectById(projectId)
+            val userSettings = DataBuilder.createExampleUserSettings()
+            val projectBuilder = Project.Create.newBuilder().setName("Test Project").build()
+            val project = repo.createProject(projectBuilder, testUserId, userSettings)
 
             assertThat(project.name).isEqualTo("Test Project")
             assertThat(project.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE)
             assertThat(project.currentStage).isEqualTo(0)
             assertThat(project.maxStage).isEqualTo(0)
             // Assert default settings from user
-            assertThat(project.similarityThreshold).isEqualTo(0F)
+            assertThat(project.similarityThreshold).isEqualTo(0.5F)
             assertThat(project.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_BOTH)
-            assertThat(project.reviewMaybeAllowed).isTrue()
+            assertThat(project.reviewMaybeAllowed).isFalse()
             assertThat(project.reviewDecisionMatrix).isEqualTo(ReviewDecisionMatrix.getDefaultInstance())
             assertThat(project.fetcherApis).isEmpty()
         }
 
         @Test
         fun `When two projects are created, then they have different IDs`() = runTest {
-            val projectId1 = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val projectId2 = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val userSettings = DataBuilder.createExampleUserSettings()
+            val project = Project.Create.newBuilder().setName("Test Project 1").build()
+            val projectId1 = repo.createProject(project, testUserId, userSettings)
+            val projectId2 = repo.createProject(project, testUserId, userSettings)
             assertThat(projectId1).isNotEqualTo(projectId2)
         }
 
         @Test
         fun `When a project is created, but the assigned user doesn't exist, then an exception is thrown`() = runTest {
             val request = Project.Create.newBuilder().setName("Test Project").build()
-            assertThrows<NotFoundException> { repo.createProject(request, UUID.randomUUID()) }
+            val userSettings = DataBuilder.createExampleUserSettings()
+            assertThrows<NotFoundException> { repo.createProject(request, UUID.randomUUID(), userSettings) }
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -318,7 +318,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             val userSettings = repo.getUserSettings(userId)
 
             assertThat(userSettings.areHotkeysShown).isTrue()
-            assertThat(userSettings.reviewMaybeAllowed).isFalse()
+            assertThat(userSettings.isReviewModeEnabled).isFalse()
             assertThat(userSettings.criteriaIds).isEmpty()
             assertThat(userSettings.similarityThreshold).isEqualTo(0F)
             assertThat(

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -17,6 +17,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.table.UserTable
 import snowballr.Authentication
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
@@ -306,6 +307,31 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         @Test
         fun `When a user is not found, then an exception is thrown`() = runTest {
             assertThrows<NotFoundException> { repo.getPasswordHashByEmail("non-existing email") }
+        }
+    }
+
+    @Nested
+    inner class GetUserSettings {
+        @Test
+        fun `When a user is found, then the user settings are returned`() = runTest {
+            val userId = insertTestUserAndGetId()
+            val userSettings = repo.getUserSettings(userId)
+
+            assertThat(userSettings.areHotkeysShown).isTrue()
+            assertThat(userSettings.reviewMaybeAllowed).isFalse()
+            assertThat(userSettings.criteriaIds).isEmpty()
+            assertThat(userSettings.similarityThreshold).isEqualTo(0F)
+            assertThat(
+                userSettings.decisionMatrix,
+            ).isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
+            assertThat(userSettings.fetcherApis).isEmpty()
+            assertThat(userSettings.snowballingType).isEqualTo(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH)
+            assertThat(userSettings.reviewMaybeAllowed).isTrue()
+        }
+
+        @Test
+        fun `When a user is not found, then an exception is thrown`() = runTest {
+            assertThrows<NotFoundException> { repo.getUserSettings(UUID.randomUUID()) }
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
@@ -30,7 +31,8 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 .newBuilder()
                 .setName("Test Project")
                 .build()
-        return projectRepo.createProject(request, testUserId)
+        val userSettings = DataBuilder.createExampleUserSettings()
+        return projectRepo.createProject(request, testUserId, userSettings)
     }
 
     private suspend fun setupProject(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -9,11 +9,37 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.service.MainServiceTest
+import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass
+import snowballr.CriterionOuterClass.CriterionCategory
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class CreateCriterionTest : MainServiceTest() {
+    private val dummyUserUUID = UUID.randomUUID()
+
+    private fun getProjectCriterionRequest(projectId: String): CriterionOuterClass.Criterion.Create {
+        return CriterionOuterClass.Criterion.Create.newBuilder()
+            .setTag("Tag")
+            .setName("Criterion")
+            .setDescription("Description")
+            .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+            .setProjectId(projectId)
+            .build()
+    }
+
+    private fun getUserCriterionRequest(): CriterionOuterClass.Criterion.Create {
+        return CriterionOuterClass.Criterion.Create.newBuilder()
+            .setTag("Tag")
+            .setName("Criterion")
+            .setDescription("Description")
+            .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+            .build()
+    }
+
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
@@ -24,10 +50,101 @@ class CreateCriterionTest : MainServiceTest() {
     }
 
     @Test
-    fun `When creating a criterion fails, then an exception is thrown`() = runTest {
+    fun `When an admin user creates a project criterion, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+
+        val criterion = DataBuilder.createExampleCriterion(projectId = project.id)
+        val request = getProjectCriterionRequest(project.id.toString())
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+        assertDoesNotThrow { mainService.createCriterion(request) }
+    }
+
+    @Test
+    fun `When a project admin creates a project criterion, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectMember = DataBuilder.createExampleProjectMember(userId = dummyUserUUID, projectId = project.id)
+
+        val criterion = DataBuilder.createExampleCriterion(projectId = project.id)
+        val request = getProjectCriterionRequest(project.id.toString())
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+
+        assertDoesNotThrow { mainService.createCriterion(request) }
+    }
+
+    @Test
+    fun `When a non project admin creates a project criterion, then an unauthorized exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+
+        val request = getProjectCriterionRequest(project.id.toString())
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+        assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.createCriterion(request) }
+    }
+
+    @GrpcEnumSourceTest(
+        ProjectOuterClass.ProjectStatus::class,
+        excludes = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_UNSPECIFIED"],
+    )
+    fun `When a project admin creates a project criterion for a non active project, then a failed precondition exception is thrown`(
+        status: ProjectOuterClass.ProjectStatus,
+    ) = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = status,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+        val request = getProjectCriterionRequest(project.id.toString())
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+
+        assertThrows<SnowballRException.FailedPreconditionException> { mainService.createCriterion(request) }
+    }
+
+    @Test
+    fun `When an user creates a user criterion, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+
+        val criterion = DataBuilder.createExampleCriterion()
+        val request = getUserCriterionRequest()
+
+        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { criterionRepoMock.createCriterion(any(), dummyUserUUID) } returns criterion
+
+        assertDoesNotThrow { mainService.createCriterion(request) }
+    }
+
+    @Test
+    fun `When an error occurs while a criterion is created, then an exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
+        val userId = UUID.randomUUID()
+        val user = DataBuilder.createExampleUser(id = userId)
 
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.createCriterion(request) }
@@ -36,9 +153,11 @@ class CreateCriterionTest : MainServiceTest() {
     @Test
     fun `When a criterion is correctly created, then no exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
+        val user = DataBuilder.createExampleUser(id = UUID.randomUUID())
         val criterion = DataBuilder.createExampleCriterion()
 
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -58,7 +58,7 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -83,7 +83,7 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -109,7 +109,7 @@ class UpdateCriterionTest : MainServiceTest() {
             every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.getProjectById(any()) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateCriterion(request) }
@@ -132,7 +132,7 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,6 +14,8 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+import kotlin.test.assertEquals
 
 class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
@@ -61,15 +64,16 @@ class CreateProjectTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion = DataBuilder.createExampleCriterion()
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
-            val slots = mutableListOf(criterion.id)
+            val criteriaIdsSlot = slot<List<UUID>>()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
-            coEvery { criterionRepoMock.getCriteriaByIds(slots) } returns listOf(criterion)
+            coEvery { criterionRepoMock.getCriteriaByIds(capture(criteriaIdsSlot)) } returns listOf(criterion)
             coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } returns project
             coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
             assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
+            assertEquals(listOf(criterion.id), criteriaIdsSlot.captured)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -11,7 +12,7 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
-import java.util.UUID
+import snowballr.UserOuterClass.UserRole
 
 class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
@@ -25,8 +26,14 @@ class CreateProjectTest : MainServiceTest() {
 
     @Test
     fun `When an error occurs while a project is created, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { projectRepoMock.createProject(any(), any()) } throws TestSpecificException()
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val userSettings = DataBuilder.createExampleUserSettings()
+
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+        coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
+        coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.createProject(getExampleRequest()) }
     }
@@ -34,10 +41,35 @@ class CreateProjectTest : MainServiceTest() {
     @Test
     fun `When a project is correctly created, then no exception is thrown`() = runTest {
         val project = DataBuilder.createExampleProject()
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val userSettings = DataBuilder.createExampleUserSettings()
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { projectRepoMock.createProject(any(), any()) } returns project
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+        coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
+        coEvery { projectRepoMock.createProject(any(), any(), userSettings) } returns project
 
         assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
+        coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
     }
+
+    @Test
+    fun `When a project is correctly created and the user has default criteria, then no exception is thrown`() =
+        runTest {
+            val project = DataBuilder.createExampleProject()
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val criterion = DataBuilder.createExampleCriterion()
+            val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
+            val slots = mutableListOf(criterion.id)
+
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+            coEvery { criterionRepoMock.getCriteriaByIds(slots) } returns listOf(criterion)
+            coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } returns project
+            coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
+
+            assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -1,0 +1,59 @@
+package se.uulm.snowballr.backend.service.user
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.service.MainServiceTest
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+@DelicateCoroutinesApi
+class GetUserSettingsTest : MainServiceTest() {
+    @Test
+    fun `When retrieving current user settings fails, then an exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+
+        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { userRepoMock.getUserSettings(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getUserSettings() }
+    }
+
+    @Test
+    fun `When retrieving current user settings is correct, but not default criteria exist, then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val userSettings = DataBuilder.createExampleUserSettings()
+
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
+            coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+
+            assertDoesNotThrow { mainService.getUserSettings() }
+        }
+
+    @Test
+    fun `When retrieving current user settings is correct and default criteria exist, then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val criterion = DataBuilder.createExampleCriterion()
+            val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
+
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
+            coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+
+            assertDoesNotThrow { mainService.getUserSettings() }
+        }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
@@ -40,6 +40,14 @@ class CriterionValidatorTest {
         }
 
         @Test
+        fun `When a request with an empty project ID is validated, then the no issue is returned`() {
+            val request = validCreateRequestBuilder.setProjectId("").build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
         fun `When a request with an invalid project ID is validated, then the 'InvalidId' issue is returned`() {
             val request = validCreateRequestBuilder.setProjectId("invalid-id").build()
             val result = validateRequest(request)


### PR DESCRIPTION
Closes #110 #95

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

First of all I created the `UserSettings` in the database. Then I implemented the method `getUserSettings` to be able to retrieve the user settings.

I adjusted the methods to create a criterion on the repository, service and validation layer to distinguish between user and project criteria. This includes the following behaviour:
- everyone can create a user criterion (no restrictions)
- as soon as a project is created, the default criteria of the users `UserSettings` are duplicated and stored as project criteria
- every project admin is allowed to add new project criteria

**Note:** This branch was rebased onto the `updateCriterion` branch, which is why only the last four commits are relevant for this PR.
 
## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
