### PR TITLE
Grpc health and reflection calls time out due to flawed interceptor logic

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -9,7 +9,6 @@ import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.Status
 import io.grpc.health.v1.HealthGrpc
-import io.grpc.reflection.v1alpha.ServerReflectionGrpc
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import se.uulm.snowballr.backend.auth.DummyUser
@@ -21,6 +20,8 @@ import se.uulm.snowballr.backend.service.AuthenticationService
 import se.uulm.snowballr.backend.service.IAuthenticationService
 import snowballr.Authentication.AuthenticationStatus
 import snowballr.SnowballRGrpcKt
+import io.grpc.reflection.v1.ServerReflectionGrpc as ServerReflectionV1Grpc
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc as ServerReflectionV1AlphaGrpc
 
 private val logger = KotlinLogging.logger {}
 
@@ -30,7 +31,8 @@ private val logger = KotlinLogging.logger {}
 private val PUBLIC_SERVICES =
     setOf(
         HealthGrpc.SERVICE_NAME,
-        ServerReflectionGrpc.SERVICE_NAME,
+        ServerReflectionV1Grpc.SERVICE_NAME,
+        ServerReflectionV1AlphaGrpc.SERVICE_NAME,
     )
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -94,16 +94,17 @@ val authenticationInterceptor: ServerInterceptor =
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>?,
         ): ServerCall.Listener<ReqT?>? {
+            val serviceName = call?.methodDescriptor?.serviceName
             val methodName = call?.methodDescriptor?.fullMethodName
             logger.info { "Authenticating call to $methodName" }
 
-            if (methodName == null) {
-                call?.close(Status.UNAUTHENTICATED.withDescription("Method name is null"), Metadata())
+            if (methodName == null || serviceName == null) {
+                call?.close(Status.UNAUTHENTICATED.withDescription("Method or service name is null"), Metadata())
                 return emptyListener()
             }
 
-            if (methodName in PUBLIC_SERVICES) {
-                logger.trace { "Method $methodName is a public service, bypassing authentication." }
+            if (serviceName in PUBLIC_SERVICES) {
+                logger.trace { "Service $serviceName is a public service, bypassing authentication for $methodName." }
                 return next?.startCall(call, headers)
             }
 


### PR DESCRIPTION
Closes #216 

## What I have made

- Compare correct name to bypass authentication
- Include both server reflection versions for compatibility

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ not needed
- [x] (for reviewer) I have checked the implementation against the requirements
