### PR TITLE
fix: extension `hstore` already exists error

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -75,7 +75,7 @@ class Database(
         logger.info { "Connecting to database" }
         dataSource = initDataSource(envReader.env.database)
         transaction(Database.connect(dataSource)) {
-            exec("CREATE EXTENSION hstore;")
+            exec("CREATE EXTENSION IF NOT EXISTS hstore;")
             val schema = Schema(SCHEMA_NAME, DB_USER)
             SchemaUtils.createSchema(schema)
             SchemaUtils.setSchema(schema)


### PR DESCRIPTION
Closes #220 

## What I have made

- Use `CREATE EXTENSION IF NOT EXISTS` to prevent error.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] (for reviewer) I have checked the implementation against the requirements
