### PR TITLE
Use DI for mainservice dependencies

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend
 
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.createdAtStart
 import org.koin.core.module.dsl.singleOf
@@ -23,11 +24,19 @@ import se.uulm.snowballr.backend.repository.UserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectMemberTableRepo
 import se.uulm.snowballr.backend.service.AuthenticationService
+import se.uulm.snowballr.backend.service.CriterionService
 import se.uulm.snowballr.backend.service.EmailService
+import se.uulm.snowballr.backend.service.FetcherService
 import se.uulm.snowballr.backend.service.IAuthenticationService
+import se.uulm.snowballr.backend.service.ICriterionService
 import se.uulm.snowballr.backend.service.IEmailService
+import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IMainService
+import se.uulm.snowballr.backend.service.IProjectService
+import se.uulm.snowballr.backend.service.IUserService
 import se.uulm.snowballr.backend.service.MainService
+import se.uulm.snowballr.backend.service.ProjectService
+import se.uulm.snowballr.backend.service.UserService
 
 /**
  * Defines the Koin dependency injection module for the application.
@@ -35,45 +44,83 @@ import se.uulm.snowballr.backend.service.MainService
  * This module includes the following components in a defined order of initialization:
  * - The environment service ([IEnvService]) and its reader ([EnvReader]), which are initialized first to provide
  *  access to environment variables.
- * - The JWT service ([IJwtService]), which depends on the environment reader to access necessary environment variables.
- * - The FetcherManager ([FetcherManager]), which makes fetchers available for use.
- * - The cookie service ([ICookieService]), which relies on the JWT service for token handling.
- * - The database implementation ([IDatabase]), which is initialized with no external dependencies.
- * - The email service ([IEmailService]), which uses the environment reader to configure email settings.
+ * - The database ([IDatabase]), which only requires some env variables provided by the [EnvReader].
  * - The repository layer (e.g. [IProjectTableRepo]), which uses the [IDatabase] implementation for database operations.
- * - The [IAuthenticationService] is also included to handle authentication logic, which may be used by the main service.
- * - The main service ([IMainService]), which depends on the repository layer to provide higher-level functionality.
+ * - Custom services / manager / clients that are used by the core service layer.
+ * - The core service layer, which consists of entity-related services (e.g. [IProjectService]) and the [IMainService],
+ * which combines all services into one access point.
  *
  * The ordering ensures proper dependency resolution and initialization.
  */
 val snowballRModule =
     module {
-        // First come the env service and reader
-        single<IEnvService> { EnvService() }
-        singleOf(::EnvReader)
-        // Then the JWT service, which depend on the env reader
-        singleOf(::JwtService) {
-            createdAtStart()
-            bind<IJwtService>()
-        }
-        singleOf(::FetcherManager)
-        // Then the cookie service, which depend on the JWT service
-        singleOf(::CookieService) { bind<ICookieService>() }
-        // Then the database, which only needs access to some env variables
-        singleOf(::Database) {
-            createdAtStart()
-            bind<IDatabase>()
-        }
-        singleOf(::EmailService) {
-            createdAtStart()
-            bind<IEmailService>()
-        }
-        // Here come all repos and other definitions, e.g., the http client
-        singleOf(::ProjectTableRepo) { bind<IProjectTableRepo>() }
-        singleOf(::CriterionTableRepo) { bind<ICriterionTableRepo>() }
-        singleOf(::UserTableRepo) { bind<IUserTableRepo>() }
-        singleOf(::ProjectMemberTableRepo) { bind<IProjectMemberTableRepo>() }
-        singleOf(::AuthenticationService) { bind<IAuthenticationService>() }
-        // The main service comes last
-        singleOf(::MainService) { bind<IMainService>() }
+        envDeps()
+        dbDeps()
+        repositoryLayerDeps()
+        customServicesDeps()
+        serviceLayerDeps()
     }
+
+/**
+ * Module declaration of the [IEnvService] and [EnvReader].
+ */
+private fun Module.envDeps() {
+    single<IEnvService> { EnvService() }
+    singleOf(::EnvReader)
+}
+
+/**
+ * Module declaration of the [IDatabase].
+ */
+private fun Module.dbDeps() {
+    singleOf(::Database) {
+        createdAtStart()
+        bind<IDatabase>()
+    }
+}
+
+/**
+ * Module declaration of the repository layer.
+ *
+ * Consists of all repositories.
+ */
+private fun Module.repositoryLayerDeps() {
+    singleOf(::ProjectTableRepo) { bind<IProjectTableRepo>() }
+    singleOf(::CriterionTableRepo) { bind<ICriterionTableRepo>() }
+    singleOf(::UserTableRepo) { bind<IUserTableRepo>() }
+    singleOf(::ProjectMemberTableRepo) { bind<IProjectMemberTableRepo>() }
+}
+
+/**
+ * Module declaration of all custom services / managers / clients.
+ *
+ * Consists of all dependencies that are used by the core service layer.
+ */
+private fun Module.customServicesDeps() {
+    singleOf(::JwtService) {
+        createdAtStart()
+        bind<IJwtService>()
+    }
+    singleOf(::FetcherManager)
+    singleOf(::CookieService) { bind<ICookieService>() }
+    singleOf(::EmailService) {
+        createdAtStart()
+        bind<IEmailService>()
+    }
+    singleOf(::AuthenticationService) { bind<IAuthenticationService>() }
+}
+
+/**
+ * Module declaration of the core service layer.
+ *
+ * Consists of the [MainService] and all its direct service dependencies.
+ */
+fun Module.serviceLayerDeps() {
+    // All services that are directly used by the MainService
+    singleOf(::ProjectService) { bind<IProjectService>() }
+    singleOf(::CriterionService) { bind<ICriterionService>() }
+    singleOf(::UserService) { bind<IUserService>() }
+    singleOf(::FetcherService) { bind<IFetcherService>() }
+    // The main service comes last
+    singleOf(::MainService) { bind<IMainService>() }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/AppProfile.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/AppProfile.kt
@@ -16,18 +16,19 @@ enum class AppProfile {
 
     companion object {
         /**
-         * Parses a string to an [AppProfile], defaulting to [PRODUCTION] for safety.
+         * Parses a string to an [AppProfile], defaulting to an exception for safety.
          * The matching is case-insensitive.
          *
          * @param value The string value to parse.
-         * @return The corresponding [AppProfile] or [PRODUCTION] if the input is invalid.
+         * @return The corresponding [AppProfile].
+         * @throws IllegalStateException If the [value] doesn't match an [AppProfile].
          */
-        fun fromString(value: String?): AppProfile {
-            return when (value?.uppercase()) {
+        fun fromString(value: String): AppProfile {
+            return when (value.uppercase()) {
                 "TESTING" -> TESTING
                 "DEVELOPMENT" -> DEVELOPMENT
                 "PRODUCTION" -> PRODUCTION
-                else -> PRODUCTION // Default to the safest profile
+                else -> error("Unknown profile type: $value")
             }
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -31,6 +31,7 @@ private const val SMTP_SENDER_NAME = "SMTP_SENDER_NAME"
 private const val SMTP_SENDER_EMAIL = "SMTP_SENDER_EMAIL"
 
 // Default values
+private val DEFAULT_PROFILE = AppProfile.PRODUCTION
 private const val DEFAULT_PORT = 8080
 const val DEFAULT_LOG_LEVEL = "DEBUG"
 private const val DEFAULT_DATABASE_HOST = "localhost"
@@ -53,7 +54,7 @@ class EnvReader(
     val env: Env
 
     init {
-        val activeProfile = AppProfile.fromString(envService[PROFILE])
+        val activeProfile = AppProfile.fromString(envService.getOrDefault(PROFILE, DEFAULT_PROFILE.toString()))
         logger.info { "Application starting with profile: $activeProfile" }
 
         val defaults = defaultsForProfile(activeProfile)

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -98,7 +98,7 @@ val authenticationInterceptor: ServerInterceptor =
             next: ServerCallHandler<ReqT?, RespT?>?,
         ): ServerCall.Listener<ReqT?>? {
             val serviceName = call?.run { methodDescriptor.serviceName }
-            val methodName = call?.run { methodDescriptor.serviceName }
+            val methodName = call?.run { methodDescriptor.fullMethodName }
             logger.info { "Authenticating call to ${methodName ?: "<unknown method>"}" }
 
             if (methodName == null || serviceName == null) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -1,12 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.IJwtService
-import se.uulm.snowballr.backend.fetcher.FetcherManager
-import se.uulm.snowballr.backend.repository.ICriterionTableRepo
-import se.uulm.snowballr.backend.repository.IProjectTableRepo
-import se.uulm.snowballr.backend.repository.IUserTableRepo
-import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-
 /**
  * The [IMainService] interface provides a unified contract that combines the responsibilities of all sub-services. It
  * inherits functionality from their interfaces, making it possible to handle CRUD operations related to various
@@ -27,23 +20,19 @@ interface IMainService :
  * This class implements the [IMainService] interface and delegates the execution of specific functionality to the
  * sub-service implementations, e.g. [ProjectService].
  *
- * @constructor Initializes the [MainService] with the required repositories.
- * @param projectRepo The repository responsible for handling persistence operations related to projects.
- * @param criterionRepo The repository responsible for handling persistence operations related to criteria.
- * @param userRepo The repository responsible for handling persistence operations related to users.
- * @param projectMemberRepo The repository responsible for handling persistence operations related to project members.
- * @param jwtService The utility for handling JWT operations, such as token parsing and validation.
- * @param fetcherManager The manager responsible for making fetchers available for use.
+ * @constructor Initializes the [MainService] with the required services.
+ * @param projectService The service responsible for handling business logic related to projects.
+ * @param criterionService The service responsible for handling business logic related to criteria.
+ * @param userService The service responsible for handling business logic related to users.
+ * @param fetcherService The service responsible for handling business logic related to fetchers.
  */
 class MainService(
-    private val projectRepo: IProjectTableRepo,
-    private val criterionRepo: ICriterionTableRepo,
-    private val userRepo: IUserTableRepo,
-    private val projectMemberRepo: IProjectMemberTableRepo,
-    private val jwtService: IJwtService,
-    private val fetcherManager: FetcherManager,
+    private val projectService: IProjectService,
+    private val criterionService: ICriterionService,
+    private val userService: IUserService,
+    private val fetcherService: IFetcherService,
 ) : IMainService,
-    IProjectService by ProjectService(projectRepo, userRepo, projectMemberRepo),
-    ICriterionService by CriterionService(criterionRepo, userRepo, projectRepo, projectMemberRepo),
-    IUserService by UserService(userRepo, projectMemberRepo, jwtService),
-    IFetcherService by FetcherService(fetcherManager)
+    IProjectService by projectService,
+    ICriterionService by criterionService,
+    IUserService by userService,
+    IFetcherService by fetcherService

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
@@ -4,8 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,8 +14,6 @@ import kotlin.test.assertEquals
 
 private val examplePaper = DataBuilder.createExamplePaper()
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class FetcherManagerTest {
     private var fetcherManager = FetcherManager()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
@@ -5,17 +5,10 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -25,21 +18,8 @@ private val examplePaper = DataBuilder.createExamplePaper()
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FetcherManagerTest {
-    private val threadContext = newSingleThreadContext("Test thread")
     private var fetcherManager = FetcherManager()
-
-    @BeforeAll
-    fun setThreadDispatcher() {
-        Dispatchers.setMain(threadContext)
-    }
-
-    @AfterAll
-    fun cleanThreadDispatcher() {
-        Dispatchers.resetMain()
-        threadContext.close()
-    }
 
     @BeforeEach
     fun createNewFetcherService() {

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -111,7 +111,7 @@ class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTab
 
         @GrpcEnumSourceTest(CriterionCategory::class)
         fun `When a criterion is created, but the assigned project doesn't exist, then an exception is thrown`(
-            category: CriterionOuterClass.CriterionCategory,
+            category: CriterionCategory,
         ) = runTest {
             val request =
                 CriterionOuterClass.Criterion.Create

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -24,8 +22,6 @@ import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class CriterionTableRepoTest : H2DatabaseTest(arrayOf(CriterionTable, ProjectTable), true) {
     private val repo = CriterionTableRepo(db)
     private val projectRepo = ProjectTableRepo(db)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
@@ -2,9 +2,7 @@ package se.uulm.snowballr.backend.repository
 
 import io.mockk.clearAllMocks
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
@@ -34,8 +32,6 @@ import java.util.UUID
  *
  * Example usage:
  * ```kotlin
- * @ExperimentalCoroutinesApi
- * @DelicateCoroutinesApi
  * class ExampleTest : H2DatabaseTest(arrayOf(ExampleTable)) {
  *     private val repo = ExampleTableRepo(db)
  *
@@ -60,8 +56,6 @@ import java.util.UUID
  * @property tables An array of database tables to be managed during the test lifecycle.
  * @property needsTestUser Whether a test user is required, which can be used in a test in the form of [testUserId].
  */
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class H2DatabaseTest(
     val tables: Array<Table> = emptyArray(),

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/H2DatabaseTest.kt
@@ -5,10 +5,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.Table
@@ -70,7 +67,6 @@ open class H2DatabaseTest(
     val tables: Array<Table> = emptyArray(),
     val needsTestUser: Boolean = false,
 ) {
-    private val threadContext = newSingleThreadContext("Coroutine thread")
     private val connection = Database.connect("jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1;IGNORECASE=true;")
     protected val db = TestDatabase()
 
@@ -98,7 +94,6 @@ open class H2DatabaseTest(
 
     @BeforeAll
     fun setUp() {
-        Dispatchers.setMain(threadContext)
         RepositoryHelper.db = db
     }
 
@@ -143,7 +138,5 @@ open class H2DatabaseTest(
     @AfterAll
     fun tearDown() {
         TransactionManager.closeAndUnregister(connection)
-        Dispatchers.resetMain()
-        threadContext.close()
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.sql.insertAndGetId
@@ -24,8 +22,6 @@ import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class ProjectTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectTableRepo(db)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insertAndGetId
 import se.uulm.snowballr.backend.model.EntityType
@@ -15,8 +13,6 @@ import java.util.UUID
 /**
  * This class acts as a collection of create methods to create database entries for testing purposes.
  */
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 object RepositoryHelper {
     lateinit var db: H2DatabaseTest.TestDatabase
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.exceptions.ExposedSQLException
@@ -26,8 +24,6 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class UserTableRepoTest : H2DatabaseTest(arrayOf(UserTable)) {
     private val repo = UserTableRepo(db)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.repository.association
 
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -19,8 +17,6 @@ import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class ProjectMemberTableRepoTest : H2DatabaseTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectMemberTableRepo(db)
     private val projectRepo = ProjectTableRepo(db)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -4,8 +4,6 @@ import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
@@ -22,17 +20,15 @@ import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
 /**
  * Unit test class for the [MainService] class.
  *
- * This test class provides the setup and teardown logic needed to test [MainService] effectively in a
- * controlled coroutine environment. It leverages dependency mocking for all repositories to isolate the service and
- * test its functionality without reliance on external systems.
+ * This test class provides the setup and teardown logic needed to test [MainService] effectively. It leverages
+ * dependency mocking for all repositories to isolate the service and test its functionality without reliance on
+ * external systems.
  *
  * An extension of this class can be used to implement specific test cases for the sub-services of
  * [MainService], such as [CreateCriterionTest].
  *
  * Example usage:
  * ```kotlin
- * @ExperimentalCoroutinesApi
- * @DelicateCoroutinesApi
  * class CreateExampleTest : MainServiceTest() {
  *     @Test
  *     fun `When an example is correctly created, then no exception is thrown`() =
@@ -61,8 +57,6 @@ import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
  * }
  * ```
  */
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class MainServiceTest {
     val projectRepoMock = mockk<IProjectTableRepo>(relaxed = true)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -8,6 +8,11 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.koin.core.component.inject
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.IJwtService
 import se.uulm.snowballr.backend.fetcher.FetcherManager
@@ -16,6 +21,7 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
+import se.uulm.snowballr.backend.serviceLayerDeps
 
 /**
  * Unit test class for the [MainService] class.
@@ -58,25 +64,39 @@ import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
  * ```
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-open class MainServiceTest {
+open class MainServiceTest : KoinTest {
+    // Repository layer mocks
     val projectRepoMock = mockk<IProjectTableRepo>(relaxed = true)
     val criterionRepoMock = mockk<ICriterionTableRepo>(relaxed = true)
     val userRepoMock = mockk<IUserTableRepo>(relaxed = true)
     val projectMemberRepoMock = mockk<IProjectMemberTableRepo>(relaxed = true)
+
+    // Custom services / manager / clients mocks
     val jwtServiceMock = mockk<IJwtService>(relaxed = true)
     val fetcherManagerMock = mockk<FetcherManager>(relaxed = true)
-    val mainService =
-        MainService(
-            projectRepo = projectRepoMock,
-            criterionRepo = criterionRepoMock,
-            userRepo = userRepoMock,
-            projectMemberRepo = projectMemberRepoMock,
-            jwtService = jwtServiceMock,
-            fetcherManager = fetcherManagerMock,
-        )
+
+    val mainService: IMainService by inject()
+
+    private val serviceTestModule = module {
+        // Repository layer
+        single { projectRepoMock }
+        single { criterionRepoMock }
+        single { userRepoMock }
+        single { projectMemberRepoMock }
+
+        // Custom services / managers / clients
+        single { jwtServiceMock }
+        single { fetcherManagerMock }
+
+        // The base service layer is the same as in production
+        serviceLayerDeps()
+    }
 
     @BeforeAll
     fun setUp() {
+        startKoin {
+            modules(serviceTestModule)
+        }
         mockkObject(GrpcContext)
     }
 
@@ -87,6 +107,7 @@ open class MainServiceTest {
 
     @AfterAll
     fun tearDown() {
+        stopKoin()
         unmockkObject(GrpcContext)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -5,11 +5,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
@@ -69,8 +65,6 @@ import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
 @DelicateCoroutinesApi
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class MainServiceTest {
-    private val threadContext = newSingleThreadContext("Test thread")
-
     val projectRepoMock = mockk<IProjectTableRepo>(relaxed = true)
     val criterionRepoMock = mockk<ICriterionTableRepo>(relaxed = true)
     val userRepoMock = mockk<IUserTableRepo>(relaxed = true)
@@ -89,7 +83,6 @@ open class MainServiceTest {
 
     @BeforeAll
     fun setUp() {
-        Dispatchers.setMain(threadContext)
         mockkObject(GrpcContext)
     }
 
@@ -100,8 +93,6 @@ open class MainServiceTest {
 
     @AfterAll
     fun tearDown() {
-        Dispatchers.resetMain()
-        threadContext.close()
         unmockkObject(GrpcContext)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
@@ -15,7 +14,6 @@ import snowballr.UserOuterClass.UserRole
 class ServiceChecksTest {
     @Nested
     inner class VerifyServerAdminRole {
-        @ParameterizedTest
         @GrpcEnumSourceTest(UserRole::class, excludes = ["USER_ROLE_ADMIN"])
         fun `When the user is not a server admin, then an exception is thrown`(role: UserRole) {
             val user = DataBuilder.createExampleUser(role = role)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/AuthenticateTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/AuthenticateTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.service.authentication
 import io.jsonwebtoken.JwtException
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import se.uulm.snowballr.backend.GrpcTestContextExtension
@@ -19,8 +17,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 @ExtendWith(GrpcTestContextExtension::class)
 class AuthenticateTest {
     private val jwtServiceMock = mockk<JwtService> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,8 +14,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.CriterionOuterClass
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class CreateCriterionTest : MainServiceTest() {
     @BeforeEach
     fun setUpTest() {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,8 +16,6 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetCriterionByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private val dummyUserUUID = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.service.criterion
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,8 +19,6 @@ import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class UpdateCriterionTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private val dummyUserUUID = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/GetAvailableFetchersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/GetAvailableFetchersTest.kt
@@ -1,15 +1,11 @@
 package se.uulm.snowballr.backend.service.fetcher
 
 import io.mockk.coEvery
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.service.MainServiceTest
 import kotlin.test.assertEquals
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class GetAvailableFetchersTest : MainServiceTest() {
     @Test
     fun `When the fetcherManager has fetchers registered, then the FetcherService returns them properly`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,8 +14,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,8 +17,6 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,8 +17,6 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,8 +17,6 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetAllProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,8 +15,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetAllProjectsTest : MainServiceTest() {
     @BeforeEach
     fun setupTest() {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,8 +16,6 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetProjectByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private val dummyUserUUID = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,8 +20,6 @@ import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class UpdateProjectTest : MainServiceTest() {
     private val dummyUserUUID = UUID.randomUUID()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,8 +15,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class GetAllUsersTest : MainServiceTest() {
     @BeforeEach
     fun setupTest() {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,8 +18,6 @@ import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class GetUserByEmailTest : MainServiceTest() {
     private val exampleEmail = "test@example.com"
     private fun getExampleRequest() = Base.Email.newBuilder().setEmail(exampleEmail).build()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,8 +20,6 @@ import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetUserByIdTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -22,8 +20,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Authentication.LoginRequest
 import kotlin.test.assertEquals
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 @ExtendWith(GrpcTestContextExtension::class)
 class LoginTest : MainServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LogoutTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LogoutTest.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.service.user
 
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -11,8 +9,6 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
 import kotlin.test.assertEquals
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 @ExtendWith(GrpcTestContextExtension::class)
 class LogoutTest : MainServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -18,8 +16,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Authentication
 import kotlin.test.assertEquals
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 @ExtendWith(GrpcTestContextExtension::class)
 class RegisterTest : MainServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,8 +18,6 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class SoftDeleteUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.service.user
 import com.google.protobuf.FieldMask
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,8 +18,6 @@ import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class UpdateUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
 

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -33,8 +33,10 @@ To set up the development environment, follow the steps in
 ├── src/
 │   ├── main/
 │   │   ├── kotlin/
+│   │   │   ├── auth/        (auth related classes)
 │   │   │   ├── db/          (database interface)
 │   │   │   ├── env/         (environment variables)
+│   │   │   ├── fetcher/     (fetcher related classes)
 │   │   │   ├── grpc/        (gRPC server and its interceptors)
 │   │   │   ├── model/       (model classes)
 │   │   │   ├── repository/  (repository layer)
@@ -139,21 +141,21 @@ interface IMainService :
     IExampleService
 
 class MainService(
-    /* dependencies are listed here */
+    private val exampleService: IExampleService
 ) : IMainService,
-    IExampleService by ExampleService(/* dependencies are passed here */)
+    IExampleService by exampleService
 ```
 
-Dependencies are one or more repositories, another service, or whatever the service requires to execute its logic. For
-the dependency injection to work, add all repositories to the `snowballRModule` in
+For the dependency injection to work, add all repositories and services to the `snowballRModule` in
 [Module.kt](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/Module.kt).
 Build the service method implementation in a way that preconditions are checked first. We want to fail as fast as
 possible, and if the associated entity doesn't exist or the user doesn't even have access to the operation, we don't
 want to have already persisted data. Only if every precondition is met, make changes to the persisted data and finish
 the method with returning required data, such as the updated entity for an update request.
 
-Currently, there aren't great examples of services as the existing ones only map the request to the repository layer and
-no real business logic is executed. This will change in the future and this section will be updated accordingly.
+See
+[ProjectService.kt](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt)
+for an example.
 
 ### Input Validation
 

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -66,8 +66,6 @@ The base class of each repository test class is
 which uses the in-memory database H2. A repository test class has the following structure:
 
 ```kotlin
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class ExampleRepoTest : H2DatabaseTest(arrayOf(ExampleTable, AnotherExampleTable)) {
     private val repo = ExampleTableRepo(db)
     private val otherRepo = AnotherExampleTableRepo(db)
@@ -114,12 +112,10 @@ cases. All test classes of a service are grouped in a package named after the as
 has the following test structure:
 
 ```kotlin
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class CreateExampleTest : MainServiceTest() {
     @Test
     fun `When an example is correctly created, then no exception is thrown`() =
-        testCoroutine {
+        runTest {
             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
             val example = ExampleOuterClass.Example.getDefaultInstance()
 
@@ -132,7 +128,7 @@ class CreateExampleTest : MainServiceTest() {
 
     @Test
     fun `When an error occurs during example creation, then an exception is thrown`() =
-        testCoroutine {
+        runTest {
             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
 
             // Mock the behavior of the repositories

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -113,6 +113,11 @@ has the following test structure:
 
 ```kotlin
 class CreateExampleTest : MainServiceTest() {
+    @BeforeEach
+    fun setupTest() {
+        coEvery { userRepoMock.createExample(any()) } throws NotImplementedError()
+    }
+
     @Test
     fun `When an example is correctly created, then no exception is thrown`() =
         runTest {
@@ -140,11 +145,12 @@ class CreateExampleTest : MainServiceTest() {
 }
 ```
 
-The class always needs to be annotated as shown in the example above because we use coroutines. It is important that we
-mock each external dependency such as the call to the repository. In the example, we mock the repository to always
-return a specific object or to throw an exception. This way, we can test the behavior of the service method according to
-the behavior of our dependencies. For more complex mocks such as how often a method is called, refer to the rich
-documentation of the used mocking library [MockK](https://mockk.io/).
+It is important that we mock each external dependency such as the call to the repository. In the example above, we first
+mock that the repository call throws a `NotImplementedError` and after that in each test case that the repository always
+returns a specific object or throws an exception. This way, we can ensure that every call that is made in the service
+method is also mocked and then test the behavior of the service method according to the behavior of our dependencies.
+For more complex mocks such as how often a method is called, refer to the rich documentation of the used mocking library
+[MockK](https://mockk.io/).
 
 ### Input Validation
 


### PR DESCRIPTION
Closes #230

## What I have made

As discussed, it is unnecessary to create the services that are used by the main service by constructing them with injected repositories. Instead we can just inject the services. This PR is all about that.

In the first two commits, I removed all that's left of our own `testCoroutine` implementation, which we replaced with `runTest`.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (not required)
- [x] (for reviewer) I have checked the implementation against the requirements
