### PR TITLE
Move hstore execution after schema setup

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -75,10 +75,10 @@ class Database(
         logger.info { "Connecting to database" }
         dataSource = initDataSource(envReader.env.database)
         transaction(Database.connect(dataSource)) {
-            exec("CREATE EXTENSION IF NOT EXISTS hstore;")
             val schema = Schema(SCHEMA_NAME, DB_USER)
             SchemaUtils.createSchema(schema)
             SchemaUtils.setSchema(schema)
+            exec("CREATE EXTENSION IF NOT EXISTS hstore;")
             SchemaUtils.create(
                 // Non-many-to-many tables
                 UserTable,


### PR DESCRIPTION
Closes #225 

## What I have made

- Reorder `hstore` execution and schema setup in database setup

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] (for reviewer) I have checked the implementation against the requirements
