### PR TITLE
Improve mocking in tests

### DIFF
--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -66,14 +66,14 @@ import se.uulm.snowballr.backend.serviceLayerDeps
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class MainServiceTest : KoinTest {
     // Repository layer mocks
-    val projectRepoMock = mockk<IProjectTableRepo>(relaxed = true)
-    val criterionRepoMock = mockk<ICriterionTableRepo>(relaxed = true)
-    val userRepoMock = mockk<IUserTableRepo>(relaxed = true)
-    val projectMemberRepoMock = mockk<IProjectMemberTableRepo>(relaxed = true)
+    val projectRepoMock = mockk<IProjectTableRepo>()
+    val criterionRepoMock = mockk<ICriterionTableRepo>()
+    val userRepoMock = mockk<IUserTableRepo>()
+    val projectMemberRepoMock = mockk<IProjectMemberTableRepo>()
 
     // Custom services / manager / clients mocks
-    val jwtServiceMock = mockk<IJwtService>(relaxed = true)
-    val fetcherManagerMock = mockk<FetcherManager>(relaxed = true)
+    val jwtServiceMock = mockk<IJwtService>()
+    val fetcherManagerMock = mockk<FetcherManager>()
 
     val mainService: IMainService by inject()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.service
 
+import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -75,8 +76,18 @@ open class MainServiceTest : KoinTest {
     val jwtServiceMock = mockk<IJwtService>()
     val fetcherManagerMock = mockk<FetcherManager>()
 
+    val allMocks = arrayOf(
+        projectRepoMock,
+        criterionRepoMock,
+        userRepoMock,
+        projectMemberRepoMock,
+        jwtServiceMock,
+        fetcherManagerMock,
+    )
+
     val mainService: IMainService by inject()
 
+    // Note that we cannot use the list of all mocks to add it to the module.
     private val serviceTestModule = module {
         // Repository layer
         single { projectRepoMock }
@@ -102,6 +113,7 @@ open class MainServiceTest : KoinTest {
 
     @AfterEach
     open fun tearDownTest() {
+        checkUnnecessaryStub(*allMocks)
         clearAllMocks()
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.criterion
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -15,12 +14,6 @@ import snowballr.CriterionOuterClass
 import java.util.UUID
 
 class CreateCriterionTest : MainServiceTest() {
-    @BeforeEach
-    fun setUpTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { criterionRepoMock.createCriterion(any(), any()) } throws NotImplementedError()
-    }
-
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.criterion
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -24,16 +23,6 @@ class GetCriterionByIdTest : MainServiceTest() {
         .newBuilder()
         .setId(requestId.toString())
         .build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.addUserToProject(any(), any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
-        coEvery { criterionRepoMock.getCriterionById(any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When the requesting user is a server admin, then a project criterion can be retrieved`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -61,7 +61,6 @@ class GetCriterionByIdTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
-            coEvery { projectMemberRepoMock.addUserToProject(user.id, project.id) } returns projectMember
             coEvery { projectMemberRepoMock.getMembersOfProject(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
@@ -148,13 +147,9 @@ class GetCriterionByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-        val projectMember = DataBuilder.createExampleProjectMember(userId = adminUser.id, projectId = project.id)
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
-        coEvery { projectMemberRepoMock.getMembersOfProject(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.getCriterionById(requestId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -40,16 +39,6 @@ class UpdateCriterionTest : MainServiceTest() {
             .setCriterion(updatedCriterion.toGrpcCriterion())
             .setMask(updateFieldMask)
             .build()
-    }
-
-    @BeforeEach
-    fun setUpTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { criterionRepoMock.getCriterionById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } throws NotImplementedError()
-        coEvery { criterionRepoMock.updateCriterion(any()) } throws NotImplementedError()
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -111,7 +111,6 @@ class UpdateCriterionTest : MainServiceTest() {
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-            coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateCriterion(request) }
         }
@@ -135,7 +134,6 @@ class UpdateCriterionTest : MainServiceTest() {
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
-        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
     }
@@ -184,7 +182,6 @@ class UpdateCriterionTest : MainServiceTest() {
             every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-            coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
             assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
         }
@@ -200,7 +197,6 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
         coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -16,12 +15,6 @@ import java.util.UUID
 
 class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { projectRepoMock.createProject(any(), any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -20,13 +19,6 @@ import java.util.UUID
 class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When parsing the ID fails, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -20,13 +19,6 @@ import java.util.UUID
 class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When parsing the ID fails, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -20,13 +19,6 @@ import java.util.UUID
 class GetAllProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getUserProjects(any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When parsing the ID of the requested user fails, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -62,7 +62,6 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
-        coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -16,13 +15,6 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetAllProjectsTest : MainServiceTest() {
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getAllProjects() } throws NotImplementedError()
-    }
-
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -29,12 +29,10 @@ class GetProjectByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val noAccessUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(id = requestId)
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
         coEvery { projectMemberRepoMock.getMembersOfProject(any()) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
         assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
     }
@@ -64,7 +62,6 @@ class GetProjectByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
-        coEvery { projectMemberRepoMock.addUserToProject(user.id, requestId) } returns projectMember
         coEvery { projectMemberRepoMock.getMembersOfProject(requestId) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -24,15 +23,6 @@ class GetProjectByIdTest : MainServiceTest() {
         .newBuilder()
         .setId(requestId.toString())
         .build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.addUserToProject(any(), any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.getMembersOfProject(any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When the requesting user is not a member of the project, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -33,20 +33,15 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a server admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
         val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(
-            status = status,
-        )
-        val updatedProject = DataBuilder.createExampleProject(
-            id = project.id,
-            name = "Updated Project",
-        )
+        val project = DataBuilder.createExampleProject(status = status)
+        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
-        val updateFieldMask = FieldMaskUtil.fromStringList(
-            listOf("name", "status"),
-        )
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-            updatedProject.toGrpcProject(),
-        ).setMask(updateFieldMask).build()
+        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
+        val request = ProjectOuterClass.Project.Update
+            .newBuilder()
+            .setProject(updatedProject.toGrpcProject())
+            .setMask(updateFieldMask)
+            .build()
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -68,22 +63,17 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a project admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
         val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = status,
-        )
+        val project = DataBuilder.createExampleProject(status = status)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
-        val updatedProject = DataBuilder.createExampleProject(
-            id = project.id,
-            name = "Updated Project",
-        )
+        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
-        val updateFieldMask = FieldMaskUtil.fromStringList(
-            listOf("name", "status"),
-        )
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-            updatedProject.toGrpcProject(),
-        ).setMask(updateFieldMask).build()
+        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
+        val request = ProjectOuterClass.Project.Update
+            .newBuilder()
+            .setProject(updatedProject.toGrpcProject())
+            .setMask(updateFieldMask)
+            .build()
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -107,18 +97,15 @@ class UpdateProjectTest : MainServiceTest() {
         runTest {
             val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
             val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(
-                status = status,
-            )
-            val updatedProject = DataBuilder.createExampleProject(
-                id = project.id,
-                name = "Updated Project",
-            )
+            val project = DataBuilder.createExampleProject(status = status)
+            val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
             val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
-            val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-                updatedProject.toGrpcProject(),
-            ).setMask(updateFieldMask).build()
+            val request = ProjectOuterClass.Project.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
 
             every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -142,9 +129,11 @@ class UpdateProjectTest : MainServiceTest() {
             )
 
             val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-            val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-                updatedProject.toGrpcProject(),
-            ).setMask(updateFieldMask).build()
+            val request = ProjectOuterClass.Project.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
 
             every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -169,9 +158,11 @@ class UpdateProjectTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
             val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-            val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-                updatedProject.toGrpcProject(),
-            ).setMask(updateFieldMask).build()
+            val request = ProjectOuterClass.Project.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
 
             every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -187,14 +178,13 @@ class UpdateProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
         )
-        val updatedProject = DataBuilder.createExampleProject(
-            id = project.id,
-            name = "Updated Project",
-        )
+        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-            updatedProject.toGrpcProject(),
-        ).setMask(updateFieldMask).build()
+        val request = ProjectOuterClass.Project.Update
+            .newBuilder()
+            .setProject(updatedProject.toGrpcProject())
+            .setMask(updateFieldMask)
+            .build()
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -210,16 +200,15 @@ class UpdateProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
         )
-        val updatedProject = DataBuilder.createExampleProject(
-            id = project.id,
-            name = "Updated Project",
-        )
+        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(
-            updatedProject.toGrpcProject(),
-        ).setMask(updateFieldMask).build()
+        val request = ProjectOuterClass.Project.Update
+            .newBuilder()
+            .setProject(updatedProject.toGrpcProject())
+            .setMask(updateFieldMask)
+            .build()
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
@@ -232,9 +221,8 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When an error occurs while updating a project, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val updatedProject = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
-        )
+        val status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
+        val updatedProject = DataBuilder.createExampleProject(status = status)
         val request = ProjectOuterClass.Project.Update.newBuilder().setProject(updatedProject.toGrpcProject()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -22,15 +21,6 @@ import java.util.UUID
 
 class UpdateProjectTest : MainServiceTest() {
     private val dummyUserUUID = UUID.randomUUID()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.getProjectById(any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } throws NotImplementedError()
-        coEvery { projectRepoMock.updateProject(any(), any()) } throws NotImplementedError()
-    }
 
     @ParameterizedTest
     @CsvSource(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -124,7 +124,6 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
             assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateProject(request) }
         }
@@ -151,7 +150,6 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
         }
@@ -179,7 +177,6 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-            coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
         }
@@ -203,7 +200,6 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
     }
@@ -229,7 +225,6 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -16,13 +15,6 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetAllUsersTest : MainServiceTest() {
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { userRepoMock.getAllUsers() } throws NotImplementedError()
-    }
-
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -21,14 +20,6 @@ import java.util.UUID
 class GetUserByEmailTest : MainServiceTest() {
     private val exampleEmail = "test@example.com"
     private fun getExampleRequest() = Base.Email.newBuilder().setEmail(exampleEmail).build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { userRepoMock.getUserByEmail(any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -23,13 +22,6 @@ import java.util.UUID
 class GetUserByIdTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When parsing the user ID fails, then InvalidIdException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -96,11 +96,9 @@ class GetUserByIdTest : MainServiceTest() {
     fun `When current user is not authorized to access requested user, then UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> { mainService.getUserById(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -21,13 +20,6 @@ import java.util.UUID
 class SoftDeleteUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { userRepoMock.softDeleteUser(any()) } throws NotImplementedError()
-    }
 
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.FieldMask
 import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -37,14 +36,6 @@ class UpdateUserTest : MainServiceTest() {
             .setUser(user)
             .setMask(mask)
             .build()
-    }
-
-    @BeforeEach
-    fun setupTest() {
-        every { GrpcContext.getUserIdFromContext() } throws NotImplementedError()
-        coEvery { userRepoMock.getUserById(any()) } throws NotImplementedError()
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } throws NotImplementedError()
-        coEvery { userRepoMock.updateUser(any()) } throws NotImplementedError()
     }
 
     @Test

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -100,7 +100,7 @@ for an example.
 Similar to the repository tests, the service tests use the base class
 [MainServiceTest](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt).
 In there, the mocks for all repositories are declared. If the mock of the repo you are working on is not already added,
-add it below the existing mocks with the pattern `[Repository Name]Mock = mockk<I[Repository Name]>(relaxed = true)`.
+add it below the existing mocks with the pattern `[Repository Name]Mock = mockk<I[Repository Name]>()`.
 Furthermore, pass it to the `MainService` constructor because we use the `mainService` object to call the methods we
 want to test. We create a test class for each service method separately as they are expected to contain a lot of test
 cases. All test classes of a service are grouped in a package named after the associated entity. A service test class


### PR DESCRIPTION
Closes #241

## What I have made

TL;DR I made mocking in our service tests more maintainable.

See the issue description for more details.

I recommend reviewing this commit-by-commit.

In `MainServiceTest` we now have a list of all mocks. Sadly I cannot use that list to add the mocks as dependencies to the `serviceTestModule` or at least I couldn't find out how. Suggestions are welcome.

Another extension could be to remove using `any()` for mocking parameters. With these two changes, we should always use the exact parameters.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only refactored the tests)
- [x] (for reviewer) I have checked the implementation against the requirements
