### PR TITLE
Change lifecycle of `MainServiceTest` to `PER_METHOD`

### DIFF
--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -4,10 +4,8 @@ import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
@@ -64,7 +62,7 @@ import se.uulm.snowballr.backend.serviceLayerDeps
  * }
  * ```
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
 open class MainServiceTest : KoinTest {
     // Repository layer mocks
     val projectRepoMock = mockk<IProjectTableRepo>()
@@ -103,8 +101,8 @@ open class MainServiceTest : KoinTest {
         serviceLayerDeps()
     }
 
-    @BeforeAll
-    fun setUp() {
+    @BeforeEach
+    fun setUpTest() {
         startKoin {
             modules(serviceTestModule)
         }
@@ -115,11 +113,6 @@ open class MainServiceTest : KoinTest {
     open fun tearDownTest() {
         checkUnnecessaryStub(*allMocks)
         clearAllMocks()
-    }
-
-    @AfterAll
-    fun tearDown() {
         stopKoin()
-        unmockkObject(GrpcContext)
     }
 }


### PR DESCRIPTION
Closes #252 

## What I have made

This instantiates the mocks for each test method, and therefore `checkUnnecessaryStubs` fails only for a single test method.

See the issue description to reproduce the bug and apply the changes to the same commit to see how it affects the result. Otherwise, add an unnecessary mocked call that is used by other test methods in the same class and check how many tests fail with and without the fix.

For instance, add `coEvery { userRepoMock.getUserById(UUID.randomUUID()) } throws TestSpecificException()` to a test method in `GetAllDeletedProjectsForUserTest.kt`.
**Note** that now only tests that use `any()` as a parameter fail. This is another reason to use specific parameters for mocked calls.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] (for reviewer) I have checked the implementation against the requirements
