### PR TITLE
Added types for project and user criteria

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Criterion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Criterion.kt
@@ -8,16 +8,42 @@ import java.util.UUID
 /**
  * DTO of [CriterionTable].
  */
-data class Criterion(
-    val id: UUID,
-    val tag: String,
-    val name: String,
-    val description: String,
-    val category: CriterionOuterClass.CriterionCategory,
-    val projectId: UUID?,
-    val createdAt: OffsetDateTime,
-    val createdBy: UUID,
-)
+sealed class Criterion {
+    abstract val id: UUID
+    abstract val tag: String
+    abstract val name: String
+    abstract val description: String
+    abstract val category: CriterionOuterClass.CriterionCategory
+    abstract val createdAt: OffsetDateTime
+    abstract val createdBy: UUID
+
+    /**
+     * [Criterion] that is owned by the project.
+     */
+    data class ProjectCriterion(
+        override val id: UUID,
+        override val tag: String,
+        override val name: String,
+        override val description: String,
+        override val category: CriterionOuterClass.CriterionCategory,
+        override val createdAt: OffsetDateTime,
+        override val createdBy: UUID,
+        val projectId: UUID,
+    ) : Criterion()
+
+    /**
+     * [Criterion] that is owned by the user.
+     */
+    data class UserCriterion(
+        override val id: UUID,
+        override val tag: String,
+        override val name: String,
+        override val description: String,
+        override val category: CriterionOuterClass.CriterionCategory,
+        override val createdAt: OffsetDateTime,
+        override val createdBy: UUID,
+    ) : Criterion()
+}
 
 /**
  * Creates a [CriterionOuterClass.Criterion] from this [Criterion].

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -12,6 +12,7 @@ import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.toCriterion
+import se.uulm.snowballr.backend.table.toUserCriterion
 import snowballr.CriterionOuterClass
 import java.util.UUID
 
@@ -135,11 +136,11 @@ class CriterionTableRepo(
         CriterionTable.getEntitiesByIds(ids, ResultRow::toCriterion)
     }
 
-    override suspend fun getAllUserCriteria(userId: UUID): List<Criterion> = db.query {
+    override suspend fun getAllUserCriteria(userId: UUID): List<Criterion.UserCriterion> = db.query {
         CriterionTable
             .selectAll()
             .where { CriterionTable.createdBy eq userId and CriterionTable.projectId.isNull() }
-            .map { it.toCriterion() }
+            .map { it.toUserCriterion() }
     }
 
     override suspend fun getAllProjectCriteria(projectId: UUID): List<Criterion> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -7,6 +7,8 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Criterion
+import se.uulm.snowballr.backend.model.dto.Criterion.ProjectCriterion
+import se.uulm.snowballr.backend.model.dto.Criterion.UserCriterion
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
@@ -73,7 +75,7 @@ class CriterionService(
      * that belongs to an active project and throws exceptions when access is unauthorized
      * or when attempting to access a criterion of an inactive project.
      *
-     * @param criterion The [GrpcCriterion] to check the permission for or null, if it does not already exist
+     * @param criterion The [ProjectCriterion] to check the permission for or null, if it does not already exist.
      * @param projectId The projectId of the [ProjectOuterClass.Project] to check the permission for.
      * @param currentUser The user whose permissions are being validated.
      * @param accessType The type of access being requested (e.g., READ, UPDATE).
@@ -84,7 +86,7 @@ class CriterionService(
      *         in a project that is not active.
      */
     private suspend fun checkProjectCriterionPermission(
-        criterion: Criterion?,
+        criterion: ProjectCriterion?,
         projectId: UUID,
         currentUser: User,
         accessType: AccessType,
@@ -133,7 +135,7 @@ class CriterionService(
      *
      * @throws UnauthorizedException.Single If the current user does not have permissions to access the criterion.
      */
-    private fun checkUserCriterionPermission(criterion: Criterion, currentUser: User, accessType: AccessType) {
+    private fun checkUserCriterionPermission(criterion: UserCriterion, currentUser: User, accessType: AccessType) {
         if (criterion.createdBy == currentUser.id) return
 
         verifyServerAdminRole(currentUser) {
@@ -157,10 +159,14 @@ class CriterionService(
      * @param accessType The type of access being requested on the criterion (e.g., READ, UPDATE, DELETE).
      */
     private suspend fun checkCriterionPermission(criterion: Criterion, currentUser: User, accessType: AccessType) {
-        if (criterion.projectId != null) {
-            checkProjectCriterionPermission(criterion, criterion.projectId, currentUser, accessType)
-        } else {
-            checkUserCriterionPermission(criterion, currentUser, accessType)
+        when (criterion) {
+            is ProjectCriterion -> checkProjectCriterionPermission(
+                criterion,
+                criterion.projectId,
+                currentUser,
+                accessType,
+            )
+            is UserCriterion -> checkUserCriterionPermission(criterion, currentUser, accessType)
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/CriterionTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/CriterionTable.kt
@@ -44,13 +44,39 @@ object CriterionTable : UUIDTable("criterion") {
 /**
  * Creates a [Criterion] from this [ResultRow].
  */
-fun ResultRow.toCriterion() = Criterion(
-    id = this[CriterionTable.id].value,
-    tag = this[CriterionTable.tag],
-    name = this[CriterionTable.name],
-    description = this[CriterionTable.description],
-    category = this[CriterionTable.category],
-    projectId = this[CriterionTable.projectId]?.value,
-    createdAt = this[CriterionTable.createdAt],
-    createdBy = this[CriterionTable.createdBy].value,
-)
+fun ResultRow.toCriterion(): Criterion =
+    if (this[CriterionTable.projectId] == null) this.toUserCriterion() else this.toProjectCriterion()
+
+/**
+ * Creates a [Criterion.UserCriterion] from this [ResultRow].
+ */
+fun ResultRow.toUserCriterion(): Criterion.UserCriterion {
+    require(this[CriterionTable.projectId] == null) { "Project ID must be null for a user criterion" }
+    return Criterion.UserCriterion(
+        id = this[CriterionTable.id].value,
+        tag = this[CriterionTable.tag],
+        name = this[CriterionTable.name],
+        description = this[CriterionTable.description],
+        category = this[CriterionTable.category],
+        createdAt = this[CriterionTable.createdAt],
+        createdBy = this[CriterionTable.createdBy].value,
+    )
+}
+
+/**
+ * Creates a [Criterion.ProjectCriterion] from this [ResultRow].
+ */
+fun ResultRow.toProjectCriterion(): Criterion.ProjectCriterion {
+    val projectId = this[CriterionTable.projectId]
+    requireNotNull(projectId) { "Project ID must not be null for a project criterion" }
+    return Criterion.ProjectCriterion(
+        id = this[CriterionTable.id].value,
+        tag = this[CriterionTable.tag],
+        name = this[CriterionTable.name],
+        description = this[CriterionTable.description],
+        category = this[CriterionTable.category],
+        projectId = projectId.value,
+        createdAt = this[CriterionTable.createdAt],
+        createdBy = this[CriterionTable.createdBy].value,
+    )
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -66,22 +66,40 @@ object DataBuilder {
         archivedBy = archivedBy,
     )
 
-    fun createExampleCriterion(
+    fun createExampleProjectCriterion(
         id: UUID = UUID.randomUUID(),
         tag: String = "Test Tag",
         name: String = "Test Criterion",
         description: String = "Test Description",
         category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED,
-        projectId: UUID? = UUID.randomUUID(),
+        projectId: UUID = UUID.randomUUID(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
         createdBy: UUID = UUID.randomUUID(),
-    ) = Criterion(
+    ) = Criterion.ProjectCriterion(
         id = id,
         tag = tag,
         name = name,
         description = description,
         category = category,
         projectId = projectId,
+        createdAt = createdAt,
+        createdBy = createdBy,
+    )
+
+    fun createExampleUserCriterion(
+        id: UUID = UUID.randomUUID(),
+        tag: String = "Test Tag",
+        name: String = "Test Criterion",
+        description: String = "Test Description",
+        category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED,
+        createdAt: OffsetDateTime = OffsetDateTime.now(),
+        createdBy: UUID = UUID.randomUUID(),
+    ) = Criterion.UserCriterion(
+        id = id,
+        tag = tag,
+        name = name,
+        description = description,
+        category = category,
         createdAt = createdAt,
         createdBy = createdBy,
     )

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
@@ -105,12 +104,12 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .build()
                 val criterion = repo.createCriterion(request, testUserId)
 
-                Assertions.assertThat(criterion.tag).isEqualTo("Test Tag")
-                Assertions.assertThat(criterion.name).isEqualTo("Test Criterion")
-                Assertions.assertThat(criterion.description).isEqualTo("Test Description")
-                Assertions.assertThat(criterion.category).isEqualTo(category)
-                Assertions.assertThat(criterion.projectId).isEqualTo(project.id)
-                Assertions.assertThat(criterion.createdBy).isEqualTo(testUserId)
+                assertThat(criterion.tag).isEqualTo("Test Tag")
+                assertThat(criterion.name).isEqualTo("Test Criterion")
+                assertThat(criterion.description).isEqualTo("Test Description")
+                assertThat(criterion.category).isEqualTo(category)
+                assertThat(criterion.projectId).isEqualTo(project.id)
+                assertThat(criterion.createdBy).isEqualTo(testUserId)
             }
 
         @GrpcEnumSourceTest(CriterionCategory::class)
@@ -126,12 +125,11 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .build()
                 val criterion = repo.createCriterion(request, testUserId)
 
-                Assertions.assertThat(criterion.tag).isEqualTo("Test Tag")
-                Assertions.assertThat(criterion.name).isEqualTo("Test Criterion")
-                Assertions.assertThat(criterion.description).isEqualTo("Test Description")
-                Assertions.assertThat(criterion.category).isEqualTo(category)
-                Assertions.assertThat(criterion.projectId).isNull()
-                Assertions.assertThat(criterion.createdBy).isEqualTo(testUserId)
+                assertThat(criterion.tag).isEqualTo("Test Tag")
+                assertThat(criterion.name).isEqualTo("Test Criterion")
+                assertThat(criterion.description).isEqualTo("Test Description")
+                assertThat(criterion.category).isEqualTo(category)
+                assertThat(criterion.createdBy).isEqualTo(testUserId)
             }
 
         @Test
@@ -166,7 +164,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             val criterion1 = repo.createCriterion(request, testUserId)
             val criterion2 = repo.createCriterion(request, testUserId)
 
-            Assertions.assertThat(criterion1.id).isNotEqualTo(criterion2.id)
+            assertThat(criterion1.id).isNotEqualTo(criterion2.id)
         }
 
         @GrpcEnumSourceTest(CriterionCategory::class)
@@ -212,10 +210,10 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
                 val userCriteria = repo.getAllUserCriteria(testUserId)
 
-                Assertions.assertThat(userCriteria).hasSize(1)
-                Assertions.assertThat(userCriteria).containsExactly(userCriterion1)
-                Assertions.assertThat(userCriteria).doesNotContain(userCriterion2)
-                Assertions.assertThat(userCriteria).doesNotContain(projectCriterion)
+                assertThat(userCriteria).hasSize(1)
+                assertThat(userCriteria).containsExactly(userCriterion1)
+                assertThat(userCriteria).doesNotContain(userCriterion2)
+                assertThat(userCriteria).doesNotContain(projectCriterion)
             }
     }
 
@@ -372,10 +370,10 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
                 val userCriteria = repo.getAllProjectCriteria(projectId1)
 
-                Assertions.assertThat(userCriteria).hasSize(1)
-                Assertions.assertThat(userCriteria).containsExactly(projectCriterion1)
-                Assertions.assertThat(userCriteria).doesNotContain(projectCriterion2)
-                Assertions.assertThat(userCriteria).doesNotContain(userCriterion)
+                assertThat(userCriteria).hasSize(1)
+                assertThat(userCriteria).containsExactly(projectCriterion1)
+                assertThat(userCriteria).doesNotContain(projectCriterion2)
+                assertThat(userCriteria).doesNotContain(userCriterion)
             }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.repository
 import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,11 +19,15 @@ import se.uulm.snowballr.backend.model.dto.Criterion.UserCriterion
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertTestProjectAndGetId
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.toProjectCriterion
+import se.uulm.snowballr.backend.table.toUserCriterion
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
 import kotlin.test.assertIs
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
@@ -44,7 +49,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         name: String = "Test Criterion",
         description: String = "Test Description",
         category: CriterionCategory = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
-        projectId: UUID = UUID.randomUUID(),
+        projectId: UUID? = UUID.randomUUID(),
     ): UUID = db.query {
         CriterionTable.insertAndGetId {
             it[CriterionTable.tag] = tag
@@ -64,6 +69,30 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             Arguments.of(listOf("criterion.description")),
             Arguments.of(listOf("criterion.category")),
         )
+    }
+
+    @Nested
+    inner class Mapper {
+        @Test
+        fun `When project criterion is converted to user criterion, then exception is thrown`() = runTest {
+            val projectId = insertTestProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, testUserId)
+            val id = insertTestCriterionAndGetId(projectId = projectId)
+            assertThrows<IllegalArgumentException> {
+                db.query {
+                    CriterionTable.getEntityByIdOrNull(id, ResultRow::toUserCriterion)
+                }
+            }
+        }
+
+        @Test
+        fun `When user criterion is converted to project criterion, then exception is thrown`() = runTest {
+            val id = insertTestCriterionAndGetId(projectId = null)
+            assertThrows<IllegalArgumentException> {
+                db.query {
+                    CriterionTable.getEntityByIdOrNull(id, ResultRow::toProjectCriterion)
+                }
+            }
+        }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -12,6 +12,9 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.Criterion
+import se.uulm.snowballr.backend.model.dto.Criterion.ProjectCriterion
+import se.uulm.snowballr.backend.model.dto.Criterion.UserCriterion
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
@@ -21,6 +24,7 @@ import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import java.util.UUID
+import kotlin.test.assertIs
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTable), true) {
@@ -70,6 +74,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             val criterionId = insertTestCriterionAndGetId(projectId = projectId)
             val criterion = repo.getCriterionById(criterionId)
 
+            assertIs<ProjectCriterion>(criterion)
             assertThat(criterion.id).isEqualTo(criterionId)
             assertThat(criterion.tag).isEqualTo("Test Tag")
             assertThat(criterion.name).isEqualTo("Test Criterion")
@@ -104,6 +109,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .build()
                 val criterion = repo.createCriterion(request, testUserId)
 
+                assertIs<ProjectCriterion>(criterion)
                 assertThat(criterion.tag).isEqualTo("Test Tag")
                 assertThat(criterion.name).isEqualTo("Test Criterion")
                 assertThat(criterion.description).isEqualTo("Test Description")
@@ -125,6 +131,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .build()
                 val criterion = repo.createCriterion(request, testUserId)
 
+                assertIs<UserCriterion>(criterion)
                 assertThat(criterion.tag).isEqualTo("Test Tag")
                 assertThat(criterion.name).isEqualTo("Test Criterion")
                 assertThat(criterion.description).isEqualTo("Test Description")
@@ -208,7 +215,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val userCriterion2 = repo.createCriterion(userCriterionRequest, userId)
                 val projectCriterion = repo.createCriterion(projectCriterionRequest, testUserId)
 
-                val userCriteria = repo.getAllUserCriteria(testUserId)
+                val userCriteria = repo.getAllUserCriteria(testUserId) as List<Criterion>
 
                 assertThat(userCriteria).hasSize(1)
                 assertThat(userCriteria).containsExactly(userCriterion1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -19,10 +19,10 @@ import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
-import snowballr.CriterionOuterClass.Criterion
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import java.util.UUID
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTable), true) {
     private val repo = CriterionTableRepo(db)
@@ -95,7 +95,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val project = createExampleProject()
 
                 val request =
-                    Criterion.Create
+                    GrpcCriterion.Create
                         .newBuilder()
                         .setTag("Test Tag")
                         .setName("Test Criterion")
@@ -117,7 +117,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         fun `When a user criterion is created, then the values are correctly assigned`(category: CriterionCategory) =
             runTest {
                 val request =
-                    Criterion.Create
+                    GrpcCriterion.Create
                         .newBuilder()
                         .setTag("Test Tag")
                         .setName("Test Criterion")
@@ -138,7 +138,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         fun `When a project criterion is created, but the assigned project doesn't exist, then an exception is thrown`() =
             runTest {
                 val request =
-                    Criterion.Create
+                    GrpcCriterion.Create
                         .newBuilder()
                         .setTag("Test Tag")
                         .setName("Test Criterion")
@@ -155,7 +155,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             val project = createExampleProject()
 
             val request =
-                Criterion.Create
+                GrpcCriterion.Create
                     .newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
@@ -174,7 +174,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             category: CriterionCategory,
         ) = runTest {
             val request =
-                Criterion.Create
+                GrpcCriterion.Create
                     .newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
@@ -195,7 +195,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val userId = createExampleUser("test@email.com")
                 val projectId = createExampleProject().id
 
-                val baseRequestBuilder = Criterion.Create.newBuilder()
+                val baseRequestBuilder = GrpcCriterion.Create.newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
                     .setDescription("Test Description")
@@ -226,7 +226,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             runTest {
                 val projectId = createExampleProject().id
 
-                val baseRequestBuilder = Criterion.Create.newBuilder()
+                val baseRequestBuilder = GrpcCriterion.Create.newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
                     .setDescription("Test Description")
@@ -249,7 +249,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         @Test
         fun `When all criteria of the given ids are requested but not all criteria exist, then only the existing criteria are returned`() =
             runTest {
-                val baseRequestBuilder = Criterion.Create.newBuilder()
+                val baseRequestBuilder = GrpcCriterion.Create.newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
                     .setDescription("Test Description")
@@ -279,7 +279,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
         @Test
         fun `When the input list contains duplicated ids, then every criterion is returned only once`() = runTest {
-            val baseRequestBuilder = Criterion.Create.newBuilder()
+            val baseRequestBuilder = GrpcCriterion.Create.newBuilder()
                 .setTag("Test Tag")
                 .setName("Test Criterion")
                 .setDescription("Test Description")
@@ -314,7 +314,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 .setCategory(CriterionCategory.CRITERION_CATEGORY_INCLUSION)
                 .build()
 
-            val request = Criterion.Update.newBuilder()
+            val request = GrpcCriterion.Update.newBuilder()
                 .setCriterion(updatedCriterionDetails)
                 .setMask(FieldMaskUtil.fromStringList(fieldMask))
                 .build()
@@ -352,7 +352,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val projectId1 = createExampleProject().id
                 val projectId2 = createExampleProject().id
 
-                val baseRequestBuilder = Criterion.Create.newBuilder()
+                val baseRequestBuilder = GrpcCriterion.Create.newBuilder()
                     .setTag("Test Tag")
                     .setName("Test Criterion")
                     .setDescription("Test Description")

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.repository
 import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -15,6 +14,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertTestProjectAndGetId
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import snowballr.ProjectOuterClass.Project
@@ -26,21 +26,8 @@ import java.util.UUID
 class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectTableRepo(db)
 
-    private suspend fun insertTestProjectAndGetId(name: String, status: ProjectStatus): UUID = db.query {
-        ProjectTable
-            .insertAndGetId {
-                it[ProjectTable.name] = name
-                it[ProjectTable.status] = status
-                it[currentStage] = 0
-                it[maxStage] = 0
-                it[similarityThreshold] = 0F
-                it[snowballingType] = SnowballingType.SNOWBALLING_TYPE_BOTH
-                it[reviewMaybeAllowed] = true
-                it[reviewDecisionMatrixBinary] = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
-                it[fetcherApis] = emptyList()
-                it[createdBy] = testUserId
-            }.value
-    }
+    private suspend fun insertTestProjectAndGetId(name: String, status: ProjectStatus) =
+        insertTestProjectAndGetId(name, status, testUserId)
 
     companion object {
         @JvmStatic

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -21,7 +21,7 @@ object RepositoryHelper {
     lateinit var db: IDatabase
 
     /**
-     * Creates an example user in the database with the specified email and fake user details
+     * Creates an example user in the database with the specified email and fake user details.
      *
      * @param email The email address for the example user to be created.
      * @return The uuid of the created user
@@ -64,6 +64,9 @@ object RepositoryHelper {
         assignUserToProject(userId, projectId)
     }
 
+    /**
+     * Creates an example paper in the database with the specified properties.
+     */
     @Suppress("LongParameterList")
     suspend fun insertPaperAndGetId(
         title: String = "Title",
@@ -87,6 +90,9 @@ object RepositoryHelper {
         }.value
     }
 
+    /**
+     * Creates an example project in the database with the specified properties.
+     */
     suspend fun insertTestProjectAndGetId(name: String, status: ProjectOuterClass.ProjectStatus, userId: UUID): UUID =
         db.query {
             ProjectTable

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.insertAndGetId
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.table.PaperTable
+import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
@@ -85,4 +86,22 @@ object RepositoryHelper {
             it[PaperTable.fetcherMetadata] = fetcherMetadata
         }.value
     }
+
+    suspend fun insertTestProjectAndGetId(name: String, status: ProjectOuterClass.ProjectStatus, userId: UUID): UUID =
+        db.query {
+            ProjectTable
+                .insertAndGetId {
+                    it[ProjectTable.name] = name
+                    it[ProjectTable.status] = status
+                    it[currentStage] = 0
+                    it[maxStage] = 0
+                    it[similarityThreshold] = 0F
+                    it[snowballingType] = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+                    it[reviewMaybeAllowed] = true
+                    it[reviewDecisionMatrixBinary] =
+                        ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+                    it[fetcherApis] = emptyList()
+                    it[createdBy] = userId
+                }.value
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -125,7 +125,7 @@ class CreateCriterionTest : MainServiceTest() {
     fun `When an user creates a user criterion, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        val criterion = DataBuilder.createExampleProjectCriterion()
+        val criterion = DataBuilder.createExampleUserCriterion()
         val request = getUserCriterionRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -52,7 +52,7 @@ class CreateCriterionTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject()
 
-        val criterion = DataBuilder.createExampleCriterion(projectId = project.id)
+        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
@@ -70,7 +70,7 @@ class CreateCriterionTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject()
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
-        val criterion = DataBuilder.createExampleCriterion(projectId = project.id)
+        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
@@ -125,7 +125,7 @@ class CreateCriterionTest : MainServiceTest() {
     fun `When an user creates a user criterion, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        val criterion = DataBuilder.createExampleCriterion()
+        val criterion = DataBuilder.createExampleProjectCriterion()
         val request = getUserCriterionRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
@@ -152,7 +152,7 @@ class CreateCriterionTest : MainServiceTest() {
     fun `When a criterion is correctly created, then no exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
         val user = DataBuilder.createExampleUser(id = UUID.randomUUID())
-        val criterion = DataBuilder.createExampleCriterion()
+        val criterion = DataBuilder.createExampleProjectCriterion()
 
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -94,7 +94,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion = DataBuilder.createExampleCriterion(
+        val criterion = DataBuilder.createExampleProjectCriterion(
             projectId = requestId,
             createdBy = adminUser.id,
         )
@@ -115,7 +115,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleCriterion(
+            val criterion = DataBuilder.createExampleProjectCriterion(
                 projectId = requestId,
                 createdBy = user.id,
             )

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -28,7 +28,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion = DataBuilder.createExampleCriterion(
+        val criterion = DataBuilder.createExampleProjectCriterion(
             id = requestId,
             projectId = UUID.randomUUID(),
             createdBy = adminUser.id,
@@ -51,7 +51,7 @@ class GetCriterionByIdTest : MainServiceTest() {
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject()
-            val criterion = DataBuilder.createExampleCriterion(
+            val criterion = DataBuilder.createExampleProjectCriterion(
                 id = requestId,
                 projectId = project.id,
                 createdBy = user.id,
@@ -73,7 +73,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val noAccessUser = DataBuilder.createExampleUser()
-            val criterion = DataBuilder.createExampleCriterion(
+            val criterion = DataBuilder.createExampleProjectCriterion(
                 id = requestId,
                 projectId = UUID.randomUUID(),
                 createdBy = noAccessUser.id,
@@ -94,11 +94,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion = DataBuilder.createExampleCriterion(
-            id = requestId,
-            projectId = null,
-            createdBy = UUID.randomUUID(),
-        )
+        val criterion = DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
@@ -113,7 +109,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
+            val criterion = DataBuilder.createExampleUserCriterion(id = requestId, createdBy = user.id)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
@@ -128,11 +124,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val noAccessUser = DataBuilder.createExampleUser()
-            val criterion = DataBuilder.createExampleCriterion(
-                id = requestId,
-                projectId = null,
-                createdBy = UUID.randomUUID(),
-            )
+            val criterion = DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
             coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -22,7 +22,7 @@ class UpdateCriterionTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
 
     private fun getExampleRequest(): CriterionOuterClass.Criterion.Update {
-        val updatedCriterion = DataBuilder.createExampleCriterion(
+        val updatedCriterion = DataBuilder.createExampleProjectCriterion(
             id = requestId,
             tag = "Updated Tag",
             name = "Updated Criterion",
@@ -46,7 +46,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
-        val criterion = DataBuilder.createExampleCriterion(
+        val criterion = DataBuilder.createExampleProjectCriterion(
             id = requestId,
             projectId = project.id,
             createdBy = user.id,
@@ -71,7 +71,7 @@ class UpdateCriterionTest : MainServiceTest() {
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-        val criterion = DataBuilder.createExampleCriterion(
+        val criterion = DataBuilder.createExampleProjectCriterion(
             id = requestId,
             projectId = project.id,
             createdBy = user.id,
@@ -97,7 +97,7 @@ class UpdateCriterionTest : MainServiceTest() {
                 status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
             )
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-            val criterion = DataBuilder.createExampleCriterion(
+            val criterion = DataBuilder.createExampleProjectCriterion(
                 id = requestId,
                 projectId = project.id,
                 createdBy = user.id,
@@ -120,7 +120,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
-        val criterion = DataBuilder.createExampleCriterion(
+        val criterion = DataBuilder.createExampleProjectCriterion(
             id = requestId,
             projectId = project.id,
             createdBy = user.id,
@@ -141,7 +141,7 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val criterion =
-            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = UUID.randomUUID())
+            DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
 
         val request = getExampleRequest()
 
@@ -157,7 +157,7 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When a user updates a user criterion, which he created himself, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val criterion =
-            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
+            DataBuilder.createExampleUserCriterion(id = requestId, createdBy = user.id)
 
         val request = getExampleRequest()
 
@@ -174,7 +174,7 @@ class UpdateCriterionTest : MainServiceTest() {
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion =
-                DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = UUID.randomUUID())
+                DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
 
             val request = getExampleRequest()
 
@@ -189,7 +189,7 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When an error occurs while the criterion is updated, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val criterion =
-            DataBuilder.createExampleCriterion(id = requestId, projectId = null, createdBy = user.id)
+            DataBuilder.createExampleUserCriterion(id = requestId, createdBy = user.id)
 
         val request = getExampleRequest()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -62,7 +62,7 @@ class CreateProjectTest : MainServiceTest() {
         runTest {
             val project = DataBuilder.createExampleProject()
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleCriterion()
+            val criterion = DataBuilder.createExampleProjectCriterion()
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
             val criteriaIdsSlot = slot<List<UUID>>()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -46,7 +46,7 @@ class GetUserSettingsTest : MainServiceTest() {
     fun `When retrieving current user settings is correct and default criteria exist, then no exception is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
-            val criterion = DataBuilder.createExampleCriterion()
+            val criterion = DataBuilder.createExampleProjectCriterion()
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
 
             every { GrpcContext.getUserIdFromContext() } returns user.id

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/AuthenticationValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/AuthenticationValidatorTest.kt
@@ -174,7 +174,7 @@ class AuthenticationValidatorTest {
                 .setEmail("test.user@example.com")
                 .setPassword("AAbb__00")
                 .build()
-            val result = AuthenticationValidator.validateLoginRequest(request)
+            val result = validateRequest(request)
 
             EitherAssert.assertThat(result).isRight()
         }
@@ -184,7 +184,7 @@ class AuthenticationValidatorTest {
             val request = Authentication.LoginRequest.newBuilder()
                 .setEmail("invalid-email")
                 .build()
-            val result = AuthenticationValidator.validateLoginRequest(request)
+            val result = validateRequest(request)
 
             assertInvalidResult<InvalidEmail>(result)
         }
@@ -195,7 +195,7 @@ class AuthenticationValidatorTest {
                 .setEmail("test.user@example.com")
                 .setPassword("")
                 .build()
-            val result = AuthenticationValidator.validateLoginRequest(request)
+            val result = validateRequest(request)
 
             assertInvalidResult<BlankField>(result)
         }


### PR DESCRIPTION
Closes #258 
## What I have made

This adds the `ProjectCriterion` and the `UserCriterion`. By adding specific types of criteria, we make the code a bit more type-safe and don't have to differentiate using the `projectId`. 

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
