### PR TITLE
Implement `getPapersToReviewForProject` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -211,7 +211,7 @@ class SnowballRServer(
             super.getAllPapersToReview(request)
 
         override suspend fun getPapersToReviewForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
-            super.getPapersToReviewForProject(request)
+            mainService.getPapersToReviewForProject(request)
 
         override suspend fun getNextPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
             super.getNextPaper(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -49,14 +49,14 @@ fun ProjectPaperWithPaper.toGrpcProjectPaper(
 fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
     paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
     paperBackwardReferencesMap: Map<Paper, List<String>>,
-    paperReviewsMap: Map<Paper, List<ReviewOuterClass.Review>>,
+    paperReviewsMap: Map<ProjectPaper, List<ReviewOuterClass.Review>>,
 ): ProjectOuterClass.Project.Paper.List = ProjectOuterClass.Project.Paper.List
     .newBuilder()
     .addAllProjectPapers(
         this.map { projectPaper ->
             val authors = paperAuthorsMap[projectPaper.paper].orEmpty()
             val backwardRefs = paperBackwardReferencesMap[projectPaper.paper].orEmpty()
-            val reviews = paperReviewsMap[projectPaper.paper].orEmpty()
+            val reviews = paperReviewsMap[projectPaper.projectPaper].orEmpty()
 
             projectPaper.toGrpcProjectPaper(
                 authors = authors,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.model.dto
 
 import snowballr.PaperOuterClass.Author as GrpcAuthor
-import snowballr.ReviewOuterClass.Review as GrpcReview
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+import snowballr.ReviewOuterClass.Review as GrpcReview
 
 /**
  * Represents a relationship between a [ProjectPaper] and its associated [Paper].

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -1,18 +1,18 @@
 package se.uulm.snowballr.backend.model.dto
 
-import snowballr.PaperOuterClass
-import snowballr.ProjectOuterClass
-import snowballr.ReviewOuterClass
+import snowballr.PaperOuterClass.Author as GrpcAuthor
+import snowballr.ReviewOuterClass.Review as GrpcReview
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 /**
- * Represents a relationship between a project paper and its associated paper.
+ * Represents a relationship between a [ProjectPaper] and its associated [Paper].
  *
- * This data class combines information from both a `ProjectPaper` and a `Paper`.
- * It is useful for scenarios where details of the `ProjectPaper` linked to a specific
- * `Paper` need to be accessed together.
+ * This data class combines information from both a [ProjectPaper] and a [Paper].
+ * It is useful for scenarios where details of the [ProjectPaper] linked to a specific
+ * [Paper] need to be accessed together.
  *
- * @property projectPaper The `ProjectPaper` instance containing project-specific data.
- * @property paper The `Paper` instance providing detailed information about the paper itself.
+ * @property projectPaper The [ProjectPaper] instance containing project-specific data.
+ * @property paper The [Paper] instance providing detailed information about the paper itself.
  */
 data class ProjectPaperWithPaper(
     val projectPaper: ProjectPaper,
@@ -20,18 +20,18 @@ data class ProjectPaperWithPaper(
 )
 
 /**
- * Converts a `ProjectPaperWithPaper` instance into a gRPC `ProjectOuterClass.Project.Paper` object.
+ * Converts a [ProjectPaperWithPaper] instance into a gRPC [GrpcProjectPaper] object.
  *
- * @param authors A list of authors represented as `PaperOuterClass.Author`, associated with the paper.
- * @param backwardReferencedIds A list of strings representing the IDs of papers referenced by the current paper.
- * @param reviews A list of reviews represented as `ReviewOuterClass.Review`, associated with the paper.
- * @return A `ProjectOuterClass.Project.Paper` object constructed with data from the `ProjectPaperWithPaper` instance and the provided authors, backward references, and reviews.
+ * @param authors A list of authors represented as [GrpcAuthor], associated with the [Paper].
+ * @param backwardReferencedIds A list of strings representing the IDs of [Paper]s referenced by the current [Paper].
+ * @param reviews A list of reviews represented as [GrpcReview], associated with the [Paper].
+ * @return A [GrpcProjectPaper] object constructed with data from the [ProjectPaperWithPaper] instance and the provided [Author]s, backward references, and [Review]s.
  */
 fun ProjectPaperWithPaper.toGrpcProjectPaper(
-    authors: List<PaperOuterClass.Author>,
+    authors: List<GrpcAuthor>,
     backwardReferencedIds: List<String>,
-    reviews: List<ReviewOuterClass.Review>,
-): ProjectOuterClass.Project.Paper = ProjectOuterClass.Project.Paper
+    reviews: List<GrpcReview>,
+): GrpcProjectPaper = GrpcProjectPaper
     .newBuilder()
     .setId(projectPaper.id.toString())
     .setPaper(paper.toGrpcPaper(authors, backwardReferencedIds))
@@ -42,15 +42,15 @@ fun ProjectPaperWithPaper.toGrpcProjectPaper(
     .build()
 
 /**
- * Converts a list of [ProjectPaperWithPaper] objects into a gRPC list of project papers.
+ * Converts a list of [ProjectPaperWithPaper] objects into a gRPC list of [ProjectPaper]s.
  *
- * @return A [ProjectOuterClass.Project.Paper.List] containing the gRPC representation of the project papers.
+ * @return A [GrpcProjectPaper.List] containing the gRPC representation of the [ProjectPaper]s.
  */
 fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
-    paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
+    paperAuthorsMap: Map<Paper, List<GrpcAuthor>>,
     paperBackwardReferencesMap: Map<Paper, List<String>>,
-    paperReviewsMap: Map<ProjectPaper, List<ReviewOuterClass.Review>>,
-): ProjectOuterClass.Project.Paper.List = ProjectOuterClass.Project.Paper.List
+    paperReviewsMap: Map<ProjectPaper, List<GrpcReview>>,
+): GrpcProjectPaper.List = GrpcProjectPaper.List
     .newBuilder()
     .addAllProjectPapers(
         this.map { projectPaper ->
@@ -59,9 +59,9 @@ fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
             val reviews = paperReviewsMap[projectPaper.projectPaper].orEmpty()
 
             projectPaper.toGrpcProjectPaper(
-                authors = authors,
-                backwardReferencedIds = backwardRefs,
-                reviews = reviews,
+                authors,
+                backwardRefs,
+                reviews,
             )
         },
     )

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
@@ -47,6 +46,6 @@ class PaperTableRepo(
     }
 
     override suspend fun doesPaperExistById(id: UUID): Boolean = db.query {
-        !PaperTable.selectAll().where { PaperTable.id eq id }.empty()
+        PaperTable.doesEntityExistById(id)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -35,7 +35,7 @@ interface IProjectTableRepo {
     suspend fun getProjectById(id: UUID): Project
 
     /**
-     * @return whether the project with the passed [id] exists.
+     * Checks whether the project with the passed [id] exists.
      */
     suspend fun doesProjectExistById(id: UUID): Boolean
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -35,6 +35,11 @@ interface IProjectTableRepo {
     suspend fun getProjectById(id: UUID): Project
 
     /**
+     * @return whether the project with the passed [id] exists.
+     */
+    suspend fun doesProjectExistById(id: UUID): Boolean
+
+    /**
      * Creates a new project in the database with the provided project creation request and user ID.
      *
      * @param request The project creation request containing project details
@@ -110,6 +115,9 @@ class ProjectTableRepo(
 
     override suspend fun getProjectById(id: UUID): Project = db.query {
         getProjectByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT, id.toString())
+    }
+    override suspend fun doesProjectExistById(id: UUID): Boolean = db.query {
+        ProjectTable.doesEntityExistById(id)
     }
 
     override suspend fun createProject(

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -67,6 +67,17 @@ private fun <Key : Any, T : IdTable<Key>> T.getEntityId(id: Key, entityType: Ent
     ?: throw NotFoundException(entityType, id.toString())
 
 /**
+ * Checks if an entity exists in the table with the given ID.
+ *
+ * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
+ * @param T The table type as a subtype of [IdTable].
+ * @param id The ID of type [Key], which is used to find the entity.
+ * @return True if an entity with the given ID exists, false otherwise.
+ */
+fun <Key : Any, T : IdTable<Key>> T.doesEntityExistById(id: Key): Boolean = this
+    .getEntityByIdOrNull(id) { it[this.id] } != null
+
+/**
  * Combination of using [insertAndGetId] and fetching the created entity by its ID.
  *
  * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -32,10 +32,10 @@ import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.PaperOuterClass
 import snowballr.ProjectOuterClass
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.ReviewOuterClass.Review as GrpcReview
 import snowballr.ProjectOuterClass.Project as GrpcProject
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+import snowballr.ReviewOuterClass.Review as GrpcReview
 
 @Suppress("ComplexInterface", "TooManyFunctions")
 interface IProjectService {
@@ -131,7 +131,6 @@ class ProjectService(
     private val reviewTableRepo: IReviewTableRepo,
     private val reviewHasCriterionTableRepo: IReviewHasCriterionTableRepo,
 ) : IProjectService {
-
     /**
      * Retrieves a list of [ProjectPaper] associated with a specified [Project] ID. This method
      * also ensures access control for the current user. Optionally, a predicate can be provided to filter
@@ -150,7 +149,9 @@ class ProjectService(
     ): GrpcProjectPaper.List {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectId = parseUUID(request.id, EntityType.PROJECT)
-        repo.getProjectById(projectId)
+        if (!repo.doesProjectExistById(projectId)) {
+            throw SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
+        }
         val projectMembers = projectMemberRepo.getProjectMembers(projectId)
 
         if (!projectMembers.any { it.userId == currentUser.id }) {
@@ -188,9 +189,12 @@ class ProjectService(
             projectPapersWithPapers.filter { pred(it, projectPaperReviewsMap, currentUser.id.toString()) }
         } ?: projectPapersWithPapers
 
-        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, projectPaperReviewsMap)
+        return projectPapersWithPapers.toGrpcProjectPapers(
+            paperAuthorsMap,
+            paperBackwardReferencesMap,
+            projectPaperReviewsMap,
+        )
     }
-
 
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
@@ -354,12 +358,14 @@ class ProjectService(
     override suspend fun getPapersToReviewForProject(request: Base.Id): GrpcProjectPaper.List {
         val predicate: (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean =
             { projectPaper, projectPaperReviewsMap, currentUserId ->
-                val isAlreadyReviewed = projectPaperReviewsMap[projectPaper.projectPaper]
+                val isAlreadyReviewedByCurrentUser = projectPaperReviewsMap[projectPaper.projectPaper]
                     ?.any { review -> review.userId == currentUserId } == true
+                val isAlreadyDecided =
+                    projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED ||
+                        projectPaper.projectPaper.decision ==
+                        ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW
 
-                !isAlreadyReviewed &&
-                        (projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED ||
-                        projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW)
+                !isAlreadyReviewedByCurrentUser && isAlreadyDecided
             }
         return getProjectPapers(request, predicate)
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
@@ -31,8 +32,9 @@ import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.PaperOuterClass
 import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.Review as GrpcReview
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @Suppress("ComplexInterface", "TooManyFunctions")
@@ -129,6 +131,67 @@ class ProjectService(
     private val reviewTableRepo: IReviewTableRepo,
     private val reviewHasCriterionTableRepo: IReviewHasCriterionTableRepo,
 ) : IProjectService {
+
+    /**
+     * Retrieves a list of [ProjectPaper] associated with a specified [Project] ID. This method
+     * also ensures access control for the current user. Optionally, a predicate can be provided to filter
+     * the [ProjectPaper]s based on custom criteria.
+     *
+     * @param request The request containing the ID of the [Project] for which [ProjectPaper]s are to be retrieved.
+     * @param predicate An optional lambda function that takes a [ProjectPaperWithPaper], a map of [GrpcReview], and a user ID.
+     * This function should return a boolean value to filter the [ProjectPaperWithPaper]s. If null, no filtering is applied.
+     * @return A list of [GrpcProjectPaper] as a [GrpcProjectPaper.List] including associated metadata such as authors,
+     * backward references, and reviews.
+     * @throws UnauthorizedException If the user does not have the required access to the project.
+     */
+    private suspend fun getProjectPapers(
+        request: Base.Id,
+        predicate: (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean)? = null,
+    ): GrpcProjectPaper.List {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+        repo.getProjectById(projectId)
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+        if (!projectMembers.any { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+
+        var projectPapersWithPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
+        val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
+        val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
+        val projectPaperReviewsMap = mutableMapOf<ProjectPaper, List<GrpcReview>>()
+        for (projectPaper in projectPapersWithPapers) {
+            val paper = projectPaper.paper
+            paperAuthorsMap[paper] = authorOfPaperTableRepo
+                .getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
+            paperBackwardReferencesMap[paper] = citationTableRepo
+                .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map {
+                    it.toString()
+                }
+            projectPaperReviewsMap[projectPaper.projectPaper] = reviewTableRepo
+                .getAllReviewsForProjectPaper(projectPaper.projectPaper.id)
+                .map {
+                    val selectedCriteriaIds = reviewHasCriterionTableRepo
+                        .getSelectedCriteriaIdsForReviewById(it.id)
+                    it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
+                }
+        }
+        projectPapersWithPapers = predicate?.let { pred ->
+            projectPapersWithPapers.filter { pred(it, projectPaperReviewsMap, currentUser.id.toString()) }
+        } ?: projectPapersWithPapers
+
+        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, projectPaperReviewsMap)
+    }
+
+
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectId = parseUUID(request.id, EntityType.PROJECT)
@@ -285,71 +348,19 @@ class ProjectService(
         return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
     }
 
-    data class ProjectPaperData(
-        val projectPapersWithPapers: List<ProjectPaperWithPaper>,
-        val paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
-        val paperBackwardReferencesMap: Map<Paper, List<String>>,
-        val paperReviewsMap: Map<ProjectPaper, List<ReviewOuterClass.Review>>,
-    )
+    override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProjectPaper.List =
+        getProjectPapers(request)
 
-    private suspend fun getProjectPapers(request: Base.Id): ProjectPaperData {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        val projectId = parseUUID(request.id, EntityType.PROJECT)
-        repo.getProjectById(projectId)
-        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+    override suspend fun getPapersToReviewForProject(request: Base.Id): GrpcProjectPaper.List {
+        val predicate: (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean =
+            { projectPaper, projectPaperReviewsMap, currentUserId ->
+                val isAlreadyReviewed = projectPaperReviewsMap[projectPaper.projectPaper]
+                    ?.any { review -> review.userId == currentUserId } == true
 
-        if (!projectMembers.any { it.userId == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
+                !isAlreadyReviewed &&
+                        (projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED ||
+                        projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW)
             }
-        }
-
-        val projectPapersWithPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
-        val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
-        val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
-        val paperReviewsMap = mutableMapOf<ProjectPaper, List<ReviewOuterClass.Review>>()
-        for (projectPaper in projectPapersWithPapers) {
-            val paper = projectPaper.paper
-            paperAuthorsMap[paper] = authorOfPaperTableRepo
-                .getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
-            paperBackwardReferencesMap[paper] = citationTableRepo
-                .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map {
-                    it.toString()
-                }
-            paperReviewsMap[projectPaper.projectPaper] = reviewTableRepo
-                .getAllReviewsForProjectPaper(projectPaper.projectPaper.id)
-                .map {
-                    val selectedCriteriaIds = reviewHasCriterionTableRepo
-                        .getSelectedCriteriaIdsForReviewById(it.id)
-                    it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
-                }
-        }
-        return ProjectPaperData(projectPapersWithPapers, paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
-    }
-
-    override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List {
-        val (projectPapersWithPapers, paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap) =
-            getProjectPapers(request)
-        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
-    }
-
-    override suspend fun getPapersToReviewForProject(request: Base.Id): GrpcProject.Paper.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        var (projectPapersWithPapers, paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap) =
-            getProjectPapers(request)
-        projectPapersWithPapers = projectPapersWithPapers.filter {
-            val isAlreadyReviewed = paperReviewsMap[it.projectPaper]
-                ?.any { review -> review.userId == currentUser.id.toString() } == true
-
-            !isAlreadyReviewed &&
-                it.projectPaper.decision != ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED &&
-                it.projectPaper.decision != ProjectOuterClass.PaperDecision.PAPER_DECISION_DECLINED
-        }
-        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
+        return getProjectPapers(request, predicate)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
@@ -29,11 +30,12 @@ import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.PaperOuterClass
+import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ReviewOuterClass
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
-@Suppress("ComplexInterface")
+@Suppress("ComplexInterface", "TooManyFunctions")
 interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectById].
@@ -87,6 +89,11 @@ interface IProjectService {
      * Service implementation of [SnowballRService.getAllProjectPapersForProject].
      */
     suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List
+
+    /**
+     * Service implementation of [SnowballRService.getPapersToReviewForProject]
+     */
+    suspend fun getPapersToReviewForProject(request: Base.Id): GrpcProject.Paper.List
 }
 
 /**
@@ -109,7 +116,7 @@ interface IProjectService {
  * @param reviewHasCriterionTableRepo The repository responsible for managing persistence operations for the review has
  * criterion relation.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
@@ -278,7 +285,14 @@ class ProjectService(
         return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
     }
 
-    override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List {
+    data class ProjectPaperData(
+        val projectPapersWithPapers: List<ProjectPaperWithPaper>,
+        val paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
+        val paperBackwardReferencesMap: Map<Paper, List<String>>,
+        val paperReviewsMap: Map<ProjectPaper, List<ReviewOuterClass.Review>>,
+    )
+
+    private suspend fun getProjectPapers(request: Base.Id): ProjectPaperData {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectId = parseUUID(request.id, EntityType.PROJECT)
         repo.getProjectById(projectId)
@@ -298,7 +312,7 @@ class ProjectService(
         val projectPapersWithPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
         val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
         val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
-        val paperReviewsMap = mutableMapOf<Paper, List<ReviewOuterClass.Review>>()
+        val paperReviewsMap = mutableMapOf<ProjectPaper, List<ReviewOuterClass.Review>>()
         for (projectPaper in projectPapersWithPapers) {
             val paper = projectPaper.paper
             paperAuthorsMap[paper] = authorOfPaperTableRepo
@@ -307,13 +321,34 @@ class ProjectService(
                 .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map {
                     it.toString()
                 }
-            paperReviewsMap[paper] = reviewTableRepo
+            paperReviewsMap[projectPaper.projectPaper] = reviewTableRepo
                 .getAllReviewsForProjectPaper(projectPaper.projectPaper.id)
                 .map {
                     val selectedCriteriaIds = reviewHasCriterionTableRepo
                         .getSelectedCriteriaIdsForReviewById(it.id)
                     it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
                 }
+        }
+        return ProjectPaperData(projectPapersWithPapers, paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
+    }
+
+    override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProject.Paper.List {
+        val (projectPapersWithPapers, paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap) =
+            getProjectPapers(request)
+        return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
+    }
+
+    override suspend fun getPapersToReviewForProject(request: Base.Id): GrpcProject.Paper.List {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        var (projectPapersWithPapers, paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap) =
+            getProjectPapers(request)
+        projectPapersWithPapers = projectPapersWithPapers.filter {
+            val isAlreadyReviewed = paperReviewsMap[it.projectPaper]
+                ?.any { review -> review.userId == currentUser.id.toString() } == true
+
+            !isAlreadyReviewed &&
+                it.projectPaper.decision != ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED &&
+                it.projectPaper.decision != ProjectOuterClass.PaperDecision.PAPER_DECISION_DECLINED
         }
         return projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, paperReviewsMap)
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -132,14 +132,14 @@ class ProjectService(
     private val reviewHasCriterionTableRepo: IReviewHasCriterionTableRepo,
 ) : IProjectService {
     /**
-     * Retrieves a list of [ProjectPaper] associated with a specified [Project] ID. This method
-     * also ensures access control for the current user. Optionally, a predicate can be provided to filter
+     * Retrieves a list of [ProjectPaper] associated with a specified project id. This method
+     * also ensures access control for the current user. Optionally, a predicate function can be provided to filter
      * the [ProjectPaper]s based on custom criteria.
      *
      * @param request The request containing the ID of the [Project] for which [ProjectPaper]s are to be retrieved.
      * @param predicate An optional lambda function that takes a [ProjectPaperWithPaper], a map of [GrpcReview], and a user ID.
      * This function should return a boolean value to filter the [ProjectPaperWithPaper]s. If null, no filtering is applied.
-     * @return A list of [GrpcProjectPaper] as a [GrpcProjectPaper.List] including associated metadata such as authors,
+     * @return A list of [GrpcProjectPaper] including associated metadata such as authors,
      * backward references, and reviews.
      * @throws UnauthorizedException If the user does not have the required access to the project.
      */
@@ -360,12 +360,12 @@ class ProjectService(
             { projectPaper, projectPaperReviewsMap, currentUserId ->
                 val isAlreadyReviewedByCurrentUser = projectPaperReviewsMap[projectPaper.projectPaper]
                     ?.any { review -> review.userId == currentUserId } == true
-                val isAlreadyDecided =
+                val isStillUndecided =
                     projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED ||
                         projectPaper.projectPaper.decision ==
                         ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW
 
-                !isAlreadyReviewedByCurrentUser && isAlreadyDecided
+                !isAlreadyReviewedByCurrentUser && isStillUndecided
             }
         return getProjectPapers(request, predicate)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -51,4 +51,24 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
             assertFalse { repo.doesPaperExistById(UUID.randomUUID()) }
         }
     }
+
+    @Nested
+    inner class DoesPaperExistById {
+        @Test
+        fun `When a paper with the given id exists, then true returned`() = runTest {
+            val paperId =
+                insertPaperAndGetId("Test Paper")
+            val isPaperExisting = repo.doesPaperExistById(paperId)
+
+            assertTrue(isPaperExisting)
+        }
+
+        @Test
+        fun `When a paper with the given id does not exist, then false returned`() = runTest {
+            val paperId = UUID.randomUUID()
+            val isPaperExisting = repo.doesPaperExistById(paperId)
+
+            assertFalse(isPaperExisting)
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -22,6 +22,8 @@ import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
 import java.util.UUID
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectTableRepo(db)
@@ -60,6 +62,26 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         @Test
         fun `When a project is not found, then an exception is thrown`() = runTest {
             assertThrows<NotFoundException> { repo.getProjectById(UUID.randomUUID()) }
+        }
+    }
+
+    @Nested
+    inner class DoesProjectExistById {
+        @Test
+        fun `When a project with the given id exists, then true returned`() = runTest {
+            val projectId =
+                insertProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+            val isProjectExisting = repo.doesProjectExistById(projectId)
+
+            assertTrue(isProjectExisting)
+        }
+
+        @Test
+        fun `When a project with the given id does not exist, then false returned`() = runTest {
+            val projectId = UUID.randomUUID()
+            val isProjectExisting = repo.doesProjectExistById(projectId)
+
+            assertFalse(isProjectExisting)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -30,7 +30,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
         Arguments.of(userRepoMock::getUserById),
-        Arguments.of(projectRepoMock::getProjectById),
+        Arguments.of(projectRepoMock::doesProjectExistById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
         Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
@@ -40,12 +40,19 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     )
 
     @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (isUserAdmin) {
+                UserOuterClass.UserRole.USER_ROLE_ADMIN
+            } else {
+                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+            },
+        )
         val project = DataBuilder.createExampleProject(id = requestId)
         val paper = DataBuilder.createExamplePaper(id = requestId)
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
@@ -61,19 +68,22 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         }
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
 
-        if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+        if (failAt == projectRepoMock::doesProjectExistById) {
+            coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
             return
         }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
             return
         }
-        coEvery {
-            projectMemberRepoMock.getProjectMembers(project.id)
-        } returns listOf(DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id))
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
+            if (isUserAdmin) {
+                emptyList()
+            } else {
+                listOf(projectMember)
+            }
 
         if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
             coEvery {
@@ -121,7 +131,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     @ParameterizedTest
     @MethodSource("failingFunctions")
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
+        mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getAllProjectPapersForProject(getExampleRequest())
         }
@@ -129,37 +139,13 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
 
     @Test
     fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null)
+        mockHappyPathUntil(null, true)
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-
+        mockHappyPathUntil(null, false)
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
@@ -170,7 +156,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -1,0 +1,293 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass
+import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GetPapersToReviewForProjectTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(GrpcContext::getUserIdFromContext),
+        Arguments.of(userRepoMock::getUserById),
+        Arguments.of(projectRepoMock::getProjectById),
+        Arguments.of(projectMemberRepoMock::getProjectMembers),
+        Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
+        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
+        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
+        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
+        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
+    )
+
+    @Suppress("LongMethod", "ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
+
+        if (failAt == GrpcContext::getUserIdFromContext) {
+            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+            return
+        }
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+
+        if (failAt == userRepoMock::getUserById) {
+            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            return
+        }
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+
+        if (failAt == projectRepoMock::getProjectById) {
+            coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+            return
+        }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+
+        if (failAt == projectMemberRepoMock::getProjectMembers) {
+            coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            projectMemberRepoMock.getProjectMembers(project.id)
+        } returns listOf(DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id))
+
+        if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
+            coEvery {
+                projectPaperRepoMock.getAllProjectPapersWithPapers(any())
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
+
+        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) } throws TestSpecificException()
+            return
+        }
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+
+        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any())
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+
+        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } throws TestSpecificException()
+            return
+        }
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+
+        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns listOf(UUID.randomUUID())
+    }
+
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getPapersToReviewForProject(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When a server admin requests the project papers to review, then no exception is thrown`() = runTest {
+        mockHappyPathUntil(null)
+        assertDoesNotThrow { mainService.getPapersToReviewForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member requests the project papers to review, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns listOf(UUID.randomUUID())
+
+        assertDoesNotThrow { mainService.getPapersToReviewForProject(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member requests the project papers to review, then an unauthorized exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(id = requestId)
+
+            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+            assertThrows<SnowballRException.UnauthorizedException> {
+                mainService.getPapersToReviewForProject(
+                    getExampleRequest(),
+                )
+            }
+        }
+
+    @Test
+    fun `When the project papers to review are requested, then only the not already decided papers are returned`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(id = requestId)
+            val paper = DataBuilder.createExamplePaper(id = requestId)
+            val projectPaperAlreadyDecided = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper.id,
+                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+            )
+            val projectPaperNotAlreadyDecided = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper.id,
+                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+            )
+            val projectPaperWithPaper1 = ProjectPaperWithPaper(projectPaperAlreadyDecided, paper)
+            val projectPaperWithPaper2 = ProjectPaperWithPaper(projectPaperNotAlreadyDecided, paper)
+            val author = DataBuilder.createExampleAuthor()
+            val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
+
+            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+            coEvery {
+                projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+            } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            } returns listOf(UUID.randomUUID())
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperAlreadyDecided.id)
+            } returns listOf(review)
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperNotAlreadyDecided.id)
+            } returns listOf(review)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+            } returns listOf(UUID.randomUUID())
+
+            var projectPapers: ProjectOuterClass.Project.Paper.List
+            assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
+            assertThat(projectPapers.projectPapersList).hasSize(1)
+            assertThat(
+                projectPapers.projectPapersList,
+            ).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
+            assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
+        }
+
+    @Test
+    fun `When the project papers to review are requested, then only the papers that were not already reviewed by the current user are returned`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(id = requestId)
+            val paper = DataBuilder.createExamplePaper(id = requestId)
+            val projectPaperWithCurrentUserReview = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper.id,
+                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+            )
+            val projectPaperWithoutCurrentUserReview = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper.id,
+                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+            )
+            val projectPaperWithPaper1 = ProjectPaperWithPaper(projectPaperWithCurrentUserReview, paper)
+            val projectPaperWithPaper2 = ProjectPaperWithPaper(projectPaperWithoutCurrentUserReview, paper)
+            val author = DataBuilder.createExampleAuthor()
+            val reviewByCurrentUser = DataBuilder.createExampleReview(userId = currentUser.id)
+            val reviewByOtherUser = DataBuilder.createExampleReview(userId = UUID.randomUUID())
+
+            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+            coEvery {
+                projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+            } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            } returns listOf(UUID.randomUUID())
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperWithCurrentUserReview.id)
+            } returns listOf(reviewByCurrentUser)
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperWithoutCurrentUserReview.id)
+            } returns listOf(reviewByOtherUser)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviewByCurrentUser.id)
+            } returns listOf(UUID.randomUUID())
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviewByOtherUser.id)
+            } returns listOf(UUID.randomUUID())
+
+            var projectPapers: ProjectOuterClass.Project.Paper.List
+            assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
+            assertThat(projectPapers.projectPapersList).hasSize(1)
+            assertThat(
+                projectPapers.projectPapersList,
+            ).anyMatch { it.id == projectPaperWithoutCurrentUserReview.id.toString() }
+            assertThat(
+                projectPapers.projectPapersList,
+            ).noneMatch { it.id == projectPaperWithCurrentUserReview.id.toString() }
+        }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -32,7 +32,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
         Arguments.of(userRepoMock::getUserById),
-        Arguments.of(projectRepoMock::getProjectById),
+        Arguments.of(projectRepoMock::doesProjectExistById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
         Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
@@ -42,12 +42,19 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     )
 
     @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (isUserAdmin) {
+                UserOuterClass.UserRole.USER_ROLE_ADMIN
+            } else {
+                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+            },
+        )
         val project = DataBuilder.createExampleProject(id = requestId)
         val paper = DataBuilder.createExamplePaper(id = requestId)
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
@@ -63,19 +70,22 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         }
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
 
-        if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+        if (failAt == projectRepoMock::doesProjectExistById) {
+            coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
             return
         }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
             return
         }
-        coEvery {
-            projectMemberRepoMock.getProjectMembers(project.id)
-        } returns listOf(DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id))
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
+            if (isUserAdmin) {
+                emptyList()
+            } else {
+                listOf(projectMember)
+            }
 
         if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
             coEvery {
@@ -123,7 +133,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     @ParameterizedTest
     @MethodSource("failingFunctions")
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
+        mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getPapersToReviewForProject(getExampleRequest())
         }
@@ -131,37 +141,13 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
     @Test
     fun `When a server admin requests the project papers to review, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null)
+        mockHappyPathUntil(null, true)
         assertDoesNotThrow { mainService.getPapersToReviewForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member requests the project papers to review, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-
+        mockHappyPathUntil(null, false)
         assertDoesNotThrow { mainService.getPapersToReviewForProject(getExampleRequest()) }
     }
 
@@ -173,7 +159,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.UnauthorizedException> {
@@ -184,58 +170,57 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the project papers to review are requested, then only the not already decided papers are returned`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(id = requestId)
-            val paper = DataBuilder.createExamplePaper(id = requestId)
-            val projectPaperAlreadyDecided = DataBuilder.createExampleProjectPaper(
-                projectId = project.id,
-                paperId = paper.id,
-                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
-            )
-            val projectPaperNotAlreadyDecided = DataBuilder.createExampleProjectPaper(
-                projectId = project.id,
-                paperId = paper.id,
-                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
-            )
-            val projectPaperWithPaper1 = ProjectPaperWithPaper(projectPaperAlreadyDecided, paper)
-            val projectPaperWithPaper2 = ProjectPaperWithPaper(projectPaperNotAlreadyDecided, paper)
-            val author = DataBuilder.createExampleAuthor()
-            val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
+    fun `When the project papers to review are requested, then only the undecided papers are returned`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val projectPaperAlreadyDecided = DataBuilder.createExampleProjectPaper(
+            projectId = project.id,
+            paperId = paper.id,
+            decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+        )
+        val projectPaperNotAlreadyDecided = DataBuilder.createExampleProjectPaper(
+            projectId = project.id,
+            paperId = paper.id,
+            decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+        )
+        val projectPaperWithPaper1 = ProjectPaperWithPaper(projectPaperAlreadyDecided, paper)
+        val projectPaperWithPaper2 = ProjectPaperWithPaper(projectPaperNotAlreadyDecided, paper)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-            coEvery {
-                projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-            } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            } returns listOf(UUID.randomUUID())
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperAlreadyDecided.id)
-            } returns listOf(review)
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperNotAlreadyDecided.id)
-            } returns listOf(review)
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-            } returns listOf(UUID.randomUUID())
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
+        } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+        coEvery {
+            reviewRepoMock.getAllReviewsForProjectPaper(projectPaperAlreadyDecided.id)
+        } returns listOf(review)
+        coEvery {
+            reviewRepoMock.getAllReviewsForProjectPaper(projectPaperNotAlreadyDecided.id)
+        } returns listOf(review)
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns listOf(UUID.randomUUID())
 
-            var projectPapers: ProjectOuterClass.Project.Paper.List
-            assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
-            assertThat(projectPapers.projectPapersList).hasSize(1)
-            assertThat(
-                projectPapers.projectPapersList,
-            ).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
-            assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
-        }
+        var projectPapers: ProjectOuterClass.Project.Paper.List
+        assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
+        assertThat(projectPapers.projectPapersList).hasSize(1)
+        assertThat(
+            projectPapers.projectPapersList,
+        ).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
+        assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
+    }
 
     @Test
-    fun `When the project papers to review are requested, then only the papers that were not already reviewed by the current user are returned`() =
+    fun `When the project papers to review are requested, then only undecided papers that were not already reviewed by the current user are returned`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject(id = requestId)
@@ -258,7 +243,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
             coEvery {
                 projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -39,8 +39,14 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     )
 
     @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (isUserAdmin) {
+                UserOuterClass.UserRole.USER_ROLE_ADMIN
+            } else {
+                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+            },
+        )
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(
@@ -48,6 +54,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             projectId = project.id,
             paperId = paper.id,
         )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
@@ -73,7 +80,12 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
+            if (isUserAdmin) {
+                emptyList()
+            } else {
+                listOf(projectMember)
+            }
 
         if (failAt == paperRepoMock::getPaperById) {
             coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
@@ -119,7 +131,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     @ParameterizedTest
     @MethodSource("failingFunctions")
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
+        mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getProjectPaperById(getExampleRequest())
         }
@@ -127,38 +139,13 @@ class GetProjectPaperByIdTest : MainServiceTest() {
 
     @Test
     fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null)
+        mockHappyPathUntil(null, true)
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-
+        mockHappyPathUntil(null, false)
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -36,11 +36,18 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
     )
 
-    @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    @Suppress("ReturnCount", "LongMethod")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (isUserAdmin) {
+                UserOuterClass.UserRole.USER_ROLE_ADMIN
+            } else {
+                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+            },
+        )
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val review = DataBuilder.createExampleReview(userId = currentUser.id)
         val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
 
@@ -72,7 +79,12 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
+            if (isUserAdmin) {
+                emptyList()
+            } else {
+                listOf(projectMember)
+            }
 
         if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
             coEvery {
@@ -96,7 +108,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     @ParameterizedTest
     @MethodSource("failingFunctions")
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
+        mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getAllReviewsForProjectPaper(getExampleRequest())
         }
@@ -104,29 +116,13 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
 
     @Test
     fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null)
+        mockHappyPathUntil(null, true)
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val review = DataBuilder.createExampleReview(userId = currentUser.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns selectedCriteriaIds
-
+        mockHappyPathUntil(null, false)
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -37,11 +37,18 @@ class GetReviewByIdTest : MainServiceTest() {
     )
 
     @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (isUserAdmin) {
+                UserOuterClass.UserRole.USER_ROLE_ADMIN
+            } else {
+                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+            },
+        )
         val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
 
         if (failAt == GrpcContext::getUserIdFromContext) {
@@ -78,7 +85,12 @@ class GetReviewByIdTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
+            if (isUserAdmin) {
+                emptyList()
+            } else {
+                listOf(projectMember)
+            }
 
         if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
             coEvery {
@@ -94,7 +106,7 @@ class GetReviewByIdTest : MainServiceTest() {
     @ParameterizedTest
     @MethodSource("failingFunctions")
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
+        mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getReviewById(getExampleRequest())
         }
@@ -102,29 +114,13 @@ class GetReviewByIdTest : MainServiceTest() {
 
     @Test
     fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null)
+        mockHappyPathUntil(null, true)
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves the review, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
-
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns selectedCriteriaIds
-
+        mockHappyPathUntil(null, false)
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
     }
 


### PR DESCRIPTION
Closes #99 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

**Note:** Only the last four commits are relevant for this PR. Since this PR is based on many functionality, which is implemented in #181  I rebased this branch on #257, which will be merged soon.

**Note:** This PR can already be reviewed even though the formatter fails. Depending on the review I will clean up the code for the formatter.

**Note:** For the reviewer: Please have a look into the service implementation of the `getPapersToReviewForProject` method. I am not completely happy with this implementation, since we would have to iterate over the project papers two times, but this way we can avoid a lot of duplicated code and I did not find a good way to implement this with getting the best of both worlds. Maybe you can have a look and let me know if you have any good ideas.

I have implemented the `getPapersToReviewForProject` method by refactoring the `getAllProjectPapersForProject` method and adding a bit of functinality.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
