### PR TITLE
Enabled type resolution for detekt tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,10 +190,12 @@ sourceSets {
 }
 
 // Alias for regular detekt lint check
-tasks.register("lint") {
+tasks.register<io.gitlab.arturbosch.detekt.Detekt>("lint") {
     group = "verification"
     description = "Runs Detekt linter"
-    dependsOn("detekt")
+
+    config.setFrom(files("detekt.yml"))
+    autoCorrect = false
 }
 
 // Custom format task as alias for "detekt --auto-correct"
@@ -203,9 +205,14 @@ tasks.register<io.gitlab.arturbosch.detekt.Detekt>("format") {
 
     config.setFrom(files("detekt.yml"))
     autoCorrect = true
+}
 
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     setSource(files("src"))
-
     include("**/*.kt", "**/*.kts")
-    exclude("**/build/**")
+    exclude {
+        it.file.path.contains("build")
+    }
+    jvmTarget = "1.8"
+    classpath = sourceSets["main"].runtimeClasspath
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -215,4 +215,15 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     }
     jvmTarget = "1.8"
     classpath = sourceSets["main"].runtimeClasspath
+    baseline.set(file("$rootDir/detekt-baseline.xml"))
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
+    setSource(files("src"))
+    include("**/*.kt", "**/*.kts")
+    exclude {
+        it.file.path.contains("build")
+    }
+    jvmTarget = "1.8"
+    classpath = sourceSets["main"].runtimeClasspath
 }

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>Deprecation:SnowballRServer.kt$SnowballRServer$newInstance</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/detekt.yml
+++ b/detekt.yml
@@ -144,7 +144,7 @@ complexity:
         threshold: 6
     NamedArguments:
         active: true
-        threshold: 3
+        threshold: 5
         ignoreArgumentsMatchingNames: true
     NestedBlockDepth:
         active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -583,7 +583,7 @@ naming:
     active: true
     BooleanPropertyNaming:
         active: true
-        allowedPattern: '^(is|has|are)'
+        allowedPattern: '(^(is|has|are|needs))|((Enabled|Allowed)$)'
     ClassNaming:
         active: true
         classPattern: '[A-Z][a-zA-Z0-9]*'

--- a/detekt.yml
+++ b/detekt.yml
@@ -728,6 +728,7 @@ potential-bugs:
             - 'kotlinx.coroutines.flow.*Flow'
             - 'java.util.stream.*Stream'
         ignoreFunctionCall: [ ]
+        excludes: [ '**/test/**' ]
     ImplicitDefaultLocale:
         active: true
     ImplicitUnitReturnType:

--- a/detekt.yml
+++ b/detekt.yml
@@ -150,7 +150,7 @@ complexity:
         active: true
         threshold: 4
     NestedScopeFunctions:
-        active: true
+        active: false
         threshold: 1
         functions:
             - 'kotlin.apply'
@@ -732,7 +732,7 @@ potential-bugs:
     ImplicitDefaultLocale:
         active: true
     ImplicitUnitReturnType:
-        active: true
+        active: false
         allowExplicitReturnType: true
     InvalidRange:
         active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -998,6 +998,7 @@ style:
         active: true
     UnnecessaryInnerClass:
         active: true
+        excludes: [ '**/test/**' ]
     UnnecessaryLet:
         active: true
     UnnecessaryParentheses:

--- a/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
@@ -39,7 +39,7 @@ fun main() {
  * If an invalid log level is provided, the default log level [DEFAULT_LOG_LEVEL] will be used.
  */
 fun configureRootLogger(logLevel: String) {
-    val context = LoggerFactory.getILoggerFactory() as LoggerContext
+    val context = (LoggerFactory.getILoggerFactory() ?: error("unable to get logger context")) as LoggerContext
     val rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
 
     rootLogger.level = Level.toLevel(logLevel, Level.toLevel(DEFAULT_LOG_LEVEL))

--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/CookieService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/CookieService.kt
@@ -71,7 +71,7 @@ class CookieService(private val jwtService: IJwtService) : ICookieService {
 
         val authCookieConfig = CookieConfig(
             name = name,
-            value = value ?: "", // Use empty string for expiration
+            value = value.orEmpty(), // Use empty string for expiration
             maxAgeSeconds = ttl,
             path = "/",
             sameSite = "Strict", // Stricter policy for auth tokens

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.db
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Schema
@@ -57,7 +58,7 @@ private const val DB_USER = "postgres"
  * managing transaction lifecycles, allowing for simpler and more testable database interactions.
  */
 interface IDatabase {
-    suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T
+    suspend fun <T> dbQuery(dispatcher: CoroutineDispatcher = Dispatchers.IO, block: suspend Transaction.() -> T): T
 }
 
 /**
@@ -117,13 +118,14 @@ class Database(
         return HikariDataSource(config)
     }
 
-    override suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T = newSuspendedTransaction(
-        Dispatchers.IO,
-        Database.connect(dataSource),
-        Connection.TRANSACTION_SERIALIZABLE,
-    ) {
-        block()
-    }
+    override suspend fun <T> dbQuery(dispatcher: CoroutineDispatcher, block: suspend Transaction.() -> T): T =
+        newSuspendedTransaction(
+            dispatcher,
+            Database.connect(dataSource),
+            Connection.TRANSACTION_SERIALIZABLE,
+        ) {
+            block()
+        }
 
     /**
      * Seeds the database with a dummy user if the environment configuration requires it.

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -68,7 +68,6 @@ class SnowballRServer(
      *
      * **Note:** ProtoReflectionServiceV1 does not work - calls are not registered by the server.
      */
-    @Suppress("Deprecation")
     private val reflectionService = ProtoReflectionService.newInstance()
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -68,6 +68,7 @@ class SnowballRServer(
      *
      * **Note:** ProtoReflectionServiceV1 does not work - calls are not registered by the server.
      */
+    @Suppress("Deprecation")
     private val reflectionService = ProtoReflectionService.newInstance()
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -97,8 +97,8 @@ val authenticationInterceptor: ServerInterceptor =
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>?,
         ): ServerCall.Listener<ReqT?>? {
-            val serviceName = call?.methodDescriptor?.serviceName
-            val methodName = call?.methodDescriptor?.fullMethodName
+            val serviceName = call?.run { methodDescriptor.serviceName }
+            val methodName = call?.run { methodDescriptor.serviceName }
             logger.info { "Authenticating call to ${methodName ?: "<unknown method>"}" }
 
             if (methodName == null || serviceName == null) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -99,7 +99,7 @@ val authenticationInterceptor: ServerInterceptor =
         ): ServerCall.Listener<ReqT?>? {
             val serviceName = call?.methodDescriptor?.serviceName
             val methodName = call?.methodDescriptor?.fullMethodName
-            logger.info { "Authenticating call to $methodName" }
+            logger.info { "Authenticating call to ${methodName ?: "<unknown method>"}" }
 
             if (methodName == null || serviceName == null) {
                 call?.close(Status.UNAUTHENTICATED.withDescription("Method or service name is null"), Metadata())

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -87,8 +87,8 @@ private class ExceptionCall<ReqT, RespT>(
             }.withDescription(e.message).withCause(e.cause)
 
         logger.debug {
-            "gRPC call failed due to ${e::class.qualifiedName} with status: ${status.code}." +
-                " Message: ${status.description}"
+            "gRPC call failed due to ${e::class.qualifiedName ?: "<unknown class>"} with status: ${status.code}." +
+                " Message: ${status.description ?: "<no message>"}"
         }
         logger.trace { e.stackTraceToString() }
         return status
@@ -99,7 +99,10 @@ private class ExceptionCall<ReqT, RespT>(
      * They are logged as warning so that they can be handled in the future.
      */
     private fun getStatusForSpecificUnexpectedException(status: Status, e: Exception): Status {
-        logger.warn(e) { "gRPC call failed due to unexpected ${e::class.simpleName} with message: ${e.message}" }
+        logger.warn(e) {
+            "gRPC call failed due to unexpected ${e::class.simpleName ?: "<unknown class>"} " +
+                "with message: ${e.message ?: "<no message>"}."
+        }
         return status
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/LoggingInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/LoggingInterceptor.kt
@@ -21,7 +21,7 @@ val loggingInterceptor =
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>?,
         ): ServerCall.Listener<ReqT?>? {
-            logger.info { "Received call to ${call?.methodDescriptor?.fullMethodName}" }
+            logger.info { "Received call to ${call?.methodDescriptor?.fullMethodName ?: "<unknown method>"}" }
             return next?.startCall(call, headers)
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/LoggingInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/LoggingInterceptor.kt
@@ -21,7 +21,7 @@ val loggingInterceptor =
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>?,
         ): ServerCall.Listener<ReqT?>? {
-            logger.info { "Received call to ${call?.methodDescriptor?.fullMethodName ?: "<unknown method>"}" }
+            logger.info { "Received call to ${call?.run { methodDescriptor.fullMethodName } ?: "<unknown method>"}" }
             return next?.startCall(call, headers)
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ValidationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ValidationInterceptor.kt
@@ -46,7 +46,7 @@ private class ValidationCallListener<ReqT, RespT>(
         // Return `INVALID_ARGUMENT` status if input validation failed
         if (result is Either.Left) {
             val reasons = result.value.toList().map { it.toString() }
-            logger.debug { "Received invalid request: ${message?.javaClass} - $reasons" }
+            logger.debug { "Received invalid request: ${message?.javaClass ?: "<unknown class>"} - $reasons" }
             call?.close(
                 Status.INVALID_ARGUMENT
                     .withDescription("Request validation failed: $reasons"),

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ValidationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ValidationInterceptor.kt
@@ -37,7 +37,7 @@ private class ValidationCallListener<ReqT, RespT>(
     listener: ServerCall.Listener<ReqT?>?,
 ) : SimpleForwardingServerCallListener<ReqT>(listener) {
     // Track whether the call was already closed and return if that's the case
-    private var callClosedByInterceptor = false
+    private var isCallClosedByInterceptor = false
 
     override fun onMessage(message: ReqT?) {
         // Perform input validation
@@ -52,7 +52,7 @@ private class ValidationCallListener<ReqT, RespT>(
                     .withDescription("Request validation failed: $reasons"),
                 Metadata(),
             )
-            callClosedByInterceptor = true
+            isCallClosedByInterceptor = true
             // Stop further processing
             return
         }
@@ -62,21 +62,21 @@ private class ValidationCallListener<ReqT, RespT>(
     }
 
     override fun onHalfClose() {
-        if (callClosedByInterceptor) {
+        if (isCallClosedByInterceptor) {
             return
         }
         super.onHalfClose()
     }
 
     override fun onCancel() {
-        if (callClosedByInterceptor) {
+        if (isCallClosedByInterceptor) {
             return
         }
         super.onCancel()
     }
 
     override fun onComplete() {
-        if (callClosedByInterceptor) {
+        if (isCallClosedByInterceptor) {
             return
         }
         super.onComplete()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/auth/CookieConfig.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/auth/CookieConfig.kt
@@ -19,6 +19,8 @@ data class CookieConfig(
     val path: String = "/",
     val domain: String? = null,
     val sameSite: String = "Lax",
+    @Suppress("BooleanPropertyNaming")
     val httpOnly: Boolean = true,
+    @Suppress("BooleanPropertyNaming")
     val secure: Boolean = true,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -157,9 +157,9 @@ class ProjectTableRepo(
             .map { ProjectTable.status eq it }
             .reduceOrNull { acc, filter -> acc or filter }
 
-        require(
-            projectFilter != null,
-        ) { "Unsupported filter statuses: ${statusFilters.joinToString(", ") { it.name }}." }
+        requireNotNull(projectFilter) {
+            "Unsupported filter statuses: ${statusFilters.joinToString(", ") { it.name }}."
+        }
 
         (ProjectTable innerJoin ProjectMemberTable)
             .select(ProjectTable.columns)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -90,7 +90,7 @@ class CriterionService(
         val members = when (accessType) {
             AccessType.READ -> projectMemberRepo.getMembersOfProject(project.id)
             AccessType.UPDATE -> projectMemberRepo.getAllProjectAdmins(project.id)
-            else -> emptyList()
+            AccessType.CREATE, AccessType.DELETE -> emptyList()
         }
 
         if (!members.any { it.userId == currentUser.id }) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -17,6 +17,7 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.ProjectOuterClass
+import java.util.UUID
 
 interface ICriterionService {
     /**
@@ -82,7 +83,10 @@ class CriterionService(
         accessType: AccessType,
     ) {
         val criterionId = criterion.id.toString()
-        val project = projectRepo.getProjectById(criterion.projectId!!)
+        val project = projectRepo.getProjectById(
+            // TODO: This will be refactored in #163
+            criterion.projectId ?: UUID.fromString("00000000-0000-0000-0000-000000000000"),
+        )
         val members = when (accessType) {
             AccessType.READ -> projectMemberRepo.getMembersOfProject(project.id)
             AccessType.UPDATE -> projectMemberRepo.getAllProjectAdmins(project.id)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -20,7 +20,7 @@ interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectById].
      */
-    suspend fun getProjectById(projectId: Base.Id): GrpcProject
+    suspend fun getProjectById(request: Base.Id): GrpcProject
 
     /**
      * Service implementation of [SnowballRService.createProject].
@@ -72,9 +72,9 @@ class ProjectService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
 ) : IProjectService {
-    override suspend fun getProjectById(projectId: Base.Id): GrpcProject {
+    override suspend fun getProjectById(request: Base.Id): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        val projectId = parseUUID(projectId.id, EntityType.PROJECT)
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
         val isInProject = projectMemberRepo.getMembersOfProject(projectId)
             .any { it.userId == currentUser.id }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.table
 
+import arrow.core.mapValuesNotNull
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
@@ -57,12 +58,11 @@ fun Table.obfuscatedText(name: String, collate: String? = null, eagerLoading: Bo
 fun Table.stringMap(name: String): Column<Map<String, String>> = registerColumn(
     name,
     HStoreColumnType(),
-).transform<String, Map<String, String>>(
+).transform(
     wrap = {
         HStoreConverter
             .fromString(it)
-            .filterValues { it !== null }
-            .mapValues { it.value!! }
+            .mapValuesNotNull { entry -> entry.value }
     },
     unwrap = {
         HStoreConverter.toString(it)

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -1,5 +1,6 @@
 // Suppress the 'FunctionName' rule because it cannot detect that this is a test file.
-@file:Suppress("FunctionName")
+// Suppress the 'ForbiddenMethodCall' rule because we can use println here.
+@file:Suppress("FunctionName", "ForbiddenMethodCall")
 
 package se.uulm.snowballr.backend.arch
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
@@ -57,7 +57,7 @@ class FetcherManagerTest {
         fetcherManager.registerFetcher("foo", mockk())
         assertEquals(setOf("foo"), fetcherManager.getAvailableFetchers())
         fetcherManager.removeFetcher("foo")
-        assertEquals(setOf(), fetcherManager.getAvailableFetchers())
+        assertEquals(emptySet(), fetcherManager.getAvailableFetchers())
     }
 
     @Test
@@ -112,9 +112,9 @@ class FetcherManagerTest {
         fetcherManager.registerFetcher("foo", mockk())
 
         assertThrows<Exception> { fetcherManager.getAvailableOptions("bar") }
-        assertThrows<Exception> { fetcherManager.searchPapers("bar", "", mapOf()) }
-        assertThrows<Exception> { fetcherManager.fetchForwardReferences("bar", examplePaper, mapOf()) }
-        assertThrows<Exception> { fetcherManager.fetchBackwardReferences("bar", examplePaper, mapOf()) }
+        assertThrows<Exception> { fetcherManager.searchPapers("bar", "", emptyMap()) }
+        assertThrows<Exception> { fetcherManager.fetchForwardReferences("bar", examplePaper, emptyMap()) }
+        assertThrows<Exception> { fetcherManager.fetchBackwardReferences("bar", examplePaper, emptyMap()) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
@@ -60,14 +60,14 @@ import java.util.UUID
  * ```
  *
  * @property tables An array of database tables to be managed during the test lifecycle.
- * @property useTestUser Whether a test user should be created, which can be used in a test in the form of [testUserId].
+ * @property needsTestUser Whether a test user is required, which can be used in a test in the form of [testUserId].
  */
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class H2DatabaseTest(
     val tables: Array<Table> = emptyArray(),
-    val useTestUser: Boolean = false,
+    val needsTestUser: Boolean = false,
 ) {
     private val threadContext = newSingleThreadContext("Coroutine thread")
     private val connection = Database.connect("jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1;IGNORECASE=true;")
@@ -107,7 +107,7 @@ open class H2DatabaseTest(
                 SchemaUtils.create(*tables)
 
                 // Create the user table and a test entity if requested
-                if (useTestUser) {
+                if (needsTestUser) {
                     SchemaUtils.create(UserTable)
                     // Create the test user
                     val userId =
@@ -130,7 +130,7 @@ open class H2DatabaseTest(
         runBlocking {
             db.dbQuery {
                 SchemaUtils.drop(*tables)
-                if (useTestUser) {
+                if (needsTestUser) {
                     SchemaUtils.drop(UserTable)
                 }
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.repository
 
 import io.mockk.clearAllMocks
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -86,12 +87,13 @@ open class H2DatabaseTest(
      * and use the [Connection.TRANSACTION_SERIALIZABLE] isolation level to ensure data consistency.
      */
     class TestDatabase : IDatabase {
-        override suspend fun <T> dbQuery(block: suspend Transaction.() -> T): T = newSuspendedTransaction(
-            Dispatchers.IO,
-            transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
-        ) {
-            block()
-        }
+        override suspend fun <T> dbQuery(dispatcher: CoroutineDispatcher, block: suspend Transaction.() -> T): T =
+            newSuspendedTransaction(
+                dispatcher,
+                transactionIsolation = Connection.TRANSACTION_SERIALIZABLE,
+            ) {
+                block()
+            }
     }
 
     @BeforeAll

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -79,12 +79,12 @@ open class MainServiceTest {
     val fetcherManagerMock = mockk<FetcherManager>(relaxed = true)
     val mainService =
         MainService(
-            projectRepoMock,
-            criterionRepoMock,
-            userRepoMock,
-            projectMemberRepoMock,
-            jwtServiceMock,
-            fetcherManagerMock,
+            projectRepo = projectRepoMock,
+            criterionRepo = criterionRepoMock,
+            userRepo = userRepoMock,
+            projectMemberRepo = projectMemberRepoMock,
+            jwtService = jwtServiceMock,
+            fetcherManager = fetcherManagerMock,
         )
 
     @BeforeAll

--- a/src/test/kotlin/se/uulm/snowballr/backend/utils/GrpcEnumSourceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/utils/GrpcEnumSourceTest.kt
@@ -50,7 +50,7 @@ class GenericEnumProvider : ArgumentsProvider {
         parameters: ParameterDeclarations,
         context: ExtensionContext?,
     ): Stream<out Arguments> {
-        val method = checkNotNull(context?.testMethod?.getOrNull()) { "No test method found." }
+        val method = checkNotNull(context?.run { testMethod.getOrNull() }) { "No test method found." }
 
         val annotation = method.getAnnotation(GrpcEnumSourceTest::class.java)
         requireNonNull(annotation, "Missing @GrpcEnumSourceTest annotation.")

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
@@ -128,7 +128,7 @@ class CriterionValidatorTest {
 
         @Test
         fun `When a blank field mask is validated, then the 'InvalidFieldMask' issue is returned`() {
-            val inValidFieldMask = FieldMaskUtil.fromStringList(listOf())
+            val inValidFieldMask = FieldMaskUtil.fromStringList(emptyList())
             val request =
                 validUpdateRequestBuilder
                     .setMask(inValidFieldMask)

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -96,7 +96,7 @@ class ProjectValidatorTest {
 
         @Test
         fun `When a blank field mask is validated, then the 'InvalidFieldMask' issue is returned`() {
-            val inValidFieldMask = FieldMaskUtil.fromStringList(listOf())
+            val inValidFieldMask = FieldMaskUtil.fromStringList(emptyList())
             val request =
                 validUpdateRequestBuilder
                     .setMask(inValidFieldMask)

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
@@ -44,7 +44,7 @@ class UserValidatorTest {
 
         @Test
         fun `When a blank field mask is validated, then the 'InvalidFieldMask' issue is returned`() {
-            val inValidFieldMask = FieldMaskUtil.fromStringList(listOf())
+            val inValidFieldMask = FieldMaskUtil.fromStringList(emptyList())
             val request =
                 validUpdateRequestBuilder
                     .setMask(inValidFieldMask)


### PR DESCRIPTION
Closes #227 

## What I have made

I enabled type resolution for detekt tasks. Some rules require type resolution and didn't work before. Now they do.
I applied changes to adhere to these rules so that we have a clean state again.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~ (only linter changes)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only linter changes)
- [x] (for reviewer) I have checked the implementation against the requirements
