### PR TITLE
Implement getallcriteriaforproject call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -301,7 +301,7 @@ class SnowballRServer(
             mainService.getCriterionById(request)
 
         override suspend fun getAllCriteriaForProject(request: Base.Id): CriterionOuterClass.Criterion.List =
-            super.getAllCriteriaForProject(request)
+            mainService.getAllCriteriaForProject(request)
 
         override suspend fun createCriterion(
             request: CriterionOuterClass.Criterion.Create,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Criterion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Criterion.kt
@@ -30,3 +30,12 @@ fun Criterion.toGrpcCriterion(): CriterionOuterClass.Criterion = CriterionOuterC
     .setDescription(this.description)
     .setCategory(this.category)
     .build()
+
+/**
+ * Creates a list of [CriterionOuterClass.Criterion]s from this list of [Criterion]s.
+ */
+fun List<Criterion>.toGrpcCriteria(): CriterionOuterClass.Criterion.List {
+    val builder = CriterionOuterClass.Criterion.List.newBuilder()
+    this.forEach { builder.addCriteria(it.toGrpcCriterion()) }
+    return builder.build()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -66,6 +66,14 @@ interface ICriterionTableRepo {
      *         If no criteria are found for certain IDs, they may be excluded from the result.
      */
     suspend fun getCriteriaByIds(ids: List<UUID>): List<Criterion>
+
+    /**
+     * Retrieves all criteria associated with a specific project.
+     *
+     * @param projectId The unique identifier of the project for which the criteria are being retrieved.
+     * @return A list of [Criterion] objects associated with the given project.
+     */
+    suspend fun getAllProjectCriteria(projectId: UUID): List<Criterion>
 }
 
 /**
@@ -131,6 +139,13 @@ class CriterionTableRepo(
         CriterionTable
             .selectAll()
             .where { CriterionTable.createdBy eq userId and CriterionTable.projectId.isNull() }
+            .map { it.toCriterion() }
+    }
+
+    override suspend fun getAllProjectCriteria(projectId: UUID): List<Criterion> = db.query {
+        CriterionTable
+            .selectAll()
+            .where { CriterionTable.projectId eq projectId }
             .map { it.toCriterion() }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -8,6 +8,7 @@ import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
@@ -37,6 +38,11 @@ interface ICriterionService {
      * @return The updated criterion after the changes have been applied.
      */
     suspend fun updateCriterion(request: GrpcCriterion.Update): GrpcCriterion
+
+    /**
+     * Service implementation of [SnowballRService.getAllCriteriaForProject].
+     */
+    suspend fun getAllCriteriaForProject(request: Base.Id): GrpcCriterion.List
 }
 
 /**
@@ -67,7 +73,7 @@ class CriterionService(
      * that belongs to an active project and throws exceptions when access is unauthorized
      * or when attempting to access a criterion of an inactive project.
      *
-     * @param criterion The [GrpcCriterion] to check the permission for or null, if it does not already exists
+     * @param criterion The [GrpcCriterion] to check the permission for or null, if it does not already exist
      * @param projectId The projectId of the [ProjectOuterClass.Project] to check the permission for.
      * @param currentUser The user whose permissions are being validated.
      * @param accessType The type of access being requested (e.g., READ, UPDATE).
@@ -187,5 +193,25 @@ class CriterionService(
 
         checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
         return repo.updateCriterion(request).toGrpcCriterion()
+    }
+
+    override suspend fun getAllCriteriaForProject(request: Base.Id): GrpcCriterion.List {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+        // This call exists to throw a NotFoundException if the project with the given id does not exist
+        projectRepo.getProjectById(projectId)
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+        if (!projectMembers.any { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+        return repo.getAllProjectCriteria(projectId).toGrpcCriteria()
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -19,7 +19,6 @@ import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
-import snowballr.CriterionOuterClass
 import snowballr.CriterionOuterClass.Criterion
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
@@ -315,7 +314,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 .setCategory(CriterionCategory.CRITERION_CATEGORY_INCLUSION)
                 .build()
 
-            val request = CriterionOuterClass.Criterion.Update.newBuilder()
+            val request = Criterion.Update.newBuilder()
                 .setCriterion(updatedCriterionDetails)
                 .setMask(FieldMaskUtil.fromStringList(fieldMask))
                 .build()
@@ -343,5 +342,40 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 assertThat(updatedCriterion.category).isEqualTo(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
             }
         }
+    }
+
+    @Nested
+    inner class GetAllProjectCriteria {
+        @Test
+        fun `When all criteria of a specific project are requested, then the only criteria associated with this project are returned`() =
+            runTest {
+                val projectId1 = createExampleProject().id
+                val projectId2 = createExampleProject().id
+
+                val baseRequestBuilder = Criterion.Create.newBuilder()
+                    .setTag("Test Tag")
+                    .setName("Test Criterion")
+                    .setDescription("Test Description")
+                    .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+
+                val userCriterionRequest = baseRequestBuilder.build()
+                val projectCriterionRequest1 = baseRequestBuilder
+                    .setProjectId(projectId1.toString())
+                    .build()
+                val projectCriterionRequest2 = baseRequestBuilder
+                    .setProjectId(projectId2.toString())
+                    .build()
+
+                val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
+                val projectCriterion1 = repo.createCriterion(projectCriterionRequest1, testUserId)
+                val projectCriterion2 = repo.createCriterion(projectCriterionRequest2, testUserId)
+
+                val userCriteria = repo.getAllProjectCriteria(projectId1)
+
+                Assertions.assertThat(userCriteria).hasSize(1)
+                Assertions.assertThat(userCriteria).containsExactly(projectCriterion1)
+                Assertions.assertThat(userCriteria).doesNotContain(projectCriterion2)
+                Assertions.assertThat(userCriteria).doesNotContain(userCriterion)
+            }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -19,8 +19,6 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class CreateCriterionTest : MainServiceTest() {
-    private val dummyUserUUID = UUID.randomUUID()
-
     private fun getProjectCriterionRequest(projectId: String): CriterionOuterClass.Criterion.Create {
         return CriterionOuterClass.Criterion.Create.newBuilder()
             .setTag("Tag")
@@ -51,13 +49,13 @@ class CreateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When an admin user creates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject()
 
         val criterion = DataBuilder.createExampleCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
@@ -68,14 +66,14 @@ class CreateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a project admin creates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
-        val projectMember = DataBuilder.createExampleProjectMember(userId = dummyUserUUID, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
         val criterion = DataBuilder.createExampleCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
@@ -92,7 +90,7 @@ class CreateCriterionTest : MainServiceTest() {
 
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -107,7 +105,7 @@ class CreateCriterionTest : MainServiceTest() {
     fun `When a project admin creates a project criterion for a non active project, then a failed precondition exception is thrown`(
         status: ProjectOuterClass.ProjectStatus,
     ) = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = status,
         )
@@ -115,7 +113,7 @@ class CreateCriterionTest : MainServiceTest() {
 
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -125,14 +123,14 @@ class CreateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When an user creates a user criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
         val criterion = DataBuilder.createExampleCriterion()
         val request = getUserCriterionRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
-        coEvery { criterionRepoMock.createCriterion(any(), dummyUserUUID) } returns criterion
+        coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -1,0 +1,149 @@
+package se.uulm.snowballr.backend.service.criterion
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+class GetAllCriteriaForProjectTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestId.toString())
+        .build()
+
+    @Test
+    fun `When an error occurs while user context is retrieved, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
+    }
+
+    @Test
+    fun `When an error occurs while user is retrieved, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
+    }
+
+    @Test
+    fun `When an error occurs while project is retrieved, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
+    }
+
+    @Test
+    fun `When an error occurs while project members are retrieved, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(any()) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
+    }
+
+    @Test
+    fun `When an error occurs while the criteria are retrieved, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(userId = adminUser.id, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a server admin, then no exception is thrown`() = runTest {
+        val request = getExampleRequest()
+
+        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val criterion = DataBuilder.createExampleCriterion(
+            projectId = requestId,
+            createdBy = adminUser.id,
+        )
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { projectRepoMock.getProjectById(any()) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
+        coEvery { criterionRepoMock.getAllProjectCriteria(requestId) } returns listOf(criterion)
+
+        assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
+    }
+
+    @Test
+    fun `When the requesting user is a project member and wants to retrieve all project criteria, then no exception is thrown`() =
+        runTest {
+            val request = getExampleRequest()
+
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val criterion = DataBuilder.createExampleCriterion(
+                projectId = requestId,
+                createdBy = user.id,
+            )
+            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = requestId)
+            val project = DataBuilder.createExampleProject(id = requestId)
+
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { projectRepoMock.getProjectById(requestId) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns listOf(projectMember)
+            coEvery { criterionRepoMock.getAllProjectCriteria(requestId) } returns listOf(criterion)
+
+            assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
+        }
+
+    @Test
+    fun `When the requesting user is a non project member and wants to retrieve all project criteria, then an unauthorized exception is thrown`() =
+        runTest {
+            val request = getExampleRequest()
+
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(id = requestId)
+
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { projectRepoMock.getProjectById(requestId) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns emptyList()
+
+            assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }
+        }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -17,7 +17,6 @@ import java.util.UUID
 
 class GetCriterionByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
-    private val dummyUserUUID = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
@@ -32,12 +31,12 @@ class GetCriterionByIdTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleCriterion(
             id = requestId,
             projectId = UUID.randomUUID(),
-            createdBy = dummyUserUUID,
+            createdBy = adminUser.id,
         )
         val project = DataBuilder.createExampleProject(id = requestId)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
@@ -55,12 +54,12 @@ class GetCriterionByIdTest : MainServiceTest() {
             val criterion = DataBuilder.createExampleCriterion(
                 id = requestId,
                 projectId = project.id,
-                createdBy = dummyUserUUID,
+                createdBy = user.id,
             )
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
@@ -77,12 +76,12 @@ class GetCriterionByIdTest : MainServiceTest() {
             val criterion = DataBuilder.createExampleCriterion(
                 id = requestId,
                 projectId = UUID.randomUUID(),
-                createdBy = dummyUserUUID,
+                createdBy = noAccessUser.id,
             )
             val project = DataBuilder.createExampleProject()
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+            every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
+            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
             coEvery { projectRepoMock.getProjectById(any()) } returns project
             coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
@@ -101,8 +100,8 @@ class GetCriterionByIdTest : MainServiceTest() {
             createdBy = UUID.randomUUID(),
         )
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
@@ -116,8 +115,8 @@ class GetCriterionByIdTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion = DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
@@ -135,8 +134,8 @@ class GetCriterionByIdTest : MainServiceTest() {
                 createdBy = UUID.randomUUID(),
             )
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+            every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
+            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
@@ -148,8 +147,8 @@ class GetCriterionByIdTest : MainServiceTest() {
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { criterionRepoMock.getCriterionById(requestId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -20,7 +20,6 @@ import java.util.UUID
 
 class UpdateCriterionTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
-    private val dummyUserUUID = UUID.randomUUID()
 
     private fun getExampleRequest(): CriterionOuterClass.Criterion.Update {
         val updatedCriterion = DataBuilder.createExampleCriterion(
@@ -43,20 +42,20 @@ class UpdateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a server admin updates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val criterion = DataBuilder.createExampleCriterion(
             id = requestId,
             projectId = project.id,
-            createdBy = dummyUserUUID,
+            createdBy = user.id,
         )
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
@@ -67,7 +66,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a project admin updates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
@@ -75,13 +74,13 @@ class UpdateCriterionTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleCriterion(
             id = requestId,
             projectId = project.id,
-            createdBy = dummyUserUUID,
+            createdBy = user.id,
         )
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -93,7 +92,7 @@ class UpdateCriterionTest : MainServiceTest() {
     @Test
     fun `When a project admin updates a project criterion of a non-active project, then a failed precondition exception is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
             )
@@ -101,13 +100,13 @@ class UpdateCriterionTest : MainServiceTest() {
             val criterion = DataBuilder.createExampleCriterion(
                 id = requestId,
                 projectId = project.id,
-                createdBy = dummyUserUUID,
+                createdBy = user.id,
             )
 
             val request = getExampleRequest()
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
             coEvery { projectRepoMock.getProjectById(any()) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -117,20 +116,20 @@ class UpdateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a project member updates a project criterion, then an unauthorized exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val criterion = DataBuilder.createExampleCriterion(
             id = requestId,
             projectId = project.id,
-            createdBy = dummyUserUUID,
+            createdBy = user.id,
         )
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
@@ -140,14 +139,14 @@ class UpdateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val criterion =
             DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = UUID.randomUUID())
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -156,14 +155,14 @@ class UpdateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a user updates a user criterion, which he created himself, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val criterion =
-            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = dummyUserUUID)
+            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -173,14 +172,14 @@ class UpdateCriterionTest : MainServiceTest() {
     @Test
     fun `When a user updates a user criterion, which he did not created himself, then no exception is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion =
                 DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = UUID.randomUUID())
 
             val request = getExampleRequest()
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
 
             assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
@@ -188,14 +187,14 @@ class UpdateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When an error occurs while the criterion is updated, then an exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val criterion =
-            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = dummyUserUUID)
+            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
         coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -17,7 +17,6 @@ import java.util.UUID
 
 class GetProjectByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
-    private val dummyUserUUID = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
@@ -30,8 +29,8 @@ class GetProjectByIdTest : MainServiceTest() {
 
         val noAccessUser = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns noAccessUser
+        every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
+        coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
@@ -44,8 +43,8 @@ class GetProjectByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = requestId)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
@@ -60,8 +59,8 @@ class GetProjectByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = requestId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = requestId)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
@@ -74,8 +73,8 @@ class GetProjectByIdTest : MainServiceTest() {
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -19,7 +19,6 @@ import java.util.UUID
 
 class GetProjectMembersTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
-    private val dummyUserUUID = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
@@ -39,8 +38,8 @@ class GetProjectMembersTest : MainServiceTest() {
         )
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, projectMemberUser)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
@@ -57,8 +56,8 @@ class GetProjectMembersTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, user)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
@@ -73,8 +72,8 @@ class GetProjectMembersTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = requestId)
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns emptyList()
 
@@ -88,8 +87,8 @@ class GetProjectMembersTest : MainServiceTest() {
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery {
                 projectRepoMock.getProjectById(requestId)
             } throws SnowballRException.NotFoundException(EntityType.PROJECT, request.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -17,11 +17,8 @@ import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 
 class UpdateProjectTest : MainServiceTest() {
-    private val dummyUserUUID = UUID.randomUUID()
-
     @ParameterizedTest
     @CsvSource(
         value = [
@@ -32,7 +29,7 @@ class UpdateProjectTest : MainServiceTest() {
     )
     fun `When a server admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
         val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(status = status)
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
@@ -43,8 +40,8 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
@@ -62,7 +59,7 @@ class UpdateProjectTest : MainServiceTest() {
     )
     fun `When a project admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
         val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(status = status)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
@@ -75,8 +72,8 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
@@ -96,7 +93,7 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a project member updates a project, then an unauthorized exception is thrown`(statusName: String) =
         runTest {
             val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
-            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(status = status)
             val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
@@ -107,8 +104,8 @@ class UpdateProjectTest : MainServiceTest() {
                 .setMask(updateFieldMask)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -118,7 +115,7 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When a server admin updates project to the project status DELETED, then a failed precondition exception is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject(
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
             )
@@ -135,8 +132,8 @@ class UpdateProjectTest : MainServiceTest() {
                 .setMask(updateFieldMask)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -146,7 +143,7 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When a project admin updates project to the project status DELETED, then a failed precondition exception is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
             )
@@ -164,8 +161,8 @@ class UpdateProjectTest : MainServiceTest() {
                 .setMask(updateFieldMask)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-            coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -174,7 +171,7 @@ class UpdateProjectTest : MainServiceTest() {
 
     @Test
     fun `When a server admin updates a deleted project, then a failed precondition exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
         )
@@ -186,8 +183,8 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -196,7 +193,7 @@ class UpdateProjectTest : MainServiceTest() {
 
     @Test
     fun `When a project admin updates a deleted project, then a failed precondition exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(id = dummyUserUUID, role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
         )
@@ -210,8 +207,8 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
-        coEvery { userRepoMock.getUserById(dummyUserUUID) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -225,7 +222,7 @@ class UpdateProjectTest : MainServiceTest() {
         val updatedProject = DataBuilder.createExampleProject(status = status)
         val request = ProjectOuterClass.Project.Update.newBuilder().setProject(updatedProject.toGrpcProject()).build()
 
-        every { GrpcContext.getUserIdFromContext() } returns dummyUserUUID
+        every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(any()) } returns user
         coEvery { projectRepoMock.getProjectById(updatedProject.id) } returns updatedProject
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()


### PR DESCRIPTION
Closes #90 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

**Note**: This branch was rebased onto #163. Thus, you must only have a look on the last 4 commits. Everything else is already in review.

I have implemented the call `getAllCriteriaForProject`. This includes the implementation of the following layers:
- repository layer
- service layer
- grpc layer

I have also added a method to get the `Criterion.List` for the grpc call.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
