### PR TITLE
Introduce profile for environment specific configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
-# Http
-PORT=8080
-
-# Miscellaneous
-LOG_LEVEL=DEBUG
+# Profile
+PROFILE=DEVELOPMENT
 
 # Database
 DATABASE_PASSWORD=postgres_password

--- a/README.md
+++ b/README.md
@@ -55,31 +55,31 @@ The `PROFILE` variable determines the default behavior of the application.
 
 ### Environment Variables Table
 
-| Variable                 |               Required               |    Default    | Description                                                                       |
-|--------------------------|:------------------------------------:|:-------------:|-----------------------------------------------------------------------------------|
-| `PROFILE`                |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).          |
-| `PORT`                   | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                             |
-| `DATABASE_HOST`          | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                              |
-| `LOG_LEVEL`              |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`. |
-| `AUTH_BYPASS`            |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.     |
-| `DATABASE_SEED_USER`     |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                |
-| `DATABASE_PASSWORD`      |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                               |
-| `JWT_PRIVATE_KEY_BASE64` |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                |
-| `JWT_PUBLIC_KEY_BASE64`  |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                 |
-| `WEB_PORT`               |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                           |
-| `BACKEND_TAG`            |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.       |
+| Variable                     |               Required               |    Default    | Description                                                                       |
+|------------------------------|:------------------------------------:|:-------------:|-----------------------------------------------------------------------------------|
+| `PROFILE`                    |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).          |
+| `PORT`                       | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                             |
+| `DATABASE_HOST`              | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                              |
+| `LOG_LEVEL`                  |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`. |
+| `AUTH_BYPASS_ENABLED`        |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.     |
+| `DATABASE_SEED_USER_ENABLED` |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                |
+| `DATABASE_PASSWORD`          |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                               |
+| `JWT_PRIVATE_KEY_BASE64`     |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                |
+| `JWT_PUBLIC_KEY_BASE64`      |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                 |
+| `WEB_PORT`                   |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                           |
+| `BACKEND_TAG`                |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.       |
 
 \* only used when using the docker compose profiles.
 
 #### Profile-based Defaults
 
-| Profile              | `PRODUCTION` | `DEVELOPMENT` | `TESTING`   |
-|----------------------|--------------|---------------|-------------|
-| `PORT`               | -            | 8080          | 8080        |
-| `DATABASE_HOST`      | -            | `localhost`   | `localhost` |
-| `LOG_LEVEL`          | `INFO`       | `DEBUG`       | `TRACE`     |
-| `AUTH_BYPASS`        | `false`      | `false`       | `true`      |
-| `DATABASE_SEED_USER` | `false`      | `true`        | `true`      |
+| Profile                      | `PRODUCTION` | `DEVELOPMENT` | `TESTING`   |
+|------------------------------|--------------|---------------|-------------|
+| `PORT`                       | -            | 8080          | 8080        |
+| `DATABASE_HOST`              | -            | `localhost`   | `localhost` |
+| `LOG_LEVEL`                  | `INFO`       | `DEBUG`       | `TRACE`     |
+| `AUTH_BYPASS_ENABLED`        | `false`      | `false`       | `true`      |
+| `DATABASE_SEED_USER_ENABLED` | `false`      | `true`        | `true`      |
 
 ### JWT Private/Public Key
 

--- a/README.md
+++ b/README.md
@@ -34,28 +34,52 @@ environment variable (default: `8081`).
 
 ## Environment Variables
 
-The app requires a set of environment variables to run. You can set them in a `.env` file in the root directory of the
-project. Either create the file manually or copy the provided example:
+The app's configuration is driven by the `PROFILE` environment variable, which sets sensible defaults for different
+environments. You can specify `PROFILE` and other variables in a `.env` file in the root directory. Either create the
+file manually or copy the provided example:
 
 ```bash
 cp .env.example .env
 ```
 
-The environment variables are as follows:
+### Configuration Profiles
 
-| Variable                 |      Required      |   Default    | Description                                                                      |
-|--------------------------|:------------------:|:------------:|----------------------------------------------------------------------------------|
-| `PORT`                   | :white_check_mark: |      -       | The port where the backend is served                                             |
-| `WEB_PORT`               |        :x:*        |     8081     | The port where the proxy is served (used for gRPC-Web)                           |
-| `LOG_LEVEL`              |        :x:         |   `DEBUG`    | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
-| `DATABASE_PASSWORD`      | :white_check_mark: |      -       | Password for the database e.g. `postgres_password`                               |
-| `DATABASE_HOST`          |        :x:         | `localhost`  | Hostname of database connection                                                  |
-| `BACKEND_TAG`            |        :x:*        | `latest-dev` | Tag of registry backend image to use for `registry` docker compose profile       |
-| `JWT_PRIVATE_KEY_BASE64` | :white_check_mark: |      -       | Base64 encoded private key for JWT authentication                                |
-| `JWT_PUBLIC_KEY_BASE64`  | :white_check_mark: |      -       | Base64 encoded public key for JWT authentication                                 |
-| `USE_DUMMY_USER`         |        :x:         |   `false`    | Whether to use a dummy user for development purposes                             |
+The `PROFILE` variable determines the default behavior of the application.
+
+- `PRODUCTION` (Default): For live deployments. Requires explicit configuration for critical settings like PORT and
+  DATABASE_HOST. Disables all development helpers.
+- `DEVELOPMENT`: For local development. Provides convenient defaults for the server and database and automatically
+  seeds a dummy user for easy interaction with the API.
+- `TESTING`: For local manual testing. Similar to development, but enables authentication bypass for easier testing of
+  authenticated endpoints.
+
+### Environment Variables Table
+
+| Variable                 |               Required               |    Default    | Description                                                                       |
+|--------------------------|:------------------------------------:|:-------------:|-----------------------------------------------------------------------------------|
+| `PROFILE`                |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).          |
+| `PORT`                   | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                             |
+| `DATABASE_HOST`          | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                              |
+| `LOG_LEVEL`              |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`. |
+| `AUTH_BYPASS`            |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.     |
+| `DATABASE_SEED_USER`     |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                |
+| `DATABASE_PASSWORD`      |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                               |
+| `JWT_PRIVATE_KEY_BASE64` |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                |
+| `JWT_PUBLIC_KEY_BASE64`  |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                 |
+| `WEB_PORT`               |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                           |
+| `BACKEND_TAG`            |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.       |
 
 \* only used when using the docker compose profiles.
+
+#### Profile-based Defaults
+
+| Profile              | `PRODUCTION` | `DEVELOPMENT` | `TESTING`   |
+|----------------------|--------------|---------------|-------------|
+| `PORT`               | -            | 8080          | 8080        |
+| `DATABASE_HOST`      | -            | `localhost`   | `localhost` |
+| `LOG_LEVEL`          | `INFO`       | `DEBUG`       | `TRACE`     |
+| `AUTH_BYPASS`        | `false`      | `false`       | `true`      |
+| `DATABASE_SEED_USER` | `false`      | `true`        | `true`      |
 
 ### JWT Private/Public Key
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
@@ -36,7 +36,7 @@ fun main() {
  *
  * @param logLevel The desired log level for the root logger. Acceptable values are one of
  * [io.github.oshai.kotlinlogging.Level] as string such as `DEBUG` or `INFO`.
- * If an invalid log level is provided, the `DEBUG` log level will be used.
+ * If an invalid log level is provided, the default log level [DEFAULT_LOG_LEVEL] will be used.
  */
 fun configureRootLogger(logLevel: String) {
     val context = LoggerFactory.getILoggerFactory() as LoggerContext

--- a/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
@@ -36,7 +36,7 @@ fun main() {
  *
  * @param logLevel The desired log level for the root logger. Acceptable values are one of
  * [io.github.oshai.kotlinlogging.Level] as string such as `DEBUG` or `INFO`.
- * If an invalid log level is provided, the default log level [DEFAULT_LOG_LEVEL] will be used.
+ * If an invalid log level is provided, the `DEBUG` log level will be used.
  */
 fun configureRootLogger(logLevel: String) {
     val context = LoggerFactory.getILoggerFactory() as LoggerContext

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -98,7 +98,7 @@ class Database(
                 ReviewHasCriterionTable,
             )
 
-            setupDummyUser()
+            seedDummyUserIfEnabled()
         }
         logger.info { "Database connection established" }
     }
@@ -126,14 +126,13 @@ class Database(
     }
 
     /**
-     * Sets up a dummy user in the database if the environment configuration requires it.
+     * Seeds the database with a dummy user if the environment configuration requires it.
      *
-     * This method checks if a dummy user is needed based on the environment settings. If so, it
-     * creates the dummy user if it does not already exist. If the dummy user is not needed, it
-     * deletes the dummy user from the database, in case it exists.
+     * This method checks the `seedUser` flag. If true, it ensures the dummy user exists.
+     * If false, it ensures the dummy user is deleted, keeping the database clean.
      */
-    fun setupDummyUser() {
-        val useDummyUser = envReader.env.miscellaneous.useDummyUser
+    fun seedDummyUserIfEnabled() {
+        val shouldSeedUser = envReader.env.database.seedUser
 
         val existingId = UserTable
             .select(UserTable.id)
@@ -141,23 +140,27 @@ class Database(
             .map { it[UserTable.id].value }
             .singleOrNull()
 
-        if (useDummyUser) {
-            // If the dummy user is needed, create it if it does not exist
-            DummyUser.id = existingId ?: UserTable.insertAndGetId {
-                it[email] = DummyUser.email
-                it[firstName] = DummyUser.firstName
-                it[lastName] = DummyUser.lastName
-                it[passwordHash] = DummyUser.passwordHash
-                it[role] = DummyUser.role
-                it[status] = DummyUser.status
-            }.value
-
-            logger.info { "Dummy User ID: ${DummyUser.id}" }
-        } else if (existingId != null) {
-            // If the dummy user is not needed, delete it if it exists
-            UserTable.deleteWhere { UserTable.id eq existingId }.also {
-                logger.info { "Dummy user deleted" }
+        if (shouldSeedUser) {
+            if (existingId == null) {
+                // If seeding is enabled and a user doesn't exist, create it.
+                DummyUser.id = UserTable.insertAndGetId {
+                    it[email] = DummyUser.email
+                    it[firstName] = DummyUser.firstName
+                    it[lastName] = DummyUser.lastName
+                    it[passwordHash] = DummyUser.passwordHash
+                    it[role] = DummyUser.role
+                    it[status] = DummyUser.status
+                }.value
+                logger.info { "Dummy User seeded with ID: ${DummyUser.id}" }
+            } else {
+                // If the user already exists, update the static ID.
+                DummyUser.id = existingId
+                logger.info { "Dummy User already exists with ID: ${DummyUser.id}" }
             }
+        } else if (existingId != null) {
+            // If seeding is disabled and a user exists, delete it.
+            UserTable.deleteWhere { UserTable.id eq existingId }
+            logger.info { "Dummy user deleted as seeding is disabled." }
         }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -128,11 +128,11 @@ class Database(
     /**
      * Seeds the database with a dummy user if the environment configuration requires it.
      *
-     * This method checks the `seedUser` flag. If true, it ensures the dummy user exists.
+     * This method checks the `seedUserEnabled` flag. If true, it ensures the dummy user exists.
      * If false, it ensures the dummy user is deleted, keeping the database clean.
      */
     fun seedDummyUserIfEnabled() {
-        val shouldSeedUser = envReader.env.database.seedUser
+        val seedUserEnabled = envReader.env.database.seedUserEnabled
 
         val existingId = UserTable
             .select(UserTable.id)
@@ -140,7 +140,7 @@ class Database(
             .map { it[UserTable.id].value }
             .singleOrNull()
 
-        if (shouldSeedUser) {
+        if (seedUserEnabled) {
             if (existingId == null) {
                 // If seeding is enabled and a user doesn't exist, create it.
                 DummyUser.id = UserTable.insertAndGetId {

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/AppProfile.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/AppProfile.kt
@@ -1,0 +1,34 @@
+package se.uulm.snowballr.backend.env
+
+/**
+ * Represents the application's active configuration profile.
+ * This dictates the default values for various environment settings.
+ *
+ * - **TESTING**: For local testing. Bypasses authentication.
+ * - **DEVELOPMENT**: For local development. Enables features like user seeding.
+ * - **PRODUCTION**: For live environments. Enforces stricter configuration and disables development features.
+ */
+enum class AppProfile {
+    TESTING,
+    DEVELOPMENT,
+    PRODUCTION,
+    ;
+
+    companion object {
+        /**
+         * Parses a string to an [AppProfile], defaulting to [PRODUCTION] for safety.
+         * The matching is case-insensitive.
+         *
+         * @param value The string value to parse.
+         * @return The corresponding [AppProfile] or [PRODUCTION] if the input is invalid.
+         */
+        fun fromString(value: String?): AppProfile {
+            return when (value?.uppercase()) {
+                "TESTING" -> TESTING
+                "DEVELOPMENT" -> DEVELOPMENT
+                "PRODUCTION" -> PRODUCTION
+                else -> PRODUCTION // Default to the safest profile
+            }
+        }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
@@ -20,13 +20,13 @@ data class Env(
 
     data class Miscellaneous(
         val logLevel: String,
-        val authBypass: Boolean,
+        val authBypassEnabled: Boolean,
     )
 
     data class Database(
         val password: String,
         val host: String,
-        val seedUser: Boolean,
+        val seedUserEnabled: Boolean,
     )
 
     data class Encryption(

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
@@ -20,12 +20,13 @@ data class Env(
 
     data class Miscellaneous(
         val logLevel: String,
-        val useDummyUser: Boolean,
+        val authBypass: Boolean,
     )
 
     data class Database(
         val password: String,
         val host: String,
+        val seedUser: Boolean,
     )
 
     data class Encryption(

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -82,8 +82,8 @@ class EnvReader(
         }
 
         // Read final values, applying defaults and allowing overrides
-        val port = defaultPort?.let { envService.getOrDefault(PORT, it.toString()).toInt() } ?: envService[PORT].toInt()
-        val host = defaultDBHost?.let { envService.getOrDefault(DATABASE_HOST, it) } ?: envService[DATABASE_HOST]
+        val port = envService.getRequiredOrDefault(PORT, defaultPort?.toString()).toInt()
+        val host = envService.getRequiredOrDefault(DATABASE_HOST, defaultDBHost)
         val logLevel = envService.getOrDefault(LOG_LEVEL, defaultLogLevel)
 
         // If AUTH_BYPASS is true, we must also seed the user

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -1,27 +1,39 @@
 package se.uulm.snowballr.backend.env
 
-// Default values
-const val DEFAULT_LOG_LEVEL = "DEBUG"
-const val DEFAULT_USE_DUMMY_USER = false
-const val DEFAULT_DATABASE_HOST = "localhost"
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+// Environment variable keys
+private const val PROFILE = "PROFILE"
 
 // Http
 private const val PORT = "PORT"
 
 // Miscellaneous
 private const val LOG_LEVEL = "LOG_LEVEL"
-private const val USE_DUMMY_USER = "USE_DUMMY_USER"
+private const val AUTH_BYPASS = "AUTH_BYPASS"
 
 // Database
 private const val DATABASE_PASSWORD = "DATABASE_PASSWORD"
 private const val DATABASE_HOST = "DATABASE_HOST"
+private const val DATABASE_SEED_USER = "DATABASE_SEED_USER"
 
 // Encryption
 private const val JWT_PRIVATE_KEY_BASE64 = "JWT_PRIVATE_KEY_BASE64"
 private const val JWT_PUBLIC_KEY_BASE64 = "JWT_PUBLIC_KEY_BASE64"
 
+// Default values
+private const val DEFAULT_PORT = 8080
+const val DEFAULT_LOG_LEVEL = "DEBUG"
+private const val DEFAULT_DATABASE_HOST = "localhost"
+
+private val logger = KotlinLogging.logger {}
+
 /**
- * The entrypoint for accessing environment variables. All registered variables can be accessed using this reader class.
+ * The entrypoint for accessing environment variables. It determines the active configuration [AppProfile]
+ * via the `PROFILE` variable to set sensible defaults. Explicitly set variables will always override
+ * profile-based defaults.
+ *
+ * All registered variables can be accessed using this reader class.
  * Use the [env] property to access the environment variables in their respective group objects.
  *
  * @param envService The underlying service that provides methods to access variables by their key.
@@ -29,21 +41,67 @@ private const val JWT_PUBLIC_KEY_BASE64 = "JWT_PUBLIC_KEY_BASE64"
 class EnvReader(
     envService: IEnvService,
 ) {
-    val env = Env(
-        http = Env.Http(
-            port = envService[PORT].toInt(),
-        ),
-        miscellaneous = Env.Miscellaneous(
-            logLevel = envService.getOrDefault(LOG_LEVEL, DEFAULT_LOG_LEVEL),
-            useDummyUser = envService.getBooleanOrDefault(USE_DUMMY_USER, DEFAULT_USE_DUMMY_USER),
-        ),
-        database = Env.Database(
-            password = envService[DATABASE_PASSWORD],
-            host = envService.getOrDefault(DATABASE_HOST, DEFAULT_DATABASE_HOST),
-        ),
-        encryption = Env.Encryption(
-            jwtPrivateKeyBase64 = envService[JWT_PRIVATE_KEY_BASE64],
-            jwtPublicKeyBase64 = envService[JWT_PUBLIC_KEY_BASE64],
-        ),
-    )
+    val env: Env
+
+    init {
+        val activeProfile = AppProfile.fromString(envService[PROFILE])
+        logger.info { "Application starting with profile: $activeProfile" }
+
+        // Define profile-based defaults
+        // For PRODUCTION, required values are left as null to enforce they are explicitly set
+        val defaultPort: Int?
+        val defaultDBHost: String?
+        val defaultLogLevel: String
+        val defaultAuthBypass: Boolean
+        val defaultSeedUser: Boolean
+
+        when (activeProfile) {
+            AppProfile.TESTING -> {
+                defaultPort = DEFAULT_PORT
+                defaultDBHost = DEFAULT_DATABASE_HOST
+                defaultLogLevel = "TRACE"
+                defaultAuthBypass = true
+                defaultSeedUser = true
+            }
+
+            AppProfile.DEVELOPMENT -> {
+                defaultPort = DEFAULT_PORT
+                defaultDBHost = DEFAULT_DATABASE_HOST
+                defaultLogLevel = "DEBUG"
+                defaultAuthBypass = false
+                defaultSeedUser = true
+            }
+
+            AppProfile.PRODUCTION -> {
+                defaultPort = null
+                defaultDBHost = null
+                defaultLogLevel = "INFO"
+                defaultAuthBypass = false
+                defaultSeedUser = false
+            }
+        }
+
+        // Read final values, applying defaults and allowing overrides
+        val port = defaultPort?.let { envService.getOrDefault(PORT, it.toString()).toInt() } ?: envService[PORT].toInt()
+        val host = defaultDBHost?.let { envService.getOrDefault(DATABASE_HOST, it) } ?: envService[DATABASE_HOST]
+        val logLevel = envService.getOrDefault(LOG_LEVEL, defaultLogLevel)
+
+        // If AUTH_BYPASS is true, we must also seed the user
+        val authBypass = envService.getBooleanOrDefault(AUTH_BYPASS, defaultAuthBypass)
+        val seedUser = authBypass || envService.getBooleanOrDefault(DATABASE_SEED_USER, defaultSeedUser)
+
+        env = Env(
+            http = Env.Http(port),
+            miscellaneous = Env.Miscellaneous(logLevel, authBypass),
+            database = Env.Database(
+                password = envService[DATABASE_PASSWORD],
+                host = host,
+                seedUser = seedUser,
+            ),
+            encryption = Env.Encryption(
+                jwtPrivateKeyBase64 = envService[JWT_PRIVATE_KEY_BASE64],
+                jwtPublicKeyBase64 = envService[JWT_PUBLIC_KEY_BASE64],
+            ),
+        )
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -47,49 +47,17 @@ class EnvReader(
         val activeProfile = AppProfile.fromString(envService[PROFILE])
         logger.info { "Application starting with profile: $activeProfile" }
 
-        // Define profile-based defaults
-        // For PRODUCTION, required values are left as null to enforce they are explicitly set
-        val defaultPort: Int?
-        val defaultDBHost: String?
-        val defaultLogLevel: String
-        val defaultAuthBypassEnabled: Boolean
-        val defaultSeedUserEnabled: Boolean
-
-        when (activeProfile) {
-            AppProfile.TESTING -> {
-                defaultPort = DEFAULT_PORT
-                defaultDBHost = DEFAULT_DATABASE_HOST
-                defaultLogLevel = "TRACE"
-                defaultAuthBypassEnabled = true
-                defaultSeedUserEnabled = true
-            }
-
-            AppProfile.DEVELOPMENT -> {
-                defaultPort = DEFAULT_PORT
-                defaultDBHost = DEFAULT_DATABASE_HOST
-                defaultLogLevel = "DEBUG"
-                defaultAuthBypassEnabled = false
-                defaultSeedUserEnabled = true
-            }
-
-            AppProfile.PRODUCTION -> {
-                defaultPort = null
-                defaultDBHost = null
-                defaultLogLevel = "INFO"
-                defaultAuthBypassEnabled = false
-                defaultSeedUserEnabled = false
-            }
-        }
+        val defaults = defaultsForProfile(activeProfile)
 
         // Read final values, applying defaults and allowing overrides
-        val port = envService.getRequiredOrDefault(PORT, defaultPort?.toString()).toInt()
-        val host = envService.getRequiredOrDefault(DATABASE_HOST, defaultDBHost)
-        val logLevel = envService.getOrDefault(LOG_LEVEL, defaultLogLevel)
+        val port = envService.getRequiredOrDefault(PORT, defaults.port?.toString()).toInt()
+        val host = envService.getRequiredOrDefault(DATABASE_HOST, defaults.databaseHost)
+        val logLevel = envService.getOrDefault(LOG_LEVEL, defaults.logLevel)
 
-        // If AUTH_BYPASS is true, we must also seed the user
-        val authBypassEnabled = envService.getBooleanOrDefault(AUTH_BYPASS_ENABLED, defaultAuthBypassEnabled)
+        // If AUTH_BYPASS_ENABLED is `true`, we must also seed the user
+        val authBypassEnabled = envService.getBooleanOrDefault(AUTH_BYPASS_ENABLED, defaults.authBypassEnabled)
         val seedUserEnabled =
-            authBypassEnabled || envService.getBooleanOrDefault(DATABASE_SEED_USER_ENABLED, defaultSeedUserEnabled)
+            authBypassEnabled || envService.getBooleanOrDefault(DATABASE_SEED_USER_ENABLED, defaults.seedUserEnabled)
 
         env = Env(
             http = Env.Http(port),
@@ -105,4 +73,54 @@ class EnvReader(
             ),
         )
     }
+
+    /**
+     * Returns the default values for the specified [profile]. These defaults are used to
+     * initialize the environment configuration if the corresponding environment variables are not set.
+     *
+     * @param profile The application profile for which to retrieve the defaults.
+     * @return A [ProfileDefaults] object containing the default values for the specified profile.
+     */
+    private fun defaultsForProfile(profile: AppProfile): ProfileDefaults = when (profile) {
+        AppProfile.TESTING -> ProfileDefaults(
+            port = DEFAULT_PORT,
+            databaseHost = DEFAULT_DATABASE_HOST,
+            logLevel = "TRACE",
+            authBypassEnabled = true,
+            seedUserEnabled = true,
+        )
+
+        AppProfile.DEVELOPMENT -> ProfileDefaults(
+            port = DEFAULT_PORT,
+            databaseHost = DEFAULT_DATABASE_HOST,
+            logLevel = "DEBUG",
+            authBypassEnabled = false,
+            seedUserEnabled = true,
+        )
+
+        AppProfile.PRODUCTION -> ProfileDefaults(
+            port = null,
+            databaseHost = null,
+            logLevel = "INFO",
+            authBypassEnabled = false,
+            seedUserEnabled = false,
+        )
+    }
+
+    /**
+     * Represents the application profile, which determines the environment configuration.
+     *
+     * @property port The port number for the HTTP server, or null if not set.
+     * @property databaseHost The host for the database, or null if not set.
+     * @property logLevel The logging level for the application.
+     * @property authBypassEnabled Whether authentication bypass is enabled.
+     * @property seedUserEnabled Whether the seed user is enabled.
+     */
+    private data class ProfileDefaults(
+        val port: Int?,
+        val databaseHost: String?,
+        val logLevel: String,
+        val authBypassEnabled: Boolean,
+        val seedUserEnabled: Boolean,
+    )
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -10,12 +10,12 @@ private const val PORT = "PORT"
 
 // Miscellaneous
 private const val LOG_LEVEL = "LOG_LEVEL"
-private const val AUTH_BYPASS = "AUTH_BYPASS"
+private const val AUTH_BYPASS_ENABLED = "AUTH_BYPASS_ENABLED"
 
 // Database
 private const val DATABASE_PASSWORD = "DATABASE_PASSWORD"
 private const val DATABASE_HOST = "DATABASE_HOST"
-private const val DATABASE_SEED_USER = "DATABASE_SEED_USER"
+private const val DATABASE_SEED_USER_ENABLED = "DATABASE_SEED_USER_ENABLED"
 
 // Encryption
 private const val JWT_PRIVATE_KEY_BASE64 = "JWT_PRIVATE_KEY_BASE64"
@@ -52,32 +52,32 @@ class EnvReader(
         val defaultPort: Int?
         val defaultDBHost: String?
         val defaultLogLevel: String
-        val defaultAuthBypass: Boolean
-        val defaultSeedUser: Boolean
+        val defaultAuthBypassEnabled: Boolean
+        val defaultSeedUserEnabled: Boolean
 
         when (activeProfile) {
             AppProfile.TESTING -> {
                 defaultPort = DEFAULT_PORT
                 defaultDBHost = DEFAULT_DATABASE_HOST
                 defaultLogLevel = "TRACE"
-                defaultAuthBypass = true
-                defaultSeedUser = true
+                defaultAuthBypassEnabled = true
+                defaultSeedUserEnabled = true
             }
 
             AppProfile.DEVELOPMENT -> {
                 defaultPort = DEFAULT_PORT
                 defaultDBHost = DEFAULT_DATABASE_HOST
                 defaultLogLevel = "DEBUG"
-                defaultAuthBypass = false
-                defaultSeedUser = true
+                defaultAuthBypassEnabled = false
+                defaultSeedUserEnabled = true
             }
 
             AppProfile.PRODUCTION -> {
                 defaultPort = null
                 defaultDBHost = null
                 defaultLogLevel = "INFO"
-                defaultAuthBypass = false
-                defaultSeedUser = false
+                defaultAuthBypassEnabled = false
+                defaultSeedUserEnabled = false
             }
         }
 
@@ -87,16 +87,17 @@ class EnvReader(
         val logLevel = envService.getOrDefault(LOG_LEVEL, defaultLogLevel)
 
         // If AUTH_BYPASS is true, we must also seed the user
-        val authBypass = envService.getBooleanOrDefault(AUTH_BYPASS, defaultAuthBypass)
-        val seedUser = authBypass || envService.getBooleanOrDefault(DATABASE_SEED_USER, defaultSeedUser)
+        val authBypassEnabled = envService.getBooleanOrDefault(AUTH_BYPASS_ENABLED, defaultAuthBypassEnabled)
+        val seedUserEnabled =
+            authBypassEnabled || envService.getBooleanOrDefault(DATABASE_SEED_USER_ENABLED, defaultSeedUserEnabled)
 
         env = Env(
             http = Env.Http(port),
-            miscellaneous = Env.Miscellaneous(logLevel, authBypass),
+            miscellaneous = Env.Miscellaneous(logLevel, authBypassEnabled),
             database = Env.Database(
                 password = envService[DATABASE_PASSWORD],
                 host = host,
-                seedUser = seedUser,
+                seedUserEnabled = seedUserEnabled,
             ),
             encryption = Env.Encryption(
                 jwtPrivateKeyBase64 = envService[JWT_PRIVATE_KEY_BASE64],

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
@@ -28,6 +28,12 @@ interface IEnvService {
      * value if the env variable couldn't be found or is not a valid boolean.
      */
     fun getBooleanOrDefault(key: String, default: Boolean): Boolean
+
+    /**
+     * Retrieves the value of the environment variable identified by [key], or returns [default] if [default]
+     * is non-null. If [default] is null, throws [EnvVariableNotFoundException] if the environment variable is not set.
+     */
+    fun getRequiredOrDefault(key: String, default: String?): String
 }
 
 /**
@@ -52,6 +58,14 @@ class EnvService : IEnvService {
         val value = dotenv[key] ?: return default
         return value.toBooleanStrictOrNull()
             ?: throw EnvVariableNotFoundException("Invalid boolean value for key '$key': '$value'")
+    }
+
+    override fun getRequiredOrDefault(key: String, default: String?): String {
+        if (default != null) {
+            return getOrDefault(key, default)
+        }
+
+        return dotenv[key] ?: throw EnvVariableNotFoundException(key)
     }
 
     companion object {

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -52,11 +52,12 @@ private val PUBLIC_METHODS =
     )
 
 /**
- * A set of dummy user methods that are used for testing purposes.
+ * A whitelist of gRPC methods that are allowed to be called when authentication bypass is active.
  *
- * Only these methods are allowed to be called by the dummy user.
+ * When `AUTH_BYPASS` is enabled, only calls to methods listed in this set will be permitted
+ * to proceed with the dummy user's context. All other calls will be rejected.
  */
-private val DUMMY_USER_METHODS =
+private val AUTH_BYPASS_METHODS =
     setOf(SnowballRGrpcKt.getAuthenticationStatusMethod.fullMethodName)
 
 /**
@@ -170,8 +171,8 @@ val authenticationInterceptor: ServerInterceptor =
             skipRefresh: Boolean,
             methodName: String,
         ): ServerCall.Listener<ReqT?>? {
-            val useDummyUser = this.envReader.env.miscellaneous.useDummyUser
-            if (useDummyUser) {
+            val authBypass = this.envReader.env.miscellaneous.authBypass
+            if (authBypass) {
                 return proceedWithDummyUser(authState)
             }
 
@@ -211,7 +212,7 @@ val authenticationInterceptor: ServerInterceptor =
             authState: AuthRequestState<ReqT, RespT>,
         ): ServerCall.Listener<ReqT?>? {
             val methodName = authState.call.methodDescriptor.fullMethodName
-            if (methodName !in DUMMY_USER_METHODS) {
+            if (methodName !in AUTH_BYPASS_METHODS) {
                 logger.warn { "Dummy user is not allowed to call $methodName" }
                 authState.call.close(
                     Status.PERMISSION_DENIED.withDescription("Dummy user cannot call this method"),

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -54,7 +54,7 @@ private val PUBLIC_METHODS =
 /**
  * A whitelist of gRPC methods that are allowed to be called when authentication bypass is active.
  *
- * When `AUTH_BYPASS` is enabled, only calls to methods listed in this set will be permitted
+ * When `AUTH_BYPASS_ENABLED` is `true`, only calls to methods listed in this set will be permitted
  * to proceed with the dummy user's context. All other calls will be rejected.
  */
 private val AUTH_BYPASS_METHODS =
@@ -171,8 +171,8 @@ val authenticationInterceptor: ServerInterceptor =
             skipRefresh: Boolean,
             methodName: String,
         ): ServerCall.Listener<ReqT?>? {
-            val authBypass = this.envReader.env.miscellaneous.authBypass
-            if (authBypass) {
+            val authBypassEnabled = this.envReader.env.miscellaneous.authBypassEnabled
+            if (authBypassEnabled) {
                 return proceedWithDummyUser(authState)
             }
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -46,31 +46,31 @@ The `PROFILE` variable determines the default behavior of the application.
 
 ### Environment Variables Table
 
-| Variable                 |               Required               |    Default    | Description                                                                       |
-|--------------------------|:------------------------------------:|:-------------:|-----------------------------------------------------------------------------------|
-| `PROFILE`                |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).          |
-| `PORT`                   | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                             |
-| `DATABASE_HOST`          | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                              |
-| `LOG_LEVEL`              |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`. |
-| `AUTH_BYPASS`            |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.     |
-| `DATABASE_SEED_USER`     |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                |
-| `DATABASE_PASSWORD`      |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                               |
-| `JWT_PRIVATE_KEY_BASE64` |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                |
-| `JWT_PUBLIC_KEY_BASE64`  |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                 |
-| `WEB_PORT`               |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                           |
-| `BACKEND_TAG`            |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.       |
+| Variable                     |               Required               |    Default    | Description                                                                       |
+|------------------------------|:------------------------------------:|:-------------:|-----------------------------------------------------------------------------------|
+| `PROFILE`                    |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).          |
+| `PORT`                       | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                             |
+| `DATABASE_HOST`              | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                              |
+| `LOG_LEVEL`                  |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`. |
+| `AUTH_BYPASS_ENABLED`        |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.     |
+| `DATABASE_SEED_USER_ENABLED` |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                |
+| `DATABASE_PASSWORD`          |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                               |
+| `JWT_PRIVATE_KEY_BASE64`     |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                |
+| `JWT_PUBLIC_KEY_BASE64`      |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                 |
+| `WEB_PORT`                   |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                           |
+| `BACKEND_TAG`                |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.       |
 
 \* only used when using the docker compose profiles.
 
 #### Profile-based Defaults
 
-| Profile              | `PRODUCTION` | `DEVELOPMENT` | `TESTING`   |
-|----------------------|--------------|---------------|-------------|
-| `PORT`               | -            | 8080          | 8080        |
-| `DATABASE_HOST`      | -            | `localhost`   | `localhost` |
-| `LOG_LEVEL`          | `INFO`       | `DEBUG`       | `TRACE`     |
-| `AUTH_BYPASS`        | `false`      | `false`       | `true`      |
-| `DATABASE_SEED_USER` | `false`      | `true`        | `true`      |
+| Profile                      | `PRODUCTION` | `DEVELOPMENT` | `TESTING`   |
+|------------------------------|--------------|---------------|-------------|
+| `PORT`                       | -            | 8080          | 8080        |
+| `DATABASE_HOST`              | -            | `localhost`   | `localhost` |
+| `LOG_LEVEL`                  | `INFO`       | `DEBUG`       | `TRACE`     |
+| `AUTH_BYPASS_ENABLED`        | `false`      | `false`       | `true`      |
+| `DATABASE_SEED_USER_ENABLED` | `false`      | `true`        | `true`      |
 
 ### JWT Private/Public Key
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -25,28 +25,52 @@ environment variable (default: `8081`).
 
 ## Environment Variables
 
-The app requires a set of environment variables to run. You can set them in a `.env` file in the root directory of the
-project. Either create the file manually or copy the provided example:
+The app's configuration is driven by the `PROFILE` environment variable, which sets sensible defaults for different
+environments. You can specify `PROFILE` and other variables in a `.env` file in the root directory. Either create the
+file manually or copy the provided example:
 
 ```bash
 cp .env.example .env
 ```
 
-The environment variables are as follows:
+### Configuration Profiles
 
-| Variable                 |      Required      |   Default    | Description                                                                      |
-|--------------------------|:------------------:|:------------:|----------------------------------------------------------------------------------|
-| `PORT`                   | :white_check_mark: |      -       | The port where the backend is served                                             |
-| `WEB_PORT`               |        :x:*        |     8081     | The port where the proxy is served (used for gRPC-Web)                           |
-| `LOG_LEVEL`              |        :x:         |   `DEBUG`    | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF` |
-| `DATABASE_PASSWORD`      | :white_check_mark: |      -       | Password for the database e.g. `postgres_password`                               |
-| `DATABASE_HOST`          |        :x:         | `localhost`  | Hostname of database connection                                                  |
-| `BACKEND_TAG`            |        :x:*        | `latest-dev` | Tag of registry backend image to use for `registry` docker compose profile       |
-| `JWT_PRIVATE_KEY_BASE64` | :white_check_mark: |      -       | Base64 encoded private key for JWT authentication                                |
-| `JWT_PUBLIC_KEY_BASE64`  | :white_check_mark: |      -       | Base64 encoded public key for JWT authentication                                 |
-| `USE_DUMMY_USER`         |        :x:         |   `false`    | Whether to use a dummy user for development purposes                             |
+The `PROFILE` variable determines the default behavior of the application.
+
+- `PRODUCTION` (Default): For live deployments. Requires explicit configuration for critical settings like PORT and
+  DATABASE_HOST. Disables all development helpers.
+- `DEVELOPMENT`: For local development. Provides convenient defaults for the server and database and automatically
+  seeds a dummy user for easy interaction with the API.
+- `TESTING`: For local manual testing. Similar to development, but enables authentication bypass for easier testing of
+  authenticated endpoints.
+
+### Environment Variables Table
+
+| Variable                 |               Required               |    Default    | Description                                                                       |
+|--------------------------|:------------------------------------:|:-------------:|-----------------------------------------------------------------------------------|
+| `PROFILE`                |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).          |
+| `PORT`                   | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                             |
+| `DATABASE_HOST`          | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                              |
+| `LOG_LEVEL`              |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`. |
+| `AUTH_BYPASS`            |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.     |
+| `DATABASE_SEED_USER`     |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                |
+| `DATABASE_PASSWORD`      |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                               |
+| `JWT_PRIVATE_KEY_BASE64` |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                |
+| `JWT_PUBLIC_KEY_BASE64`  |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                 |
+| `WEB_PORT`               |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                           |
+| `BACKEND_TAG`            |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.       |
 
 \* only used when using the docker compose profiles.
+
+#### Profile-based Defaults
+
+| Profile              | `PRODUCTION` | `DEVELOPMENT` | `TESTING`   |
+|----------------------|--------------|---------------|-------------|
+| `PORT`               | -            | 8080          | 8080        |
+| `DATABASE_HOST`      | -            | `localhost`   | `localhost` |
+| `LOG_LEVEL`          | `INFO`       | `DEBUG`       | `TRACE`     |
+| `AUTH_BYPASS`        | `false`      | `false`       | `true`      |
+| `DATABASE_SEED_USER` | `false`      | `true`        | `true`      |
 
 ### JWT Private/Public Key
 

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -18,8 +18,8 @@ On this page, we cover the following topics:
     * [Service](#service)
     * [Input Validation](#input-validation)
   * [Authentication Bypass and User Seeding](#authentication-bypass-and-user-seeding)
-    * [`DATABASE_SEED_USER`](#database_seed_user)
-    * [`AUTH_BYPASS`](#auth_bypass)
+    * [`DATABASE_SEED_USER_ENABLED`](#database_seed_user_enabled)
+    * [`AUTH_BYPASS_ENABLED`](#auth_bypass_enabled)
     * [How They Work Together](#how-they-work-together)
 <!-- TOC -->
 <!-- @formatter:on -->
@@ -192,9 +192,9 @@ for an example.
 ## Authentication Bypass and User Seeding
 
 For local development and manual testing, we provide helpers to simplify working with authenticated endpoints. These are
-controlled by the `PROFILE` environment variable or the `AUTH_BYPASS` and `DATABASE_SEED_USER` flags.
+controlled by the `PROFILE` environment variable or the `AUTH_BYPASS_ENABLED` and `DATABASE_SEED_USER_ENABLED` flags.
 
-### `DATABASE_SEED_USER`
+### `DATABASE_SEED_USER_ENABLED`
 
 * **What it does**: When set to `true`, the application will insert a pre-defined "dummy" user into the database on
   startup. If set to `false`, it will ensure the dummy user is removed.
@@ -202,7 +202,7 @@ controlled by the `PROFILE` environment variable or the `AUTH_BYPASS` and `DATAB
   registration.
 * **Default Behavior**: Enabled in `DEVELOPMENT` and `TESTING` profiles.
 
-### `AUTH_BYPASS`
+### `AUTH_BYPASS_ENABLED`
 
 * **What it does**: When set to `true`, the
   [AuthenticationInterceptor](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt)
@@ -214,16 +214,16 @@ controlled by the `PROFILE` environment variable or the `AUTH_BYPASS` and `DATAB
 
 ### How They Work Together
 
-* Enabling `AUTH_BYPASS` automatically enables `DATABASE_SEED_USER`, because the user must exist in the database for the
-  bypass to function.
-* In the `DEVELOPMENT` profile, `DATABASE_SEED_USER` is on but `AUTH_BYPASS` is off. This is useful for developing
-  features related to login and authentication, as you can log in with the known dummy user's credentials.
+* Enabling `AUTH_BYPASS_ENABLED` automatically enables `DATABASE_SEED_USER_ENABLED`, because the user must exist in the
+  database for the bypass to function.
+* In the `DEVELOPMENT` profile, `DATABASE_SEED_USER_ENABLED` is on but `AUTH_BYPASS_ENABLED` is off. This is useful for
+  developing features related to login and authentication, as you can log in with the known dummy user's credentials.
 * In the `TESTING` profile, both are on, allowing you to directly call authenticated endpoints without logging in first.
 
 > **Note**: Restricting Allowed Calls
 >
 > The authentication bypass does not grant unrestricted access. The `authenticationInterceptor` maintains a whitelist of
-> gRPC methods that can be called when `AUTH_BYPASS` is active.
+> gRPC methods that can be called when `AUTH_BYPASS_ENABLED` is active.
 >
-> To modify this list, update the `AUTH_BYPASS_METHODS` set in the authenticationInterceptor. Ensure that only endpoints
+> To modify this list, update the `AUTH_BYPASS_ENABLED` set in the authenticationInterceptor. Ensure that only endpoints
 > required for local development or testing are permitted to avoid inadvertently bypassing critical authorization logic.

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -17,7 +17,10 @@ On this page, we cover the following topics:
     * [Repository](#repository)
     * [Service](#service)
     * [Input Validation](#input-validation)
-  * [Dummy User](#dummy-user)
+  * [Authentication Bypass and User Seeding](#authentication-bypass-and-user-seeding)
+    * [`DATABASE_SEED_USER`](#database_seed_user)
+    * [`AUTH_BYPASS`](#auth_bypass)
+    * [How They Work Together](#how-they-work-together)
 <!-- TOC -->
 <!-- @formatter:on -->
 <!-- markdownlint-enable MD007 -->
@@ -186,23 +189,41 @@ See
 [CriterionValidatorTest](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt)
 for an example.
 
-## Dummy User
+## Authentication Bypass and User Seeding
 
-For development and testing, you can enable a dummy user to avoid creating a real user account. When the
-`USE_DUMMY_USER` environment variable is set to `true`, the backend will:
+For local development and manual testing, we provide helpers to simplify working with authenticated endpoints. These are
+controlled by the `PROFILE` environment variable or the `AUTH_BYPASS` and `DATABASE_SEED_USER` flags.
 
-1. **Create a dummy user** and insert it into the database.
-2. **Automatically authenticate** the dummy user, allowing all whitelisted requests to proceed as if a real user were
-   logged in.
+### `DATABASE_SEED_USER`
 
-This mechanism simplifies backend testing that requires an authenticated user context without the overhead of
-registration and login flows.
+* **What it does**: When set to `true`, the application will insert a pre-defined "dummy" user into the database on
+  startup. If set to `false`, it will ensure the dummy user is removed.
+* **Purpose**: This ensures the user account needed for development or testing exists without requiring manual
+  registration.
+* **Default Behavior**: Enabled in `DEVELOPMENT` and `TESTING` profiles.
+
+### `AUTH_BYPASS`
+
+* **What it does**: When set to `true`, the
+  [AuthenticationInterceptor](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt)
+  will automatically treat all incoming whitelisted requests as if they were made by the dummy user, bypassing JWT
+  validation.
+* **Purpose**: This is ideal for local manual testing of authenticated endpoints, as you don't need to handle login
+  flows or manage JWTs in your API client (e.g., Postman, grpcurl).
+* **Default Behavior**: Enabled in the `TESTING` profile only.
+
+### How They Work Together
+
+* Enabling `AUTH_BYPASS` automatically enables `DATABASE_SEED_USER`, because the user must exist in the database for the
+  bypass to function.
+* In the `DEVELOPMENT` profile, `DATABASE_SEED_USER` is on but `AUTH_BYPASS` is off. This is useful for developing
+  features related to login and authentication, as you can log in with the known dummy user's credentials.
+* In the `TESTING` profile, both are on, allowing you to directly call authenticated endpoints without logging in first.
 
 > **Note**: Restricting Allowed Calls
 >
-> The dummy user is not intended to have unrestricted access. The `authenticationInterceptor` defines a whitelist of
-> allowed endpoints for the dummy user.
+> The authentication bypass does not grant unrestricted access. The `authenticationInterceptor` maintains a whitelist of
+> gRPC methods that can be called when `AUTH_BYPASS` is active.
 >
-> To modify which endpoints the dummy user can access, update the allowed calls list in the `authenticationInterceptor`.
-> Ensure that only endpoints required for local development or automated tests are permitted to avoid inadvertently
-> bypassing critical authorization logic during testing.
+> To modify this list, update the `AUTH_BYPASS_METHODS` set in the authenticationInterceptor. Ensure that only endpoints
+> required for local development or testing are permitted to avoid inadvertently bypassing critical authorization logic.


### PR DESCRIPTION
Closes #218 

## What I have made

- Renamed `USE_DUMMY_USER` to `AUTH_BYPASS`
- Added `DATABASE_SEED_USER` env var for inserting a default user into the db
- Added `PROFILE` env var for testing, development and production profiles

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] (for reviewer) I have checked the implementation against the requirements
