### PR TITLE
Fix Login Issues with Safari and Http

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/CookieService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/CookieService.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.auth
 
+import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.auth.CookieConfig
 
 interface ICookieService {
@@ -49,8 +50,12 @@ interface ICookieService {
  * Utility object for parsing and constructing HTTP cookie headers.
  *
  * @param jwtService The JWT service used to resolve token TTLs.
+ * @param envReader The environment reader used to access the current configuration.
  */
-class CookieService(private val jwtService: IJwtService) : ICookieService {
+class CookieService(
+    private val jwtService: IJwtService,
+    private val envReader: EnvReader,
+) : ICookieService {
     override fun parseCookies(cookieHeader: String?): Map<String, String> {
         if (cookieHeader.isNullOrBlank()) return emptyMap()
         return cookieHeader
@@ -78,7 +83,8 @@ class CookieService(private val jwtService: IJwtService) : ICookieService {
             path = "/",
             sameSite = "Strict", // Stricter policy for auth tokens
             httpOnly = true,
-            secure = true,
+            // Inverted condition here so it defaults to `true`
+            secure = !envReader.env.miscellaneous.frontendBaseUrl.startsWith("http:"),
         )
 
         return createCookieString(authCookieConfig)

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -71,6 +71,13 @@ class EnvReader(
                 defaults.smtpTransportLoggingOnlyEnabled,
             )
 
+        if (frontendBaseUrl.startsWith("http:")) {
+            logger.warn {
+                "The frontend url is set to the 'http' protocol, hinting at a possible security issue." +
+                    " Prefer 'https' wherever you can."
+            }
+        }
+
         // If AUTH_BYPASS_ENABLED is `true`, we must also seed the user
         val authBypassEnabled = envService.getBooleanOrDefault(AUTH_BYPASS_ENABLED, defaults.authBypassEnabled)
         val seedUserEnabled =

--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/CookieServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/CookieServiceTest.kt
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
+import se.uulm.snowballr.backend.env.Env
+import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.auth.CookieConfig
 
 class CookieServiceTest {
@@ -16,7 +18,18 @@ class CookieServiceTest {
         every { getAccessTokenTTL() } returns JwtService.ACCESS_TOKEN_EXPIRATION_MS
         every { getRefreshTokenTTL() } returns JwtService.REFRESH_TOKEN_EXPIRATION_MS
     }
-    private val cookieService = CookieService(jwtServiceMock)
+    private val cookieService = CookieService(jwtServiceMock, createEnvReader("https://"))
+
+    private fun createEnvReader(frontendBaseUrl: String): EnvReader {
+        val envReaderMock = mockk<EnvReader>()
+        val miscellaneousMock = mockk<Env.Miscellaneous>()
+        every { miscellaneousMock.frontendBaseUrl } returns frontendBaseUrl
+
+        val envMock = mockk<Env>()
+        every { envMock.miscellaneous } returns miscellaneousMock
+        every { envReaderMock.env } returns envMock
+        return envReaderMock
+    }
 
     @Nested
     inner class ParseCookies {
@@ -103,6 +116,24 @@ class CookieServiceTest {
             val cookie = cookieService.buildAuthCookieString("unknown_cookie", "value")
 
             assertNull(cookie)
+        }
+
+        @Test
+        fun `When the frontend base url starts with http(colon), then secure defaults to false`() {
+            val cookieService = CookieService(jwtServiceMock, createEnvReader("http://"))
+            val cookie = cookieService.buildAuthCookieString(GrpcContext.REFRESH_TOKEN_COOKIE_NAME, "value")
+
+            assertNotNull(cookie)
+            assertFalse(cookie.contains("Secure"))
+        }
+
+        @Test
+        fun `When the frontend base url starts with https(colon), then secure defaults to true`() {
+            val cookieService = CookieService(jwtServiceMock, createEnvReader("https://"))
+            val cookie = cookieService.buildAuthCookieString(GrpcContext.REFRESH_TOKEN_COOKIE_NAME, "value")
+
+            assertNotNull(cookie)
+            assertTrue(cookie.contains("Secure"))
         }
     }
 


### PR DESCRIPTION
Closes #269

## What I have made

The `set-cookie` `secure` attribute is now not set anymore if the frontend's base URL starts with `http:` indicating an insecure connection. The rationale behind disabling it in case `http:` is found is that it should default to enabled in unknown cases.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have ~~added tests that~~ manually tested it to prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
