### PR TITLE
feat: implement `getAllProjectPapersForProject` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -34,9 +34,13 @@ import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ReadingListTableRepo
+import se.uulm.snowballr.backend.repository.association.ReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.repository.association.ReviewTableRepo
 import se.uulm.snowballr.backend.service.AuthenticationService
 import se.uulm.snowballr.backend.service.CriterionService
 import se.uulm.snowballr.backend.service.EmailService
@@ -48,10 +52,12 @@ import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IMainService
 import se.uulm.snowballr.backend.service.IProjectService
 import se.uulm.snowballr.backend.service.IReadingListService
+import se.uulm.snowballr.backend.service.IReviewService
 import se.uulm.snowballr.backend.service.IUserService
 import se.uulm.snowballr.backend.service.MainService
 import se.uulm.snowballr.backend.service.ProjectService
 import se.uulm.snowballr.backend.service.ReadingListService
+import se.uulm.snowballr.backend.service.ReviewService
 import se.uulm.snowballr.backend.service.UserService
 
 /**
@@ -112,6 +118,8 @@ private fun Module.repositoryLayerDeps() {
     singleOf(::ReadingListTableRepo) { bind<IReadingListTableRepo>() }
     singleOf(::VerificationTokenTableRepo) { bind<IVerificationTokenTableRepo>() }
     singleOf(::ProjectPaperTableRepo) { bind<IProjectPaperTableRepo>() }
+    singleOf(::ReviewTableRepo) { bind<IReviewTableRepo>() }
+    singleOf(::ReviewHasCriterionTableRepo) { bind<IReviewHasCriterionTableRepo>() }
 }
 
 /**
@@ -145,6 +153,7 @@ fun Module.serviceLayerDeps() {
     singleOf(::UserService) { bind<IUserService>() }
     singleOf(::FetcherService) { bind<IFetcherService>() }
     singleOf(::ReadingListService) { bind<IReadingListService>() }
+    singleOf(::ReviewService) { bind<IReviewService>() }
     // The main service comes last
     singleOf(::MainService) { bind<IMainService>() }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -32,8 +32,10 @@ import se.uulm.snowballr.backend.repository.association.CitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.ProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ReadingListTableRepo
 import se.uulm.snowballr.backend.service.AuthenticationService
 import se.uulm.snowballr.backend.service.CriterionService
@@ -109,6 +111,7 @@ private fun Module.repositoryLayerDeps() {
     singleOf(::CitationTableRepo) { bind<ICitationTableRepo>() }
     singleOf(::ReadingListTableRepo) { bind<IReadingListTableRepo>() }
     singleOf(::VerificationTokenTableRepo) { bind<IVerificationTokenTableRepo>() }
+    singleOf(::ProjectPaperTableRepo) { bind<IProjectPaperTableRepo>() }
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -324,14 +324,14 @@ class SnowballRServer(
         override suspend fun deleteCriterion(request: Base.Id): Base.Nothing = super.deleteCriterion(request)
 
         override suspend fun getProjectPaperById(request: Base.Id): ProjectOuterClass.Project.Paper =
-            super.getProjectPaperById(request)
+            mainService.getProjectPaperById(request)
 
         override suspend fun getProjectPaperByRelativeId(
             request: ProjectOuterClass.Project.Paper.Get,
         ): ProjectOuterClass.Project.Paper = super.getProjectPaperByRelativeId(request)
 
         override suspend fun getAllProjectPapersForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
-            super.getAllProjectPapersForProject(request)
+            mainService.getAllProjectPapersForProject(request)
 
         override suspend fun addPaperToProject(
             request: ProjectOuterClass.Project.Paper.Add,

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -344,10 +344,12 @@ class SnowballRServer(
         override suspend fun removePaperFromProject(request: Base.Id): Base.Nothing =
             super.removePaperFromProject(request)
 
-        override suspend fun getReviewById(request: Base.Id): ReviewOuterClass.Review = super.getReviewById(request)
+        override suspend fun getReviewById(request: Base.Id): ReviewOuterClass.Review = mainService.getReviewById(
+            request,
+        )
 
         override suspend fun getAllReviewsForProjectPaper(request: Base.Id): ReviewOuterClass.Review.List =
-            super.getAllReviewsForProjectPaper(request)
+            mainService.getAllReviewsForProjectPaper(request)
 
         override suspend fun createReview(request: ReviewOuterClass.Review.Create): ReviewOuterClass.Review =
             super.createReview(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
@@ -14,6 +14,7 @@ enum class EntityType(val singular: String, val plural: String) {
     PAPER("paper", "papers"),
     PROJECT_PAPER("project paper", "project papers"),
     AUTHOR("author", "authors"),
+    REVIEW("review", "reviews"),
     VERIFICATION_TOKEN("verification token", "verification tokens"),
     ;
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/EntityType.kt
@@ -12,6 +12,7 @@ enum class EntityType(val singular: String, val plural: String) {
     CRITERION("criterion", "criteria"),
     PROJECT_MEMBER("project member", "project members"),
     PAPER("paper", "papers"),
+    PROJECT_PAPER("project paper", "project papers"),
     AUTHOR("author", "authors"),
     VERIFICATION_TOKEN("verification token", "verification tokens"),
     ;

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Author.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Author.kt
@@ -20,12 +20,8 @@ data class Author(
 /**
  * Creates a [PaperOuterClass.Author] from this [Author].
  */
-fun Author.toGrpcAuthor(): PaperOuterClass.Author = with(
-    PaperOuterClass.Author
-        .newBuilder(),
-) {
-    setFirstName(this.firstName)
-    setLastName(this.lastName)
-    this.orcid?.let { setOrcid(it) }
-    build()
-}
+fun Author.toGrpcAuthor(): PaperOuterClass.Author = PaperOuterClass.Author.newBuilder()
+    .setFirstName(firstName)
+    .setLastName(lastName)
+    .also { if (orcid != null) it.setOrcid(orcid) }
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -55,9 +55,7 @@ fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
     .addAllProjectPapers(
         this.map { projectPaper ->
             val authors = paperAuthorsMap[projectPaper.paper].orEmpty()
-
             val backwardRefs = paperBackwardReferencesMap[projectPaper.paper].orEmpty()
-
             val reviews = paperReviewsMap[projectPaper.paper].orEmpty()
 
             projectPaper.toGrpcProjectPaper(

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -1,0 +1,66 @@
+package se.uulm.snowballr.backend.model.dto
+
+import snowballr.PaperOuterClass
+import snowballr.ProjectOuterClass
+import java.util.UUID
+
+/**
+ * Represents a relationship between a project paper and its associated paper.
+ *
+ * This data class combines information from both a `ProjectPaper` and a `Paper`.
+ * It is useful for scenarios where details of the `ProjectPaper` linked to a specific
+ * `Paper` need to be accessed together.
+ *
+ * @property projectPaper The `ProjectPaper` instance containing project-specific data.
+ * @property paper The `Paper` instance providing detailed information about the paper itself.
+ */
+data class ProjectPaperWithPaper(
+    val projectPaper: ProjectPaper,
+    val paper: Paper,
+)
+
+/**
+ * Converts a [ProjectPaperWithPaper] instance to a gRPC-compatible representation of
+ * [ProjectOuterClass.Project.Paper].
+ *
+ * @param authors The list of gRPC authors to associate with the paper.
+ * @param backwardReferencedIds The list of backward-referenced paper IDs.
+ * @return A gRPC-compatible [ProjectOuterClass.Project.Paper] object containing the converted data.
+ */
+fun ProjectPaperWithPaper.toGrpcProjectPaper(
+    authors: List<PaperOuterClass.Author>,
+    backwardReferencedIds: List<String>,
+): ProjectOuterClass.Project.Paper = ProjectOuterClass.Project.Paper
+    .newBuilder()
+    .setId(projectPaper.id.toString())
+    .setPaper(paper.toGrpcPaper(authors, backwardReferencedIds))
+    .setStage(projectPaper.stage)
+    .setDecision(projectPaper.decision)
+    .setLocalId(projectPaper.localPaperId.toString())
+    .build()
+
+/**
+ * Converts a list of [ProjectPaperWithPaper] objects into a gRPC list of project papers.
+ *
+ * @return A [ProjectOuterClass.Project.Paper.List] containing the gRPC representation of the project papers.
+ */
+fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
+    paperAuthorsMap: Map<Paper, List<Author>>,
+    paperBackwardReferencesMap: Map<Paper, List<UUID>>,
+): ProjectOuterClass.Project.Paper.List = ProjectOuterClass.Project.Paper.List
+    .newBuilder()
+    .addAllProjectPapers(
+        this.map { projectPaper ->
+            val authors = paperAuthorsMap[projectPaper.paper]
+                ?.map { it.toGrpcAuthor() }.orEmpty()
+
+            val backwardRefs = paperBackwardReferencesMap[projectPaper.paper]
+                ?.map { it.toString() }.orEmpty()
+
+            projectPaper.toGrpcProjectPaper(
+                authors = authors,
+                backwardReferencedIds = backwardRefs,
+            )
+        },
+    )
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -2,7 +2,7 @@ package se.uulm.snowballr.backend.model.dto
 
 import snowballr.PaperOuterClass
 import snowballr.ProjectOuterClass
-import java.util.UUID
+import snowballr.ReviewOuterClass
 
 /**
  * Represents a relationship between a project paper and its associated paper.
@@ -20,22 +20,24 @@ data class ProjectPaperWithPaper(
 )
 
 /**
- * Converts a [ProjectPaperWithPaper] instance to a gRPC-compatible representation of
- * [ProjectOuterClass.Project.Paper].
+ * Converts a `ProjectPaperWithPaper` instance into a gRPC `ProjectOuterClass.Project.Paper` object.
  *
- * @param authors The list of gRPC authors to associate with the paper.
- * @param backwardReferencedIds The list of backward-referenced paper IDs.
- * @return A gRPC-compatible [ProjectOuterClass.Project.Paper] object containing the converted data.
+ * @param authors A list of authors represented as `PaperOuterClass.Author`, associated with the paper.
+ * @param backwardReferencedIds A list of strings representing the IDs of papers referenced by the current paper.
+ * @param reviews A list of reviews represented as `ReviewOuterClass.Review`, associated with the paper.
+ * @return A `ProjectOuterClass.Project.Paper` object constructed with data from the `ProjectPaperWithPaper` instance and the provided authors, backward references, and reviews.
  */
 fun ProjectPaperWithPaper.toGrpcProjectPaper(
     authors: List<PaperOuterClass.Author>,
     backwardReferencedIds: List<String>,
+    reviews: List<ReviewOuterClass.Review>,
 ): ProjectOuterClass.Project.Paper = ProjectOuterClass.Project.Paper
     .newBuilder()
     .setId(projectPaper.id.toString())
     .setPaper(paper.toGrpcPaper(authors, backwardReferencedIds))
     .setStage(projectPaper.stage)
     .setDecision(projectPaper.decision)
+    .addAllReviews(reviews)
     .setLocalId(projectPaper.localPaperId.toString())
     .build()
 
@@ -45,21 +47,23 @@ fun ProjectPaperWithPaper.toGrpcProjectPaper(
  * @return A [ProjectOuterClass.Project.Paper.List] containing the gRPC representation of the project papers.
  */
 fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
-    paperAuthorsMap: Map<Paper, List<Author>>,
-    paperBackwardReferencesMap: Map<Paper, List<UUID>>,
+    paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
+    paperBackwardReferencesMap: Map<Paper, List<String>>,
+    paperReviewsMap: Map<Paper, List<ReviewOuterClass.Review>>,
 ): ProjectOuterClass.Project.Paper.List = ProjectOuterClass.Project.Paper.List
     .newBuilder()
     .addAllProjectPapers(
         this.map { projectPaper ->
-            val authors = paperAuthorsMap[projectPaper.paper]
-                ?.map { it.toGrpcAuthor() }.orEmpty()
+            val authors = paperAuthorsMap[projectPaper.paper].orEmpty()
 
-            val backwardRefs = paperBackwardReferencesMap[projectPaper.paper]
-                ?.map { it.toString() }.orEmpty()
+            val backwardRefs = paperBackwardReferencesMap[projectPaper.paper].orEmpty()
+
+            val reviews = paperReviewsMap[projectPaper.paper].orEmpty()
 
             projectPaper.toGrpcProjectPaper(
                 authors = authors,
                 backwardReferencedIds = backwardRefs,
+                reviews = reviews,
             )
         },
     )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Review.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Review.kt
@@ -4,6 +4,7 @@ import se.uulm.snowballr.backend.table.association.ReviewTable
 import snowballr.ReviewOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID
+import kotlin.collections.orEmpty
 
 /**
  * DTO of [ReviewTable].
@@ -16,3 +17,25 @@ data class Review(
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
 )
+
+fun Review.toGrpcReview(selectedCriteriaIds: List<String>): ReviewOuterClass.Review = ReviewOuterClass.Review
+    .newBuilder()
+    .setId(id.toString())
+    .setUserId(userId.toString())
+    .setDecision(decision)
+    .addAllSelectedCriteriaIds(selectedCriteriaIds)
+    .build()
+
+fun List<Review>.toGrpcReviews(reviewSelectedCriteriaMap: Map<Review, List<String>>): ReviewOuterClass.Review.List =
+    ReviewOuterClass.Review.List
+        .newBuilder()
+        .addAllReviews(
+            this.map { review ->
+                val selectedCriteria = reviewSelectedCriteriaMap[review].orEmpty()
+
+                review.toGrpcReview(
+                    selectedCriteria,
+                )
+            },
+        )
+        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -1,0 +1,76 @@
+package se.uulm.snowballr.backend.repository.association
+
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.selectAll
+import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
+import se.uulm.snowballr.backend.table.PaperTable
+import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.table.association.toProjectPaper
+import se.uulm.snowballr.backend.table.association.toProjectPaperWithPaper
+import java.util.UUID
+
+/**
+ * Defines an interface for repository operations related to the [ProjectPaperTable].
+ *
+ * This interface provides abstraction for handling persistence and retrieval
+ * operations for project papers. By using this interface, the functionality for creating
+ * project papers can remain decoupled from the specifics of the database layer.
+ */
+interface IProjectPaperTableRepo {
+    /**
+     * Returns a project paper by its ID or throws a [NotFoundException] if the project paper with the passed [id] doesn't exist.
+     */
+    suspend fun getProjectPaperById(id: UUID): ProjectPaper
+
+    /**
+     * Retrieves a list of project papers along with their associated papers for the specified project.
+     *
+     * This method fetches data that combines information from a `ProjectPaper` and its related `Paper`
+     * for a given project, represented by its unique identifier.
+     *
+     * @param projectId The unique identifier of the project for which the project papers and
+     *                  their associated papers should be retrieved.
+     * @return A list of [ProjectPaperWithPaper] instances, each representing a relationship
+     *         between a project paper and its associated paper.
+     */
+    suspend fun getProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper>
+}
+
+/**
+ * Repository implementation for managing the [ProjectPaperTable] in the database.
+ *
+ * This class provides functionality to handle persistence and retrieval operations
+ * for project paper data by leveraging the database abstraction defined in [IDatabase]. It
+ * facilitates CRUD operations on project paper records associated with a given project and
+ * ensures database transactions are handled properly.
+ *
+ * @param db The database abstraction used for executing queries within a transaction.
+ */
+class ProjectPaperTableRepo(
+    private val db: IDatabase,
+) : IProjectPaperTableRepo {
+    private fun getProjectPaperByIdOrNull(id: UUID): ProjectPaper? = ProjectPaperTable.getEntityByIdOrNull(
+        id,
+        ResultRow::toProjectPaper,
+    )
+
+    override suspend fun getProjectPaperById(id: UUID): ProjectPaper = db.query {
+        getProjectPaperByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT_PAPER, id.toString())
+    }
+
+    override suspend fun getProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {
+        ProjectPaperTable
+            .join(ProjectTable, JoinType.INNER, onColumn = ProjectPaperTable.projectId, otherColumn = ProjectTable.id)
+            .join(PaperTable, JoinType.INNER, onColumn = ProjectPaperTable.paperId, otherColumn = PaperTable.id)
+            .selectAll()
+            .where { ProjectPaperTable.projectId eq projectId }
+            .map { it.toProjectPaperWithPaper() }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -10,7 +10,6 @@ import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
 import se.uulm.snowballr.backend.table.PaperTable
-import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.toProjectPaper
 import se.uulm.snowballr.backend.table.association.toProjectPaperWithPaper
@@ -40,7 +39,7 @@ interface IProjectPaperTableRepo {
      * @return A list of [ProjectPaperWithPaper] instances, each representing a relationship
      *         between a project paper and its associated paper.
      */
-    suspend fun getProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper>
+    suspend fun getAllProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper>
 }
 
 /**
@@ -65,9 +64,8 @@ class ProjectPaperTableRepo(
         getProjectPaperByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT_PAPER, id.toString())
     }
 
-    override suspend fun getProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {
+    override suspend fun getAllProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {
         ProjectPaperTable
-            .join(ProjectTable, JoinType.INNER, onColumn = ProjectPaperTable.projectId, otherColumn = ProjectTable.id)
             .join(PaperTable, JoinType.INNER, onColumn = ProjectPaperTable.paperId, otherColumn = PaperTable.id)
             .selectAll()
             .where { ProjectPaperTable.projectId eq projectId }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepo.kt
@@ -8,8 +8,8 @@ import java.util.UUID
 /**
  * Defines an interface for repository operations related to the [ReviewHasCriterionTable].
  *
- * This interface provides abstraction for handling persistence and retrieval operations for review criteria. By
- * using this interface, the functionality for managing review criteria can remain decoupled from the specifics of the database
+ * This interface provides abstraction for handling persistence and retrieval operations for selected criteria of a review. By
+ * using this interface, the functionality for managing selected criteria of a review can remain decoupled from the specifics of the database
  * layer.
  */
 interface IReviewHasCriterionTableRepo {
@@ -19,8 +19,8 @@ interface IReviewHasCriterionTableRepo {
 /**
  * Repository implementation for managing the [ReviewHasCriterionTable] in the database.
  *
- * This class provides functionality to handle persistence and retrieval operations for review criteria by
- * leveraging the database abstraction defined in [IDatabase]. It facilitates CRUD operations on review criteria and
+ * This class provides functionality to handle persistence and retrieval operations for selected criteria of a review by
+ * leveraging the database abstraction defined in [IDatabase]. It facilitates CRUD operations on selected criteria of a review and
  * ensures database transactions are handled properly.
  *
  * @param db The database abstraction used for executing queries within a transaction.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepo.kt
@@ -1,0 +1,37 @@
+package se.uulm.snowballr.backend.repository.association
+
+import org.jetbrains.exposed.sql.selectAll
+import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
+import java.util.UUID
+
+/**
+ * Defines an interface for repository operations related to the [ReviewHasCriterionTable].
+ *
+ * This interface provides abstraction for handling persistence and retrieval operations for review criteria. By
+ * using this interface, the functionality for managing review criteria can remain decoupled from the specifics of the database
+ * layer.
+ */
+interface IReviewHasCriterionTableRepo {
+    suspend fun getSelectedCriteriaIdsForReviewById(reviewId: UUID): List<UUID>
+}
+
+/**
+ * Repository implementation for managing the [ReviewHasCriterionTable] in the database.
+ *
+ * This class provides functionality to handle persistence and retrieval operations for review criteria by
+ * leveraging the database abstraction defined in [IDatabase]. It facilitates CRUD operations on review criteria and
+ * ensures database transactions are handled properly.
+ *
+ * @param db The database abstraction used for executing queries within a transaction.
+ */
+class ReviewHasCriterionTableRepo(
+    private val db: IDatabase,
+) : IReviewHasCriterionTableRepo {
+    override suspend fun getSelectedCriteriaIdsForReviewById(reviewId: UUID): List<UUID> = db.query {
+        ReviewHasCriterionTable
+            .selectAll()
+            .where { ReviewHasCriterionTable.reviewId eq reviewId }
+            .map { it[ReviewHasCriterionTable.criterionId].value }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepo.kt
@@ -1,0 +1,60 @@
+package se.uulm.snowballr.backend.repository.association
+
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.selectAll
+import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
+import se.uulm.snowballr.backend.table.association.ReviewTable
+import se.uulm.snowballr.backend.table.association.toReview
+import java.util.UUID
+
+/**
+ * Defines an interface for repository operations related to the [Review].
+ *
+ * This interface is used to handle persistence and retrieval operations for reviews by providing
+ * abstraction over the underlying database implementation. By using this interface, the logic
+ * for creating and managing reviews can remain decoupled from the specifics of the database layer.
+ */
+interface IReviewTableRepo {
+    /**
+     * Returns a review by its ID or throws a [NotFoundException] if the review with the passed [id] doesn't exist.
+     */
+    suspend fun getReviewById(id: UUID): Review
+
+    /**
+     * Retrieves all reviews associated with the specified project paper.
+     *
+     * @param projectPaperId The unique identifier of the project paper whose reviews are to be fetched.
+     * @return A list of reviews associated with the given project paper.
+     */
+    suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review>
+}
+
+/**
+ * Repository implementation for managing the [ReviewTable] in the database.
+ *
+ * This class handles the persistence and retrieval of review data by integrating
+ * with the underlying database through the [IDatabase] interface. It provides
+ * concrete methods for CRUD operations on review records within the database.
+ *
+ * @param db The database abstraction used for executing queries within a transaction.
+ */
+class ReviewTableRepo(
+    private val db: IDatabase,
+) : IReviewTableRepo {
+    private fun getReviewByIdOrNull(id: UUID): Review? = ReviewTable.getEntityByIdOrNull(id, ResultRow::toReview)
+
+    override suspend fun getReviewById(id: UUID): Review = db.query {
+        getReviewByIdOrNull(id) ?: throw NotFoundException(EntityType.REVIEW, id.toString())
+    }
+
+    override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {
+        ReviewTable
+            .selectAll()
+            .where { ReviewTable.projectPaperId eq projectPaperId }
+            .map { it.toReview() }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -12,6 +12,7 @@ package se.uulm.snowballr.backend.service
 interface IMainService :
     IProjectService,
     ICriterionService,
+    IReviewService,
     IUserService,
     IFetcherService,
     IReadingListService
@@ -24,6 +25,7 @@ interface IMainService :
  * @constructor Initializes the [MainService] with the required services.
  * @param projectService The service responsible for handling business logic related to projects.
  * @param criterionService The service responsible for handling business logic related to criteria.
+ * @param reviewService The service responsible for handling business logic related to reviews.
  * @param userService The service responsible for handling business logic related to users.
  * @param fetcherService The service responsible for handling business logic related to fetchers.
  * @param readingListService The service responsible for handling business logic related to reading lists.
@@ -31,12 +33,14 @@ interface IMainService :
 class MainService(
     private val projectService: IProjectService,
     private val criterionService: ICriterionService,
+    private val reviewService: IReviewService,
     private val userService: IUserService,
     private val fetcherService: IFetcherService,
     private val readingListService: IReadingListService,
 ) : IMainService,
     IProjectService by projectService,
     ICriterionService by criterionService,
+    IReviewService by reviewService,
     IUserService by userService,
     IFetcherService by fetcherService,
     IReadingListService by readingListService

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -6,19 +6,31 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.Author
+import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
+import se.uulm.snowballr.backend.model.dto.toGrpcProjectPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcProjectPapers
 import se.uulm.snowballr.backend.model.dto.toGrpcProjects
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
+import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
+import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
+import java.util.UUID
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
+@Suppress("ComplexInterface")
 interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectById].
@@ -62,6 +74,16 @@ interface IProjectService {
      * Service implementation of [SnowballRService.getProjectMembers].
      */
     suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List
+
+    /**
+     * Service implementation of [SnowballRService.getProjectPaperById].
+     */
+    suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper
+
+    /**
+     * Service implementation of [SnowballRService.getAllProjectPapersForProject].
+     */
+    suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List
 }
 
 /**
@@ -75,12 +97,22 @@ interface IProjectService {
  * @param userRepo The repository responsible for managing persistence operations for users.
  * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
  * @param criterionRepo The repository responsible for managing persistence operations for criteria.
+ * @param paperRepo The repository responsible for managing persistence operations for papers.
+ * @param projectPaperRepo The repository responsible for managing persistence operations for project papers.
+ * @param authorOfPaperTableRepo The repository responsible for managing persistence operations for the author
+ * paper relation.
+ * @param citationTableRepo The repository responsible for managing persistence operations for the citation relation.
  */
+@Suppress("LongParameterList")
 class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val criterionRepo: ICriterionTableRepo,
+    private val paperRepo: IPaperTableRepo,
+    private val projectPaperRepo: IProjectPaperTableRepo,
+    private val authorOfPaperTableRepo: IAuthorOfPaperTableRepo,
+    private val citationTableRepo: ICitationTableRepo,
 ) : IProjectService {
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
@@ -204,5 +236,60 @@ class ProjectService(
             }
         }
         return projectMembersWithUsers.toGrpcProjectMembers()
+    }
+
+    override suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
+        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId)
+        val projectId = projectPaper.projectId
+        val isInProject = projectMemberRepo.getProjectMembers(projectId)
+            .any { it.userId == currentUser.id }
+
+        if (!isInProject) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+
+        val paper = paperRepo.getPaperById(projectPaper.paperId)
+        val authors = authorOfPaperTableRepo.getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
+        val backwardReferences = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(
+            paper.id,
+        ).map { it.toString() }
+        return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences)
+    }
+
+    override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+        repo.getProjectById(projectId)
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+        if (!projectMembers.any { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+
+        val projectPapersWithPapers = projectPaperRepo.getProjectPapersWithPapers(projectId)
+        val paperAuthorsMap = mutableMapOf<Paper, List<Author>>()
+        val paperBackwardReferencesMap = mutableMapOf<Paper, List<UUID>>()
+        for (projectPaper in projectPapersWithPapers) {
+            val paper = projectPaper.paper
+            paperAuthorsMap[paper] = authorOfPaperTableRepo.getAuthorsOfPaperById(paper.id)
+            paperBackwardReferencesMap[paper] = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        }
+        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -6,7 +6,6 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
-import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
@@ -15,6 +14,7 @@ import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPapers
 import se.uulm.snowballr.backend.model.dto.toGrpcProjects
+import se.uulm.snowballr.backend.model.dto.toGrpcReview
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
@@ -24,10 +24,13 @@ import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import snowballr.Base
 import snowballr.CriterionOuterClass
+import snowballr.PaperOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
-import java.util.UUID
+import snowballr.ReviewOuterClass
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @Suppress("ComplexInterface")
@@ -102,6 +105,9 @@ interface IProjectService {
  * @param authorOfPaperTableRepo The repository responsible for managing persistence operations for the author
  * paper relation.
  * @param citationTableRepo The repository responsible for managing persistence operations for the citation relation.
+ * @param reviewTableRepo The repository responsible for managing persistence operations for the reviews
+ * @param reviewHasCriterionTableRepo The repository responsible for managing persistence operations for the review has
+ * criterion relation.
  */
 @Suppress("LongParameterList")
 class ProjectService(
@@ -113,6 +119,8 @@ class ProjectService(
     private val projectPaperRepo: IProjectPaperTableRepo,
     private val authorOfPaperTableRepo: IAuthorOfPaperTableRepo,
     private val citationTableRepo: ICitationTableRepo,
+    private val reviewTableRepo: IReviewTableRepo,
+    private val reviewHasCriterionTableRepo: IReviewHasCriterionTableRepo,
 ) : IProjectService {
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
@@ -243,10 +251,9 @@ class ProjectService(
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId)
         val projectId = projectPaper.projectId
-        val isInProject = projectMemberRepo.getProjectMembers(projectId)
-            .any { it.userId == currentUser.id }
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
 
-        if (!isInProject) {
+        if (!projectMembers.any { it.userId == currentUser.id }) {
             verifyServerAdminRole(currentUser) {
                 throw UnauthorizedException.Single(
                     EntityType.PROJECT,
@@ -262,7 +269,13 @@ class ProjectService(
         val backwardReferences = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(
             paper.id,
         ).map { it.toString() }
-        return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences)
+        val reviews = reviewTableRepo.getAllReviewsForProjectPaper(projectPaperId)
+            .map {
+                val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
+                it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
+            }
+
+        return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
     }
 
     override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List {
@@ -282,14 +295,26 @@ class ProjectService(
             }
         }
 
-        val projectPapersWithPapers = projectPaperRepo.getProjectPapersWithPapers(projectId)
-        val paperAuthorsMap = mutableMapOf<Paper, List<Author>>()
-        val paperBackwardReferencesMap = mutableMapOf<Paper, List<UUID>>()
+        val projectPapersWithPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
+        val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
+        val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
+        val paperReviewsMap = mutableMapOf<Paper, List<ReviewOuterClass.Review>>()
         for (projectPaper in projectPapersWithPapers) {
             val paper = projectPaper.paper
-            paperAuthorsMap[paper] = authorOfPaperTableRepo.getAuthorsOfPaperById(paper.id)
-            paperBackwardReferencesMap[paper] = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            paperAuthorsMap[paper] = authorOfPaperTableRepo
+                .getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
+            paperBackwardReferencesMap[paper] = citationTableRepo
+                .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map {
+                    it.toString()
+                }
+            paperReviewsMap[paper] = reviewTableRepo
+                .getAllReviewsForProjectPaper(projectPaper.projectPaper.id)
+                .map {
+                    val selectedCriteriaIds = reviewHasCriterionTableRepo
+                        .getSelectedCriteriaIdsForReviewById(it.id)
+                    it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
+                }
         }
-        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap)
+        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -1,0 +1,110 @@
+package se.uulm.snowballr.backend.service
+
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.toGrpcReview
+import se.uulm.snowballr.backend.model.dto.toGrpcReviews
+import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
+import snowballr.Base
+import snowballr.ReviewOuterClass.Review as GrpcReview
+
+interface IReviewService {
+    /**
+     * Service implementation of [SnowballRService.getReviewById].
+     */
+    suspend fun getReviewById(request: Base.Id): GrpcReview
+
+    /**
+     * Service implementation of [SnowballRService.getAllReviewsForProjectPaper].
+     */
+    suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List
+}
+
+/**
+ * The [ReviewService] class handles operations related to projects by implementing the [IReviewService] interface.
+ *
+ * The `Review` class provides functionality for managing reviews, including
+ * creating, retrieving, and updating them. It also handles validation of access permissions,
+ * preconditions, and interactions with underlying repositories.
+ *
+ * This service ensures that all operations related to reviews are performed
+ * in accordance with the project and user access rules.
+ *
+ * @param repo Interface for persistence and retrieval operations related to reviews.
+ * @param userRepo Interface for persistence and retrieval operations related to users.
+ * @param projectPaperRepo Interface for persistence and retrieval operations related to project papers.
+ * @param projectRepo Interface for persistence and retrieval operations related to projects.
+ * @param projectMemberRepo Interface for persistence and retrieval operations related to project members.
+ * @param reviewHasCriterionRepo Interface for persistence and retrieval operations related to review criteria.
+ */
+class ReviewService(
+    private val repo: IReviewTableRepo,
+    private val userRepo: IUserTableRepo,
+    private val projectPaperRepo: IProjectPaperTableRepo,
+    private val projectRepo: IProjectTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
+    private val reviewHasCriterionRepo: IReviewHasCriterionTableRepo,
+) : IReviewService {
+    override suspend fun getReviewById(request: Base.Id): GrpcReview {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val reviewId = parseUUID(request.id, EntityType.REVIEW)
+        val review = repo.getReviewById(reviewId)
+        val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId)
+        val projectId = projectRepo.getProjectById(projectPaper.projectId).id
+
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+        if (!projectMembers.any { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+        val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(reviewId)
+        return review.toGrpcReview(selectedCriteriaIds.map { it.toString() })
+    }
+
+    override suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
+        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId)
+        val projectId = projectRepo.getProjectById(projectPaper.projectId).id
+
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+        if (!projectMembers.any { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+
+        val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
+        val reviewSelectedCriteriaMap = mutableMapOf<Review, List<String>>()
+        for (review in reviews) {
+            reviewSelectedCriteriaMap[review] = reviewHasCriterionRepo
+                .getSelectedCriteriaIdsForReviewById(review.id).map {
+                    it.toString()
+                }
+        }
+        return reviews.toGrpcReviews(reviewSelectedCriteriaMap)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/association/ProjectPaperTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/association/ProjectPaperTable.kt
@@ -4,12 +4,14 @@ import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.createdAt
 import se.uulm.snowballr.backend.table.createdBy
 import se.uulm.snowballr.backend.table.modifiedAt
 import se.uulm.snowballr.backend.table.modifiedBy
+import se.uulm.snowballr.backend.table.toPaper
 import snowballr.ProjectOuterClass
 import java.time.OffsetDateTime
 
@@ -78,4 +80,12 @@ fun ResultRow.toProjectPaper() = ProjectPaper(
     createdBy = this[ProjectPaperTable.createdBy].value,
     modifiedAt = this[ProjectPaperTable.modifiedAt],
     modifiedBy = this[ProjectPaperTable.modifiedBy]?.value,
+)
+
+/**
+ * Creates a [ProjectPaperWithPaper] from this [ResultRow].
+ */
+fun ResultRow.toProjectPaperWithPaper() = ProjectPaperWithPaper(
+    projectPaper = toProjectPaper(),
+    paper = toPaper(),
 )

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
+import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
@@ -17,6 +18,7 @@ import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
+import snowballr.ReviewOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
@@ -229,6 +231,22 @@ object DataBuilder {
         firstName,
         lastName,
         orcid,
+        createdAt,
+        modifiedAt,
+    )
+
+    fun createExampleReview(
+        id: UUID = UUID.randomUUID(),
+        projectPaperId: UUID = UUID.randomUUID(),
+        userId: UUID = UUID.randomUUID(),
+        decision: ReviewOuterClass.ReviewDecision = ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED,
+        createdAt: OffsetDateTime = OffsetDateTime.now(),
+        modifiedAt: OffsetDateTime? = null,
+    ) = Review(
+        id,
+        projectPaperId,
+        userId,
+        decision,
         createdAt,
         modifiedAt,
     )

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -6,11 +6,13 @@ import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
 import snowballr.Base
 import snowballr.CriterionOuterClass.CriterionCategory
+import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
@@ -187,6 +189,30 @@ object DataBuilder {
         pdfId,
         fetcherMetadata,
         createdAt,
+        modifiedAt,
+        modifiedBy,
+    )
+
+    fun createExampleProjectPaper(
+        id: UUID = UUID.randomUUID(),
+        paperId: UUID = UUID.randomUUID(),
+        projectId: UUID = UUID.randomUUID(),
+        localPaperId: Long = 0,
+        stage: Long = 0,
+        decision: ProjectOuterClass.PaperDecision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+        createdAt: OffsetDateTime = OffsetDateTime.now(),
+        createdBy: UUID = UUID.randomUUID(),
+        modifiedAt: OffsetDateTime? = null,
+        modifiedBy: UUID? = null,
+    ) = ProjectPaper(
+        id,
+        paperId,
+        projectId,
+        localPaperId,
+        stage,
+        decision,
+        createdAt,
+        createdBy,
         modifiedAt,
         modifiedBy,
     )

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.repository
 import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -19,15 +17,12 @@ import se.uulm.snowballr.backend.model.dto.Criterion.UserCriterion
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
-import se.uulm.snowballr.backend.repository.RepositoryHelper.insertTestProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndGetId
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
-import se.uulm.snowballr.backend.table.toProjectCriterion
-import se.uulm.snowballr.backend.table.toUserCriterion
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
-import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
 import kotlin.test.assertIs
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
@@ -44,23 +39,6 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         return projectRepo.createProject(request, testUserId, DataBuilder.createExampleUserSettings())
     }
 
-    private suspend fun insertTestCriterionAndGetId(
-        tag: String = "Test Tag",
-        name: String = "Test Criterion",
-        description: String = "Test Description",
-        category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
-        projectId: UUID? = UUID.randomUUID(),
-    ): UUID = db.query {
-        CriterionTable.insertAndGetId {
-            it[CriterionTable.tag] = tag
-            it[CriterionTable.name] = name
-            it[CriterionTable.description] = description
-            it[CriterionTable.category] = category
-            it[CriterionTable.projectId] = projectId
-            it[CriterionTable.createdBy] = testUserId
-        }.value
-    }
-
     companion object {
         @JvmStatic
         fun validFieldMasks(): List<Arguments> = listOf(
@@ -72,35 +50,11 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
     }
 
     @Nested
-    inner class Mapper {
-        @Test
-        fun `When project criterion is converted to user criterion, then exception is thrown`() = runTest {
-            val projectId = insertTestProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, testUserId)
-            val id = insertTestCriterionAndGetId(projectId = projectId)
-            assertThrows<IllegalArgumentException> {
-                db.query {
-                    CriterionTable.getEntityByIdOrNull(id, ResultRow::toUserCriterion)
-                }
-            }
-        }
-
-        @Test
-        fun `When user criterion is converted to project criterion, then exception is thrown`() = runTest {
-            val id = insertTestCriterionAndGetId(projectId = null)
-            assertThrows<IllegalArgumentException> {
-                db.query {
-                    CriterionTable.getEntityByIdOrNull(id, ResultRow::toProjectCriterion)
-                }
-            }
-        }
-    }
-
-    @Nested
     inner class GetCriterionById {
         @Test
         fun `When a criterion is found, then the correct criterion is returned`() = runTest {
             val projectId = createExampleProject().id
-            val criterionId = insertTestCriterionAndGetId(projectId = projectId)
+            val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
             val criterion = repo.getCriterionById(criterionId)
 
             assertIs<ProjectCriterion>(criterion)
@@ -338,7 +292,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             fieldMask: List<String>,
         ) = runTest {
             val projectId = createExampleProject().id
-            val criterionId = insertTestCriterionAndGetId(projectId = projectId)
+            val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
             val originalCriterion = repo.getCriterionById(criterionId)
 
             val updatedCriterionDetails = originalCriterion.toGrpcCriterion().toBuilder()

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -20,7 +20,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
     inner class GetPaperById {
         @Test
         fun `When a paper is found, then the correct paper is returned`() = runTest {
-            val paperId = insertPaperAndGetId()
+            val paperId = insertPaperAndGetId(externalId = "ExternalId")
             val paper = repo.getPaperById(paperId)
 
             with(paper) {

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -26,9 +26,6 @@ import java.util.UUID
 class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectTableRepo(db)
 
-    private suspend fun insertTestProjectAndGetId(name: String, status: ProjectStatus) =
-        insertProjectAndGetId(name = name, status = status, createdBy = testUserId)
-
     companion object {
         @JvmStatic
         fun validFieldMasks(): List<Arguments> = listOf(

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -14,7 +14,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
-import se.uulm.snowballr.backend.repository.RepositoryHelper.insertTestProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import snowballr.ProjectOuterClass.Project
@@ -27,7 +27,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
     private val repo = ProjectTableRepo(db)
 
     private suspend fun insertTestProjectAndGetId(name: String, status: ProjectStatus) =
-        insertTestProjectAndGetId(name, status, testUserId)
+        insertProjectAndGetId(name = name, status = status, createdBy = testUserId)
 
     companion object {
         @JvmStatic
@@ -44,7 +44,8 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
     inner class GetProjectById {
         @Test
         fun `When a project is found, then the correct project is returned`() = runTest {
-            val projectId = insertTestProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val projectId =
+                insertProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
             val project = repo.getProjectById(projectId)
 
             assertThat(project.id).isEqualTo(projectId)
@@ -106,8 +107,14 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
     inner class GetAllProjects {
         @Test
         fun `When projects are found, then all projects are returned`() = runTest {
-            val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            val project1Id =
+                insertProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+            val project2Id =
+                insertProjectAndGetId(
+                    "Test Project 2",
+                    ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+                    createdBy = testUserId,
+                )
 
             val projects = repo.getAllProjects()
             assertThat(projects).hasSize(2)
@@ -119,9 +126,12 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
 
         @Test
         fun `When archived and deleted projects exist, then they are not returned`() = runTest {
-            val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
+            val project1Id =
+                insertProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+            val project2Id =
+                insertProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ARCHIVED, createdBy = testUserId)
+            val project3Id =
+                insertProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED, createdBy = testUserId)
 
             val projects = repo.getAllProjects()
             assertThat(projects).hasSize(1)
@@ -143,7 +153,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         ) = runTest {
             val projectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE
             val projectId =
-                insertTestProjectAndGetId(name = "Test Project", projectStatus)
+                insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
             val originalProject = repo.getProjectById(projectId)
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
@@ -199,7 +209,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         ) = runTest {
             val projectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
             val projectId =
-                insertTestProjectAndGetId(name = "Test Project", projectStatus)
+                insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
             val originalProject = repo.getProjectById(projectId)
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
@@ -243,7 +253,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         ) = runTest {
             val projectStatus = ProjectStatus.PROJECT_STATUS_ARCHIVED
             val projectId =
-                insertTestProjectAndGetId(name = "Test Project", projectStatus)
+                insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
             val originalProject = repo.getProjectById(projectId)
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
@@ -282,10 +292,22 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         @Test
         fun `When active projects are found where the user is member of, then all (and only these) active projects are returned`() =
             runTest {
-                val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-                val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-                val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-                val project4Id = insertTestProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_ACTIVE)
+                val project1Id =
+                    insertProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+                val project2Id =
+                    insertProjectAndGetId(
+                        "Test Project 2",
+                        ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+                        createdBy = testUserId,
+                    )
+                val project3Id =
+                    insertProjectAndGetId(
+                        "Test Project 3",
+                        ProjectStatus.PROJECT_STATUS_ARCHIVED,
+                        createdBy = testUserId,
+                    )
+                val project4Id =
+                    insertProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
 
                 val userId = createExampleUser("userWithActiveProjects@example.com")
 
@@ -305,10 +327,26 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         @Test
         fun `When archived projects are found where the user is member of, then all (and only these) archived projects are returned`() =
             runTest {
-                val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-                val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-                val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-                val project4Id = insertTestProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_ARCHIVED)
+                val project1Id =
+                    insertProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+                val project2Id =
+                    insertProjectAndGetId(
+                        "Test Project 2",
+                        ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+                        createdBy = testUserId,
+                    )
+                val project3Id =
+                    insertProjectAndGetId(
+                        "Test Project 3",
+                        ProjectStatus.PROJECT_STATUS_ARCHIVED,
+                        createdBy = testUserId,
+                    )
+                val project4Id =
+                    insertProjectAndGetId(
+                        "Test Project 4",
+                        ProjectStatus.PROJECT_STATUS_ARCHIVED,
+                        createdBy = testUserId,
+                    )
 
                 val userId = createExampleUser("userWithActiveProjects@example.com")
 
@@ -328,10 +366,26 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         @Test
         fun `When deleted projects are found where the user is member of, then all (and only these) deleted projects are returned`() =
             runTest {
-                val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE)
-                val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-                val project3Id = insertTestProjectAndGetId("Test Project 3", ProjectStatus.PROJECT_STATUS_DELETED)
-                val project4Id = insertTestProjectAndGetId("Test Project 4", ProjectStatus.PROJECT_STATUS_DELETED)
+                val project1Id =
+                    insertProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+                val project2Id =
+                    insertProjectAndGetId(
+                        "Test Project 2",
+                        ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+                        createdBy = testUserId,
+                    )
+                val project3Id =
+                    insertProjectAndGetId(
+                        "Test Project 3",
+                        ProjectStatus.PROJECT_STATUS_DELETED,
+                        createdBy = testUserId,
+                    )
+                val project4Id =
+                    insertProjectAndGetId(
+                        "Test Project 4",
+                        ProjectStatus.PROJECT_STATUS_DELETED,
+                        createdBy = testUserId,
+                    )
 
                 val userId = createExampleUser("userWithActiveProjects@example.com")
 
@@ -350,8 +404,10 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
 
         @Test
         fun `When no projects are found where the user is member of, then no projects are returned`() = runTest {
-            val project1Id = insertTestProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val project2Id = insertTestProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_DELETED)
+            val project1Id =
+                insertProjectAndGetId("Test Project 1", ProjectStatus.PROJECT_STATUS_ARCHIVED, createdBy = testUserId)
+            val project2Id =
+                insertProjectAndGetId("Test Project 2", ProjectStatus.PROJECT_STATUS_DELETED, createdBy = testUserId)
 
             val userId = createExampleUser("userWithActiveProjects@example.com")
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -9,8 +9,12 @@ import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
 import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
+import snowballr.ProjectOuterClass.SnowballingType
 import snowballr.UserOuterClass
 import java.util.UUID
 
@@ -90,24 +94,50 @@ object RepositoryHelper {
         }.value
     }
 
-    /**
-     * Creates an example project in the database with the specified properties.
-     */
-    suspend fun insertTestProjectAndGetId(name: String, status: ProjectOuterClass.ProjectStatus, userId: UUID): UUID =
-        db.query {
-            ProjectTable
-                .insertAndGetId {
-                    it[ProjectTable.name] = name
-                    it[ProjectTable.status] = status
-                    it[currentStage] = 0
-                    it[maxStage] = 0
-                    it[similarityThreshold] = 0F
-                    it[snowballingType] = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
-                    it[reviewMaybeAllowed] = true
-                    it[reviewDecisionMatrixBinary] =
-                        ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
-                    it[fetchers] = emptyMap()
-                    it[createdBy] = userId
-                }.value
-        }
+    @Suppress("LongParameterList")
+    suspend fun insertProjectAndGetId(
+        name: String = "Test Project",
+        status: ProjectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE,
+        currentStage: Long = 0,
+        maxStage: Long = 0,
+        similarityThreshold: Float = 0F,
+        snowballingType: SnowballingType = SnowballingType.SNOWBALLING_TYPE_BOTH,
+        reviewMaybeAllowed: Boolean = true,
+        reviewDecisionMatrix: ReviewDecisionMatrix = ReviewDecisionMatrix.getDefaultInstance(),
+        fetcherApis: Map<String, Map<String, String>> = emptyMap(),
+        createdBy: UUID,
+    ): UUID = db.query {
+        ProjectTable
+            .insertAndGetId {
+                it[ProjectTable.name] = name
+                it[ProjectTable.status] = status
+                it[ProjectTable.currentStage] = currentStage
+                it[ProjectTable.maxStage] = maxStage
+                it[ProjectTable.similarityThreshold] = similarityThreshold
+                it[ProjectTable.snowballingType] = snowballingType
+                it[ProjectTable.reviewMaybeAllowed] = reviewMaybeAllowed
+                it[ProjectTable.reviewDecisionMatrixBinary] = reviewDecisionMatrix.toByteArray()
+                it[ProjectTable.fetchers] = fetchers
+                it[ProjectTable.createdBy] = createdBy
+            }.value
+    }
+
+    @Suppress("LongParameterList")
+    suspend fun insertProjectPaperAndGetId(
+        paperId: UUID,
+        projectId: UUID,
+        localPaperId: Long = 0,
+        stage: Long = 0,
+        decision: ProjectOuterClass.PaperDecision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+        createdBy: UUID,
+    ): UUID = db.query {
+        ProjectPaperTable.insertAndGetId {
+            it[ProjectPaperTable.paperId] = paperId
+            it[ProjectPaperTable.projectId] = projectId
+            it[ProjectPaperTable.localPaperId] = localPaperId
+            it[ProjectPaperTable.stage] = stage
+            it[ProjectPaperTable.decision] = decision
+            it[ProjectPaperTable.createdBy] = createdBy
+        }.value
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -123,7 +123,7 @@ object RepositoryHelper {
                 it[ProjectTable.snowballingType] = snowballingType
                 it[ProjectTable.reviewMaybeAllowed] = reviewMaybeAllowed
                 it[ProjectTable.reviewDecisionMatrixBinary] = reviewDecisionMatrix.toByteArray()
-                it[ProjectTable.fetchers] = fetchers
+                it[ProjectTable.fetchers] = fetcherApis
                 it[ProjectTable.createdBy] = createdBy
             }.value
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -2,19 +2,25 @@ package se.uulm.snowballr.backend.repository
 
 import kotlinx.datetime.Instant
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
+import se.uulm.snowballr.backend.table.association.ReviewTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
+import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
+import snowballr.ReviewOuterClass
 import snowballr.UserOuterClass
 import java.util.UUID
 
@@ -74,7 +80,7 @@ object RepositoryHelper {
     @Suppress("LongParameterList")
     suspend fun insertPaperAndGetId(
         title: String = "Title",
-        externalId: String = "ExternalId",
+        externalId: String = UUID.randomUUID().toString(),
         abstract: String = "Abstract",
         publishedAt: Instant = Instant.fromEpochSeconds(0),
         publisher: String = "Publisher",
@@ -139,5 +145,44 @@ object RepositoryHelper {
             it[ProjectPaperTable.decision] = decision
             it[ProjectPaperTable.createdBy] = createdBy
         }.value
+    }
+
+    @Suppress("LongParameterList")
+    suspend fun insertReviewAndGetId(
+        projectPaperId: UUID,
+        userId: UUID,
+        decision: ReviewOuterClass.ReviewDecision = ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED,
+    ): UUID = db.query {
+        ReviewTable.insertAndGetId {
+            it[ReviewTable.projectPaperId] = projectPaperId
+            it[ReviewTable.userId] = userId
+            it[ReviewTable.decision] = decision
+        }.value
+    }
+
+    @Suppress("LongParameterList")
+    suspend fun insertCriterionAndGetId(
+        tag: String = "Test Tag",
+        name: String = "Test Criterion",
+        description: String = "Test Description",
+        category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
+        projectId: UUID,
+        createdBy: UUID,
+    ): UUID = db.query {
+        CriterionTable.insertAndGetId {
+            it[CriterionTable.tag] = tag
+            it[CriterionTable.name] = name
+            it[CriterionTable.description] = description
+            it[CriterionTable.category] = category
+            it[CriterionTable.projectId] = projectId
+            it[CriterionTable.createdBy] = createdBy
+        }.value
+    }
+
+    suspend fun assignCriterionToReview(reviewId: UUID, criterionId: UUID) = db.query {
+        ReviewHasCriterionTable.insert {
+            it[ReviewHasCriterionTable.reviewId] = reviewId
+            it[ReviewHasCriterionTable.criterionId] = criterionId
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -41,7 +41,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
         }
 
         @Test
-        fun `When a criterion is not found, then an exception is thrown`() = runTest {
+        fun `When a project paper is not found, then an exception is thrown`() = runTest {
             assertThrows<NotFoundException> { repo.getProjectPaperById(UUID.randomUUID()) }
         }
     }
@@ -58,7 +58,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 val projectPaper = repo.getProjectPaperById(projectPaperId)
 
                 val paper = paperRepo.getPaperById(paperId)
-                val projectPapers = repo.getProjectPapersWithPapers(projectId)
+                val projectPapers = repo.getAllProjectPapersWithPapers(projectId)
 
                 assertThat(projectPapers).hasSize(1)
                 assertThat(projectPapers).anyMatch { it.projectPaper == projectPaper }
@@ -78,10 +78,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId2, createdBy = testUserId)
 
                 val paper = paperRepo.getPaperById(paperId)
-                val projectPapers = repo.getProjectPapersWithPapers(projectId1)
-
-                assertThat(projectPapers).hasSize(1)
-                assertThat(projectPapers).anyMatch { it.paper == paper }
+                val projectPapers = repo.getAllProjectPapersWithPapers(projectId1)
 
                 assertThat(projectPapers).hasSize(1)
                 assertThat(projectPapers).anyMatch { it.projectPaper == projectPaper }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -1,0 +1,92 @@
+package se.uulm.snowballr.backend.repository.association
+
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.repository.PaperTableRepo
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryTest
+import se.uulm.snowballr.backend.table.PaperTable
+import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import snowballr.ProjectOuterClass
+import java.util.UUID
+
+class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, ProjectTable, PaperTable), true) {
+    private val repo = ProjectPaperTableRepo(db)
+    private val paperRepo = PaperTableRepo(db)
+
+    @Nested
+    inner class GetProjectPaperById {
+        @Test
+        fun `When a project paper is found, then the correct project paper is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val projectPaper = repo.getProjectPaperById(projectPaperId)
+
+            assertThat(projectPaper.id).isEqualTo(projectPaperId)
+            assertThat(projectPaper.projectId).isEqualTo(projectId)
+            assertThat(projectPaper.paperId).isEqualTo(paperId)
+            assertThat(projectPaper.localPaperId).isEqualTo(0)
+            assertThat(projectPaper.stage).isEqualTo(0)
+            assertThat(projectPaper.decision).isEqualTo(ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED)
+            assertThat(projectPaper.createdBy).isEqualTo(testUserId)
+        }
+
+        @Test
+        fun `When a criterion is not found, then an exception is thrown`() = runTest {
+            assertThrows<NotFoundException> { repo.getProjectPaperById(UUID.randomUUID()) }
+        }
+    }
+
+    @Nested
+    inner class GetProjectMembersWithUsers {
+        @Test
+        fun `When a project, a project paper and the corresponding paper exists, then the project paper with paper is correctly returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+                val projectPaper = repo.getProjectPaperById(projectPaperId)
+
+                val paper = paperRepo.getPaperById(paperId)
+                val projectPapers = repo.getProjectPapersWithPapers(projectId)
+
+                assertThat(projectPapers).hasSize(1)
+                assertThat(projectPapers).anyMatch { it.projectPaper == projectPaper }
+                assertThat(projectPapers).anyMatch { it.paper == paper }
+            }
+
+        @Test
+        fun `When not all project papers are papers of the selected project, then only the correct project papers with papers are returned`() =
+            runTest {
+                val projectId1 = insertProjectAndGetId(createdBy = testUserId)
+                val projectId2 = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId1, createdBy = testUserId)
+                val projectPaper = repo.getProjectPaperById(projectPaperId)
+                val nonProjectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId2, createdBy = testUserId)
+
+                val paper = paperRepo.getPaperById(paperId)
+                val projectPapers = repo.getProjectPapersWithPapers(projectId1)
+
+                assertThat(projectPapers).hasSize(1)
+                assertThat(projectPapers).anyMatch { it.paper == paper }
+
+                assertThat(projectPapers).hasSize(1)
+                assertThat(projectPapers).anyMatch { it.projectPaper == projectPaper }
+                assertThat(projectPapers).anyMatch { it.paper == paper }
+                assertThat(projectPapers).noneMatch { it.projectPaper.id == nonProjectPaperId }
+            }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepoTest.kt
@@ -49,7 +49,7 @@ class ReviewHasCriterionTableRepoTest : RepositoryTest(
         }
 
         @Test
-        fun `When a no selected criteria for the given review exist, then an empty list is returned`() = runTest {
+        fun `When no selected criteria for the given review exist, then an empty list is returned`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             val paperId = insertPaperAndGetId()
             val projectPaperId =

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepoTest.kt
@@ -1,0 +1,87 @@
+package se.uulm.snowballr.backend.repository.association
+
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.repository.RepositoryHelper.assignCriterionToReview
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryTest
+import se.uulm.snowballr.backend.table.CriterionTable
+import se.uulm.snowballr.backend.table.PaperTable
+import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
+import se.uulm.snowballr.backend.table.association.ReviewTable
+
+class ReviewHasCriterionTableRepoTest : RepositoryTest(
+    arrayOf(
+        ReviewHasCriterionTable,
+        ProjectTable,
+        PaperTable,
+        ProjectPaperTable,
+        ReviewTable,
+        CriterionTable,
+    ),
+    true,
+) {
+    private val repo = ReviewHasCriterionTableRepo(db)
+
+    @Nested
+    inner class GetSelectedCriteriaIdsForReviewById {
+        @Test
+        fun `When a selected criteria for the given review exist, then the criteria ids are returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
+            val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+            assignCriterionToReview(reviewId, criterionId)
+            val selectedCriteriaIds = repo.getSelectedCriteriaIdsForReviewById(reviewId)
+
+            assertThat(selectedCriteriaIds).hasSize(1)
+            assertThat(selectedCriteriaIds).anyMatch { it == criterionId }
+        }
+
+        @Test
+        fun `When a no selected criteria for the given review exist, then an empty list is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
+            insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+            val selectedCriteriaIds = repo.getSelectedCriteriaIdsForReviewById(reviewId)
+
+            assertThat(selectedCriteriaIds).isEmpty()
+        }
+
+        @Test
+        fun `When a selected criteria for the given review exist beside other criteria for other reviews, then only the selected criteria ids for the given review are returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val projectPaperId1 =
+                    insertProjectPaperAndGetId(paperId = paperId1, projectId = projectId, createdBy = testUserId)
+                val projectPaperId2 =
+                    insertProjectPaperAndGetId(paperId = paperId2, projectId = projectId, createdBy = testUserId)
+                val reviewId1 = insertReviewAndGetId(projectPaperId1, userId = testUserId)
+                val reviewId2 = insertReviewAndGetId(projectPaperId2, userId = testUserId)
+                val criterionId1 = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+                val criterionId2 = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+                assignCriterionToReview(reviewId1, criterionId1)
+                assignCriterionToReview(reviewId2, criterionId2)
+                val selectedCriteriaIds = repo.getSelectedCriteriaIdsForReviewById(reviewId1)
+
+                assertThat(selectedCriteriaIds).hasSize(1)
+                assertThat(selectedCriteriaIds).anyMatch { it == criterionId1 }
+                assertThat(selectedCriteriaIds).noneMatch { it == criterionId2 }
+            }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepoTest.kt
@@ -47,7 +47,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
     @Nested
     inner class GetAllReviewsForProjectPaper {
         @Test
-        fun `When a the project paper has reviews, then the reviews are correctly returned`() = runTest {
+        fun `When the project paper has reviews, then the reviews are correctly returned`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             val paperId = insertPaperAndGetId()
             val projectPaperId =
@@ -60,7 +60,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
         }
 
         @Test
-        fun `When a the project paper has no reviews, then an empty list is returned`() = runTest {
+        fun `When the project paper has no reviews, then an empty list is returned`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             val paperId1 = insertPaperAndGetId()
             val paperId2 = insertPaperAndGetId()
@@ -82,7 +82,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
         }
 
         @Test
-        fun `When a the project paper has no reviews and other reviews exist, then only the project paper reviews are returned`() =
+        fun `When the project paper has no reviews and other reviews exist, then only the project paper reviews are returned`() =
             runTest {
                 val projectId = insertProjectAndGetId(createdBy = testUserId)
                 val paperId1 = insertPaperAndGetId()

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepoTest.kt
@@ -1,0 +1,109 @@
+package se.uulm.snowballr.backend.repository.association
+
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryTest
+import se.uulm.snowballr.backend.table.PaperTable
+import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.table.association.ReviewTable
+import snowballr.ReviewOuterClass
+import java.util.UUID
+
+class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable), true) {
+    private val repo = ReviewTableRepo(db)
+
+    @Nested
+    inner class GetReviewById {
+        @Test
+        fun `When a review is found, then the correct review is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
+            val review = repo.getReviewById(reviewId)
+
+            assertThat(review.id).isEqualTo(reviewId)
+            assertThat(review.projectPaperId).isEqualTo(projectPaperId)
+            assertThat(review.userId).isEqualTo(testUserId)
+            assertThat(review.decision).isEqualTo(ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED)
+        }
+
+        @Test
+        fun `When a review is not found, then an exception is thrown`() = runTest {
+            assertThrows<NotFoundException> { repo.getReviewById(UUID.randomUUID()) }
+        }
+    }
+
+    @Nested
+    inner class GetAllReviewsForProjectPaper {
+        @Test
+        fun `When a the project paper has reviews, then the reviews are correctly returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
+            val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
+
+            assertThat(reviews).hasSize(1)
+            assertThat(reviews).anyMatch { it.id == reviewId }
+        }
+
+        @Test
+        fun `When a the project paper has no reviews, then an empty list is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId1 = insertPaperAndGetId()
+            val paperId2 = insertPaperAndGetId()
+            val noReviewProjectPaperId = insertProjectPaperAndGetId(
+                paperId = paperId1,
+                projectId = projectId,
+                createdBy = testUserId,
+            )
+            val reviewProjectPaperId = insertProjectPaperAndGetId(
+                paperId = paperId2,
+                projectId = projectId,
+                createdBy = testUserId,
+            )
+            val reviewId = insertReviewAndGetId(reviewProjectPaperId, userId = testUserId)
+            val reviews = repo.getAllReviewsForProjectPaper(noReviewProjectPaperId)
+
+            assertThat(reviews).hasSize(0)
+            assertThat(reviews).noneMatch { it.id == reviewId }
+        }
+
+        @Test
+        fun `When a the project paper has no reviews and other reviews exist, then only the project paper reviews are returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val projectPaperId1 = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    createdBy = testUserId,
+                )
+                val projectPaperId2 = insertProjectPaperAndGetId(
+                    paperId = paperId2,
+                    projectId = projectId,
+                    createdBy = testUserId,
+                )
+                val reviewId1 = insertReviewAndGetId(projectPaperId1, userId = testUserId)
+                val reviewId2 = insertReviewAndGetId(projectPaperId2, userId = testUserId)
+                val reviews = repo.getAllReviewsForProjectPaper(projectPaperId1)
+
+                assertThat(reviews).hasSize(1)
+                assertThat(reviews).anyMatch { it.id == reviewId1 }
+                assertThat(reviews).noneMatch { it.id == reviewId2 }
+            }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -26,6 +26,7 @@ import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
 import se.uulm.snowballr.backend.serviceLayerDeps
@@ -81,6 +82,7 @@ open class MainServiceTest : KoinTest {
     val criterionRepoMock = mockk<ICriterionTableRepo>()
     val userRepoMock = mockk<IUserTableRepo>()
     val projectMemberRepoMock = mockk<IProjectMemberTableRepo>()
+    val projectPaperRepoMock = mockk<IProjectPaperTableRepo>()
     val authorOfPaperRepoMock = mockk<IAuthorOfPaperTableRepo>()
     val authorRepoMock = mockk<IAuthorTableRepo>()
     val citationRepoMock = mockk<ICitationTableRepo>()
@@ -100,6 +102,7 @@ open class MainServiceTest : KoinTest {
         projectMemberRepoMock,
         jwtServiceMock,
         fetcherManagerMock,
+        projectPaperRepoMock,
         authorOfPaperRepoMock,
         authorRepoMock,
         citationRepoMock,
@@ -120,6 +123,7 @@ open class MainServiceTest : KoinTest {
         single { criterionRepoMock }
         single { userRepoMock }
         single { projectMemberRepoMock }
+        single { projectPaperRepoMock }
         single { authorOfPaperRepoMock }
         single { authorRepoMock }
         single { citationRepoMock }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -28,6 +28,8 @@ import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
 import se.uulm.snowballr.backend.serviceLayerDeps
 
@@ -88,6 +90,8 @@ open class MainServiceTest : KoinTest {
     val citationRepoMock = mockk<ICitationTableRepo>()
     val readingListRepoMock = mockk<IReadingListTableRepo>()
     val paperRepoMock = mockk<IPaperTableRepo>()
+    val reviewRepoMock = mockk<IReviewTableRepo>()
+    val reviewHasCriterionRepoMock = mockk<IReviewHasCriterionTableRepo>()
     val verificationTokenRepoMock = mockk<IVerificationTokenTableRepo>()
 
     // Custom services / manager / clients mocks
@@ -108,6 +112,8 @@ open class MainServiceTest : KoinTest {
         citationRepoMock,
         readingListRepoMock,
         paperRepoMock,
+        reviewRepoMock,
+        reviewHasCriterionRepoMock,
     )
 
     val mainService: IMainService by inject()
@@ -129,6 +135,8 @@ open class MainServiceTest : KoinTest {
         single { citationRepoMock }
         single { readingListRepoMock }
         single { paperRepoMock }
+        single { reviewRepoMock }
+        single { reviewHasCriterionRepoMock }
         single { verificationTokenRepoMock }
 
         // Custom services / managers / clients

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -60,7 +60,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When retrieving requested project papers with project fails, then an exception is thrown`() = runTest {
+    fun `When retrieving project papers with project fails, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(id = requestId)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
@@ -69,13 +69,15 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } throws TestSpecificException()
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
-    fun `When retrieving requested authors by paper id fails, then an exception is thrown`() = runTest {
+    fun `When retrieving authors fails, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(id = requestId)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
@@ -87,14 +89,16 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
-    fun `When retrieving requested backward references by paper id fails, then an exception is thrown`() = runTest {
+    fun `When retrieving backward references fails, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(id = requestId)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
@@ -107,9 +111,69 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } throws TestSpecificException()
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving reviews fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery {
+            reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
@@ -122,15 +186,22 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
         val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
 
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
@@ -145,15 +216,22 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
         val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
 
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -1,0 +1,178 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass
+import java.util.UUID
+
+class GetAllProjectPapersForProjectTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+
+    @Test
+    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested project fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested project members fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested project papers with project fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested authors by paper id fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested backward references by paper id fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+
+        assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectPaperRepoMock.getProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+
+        assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member requests the project papers, then an unauthorized exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        assertThrows<SnowballRException.UnauthorizedException> {
+            mainService.getAllProjectPapersForProject(
+                getExampleRequest(),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -4,8 +4,12 @@ import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
@@ -15,142 +19,28 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
 import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllProjectPapersForProjectTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
-    @Test
-    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(GrpcContext::getUserIdFromContext),
+        Arguments.of(userRepoMock::getUserById),
+        Arguments.of(projectRepoMock::getProjectById),
+        Arguments.of(projectMemberRepoMock::getProjectMembers),
+        Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
+        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
+        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
+        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
+        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
+    )
 
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested project fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested project members fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(id = requestId)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project papers with project fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving authors fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving backward references fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val author = DataBuilder.createExampleAuthor()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving reviews fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val author = DataBuilder.createExampleAuthor()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery {
-            reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
-        } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
+    @Suppress("LongMethod", "ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = requestId)
         val paper = DataBuilder.createExamplePaper(id = requestId)
@@ -159,51 +49,87 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
+        if (failAt == GrpcContext::getUserIdFromContext) {
+            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+            return
+        }
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+
+        if (failAt == userRepoMock::getUserById) {
+            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            return
+        }
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+
+        if (failAt == projectRepoMock::getProjectById) {
+            coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+            return
+        }
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        if (failAt == projectMemberRepoMock::getProjectMembers) {
+            coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            projectMemberRepoMock.getProjectMembers(project.id)
+        } returns listOf(DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id))
+
+        if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
+            coEvery {
+                projectPaperRepoMock.getAllProjectPapersWithPapers(any())
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
         } returns listOf(projectPaperWithPaper)
+
+        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) } throws TestSpecificException()
+            return
+        }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+
+        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any())
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
+
+        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } throws TestSpecificException()
+            return
+        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+
+        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } throws TestSpecificException()
+        } returns listOf(UUID.randomUUID())
+    }
 
-        assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getAllProjectPapersForProject(getExampleRequest())
+        }
     }
 
     @Test
     fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-
+        mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -132,6 +132,65 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     }
 
     @Test
+    fun `When retrieving reviews fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
     fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject()
@@ -142,6 +201,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             paperId = paper.id,
         )
         val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -151,6 +211,10 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
 
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
@@ -168,6 +232,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             paperId = paper.id,
         )
         val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -177,6 +242,10 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
 
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -1,0 +1,203 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass
+import java.util.UUID
+
+class GetProjectPaperByIdTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+
+    @Test
+    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested project paper fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested project members fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested paper by id fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested authors by paper id fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving requested backward references by paper id fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+
+        assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+        val author = DataBuilder.createExampleAuthor()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+
+        assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member retrieves the project paper, then an unauthorized exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = requestId,
+            projectId = project.id,
+            paperId = paper.id,
+        )
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        assertThrows<SnowballRException.UnauthorizedException> { mainService.getProjectPaperById(getExampleRequest()) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -4,8 +4,12 @@ import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
@@ -14,184 +18,28 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
 import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
-    @Test
-    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(GrpcContext::getUserIdFromContext),
+        Arguments.of(userRepoMock::getUserById),
+        Arguments.of(projectPaperRepoMock::getProjectPaperById),
+        Arguments.of(projectMemberRepoMock::getProjectMembers),
+        Arguments.of(paperRepoMock::getPaperById),
+        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
+        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
+        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
+        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
+    )
 
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested project paper fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested project members fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested paper by id fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested authors by paper id fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested backward references by paper id fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val author = DataBuilder.createExampleAuthor()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving reviews fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getProjectPaperById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
+    @Suppress("LongMethod", "ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -203,20 +51,83 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
+        if (failAt == GrpcContext::getUserIdFromContext) {
+            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+            return
+        }
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+
+        if (failAt == userRepoMock::getUserById) {
+            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            return
+        }
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+
+        if (failAt == projectPaperRepoMock::getProjectPaperById) {
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+
+        if (failAt == projectMemberRepoMock::getProjectMembers) {
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        if (failAt == paperRepoMock::getPaperById) {
+            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
+            return
+        }
         coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+
+        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
+            return
+        }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+
+        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
+
+        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
+            } throws TestSpecificException()
+            return
+        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+
+        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
+    }
 
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getProjectPaperById(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
+        mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -4,8 +4,12 @@ import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
@@ -14,122 +18,93 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
 import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
-    @Test
-    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(GrpcContext::getUserIdFromContext),
+        Arguments.of(userRepoMock::getUserById),
+        Arguments.of(projectPaperRepoMock::getProjectPaperById),
+        Arguments.of(projectRepoMock::getProjectById),
+        Arguments.of(projectMemberRepoMock::getProjectMembers),
+        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
+        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
+    )
 
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project paper fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(requestId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project members fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving all reviews for project paper fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val review = DataBuilder.createExampleReview(userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
+    @Suppress("ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
         val review = DataBuilder.createExampleReview(userId = currentUser.id)
         val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
 
+        if (failAt == GrpcContext::getUserIdFromContext) {
+            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+            return
+        }
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+
+        if (failAt == userRepoMock::getUserById) {
+            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            return
+        }
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+
+        if (failAt == projectPaperRepoMock::getProjectPaperById) {
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+
+        if (failAt == projectRepoMock::getProjectById) {
+            coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
+
+        if (failAt == projectMemberRepoMock::getProjectMembers) {
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
+            } throws TestSpecificException()
+            return
+        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+
+        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
+    }
 
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getAllReviewsForProjectPaper(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
+        mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -1,0 +1,177 @@
+package se.uulm.snowballr.backend.service.review
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass
+import java.util.UUID
+
+class GetAllReviewsForProjectPaperTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+
+    @Test
+    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving project paper fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(requestId) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving project fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving project members fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving all reviews for project paper fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val review = DataBuilder.createExampleReview(userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+        val review = DataBuilder.createExampleReview(userId = currentUser.id)
+        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns selectedCriteriaIds
+
+        assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val review = DataBuilder.createExampleReview(userId = currentUser.id)
+        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns selectedCriteriaIds
+
+        assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member retrieves all reviews for a project paper, then an unauthorized exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+
+            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+            assertThrows<SnowballRException.UnauthorizedException> {
+                mainService.getAllReviewsForProjectPaper(
+                    getExampleRequest(),
+                )
+            }
+        }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -1,0 +1,175 @@
+package se.uulm.snowballr.backend.service.review
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass
+import java.util.UUID
+
+class GetReviewByIdTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+
+    @Test
+    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
+        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
+        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving review fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving project paper fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving project fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving project members fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns selectedCriteriaIds
+
+        assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member retrieves the review, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns selectedCriteriaIds
+
+        assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member retrieves the review, then an unauthorized exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        assertThrows<SnowballRException.UnauthorizedException> { mainService.getReviewById(getExampleRequest()) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -4,8 +4,12 @@ import io.mockk.coEvery
 import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
@@ -14,123 +18,91 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
 import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetReviewByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
-    @Test
-    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(GrpcContext::getUserIdFromContext),
+        Arguments.of(userRepoMock::getUserById),
+        Arguments.of(reviewRepoMock::getReviewById),
+        Arguments.of(projectPaperRepoMock::getProjectPaperById),
+        Arguments.of(projectRepoMock::getProjectById),
+        Arguments.of(projectMemberRepoMock::getProjectMembers),
+        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
+    )
 
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving review fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project paper fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving project members fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving selected criteria ids fails, then an exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReviewById(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
+    @Suppress("ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
         val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
         val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
 
+        if (failAt == GrpcContext::getUserIdFromContext) {
+            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+            return
+        }
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+
+        if (failAt == userRepoMock::getUserById) {
+            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            return
+        }
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+
+        if (failAt == reviewRepoMock::getReviewById) {
+            coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
+            return
+        }
         coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+
+        if (failAt == projectPaperRepoMock::getProjectPaperById) {
+            coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } throws TestSpecificException()
+            return
+        }
         coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+
+        if (failAt == projectRepoMock::getProjectById) {
+            coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
+
+        if (failAt == projectMemberRepoMock::getProjectMembers) {
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
+            return
+        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+            } throws TestSpecificException()
+            return
+        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
+    }
 
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getReviewById(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
+        mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
     }
 


### PR DESCRIPTION
Closes #179 #181 #189 #190
## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

**Note:** I have rebased this branch onto #172. You only have to review the last 4 commits.

I have implemented calls: `getProjectPaperById` and `getAllProjectPapersForProject`. 

Therefore the `ProjectPaperRepo` had to be created as well as a `DTO` to join on ProjectPapers and Papers.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
