### PR TITLE
fix: wiki hint generation script messing with literal "\n" in text files

### DIFF
--- a/scripts/add_auto_gen_wiki_hint.sh
+++ b/scripts/add_auto_gen_wiki_hint.sh
@@ -6,5 +6,5 @@ NOTICE="_This document was generated on $TIMESTAMP. Please do not edit this page
 find "./wiki" -type f -name "*.md" ! -name "_*" | while read -r file; do
   echo "Processing $file..."
   # Prepend text using temp file
-  echo -e "$NOTICE\n\n$(cat "$file")" > "$file"
+  sed -i "1s/^/$NOTICE\n\n/" "$file"
 done


### PR DESCRIPTION
Closes #165 

## What I have made

`cat` messes with literal `\n` in text files and interprets them as newlines. Thus, `\n` in the source file will be converted to an actual newline, messing with the wiki rendering.
`sed` can be used to prepend text without interfering with `\n`.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] (for reviewer) I have checked the implementation against the requirements
