### PR TITLE
Implement `getBackwardReferencedPapers` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -371,7 +371,7 @@ class SnowballRServer(
             super.getForwardReferencedPapers(request)
 
         override suspend fun getBackwardReferencedPapers(request: Base.Id): PaperOuterClass.Paper.List =
-            super.getBackwardReferencedPapers(request)
+            mainService.getBackwardReferencedPapers(request)
 
         override suspend fun getPaperPdf(request: Base.Id): Base.Blob = super.getPaperPdf(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -31,19 +31,38 @@ data class Paper(
 fun Paper.toGrpcPaper(
     authors: List<PaperOuterClass.Author>,
     backwardReferencedIds: List<String>,
-): PaperOuterClass.Paper {
-    val paper = this
-    return with(PaperOuterClass.Paper.newBuilder()) {
-        setId(paper.id.toString())
-        setTitle(paper.title)
-        paper.externalId?.let { setExternalId(it) }
-        setAbstrakt(paper.abstract)
-        paper.publisher?.let { setPublisher(it) }
-        paper.publicationType?.let { setPublicationType(it) }
-        paper.publicationName?.let { setPublicationName(it) }
-        setHasPdf(paper.pdfId != null)
-        addAllAuthors(authors)
-        addAllBackwardReferencedIds(backwardReferencedIds)
-        build()
-    }
-}
+): PaperOuterClass.Paper = PaperOuterClass.Paper
+    .newBuilder()
+    .setId(id.toString())
+    .setTitle(title)
+    .setExternalId(externalId)
+    .setAbstrakt(abstract)
+    .setPublisher(publisher)
+    .setPublicationType(publicationType)
+    .setPublicationName(publicationName)
+    .setHasPdf(pdfId != null)
+    .addAllAuthors(authors)
+    .addAllBackwardReferencedIds(backwardReferencedIds)
+    .build()
+
+/**
+ * Converts a list of [Paper] objects into a gRPC list of papers.
+ *
+ * @return A [PaperOuterClass.Paper.List] containing the gRPC representation of the papers.
+ */
+fun List<Paper>.toGrpcPapers(
+    paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
+    paperBackwardReferencesMap: Map<Paper, List<String>>,
+): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List
+    .newBuilder()
+    .addAllPapers(
+        this.map { paper ->
+            val authors = paperAuthorsMap[paper].orEmpty()
+            val backwardRefs = paperBackwardReferencesMap[paper].orEmpty()
+            paper.toGrpcPaper(
+                authors = authors,
+                backwardReferencedIds = backwardRefs,
+            )
+        },
+    )
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -2,13 +2,17 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcPapers
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import snowballr.Base
+import snowballr.PaperOuterClass
 import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface IPaperService {
@@ -16,6 +20,11 @@ interface IPaperService {
      * Service implementation of [SnowballRService.getPaperById].
      */
     suspend fun getPaperById(request: Base.Id): GrpcPaper
+
+    /**
+     * Service implementation of [SnowballRService.getBackwardReferencedPapers].
+     */
+    suspend fun getBackwardReferencedPapers(request: Base.Id): GrpcPaper.List
 }
 
 /**
@@ -42,5 +51,29 @@ class PaperService(
         val backwardReferencedIds = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
             .map { it.toString() }
         return paper.toGrpcPaper(authors, backwardReferencedIds)
+    }
+
+    override suspend fun getBackwardReferencedPapers(request: Base.Id): GrpcPaper.List {
+        val paperId = parseUUID(request.id, EntityType.PAPER)
+        if (!repo.doesPaperExistById(paperId)) {
+            throw SnowballRException.NotFoundException(EntityType.PAPER, paperId.toString())
+        }
+
+        val backwardReferencedIds = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
+        val papers: MutableList<Paper> = mutableListOf()
+        val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
+        val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
+        backwardReferencedIds.forEach {
+            val referencedPaper = repo.getPaperById(it)
+            papers.add(referencedPaper)
+            paperAuthorsMap[referencedPaper] = authorOfPapersRepo
+                .getAuthorsOfPaperById(referencedPaper.id).map { author -> author.toGrpcAuthor() }
+            paperBackwardReferencesMap[referencedPaper] = citationRepo
+                .getBackwardsReferencedPaperIdsOfPaperById(referencedPaper.id).map { reference ->
+                    reference.toString()
+                }
+        }
+
+        return papers.toGrpcPapers(paperAuthorsMap, paperBackwardReferencesMap)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -1,0 +1,129 @@
+package se.uulm.snowballr.backend.service.paper
+
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GetBackwardReferencedPapersTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestId.toString())
+        .build()
+
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(paperRepoMock::doesPaperExistById),
+        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
+        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
+        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
+    )
+
+    @Suppress("ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val backwardReferenceId = UUID.randomUUID()
+        val referencedPaper = DataBuilder.createExamplePaper(id = backwardReferenceId)
+        val author = DataBuilder.createExampleAuthor()
+
+        if (failAt == paperRepoMock::doesPaperExistById) {
+            coEvery { paperRepoMock.doesPaperExistById(paper.id) } throws TestSpecificException()
+            return
+        }
+        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+
+        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(backwardReferenceId)
+
+        if (failAt == paperRepoMock::getPaperById) {
+            coEvery { paperRepoMock.getPaperById(backwardReferenceId) } throws TestSpecificException()
+            return
+        }
+        coEvery { paperRepoMock.getPaperById(backwardReferenceId) } returns referencedPaper
+
+        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(backwardReferenceId) } throws TestSpecificException()
+            return
+        }
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(backwardReferenceId) } returns listOf(author)
+
+        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(backwardReferenceId)
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(backwardReferenceId)
+        } returns listOf(UUID.randomUUID())
+    }
+
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getBackwardReferencedPapers(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
+        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns false
+        assertThrows<SnowballRException.NotFoundException> {
+            mainService.getBackwardReferencedPapers(
+                getExampleRequest(),
+            )
+        }
+    }
+
+    @Test
+    fun `When one of the backward references doesn't exist, then a NotFoundException is thrown`() = runTest {
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val backwardReferenceId = UUID.randomUUID()
+
+        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns true
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(backwardReferenceId)
+        coEvery { paperRepoMock.getPaperById(backwardReferenceId) } throws SnowballRException.NotFoundException(
+            entityType = EntityType.PAPER, requestId.toString(),
+        )
+
+        assertThrows<SnowballRException.NotFoundException> {
+            mainService.getBackwardReferencedPapers(
+                getExampleRequest(),
+            )
+        }
+    }
+
+    @Test
+    fun `When the backward references of an existing paper are retrieved successfully, then no error is thrown`() =
+        runTest {
+            mockHappyPathUntil(null)
+            assertDoesNotThrow { mainService.getBackwardReferencedPapers(getExampleRequest()) }
+        }
+}


### PR DESCRIPTION
Closes #168 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

**Note:** Only have a look on the last four commits, because this branch was rebased onto #267.

I have fixed a bug in the author `DTO`, because the `toGrpcAuthor` method did not correctly write the values.

Additionally, I fixed the same bug for the paper `DTO` and added the method `toGrpcPapers`.
Then I implemented the service and the grpc layer for the `getBackwardReferencedPapers` call.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
