### PR TITLE
Added script to compare used and implemented api calls

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -56,7 +56,7 @@ jobs:
                   args: --ignore-links "https://stackoverflow.com/questions/6720050/foreign-key-constraints-when-to-use-on-update-and-on-delete/6720458#6720458" wiki/
 
             - name: Calculate implementation progress (dry run)
-              run: node scripts/calc-impl-progress.js
+              run: node scripts/calc-impl-progress.js update-wiki
 
     publish-wiki:
         name: Publish Wiki
@@ -73,7 +73,7 @@ jobs:
               run: bash scripts/add_auto_gen_wiki_hint.sh
 
             - name: Calculate implementation progress
-              run: node scripts/calc-impl-progress.js
+              run: node scripts/calc-impl-progress.js update-wiki
 
             - name: Publish the Wiki
               uses: Andrew-Chen-Wang/github-wiki-action@v4

--- a/scripts/calc-impl-progress.js
+++ b/scripts/calc-impl-progress.js
@@ -66,7 +66,7 @@ try {
     assert(categoryMatches === allCallsCount, "Category matches should equal all API calls");
     console.log(`Found ${categoryMatches} API calls and all were successfully categorized.`);
     console.log("Categories:", categories);
-    
+
     if (mode === "write-files" || mode === "all") {
         fs.writeFileSync(
             "all-available-calls.md",
@@ -102,13 +102,13 @@ try {
     }
 
     // Calculate remaining work
-    const remainingCalls = allCallsCount - implementedCallsCount;
+    const remainingCallsCount = allCallsCount - implementedCallsCount;
 
     // Output the results
     console.log(`All API calls: ${allCallsCount}`);
     console.log(`Implemented API calls: ${implementedCallsCount}`);
     console.log(`Percentage implemented: ${percentage}%`);
-    console.log(`Remaining API calls: ${remainingCalls}`);
+    console.log(`Remaining API calls: ${remainingCallsCount}`);
     console.log("\nImplementation by category:");
     for (const category in categories) {
         const implemented = implementedByCategory[category] ?? 0;

--- a/scripts/calc-impl-progress.js
+++ b/scripts/calc-impl-progress.js
@@ -19,14 +19,14 @@ try {
 
     // Count occurrences of "override suspend fun"
     const allCallsMatches = fileContent.match(allCallsPattern) ?? [];
-    const allCalls = allCallsMatches.length;
+    const allCallsCount = allCallsMatches.length;
 
     // Count occurrences of not "super."
     const implementedCallsMatches = fileContent.match(implementedCallsPattern) ?? [];
-    const implementedCalls = implementedCallsMatches.length;
+    const implementedCallsCount = implementedCallsMatches.length;
 
     // Calculate percentage
-    const percentage = allCalls > 0 ? Math.round((implementedCalls / allCalls) * 100) : 0;
+    const percentage = allCallsCount > 0 ? Math.round((implementedCallsCount / allCallsCount) * 100) : 0;
 
     // Count API calls by category/service
     const categories = {};
@@ -45,36 +45,56 @@ try {
             : "Other";
     };
 
+    const allCalls = [];
     let match;
     let categoryMatches = 0;
     while ((match = allCallsPattern.exec(fileContent)) !== null) {
         const methodName = match[1];
+        allCalls.push(methodName);
         const category = getCategory(methodName);
 
         categories[category] = (categories[category] ?? 0) + 1;
         categoryMatches++;
     }
-    assert(categoryMatches === allCalls, "Category matches should equal all API calls");
+    assert(categoryMatches === allCallsCount, "Category matches should equal all API calls");
     console.log(`Found ${categoryMatches} API calls and all were successfully categorized.`);
     console.log("Categories:", categories);
+    fs.writeFileSync(
+        "all-available-calls.md",
+        allCalls
+            .toSorted()
+            .map((m) => `- ${m}`)
+            .join("\n"),
+        "utf8",
+    );
 
     // Count implemented calls by category
+    const implementedCalls = [];
     let implementedMatches = 0;
     while ((match = implementedCallsPattern.exec(fileContent)) !== null) {
         const methodName = match[1];
+        implementedCalls.push(methodName);
         const category = getCategory(methodName);
 
         implementedByCategory[category] = (implementedByCategory[category] ?? 0) + 1;
         implementedMatches++;
     }
-    assert(implementedMatches === implementedCalls, "Implemented matches should equal implemented API calls");
+    assert(implementedMatches === implementedCallsCount, "Implemented matches should equal implemented API calls");
+    fs.writeFileSync(
+        "all-implemented-calls.md",
+        implementedCalls
+            .toSorted()
+            .map((m) => `- ${m}`)
+            .join("\n"),
+        "utf8",
+    );
 
     // Calculate remaining work
-    const remainingCalls = allCalls - implementedCalls;
+    const remainingCalls = allCallsCount - implementedCallsCount;
 
     // Output the results
-    console.log(`All API calls: ${allCalls}`);
-    console.log(`Implemented API calls: ${implementedCalls}`);
+    console.log(`All API calls: ${allCallsCount}`);
+    console.log(`Implemented API calls: ${implementedCallsCount}`);
     console.log(`Percentage implemented: ${percentage}%`);
     console.log(`Remaining API calls: ${remainingCalls}`);
     console.log("\nImplementation by category:");
@@ -90,7 +110,7 @@ try {
 
     // Create the replacement string with Markdown formatting
     let replacementText = `## API Implementation Progress\n\n`;
-    replacementText += `Currently, **${implementedCalls}/${allCalls} (${percentage}%)** of the API calls are implemented.\n\n`;
+    replacementText += `Currently, **${implementedCallsCount}/${allCallsCount} (${percentage}%)** of the API calls are implemented.\n\n`;
 
     // Add progress bar
     const progressBarLength = 45;

--- a/scripts/calc-impl-progress.js
+++ b/scripts/calc-impl-progress.js
@@ -12,6 +12,13 @@ const wikiPath = "wiki/Contributing.md";
 const replacePattern = "<!-- @add-progress -->";
 const allCallsPattern = /override suspend fun (\w+)\(/g;
 const implementedCallsPattern = /override suspend fun (\w+)\(\s*.*?\s*\)\s*:\s+[\w.]+\s+=(?!\s*super\.)/g;
+// Mode can be "update-wiki" or "write-files" or "all" or "none"
+// "all" will perform both actions
+const mode = process.argv[2] || "all"; // Default to "all" if not specified
+if (!["update-wiki", "write-files", "all", "none"].includes(mode)) {
+    console.error(`Invalid mode: ${mode}. Use "update-wiki", "write-files", "all", or "none".`);
+    process.exit(1);
+}
 
 try {
     // Read the file content
@@ -59,14 +66,17 @@ try {
     assert(categoryMatches === allCallsCount, "Category matches should equal all API calls");
     console.log(`Found ${categoryMatches} API calls and all were successfully categorized.`);
     console.log("Categories:", categories);
-    fs.writeFileSync(
-        "all-available-calls.md",
-        allCalls
-            .toSorted()
-            .map((m) => `- ${m}`)
-            .join("\n"),
-        "utf8",
-    );
+    
+    if (mode === "write-files" || mode === "all") {
+        fs.writeFileSync(
+            "all-available-calls.md",
+            allCalls
+                .toSorted()
+                .map((m) => `- ${m}`)
+                .join("\n"),
+            "utf8",
+        );
+    }
 
     // Count implemented calls by category
     const implementedCalls = [];
@@ -80,14 +90,16 @@ try {
         implementedMatches++;
     }
     assert(implementedMatches === implementedCallsCount, "Implemented matches should equal implemented API calls");
-    fs.writeFileSync(
-        "all-implemented-calls.md",
-        implementedCalls
-            .toSorted()
-            .map((m) => `- ${m}`)
-            .join("\n"),
-        "utf8",
-    );
+    if (mode === "write-files" || mode === "all") {
+        fs.writeFileSync(
+            "all-implemented-calls.md",
+            implementedCalls
+                .toSorted()
+                .map((m) => `- ${m}`)
+                .join("\n"),
+            "utf8",
+        );
+    }
 
     // Calculate remaining work
     const remainingCalls = allCallsCount - implementedCallsCount;
@@ -137,9 +149,10 @@ try {
     const updatedWikiContent = wikiContent.replace(replacePattern, replacementText);
 
     // Write the updated content back to the wiki file
-    fs.writeFileSync(wikiPath, updatedWikiContent, "utf8");
-
-    console.log("\nWiki updated with progress statistics!");
+    if (mode === "update-wiki" || mode === "all") {
+        fs.writeFileSync(wikiPath, updatedWikiContent, "utf8");
+        console.log("\nWiki updated with progress statistics!");
+    }
 } catch (error) {
     console.error(`Error: ${error.message}`);
     process.exit(1);

--- a/scripts/compare-api-method-states.js
+++ b/scripts/compare-api-method-states.js
@@ -1,0 +1,82 @@
+/**
+ * Script to compare API methods between all-available-calls.md and all-used-calls.md
+ *
+ * Usage: node scripts/compare-api-method-states.js
+ */
+
+import fs from "fs";
+
+// File paths
+const allAvailableCallsPath = "all-available-calls.md";
+const allImplementedCallsPath = "all-implemented-calls.md";
+const usedApiMethodsPath = "all-used-calls.md";
+const missingCallsPath = "all-missing-calls.md";
+const unusedCallsPath = "all-unused-calls.md";
+
+try {
+    // Read the files
+    const allAvailableCallsContent = fs.readFileSync(
+        allAvailableCallsPath,
+        "utf8"
+    );
+    const allImplementedCallsContent = fs.readFileSync(
+        allImplementedCallsPath,
+        "utf8"
+    );
+    const usedApiMethodsContent = fs.readFileSync(usedApiMethodsPath, "utf8");
+
+    // Parse bullet point lists
+    const parseListItems = (content) => {
+        return content
+            .trim()
+            .split("\n")
+            .filter((line) => line.trim().startsWith("- "))
+            .map((line) => line.trim().substring(2).trim());
+    };
+
+    const allAvailableCalls = parseListItems(allAvailableCallsContent);
+    const allImplementedCalls = parseListItems(allImplementedCallsContent);
+    const usedApiMethods = parseListItems(usedApiMethodsContent);
+
+    // Find missing calls (used but not implemented)
+    const missingCalls = usedApiMethods.filter(
+        (method) => !allImplementedCalls.includes(method)
+    );
+
+    // Find unused calls (available but not used)
+    const unusedCalls = allAvailableCalls.filter(
+        (method) => !usedApiMethods.includes(method)
+    );
+
+    // Generate output files
+    const formatList = (items) =>
+        items
+            .sort()
+            .map((item) => `- ${item}`)
+            .join("\n");
+
+    // Write missing calls to file
+    const missingCallsContent =
+        missingCalls.length > 0
+            ? formatList(missingCalls)
+            : "# No missing calls found\n\nAll API methods used are available in the API.";
+    fs.writeFileSync(missingCallsPath, missingCallsContent, "utf8");
+
+    // Write unused calls to file
+    const unusedCallsContent =
+        unusedCalls.length > 0
+            ? formatList(unusedCalls)
+            : "# No unused calls found\n\nAll available API methods are being used.";
+    fs.writeFileSync(unusedCallsPath, unusedCallsContent, "utf8");
+
+    console.log(`Comparison completed successfully!`);
+    console.log(
+        `Found ${missingCalls.length} missing calls and ${unusedCalls.length} unused calls.`
+    );
+    console.log(
+        `Results written to ${missingCallsPath} and ${unusedCallsPath}.`
+    );
+} catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+}

--- a/scripts/compare-api-method-states.js
+++ b/scripts/compare-api-method-states.js
@@ -51,6 +51,11 @@ try {
         (method) => !usedApiMethods.includes(method)
     );
 
+    // Find unnecessary implemented calls (implemented but not used)
+    const unnecessaryImplementedCalls = allImplementedCalls.filter(
+        (method) => !usedApiMethods.includes(method)
+    );
+
     // Generate output files
     const formatList = (items) =>
         items
@@ -71,6 +76,17 @@ try {
             ? formatList(unusedCalls)
             : "# No unused calls found\n\nAll available API methods are being used.";
     fs.writeFileSync(unusedCallsPath, unusedCallsContent, "utf8");
+
+    // Write unnecessary implemented calls to file
+    const unnecessaryImplementedCallsContent =
+        unnecessaryImplementedCalls.length > 0
+            ? formatList(unnecessaryImplementedCalls)
+            : "# No unnecessary implemented calls found\n\nAll implemented API methods are being used.";
+    fs.writeFileSync(
+        "all-unnecessary-implemented-calls.md",
+        unnecessaryImplementedCallsContent,
+        "utf8"
+    );
 
     console.log(`Comparison completed successfully!`);
     console.log(

--- a/scripts/compare-api-method-states.js
+++ b/scripts/compare-api-method-states.js
@@ -1,5 +1,8 @@
 /**
- * Script to compare API methods between all-available-calls.md and all-used-calls.md
+ * Script to compare API methods between all-available-calls.md, all-implemented-calls.md and all-used-calls.md
+ *
+ * This script assumes that the "get-all-used-calls.js" script in the frontend repository has been run.
+ * It also assumes that the the "cacl-impl-progress.js" script has been run with the "write-files" or "all" mode.
  *
  * Usage: node scripts/compare-api-method-states.js
  */


### PR DESCRIPTION
Closes #202 

## What I have made

Modified the existing `calc-impl-progress.js` script to print its findings to files.
Added another script that takes those files and the one produced by the new frontend script to retrieve the missing, unused, and unnecessarily implemented API calls.

Mostly vibe coding.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (not required)
- [x] (for reviewer) I have checked the implementation against the requirements
