### PR TITLE
Use coverifyverify to validate execution of repo layer call in tests

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -146,7 +146,7 @@ class ProjectService(
         val userSettings = userRepo.getUserSettings(currentUser.id)
         val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        val project = repo.createProject(request, GrpcContext.getUserIdFromContext(), userSettings)
+        val project = repo.createProject(request, currentUser.id, userSettings)
 
         for (criterion in userDefaultCriteria) {
             val criterionRequest = CriterionOuterClass.Criterion.Create

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -60,6 +60,9 @@ import se.uulm.snowballr.backend.serviceLayerDeps
  *
  *             // Assert service behavior
  *             assertDoesNotThrow { mainService.createExample(request) }
+ *
+ *             // Verify that the correct method was called
+ *             coVerify(exactly = 1) { exampleRepoMock.createExample(request) }
  *         }
  *
  *     @Test
@@ -72,6 +75,9 @@ import se.uulm.snowballr.backend.serviceLayerDeps
  *
  *             // Assert service behavior
  *             assertThrows<TestSpecificException> { mainService.createExample(request) }
+ *
+ *             // Verify that the correct method was called
+ *             coVerify(exactly = 1) { exampleRepoMock.createExample(request) }
  *         }
  * }
  * ```

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -16,7 +16,6 @@ import snowballr.CriterionOuterClass
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 
 class CreateCriterionTest : MainServiceTest() {
     private fun getProjectCriterionRequest(projectId: String): CriterionOuterClass.Criterion.Create {
@@ -56,7 +55,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -74,7 +73,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
@@ -91,7 +90,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -114,7 +113,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -129,7 +128,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getUserCriterionRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
@@ -138,11 +137,10 @@ class CreateCriterionTest : MainServiceTest() {
     @Test
     fun `When an error occurs while a criterion is created, then an exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
-        val userId = UUID.randomUUID()
-        val user = DataBuilder.createExampleUser(id = userId)
+        val user = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.createCriterion(request) }
@@ -151,11 +149,11 @@ class CreateCriterionTest : MainServiceTest() {
     @Test
     fun `When a criterion is correctly created, then no exception is thrown`() = runTest {
         val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
-        val user = DataBuilder.createExampleUser(id = UUID.randomUUID())
+        val user = DataBuilder.createExampleUser()
         val criterion = DataBuilder.createExampleProjectCriterion()
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -28,18 +28,18 @@ class GetCriterionByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
         val criterion = DataBuilder.createExampleProjectCriterion(
             id = requestId,
-            projectId = UUID.randomUUID(),
+            projectId = project.id,
             createdBy = adminUser.id,
         )
-        val project = DataBuilder.createExampleProject(id = requestId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
     }
@@ -60,9 +60,9 @@ class GetCriterionByIdTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
         }
@@ -73,18 +73,18 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val noAccessUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
             val criterion = DataBuilder.createExampleProjectCriterion(
                 id = requestId,
-                projectId = UUID.randomUUID(),
+                projectId = project.id,
                 createdBy = noAccessUser.id,
             )
-            val project = DataBuilder.createExampleProject()
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
             coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
-            coEvery { projectRepoMock.getProjectById(any()) } returns project
-            coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -57,8 +57,8 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertDoesNotThrow { mainService.updateCriterion(request) }
@@ -82,7 +82,7 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -108,7 +108,7 @@ class UpdateCriterionTest : MainServiceTest() {
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-            coEvery { projectRepoMock.getProjectById(any()) } returns project
+            coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateCriterion(request) }
@@ -131,8 +131,8 @@ class UpdateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -26,6 +27,13 @@ class CreateProjectTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.createProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.getUserSettings(any()) }
+        coVerify(exactly = 0) { criterionRepoMock.getCriteriaByIds(any()) }
+        coVerify(exactly = 0) { projectRepoMock.createProject(any(), any(), any()) }
+        coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
     }
 
     @Test
@@ -41,6 +49,13 @@ class CreateProjectTest : MainServiceTest() {
         coEvery { projectRepoMock.createProject(request, user.id, userSettings) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.createProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserSettings(user.id) }
+        coVerify(exactly = 1) { criterionRepoMock.getCriteriaByIds(emptyList()) }
+        coVerify(exactly = 1) { projectRepoMock.createProject(request, user.id, userSettings) }
+        coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
     }
 
     @Test
@@ -57,6 +72,12 @@ class CreateProjectTest : MainServiceTest() {
         coEvery { projectRepoMock.createProject(request, user.id, userSettings) } returns project
 
         assertDoesNotThrow { mainService.createProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserSettings(user.id) }
+        coVerify(exactly = 1) { criterionRepoMock.getCriteriaByIds(emptyList()) }
+        coVerify(exactly = 1) { projectRepoMock.createProject(request, user.id, userSettings) }
         coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
     }
 
@@ -79,5 +100,12 @@ class CreateProjectTest : MainServiceTest() {
 
             assertDoesNotThrow { mainService.createProject(request) }
             assertEquals(listOf(criterion.id), criteriaIdsSlot.captured)
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserSettings(user.id) }
+            coVerify(exactly = 1) { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) }
+            coVerify(exactly = 1) { projectRepoMock.createProject(request, user.id, userSettings) }
+            coVerify(exactly = 1) { criterionRepoMock.createCriterion(any(), user.id) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -22,13 +22,15 @@ class CreateProjectTest : MainServiceTest() {
 
     @Test
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { mainService.createProject(getExampleRequest()) }
+        assertThrows<TestSpecificException> { mainService.createProject(request) }
     }
 
     @Test
     fun `When an error occurs while a project is created, then an exception is thrown`() = runTest {
+        val request = getExampleRequest()
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val userSettings = DataBuilder.createExampleUserSettings()
 
@@ -36,13 +38,14 @@ class CreateProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
-        coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } throws TestSpecificException()
+        coEvery { projectRepoMock.createProject(request, user.id, userSettings) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { mainService.createProject(getExampleRequest()) }
+        assertThrows<TestSpecificException> { mainService.createProject(request) }
     }
 
     @Test
     fun `When a project is correctly created, then no exception is thrown`() = runTest {
+        val request = getExampleRequest()
         val project = DataBuilder.createExampleProject()
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val userSettings = DataBuilder.createExampleUserSettings()
@@ -51,18 +54,19 @@ class CreateProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
-        coEvery { projectRepoMock.createProject(any(), any(), userSettings) } returns project
+        coEvery { projectRepoMock.createProject(request, user.id, userSettings) } returns project
 
-        assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
+        assertDoesNotThrow { mainService.createProject(request) }
         coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
     }
 
     @Test
     fun `When a project is correctly created and the user has default criteria, then no exception is thrown`() =
         runTest {
+            val request = getExampleRequest()
             val project = DataBuilder.createExampleProject()
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleProjectCriterion()
+            val criterion = DataBuilder.createExampleUserCriterion()
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
             val criteriaIdsSlot = slot<List<UUID>>()
 
@@ -70,10 +74,10 @@ class CreateProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
             coEvery { criterionRepoMock.getCriteriaByIds(capture(criteriaIdsSlot)) } returns listOf(criterion)
-            coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } returns project
+            coEvery { projectRepoMock.createProject(request, user.id, userSettings) } returns project
             coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
-            assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
+            assertDoesNotThrow { mainService.createProject(request) }
             assertEquals(listOf(criterion.id), criteriaIdsSlot.captured)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -36,8 +36,9 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
 
     @Test
     fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
     }
@@ -45,11 +46,10 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     @Test
     fun `When retrieving requested user fails, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
     }
@@ -90,7 +90,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
@@ -100,8 +100,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     @Test
     fun `When a user retrieves its own archived projects, then they are returned successfully`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
-        val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
+        val request = Base.Id.newBuilder().setId(currentUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,6 +15,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
@@ -25,6 +28,10 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
 
         assertThrows<InvalidIdException> { mainService.getAllArchivedProjectsForUser(request) }
+
+        verify(exactly = 0) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -32,6 +39,10 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -41,6 +52,10 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -52,6 +67,11 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -69,6 +89,11 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
                     getExampleRequest(),
                 )
             }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+            coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
         }
 
     @Test
@@ -82,6 +107,16 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) {
+            projectRepoMock.getUserProjects(
+                requestedUserId,
+                setOf(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED),
+            )
+        }
     }
 
     @Test
@@ -95,6 +130,16 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) {
+            projectRepoMock.getUserProjects(
+                requestedUserId,
+                setOf(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED),
+            )
+        }
     }
 
     @Test
@@ -107,5 +152,14 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 2) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) {
+            projectRepoMock.getUserProjects(
+                currentUser.id,
+                setOf(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED),
+            )
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,6 +15,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
@@ -25,6 +28,10 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
 
         assertThrows<InvalidIdException> { mainService.getAllDeletedProjectsForUser(request) }
+
+        verify(exactly = 0) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -32,6 +39,10 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -41,6 +52,10 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -52,6 +67,11 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
     }
 
     @Test
@@ -65,6 +85,11 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
 
             assertThrows<UnauthorizedException.Single> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+            coVerify(exactly = 0) { projectRepoMock.getUserProjects(any(), any()) }
         }
 
     @Test
@@ -78,6 +103,16 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) {
+            projectRepoMock.getUserProjects(
+                requestedUserId,
+                setOf(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED),
+            )
+        }
     }
 
     @Test
@@ -91,6 +126,16 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) {
+            projectRepoMock.getUserProjects(
+                requestedUserId,
+                setOf(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED),
+            )
+        }
     }
 
     @Test
@@ -103,5 +148,14 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 2) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) {
+            projectRepoMock.getUserProjects(
+                currentUser.id,
+                setOf(ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED),
+            )
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -36,8 +36,9 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
 
     @Test
     fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
     }
@@ -45,11 +46,10 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     @Test
     fun `When retrieving requested user fails, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
     }
@@ -86,7 +86,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
@@ -96,8 +96,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     @Test
     fun `When a user retrieves its own deleted projects, then they are returned successfully`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
-        val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
+        val request = Base.Id.newBuilder().setId(currentUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -24,8 +26,19 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllProjectPapersForProjectTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
-    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+    private val projectId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(projectId.toString()).build()
+
+    // Test data defined at class level for access in mock setup and verification
+    private val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private val project = DataBuilder.createExampleProject(id = projectId)
+    private val paper = DataBuilder.createExamplePaper()
+    private val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+    private val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
+    private val author = DataBuilder.createExampleAuthor()
+    private val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
+    private val adminProjectMember =
+        DataBuilder.createExampleProjectMember(projectId = project.id, userId = adminUser.id)
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
@@ -41,59 +54,45 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
 
     @Suppress("LongMethod", "ReturnCount")
     private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
         if (failAt == GrpcContext::getUserIdFromContext) {
             every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
             return
         }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
 
         if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            coEvery { userRepoMock.getUserById(adminUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
 
         if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+            coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
             return
         }
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
             return
         }
-        coEvery {
-            projectMemberRepoMock.getProjectMembers(project.id)
-        } returns listOf(DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id))
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(adminProjectMember)
 
         if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
-            coEvery {
-                projectPaperRepoMock.getAllProjectPapersWithPapers(any())
-            } throws TestSpecificException()
+            coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } throws TestSpecificException()
             return
         }
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
+        coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
 
         if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) } throws TestSpecificException()
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
             return
         }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
 
         if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
             coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any())
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
             } throws TestSpecificException()
             return
         }
@@ -102,14 +101,16 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         } returns listOf(UUID.randomUUID())
 
         if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } throws TestSpecificException()
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
+            } throws TestSpecificException()
             return
         }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
 
         if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
             coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
             } throws TestSpecificException()
             return
         }
@@ -125,32 +126,94 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         assertThrows<TestSpecificException> {
             mainService.getAllProjectPapersForProject(getExampleRequest())
         }
+
+        when (failAt) {
+            GrpcContext::getUserIdFromContext -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+            }
+
+            userRepoMock::getUserById -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 0) { projectRepoMock.getProjectById(any()) }
+            }
+
+            projectRepoMock::getProjectById -> {
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 1) { projectRepoMock.getProjectById(projectId) }
+                coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+            }
+
+            projectMemberRepoMock::getProjectMembers -> {
+                coVerify(exactly = 1) { projectRepoMock.getProjectById(projectId) }
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(projectId) }
+                coVerify(exactly = 0) { projectPaperRepoMock.getAllProjectPapersWithPapers(any()) }
+            }
+
+            projectPaperRepoMock::getAllProjectPapersWithPapers -> {
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(projectId) }
+                coVerify(exactly = 1) { projectPaperRepoMock.getAllProjectPapersWithPapers(projectId) }
+                coVerify(exactly = 0) { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) }
+            }
+
+            authorOfPaperRepoMock::getAuthorsOfPaperById -> {
+                coVerify(exactly = 1) { projectPaperRepoMock.getAllProjectPapersWithPapers(projectId) }
+                coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+                coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }
+            }
+
+            citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById -> {
+                coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+                coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+                coVerify(exactly = 0) { reviewRepoMock.getAllReviewsForProjectPaper(any()) }
+            }
+
+            reviewRepoMock::getAllReviewsForProjectPaper -> {
+                coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+                coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+                coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
+            }
+
+            reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById -> {
+                coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+                coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
+            }
+        }
     }
 
     @Test
     fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(projectId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(projectId) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getAllProjectPapersWithPapers(projectId) }
+        coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
     fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
         val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
+        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
+        coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
@@ -161,12 +224,22 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         } returns listOf(UUID.randomUUID())
 
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(projectId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(projectId) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getAllProjectPapersWithPapers(projectId) }
+        coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
     fun `When a non project member requests the project papers, then an unauthorized exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -174,9 +247,17 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> {
-            mainService.getAllProjectPapersForProject(
-                getExampleRequest(),
-            )
+            mainService.getAllProjectPapersForProject(getExampleRequest())
         }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(projectId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(projectId) }
+        coVerify(exactly = 0) { projectPaperRepoMock.getAllProjectPapersWithPapers(any()) }
+        coVerify(exactly = 0) { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) }
+        coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }
+        coVerify(exactly = 0) { reviewRepoMock.getAllReviewsForProjectPaper(any()) }
+        coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -36,8 +36,9 @@ class GetAllProjectsForUserTest : MainServiceTest() {
 
     @Test
     fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
@@ -45,11 +46,10 @@ class GetAllProjectsForUserTest : MainServiceTest() {
     @Test
     fun `When retrieving the requested user fails, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
@@ -74,7 +74,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
-        coEvery { projectRepoMock.getUserProjects(any()) } throws TestSpecificException()
+        coEvery { projectRepoMock.getUserProjects(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
@@ -86,9 +86,9 @@ class GetAllProjectsForUserTest : MainServiceTest() {
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(any()) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
-            coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+            coEvery { projectRepoMock.getUserProjects(requestedUserId) } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllProjectsForUser(getExampleRequest()) }
         }
@@ -96,13 +96,11 @@ class GetAllProjectsForUserTest : MainServiceTest() {
     @Test
     fun `When a user retrieves its own projects, then all projects are returned successfully`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
-        val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
+        val request = Base.Id.newBuilder().setId(currentUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
-        coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+        coEvery { projectRepoMock.getUserProjects(currentUser.id) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjectsForUser(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -25,6 +27,10 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
 
         assertThrows<InvalidIdException> { mainService.getAllProjectsForUser(request) }
+
+        verify(exactly = 0) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any()) }
     }
 
     @Test
@@ -32,6 +38,10 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any()) }
     }
 
     @Test
@@ -41,6 +51,10 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any()) }
     }
 
     @Test
@@ -52,6 +66,11 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any()) }
     }
 
     @Test
@@ -64,6 +83,11 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
 
         assertThrows<UnauthorizedException.Single> { mainService.getAllProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getUserProjects(any()) }
     }
 
     @Test
@@ -77,6 +101,11 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { projectRepoMock.getUserProjects(requestedUserId) }
     }
 
     @Test
@@ -91,6 +120,11 @@ class GetAllProjectsForUserTest : MainServiceTest() {
             coEvery { projectRepoMock.getUserProjects(requestedUserId) } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllProjectsForUser(getExampleRequest()) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+            coVerify(exactly = 1) { projectRepoMock.getUserProjects(requestedUserId) }
         }
 
     @Test
@@ -103,5 +137,9 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         coEvery { projectRepoMock.getUserProjects(currentUser.id) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjectsForUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 2) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getUserProjects(currentUser.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -20,6 +22,10 @@ class GetAllProjectsTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectRepoMock.getAllProjects() }
     }
 
     @Test
@@ -29,6 +35,10 @@ class GetAllProjectsTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { projectRepoMock.getAllProjects() }
     }
 
     @Test
@@ -39,6 +49,10 @@ class GetAllProjectsTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(nonAdminUser.id) } returns nonAdminUser
 
         assertThrows<UnauthorizedException.All> { mainService.getAllProjects() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(nonAdminUser.id) }
+        coVerify(exactly = 0) { projectRepoMock.getAllProjects() }
     }
 
     @Test
@@ -50,6 +64,10 @@ class GetAllProjectsTest : MainServiceTest() {
         coEvery { projectRepoMock.getAllProjects() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getAllProjects() }
     }
 
     @Test
@@ -61,5 +79,9 @@ class GetAllProjectsTest : MainServiceTest() {
         coEvery { projectRepoMock.getAllProjects() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjects() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getAllProjects() }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -24,8 +24,9 @@ class GetAllProjectsTest : MainServiceTest() {
 
     @Test
     fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
     }
@@ -34,8 +35,8 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When all projects are retrieved by a non-admin, then an exception is thrown`() = runTest {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
+        every { GrpcContext.getUserIdFromContext() } returns nonAdminUser.id
+        coEvery { userRepoMock.getUserById(nonAdminUser.id) } returns nonAdminUser
 
         assertThrows<UnauthorizedException.All> { mainService.getAllProjects() }
     }
@@ -44,8 +45,8 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When retrieving all projects fails, then an exception is thrown`() = runTest {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectRepoMock.getAllProjects() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
@@ -55,8 +56,8 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When all projects are retrieved by an admin, then no exception is thrown`() = runTest {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectRepoMock.getAllProjects() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjects() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -34,6 +36,11 @@ class GetProjectByIdTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(noAccessUser.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(requestId) }
+        coVerify(exactly = 0) { projectRepoMock.getProjectById(any()) }
     }
 
     @Test
@@ -49,6 +56,11 @@ class GetProjectByIdTest : MainServiceTest() {
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
         assertDoesNotThrow { mainService.getProjectById(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(requestId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
     }
 
     @Test
@@ -65,6 +77,11 @@ class GetProjectByIdTest : MainServiceTest() {
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
         assertDoesNotThrow { mainService.getProjectById(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(requestId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
     }
 
     @Test
@@ -79,5 +96,10 @@ class GetProjectByIdTest : MainServiceTest() {
         coEvery { projectRepoMock.getProjectById(requestId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getProjectById(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(requestId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -31,7 +31,7 @@ class GetProjectByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
         coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
     }
@@ -45,7 +45,7 @@ class GetProjectByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(requestId) } returns project
 
         assertDoesNotThrow { mainService.getProjectById(request) }
@@ -75,8 +75,8 @@ class GetProjectByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+        coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(requestId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getProjectById(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -45,6 +47,11 @@ class GetProjectMembersTest : MainServiceTest() {
             listOf(projectMemberWithUser)
 
         assertDoesNotThrow { mainService.getProjectMembers(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembersWithUsers(requestId) }
     }
 
     @Test
@@ -63,6 +70,11 @@ class GetProjectMembersTest : MainServiceTest() {
             listOf(projectMemberWithUser)
 
         assertDoesNotThrow { mainService.getProjectMembers(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembersWithUsers(requestId) }
     }
 
     @Test
@@ -78,6 +90,11 @@ class GetProjectMembersTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectMembers(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembersWithUsers(requestId) }
     }
 
     @Test
@@ -94,5 +111,10 @@ class GetProjectMembersTest : MainServiceTest() {
             } throws SnowballRException.NotFoundException(EntityType.PROJECT, request.id)
 
             assertThrows<SnowballRException.NotFoundException> { mainService.getProjectMembers(request) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { projectRepoMock.getProjectById(requestId) }
+            coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembersWithUsers(any()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -23,8 +25,20 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
-    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+    private val projectPaperId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(projectPaperId.toString()).build()
+
+    // Test data defined at class level for access in mock setup and verification
+    private val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private val project = DataBuilder.createExampleProject()
+    private val paper = DataBuilder.createExamplePaper()
+    private val projectPaper = DataBuilder.createExampleProjectPaper(
+        id = projectPaperId,
+        projectId = project.id,
+        paperId = paper.id,
+    )
+    private val author = DataBuilder.createExampleAuthor()
+    private val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
@@ -40,28 +54,17 @@ class GetProjectPaperByIdTest : MainServiceTest() {
 
     @Suppress("LongMethod", "ReturnCount")
     private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
-
         if (failAt == GrpcContext::getUserIdFromContext) {
             every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
             return
         }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
 
         if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            coEvery { userRepoMock.getUserById(adminUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
@@ -107,7 +110,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
 
         if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
             coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
             } throws TestSpecificException()
             return
         }
@@ -123,12 +126,76 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         assertThrows<TestSpecificException> {
             mainService.getProjectPaperById(getExampleRequest())
         }
+
+        when (failAt) {
+            GrpcContext::getUserIdFromContext -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+            }
+
+            userRepoMock::getUserById -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 0) { projectPaperRepoMock.getProjectPaperById(any()) }
+            }
+
+            projectPaperRepoMock::getProjectPaperById -> {
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+                coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+            }
+
+            projectMemberRepoMock::getProjectMembers -> {
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+                coVerify(exactly = 0) { paperRepoMock.getPaperById(any()) }
+            }
+
+            paperRepoMock::getPaperById -> {
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+                coVerify(exactly = 1) { paperRepoMock.getPaperById(paper.id) }
+                coVerify(exactly = 0) { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) }
+            }
+
+            authorOfPaperRepoMock::getAuthorsOfPaperById -> {
+                coVerify(exactly = 1) { paperRepoMock.getPaperById(paper.id) }
+                coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+                coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }
+            }
+
+            citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById -> {
+                coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+                coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+                coVerify(exactly = 0) { reviewRepoMock.getAllReviewsForProjectPaper(any()) }
+            }
+
+            reviewRepoMock::getAllReviewsForProjectPaper -> {
+                coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+                coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+                coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
+            }
+
+            reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById -> {
+                coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+                coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
+            }
+        }
     }
 
     @Test
     fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 1) { paperRepoMock.getPaperById(paper.id) }
+        coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
@@ -138,12 +205,12 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         val paper = DataBuilder.createExamplePaper()
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
+            id = projectPaperId,
             projectId = project.id,
             paperId = paper.id,
         )
         val author = DataBuilder.createExampleAuthor()
-        val review = DataBuilder.createExampleReview()
+        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -160,6 +227,16 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         } returns listOf(UUID.randomUUID())
 
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 1) { paperRepoMock.getPaperById(paper.id) }
+        coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
@@ -168,7 +245,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
+            id = projectPaperId,
             projectId = project.id,
             paperId = paper.id,
         )
@@ -179,5 +256,15 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.getProjectPaperById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 0) { paperRepoMock.getPaperById(any()) }
+        coVerify(exactly = 0) { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) }
+        coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }
+        coVerify(exactly = 0) { reviewRepoMock.getAllReviewsForProjectPaper(any()) }
+        coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -2,7 +2,9 @@ package se.uulm.snowballr.backend.service.project
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -47,6 +49,12 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
         assertDoesNotThrow { mainService.updateProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+        coVerify(exactly = 1) { projectRepoMock.updateProject(request, project.status) }
     }
 
     @ParameterizedTest
@@ -78,6 +86,12 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
         assertDoesNotThrow { mainService.updateProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+        coVerify(exactly = 1) { projectRepoMock.updateProject(request, project.status) }
     }
 
     @ParameterizedTest
@@ -109,6 +123,12 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateProject(request) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+            coVerify(exactly = 0) { projectRepoMock.updateProject(any(), any()) }
         }
 
     @Test
@@ -136,6 +156,12 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+            coVerify(exactly = 0) { projectRepoMock.updateProject(any(), any()) }
         }
 
     @Test
@@ -164,6 +190,12 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+            coVerify(exactly = 0) { projectRepoMock.updateProject(any(), any()) }
         }
 
     @Test
@@ -184,6 +216,12 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+        coVerify(exactly = 0) { projectRepoMock.updateProject(any(), any()) }
     }
 
     @Test
@@ -206,6 +244,12 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+        coVerify(exactly = 0) { projectRepoMock.updateProject(any(), any()) }
     }
 
     @Test
@@ -222,5 +266,11 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { projectRepoMock.updateProject(request, project.status) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateProject(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+        coVerify(exactly = 1) { projectRepoMock.updateProject(request, project.status) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -62,7 +62,6 @@ class UpdateProjectTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(status = status)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
@@ -116,9 +115,8 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a server admin updates project to the project status DELETED, then a failed precondition exception is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
-            )
+            val project =
+                DataBuilder.createExampleProject(status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE)
             val updatedProject = DataBuilder.createExampleProject(
                 id = project.id,
                 name = "Updated Project",
@@ -144,9 +142,8 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a project admin updates project to the project status DELETED, then a failed precondition exception is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
-            )
+            val project =
+                DataBuilder.createExampleProject(status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE)
             val updatedProject = DataBuilder.createExampleProject(
                 id = project.id,
                 name = "Updated Project",
@@ -172,9 +169,7 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When a server admin updates a deleted project, then a failed precondition exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
-        )
+        val project = DataBuilder.createExampleProject(status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED)
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
         val request = ProjectOuterClass.Project.Update
@@ -194,9 +189,7 @@ class UpdateProjectTest : MainServiceTest() {
     @Test
     fun `When a project admin updates a deleted project, then a failed precondition exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
-        )
+        val project = DataBuilder.createExampleProject(status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED)
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
@@ -219,14 +212,14 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When an error occurs while updating a project, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
-        val updatedProject = DataBuilder.createExampleProject(status = status)
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(updatedProject.toGrpcProject()).build()
+        val project = DataBuilder.createExampleProject(status = status)
+        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(project.toGrpcProject()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(any()) } returns user
-        coEvery { projectRepoMock.getProjectById(updatedProject.id) } returns updatedProject
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
-        coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.updateProject(request, project.status) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateProject(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.readinglist
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -22,6 +23,11 @@ class AddPaperToReadingListTest : MainServiceTest() {
         val paperId = Base.Id.getDefaultInstance()
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
         assertThrows<TestSpecificException> { mainService.addPaperToReadingList(paperId) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { paperRepoMock.doesPaperExistById(any()) }
+        coVerify(exactly = 0) { readingListRepoMock.createReadingListEntry(any(), any()) }
     }
 
     @Test
@@ -35,6 +41,11 @@ class AddPaperToReadingListTest : MainServiceTest() {
         coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
+        coVerify(exactly = 1) { readingListRepoMock.createReadingListEntry(user.id, paperId) }
     }
 
     @Test
@@ -48,6 +59,10 @@ class AddPaperToReadingListTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(user.id) } returns user
 
         assertDoesNotThrow { mainService.addPaperToReadingList(paperId.toGrpcId()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
         coVerify(exactly = 1) { readingListRepoMock.createReadingListEntry(user.id, paperId) }
     }
 
@@ -61,5 +76,10 @@ class AddPaperToReadingListTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(user.id) } returns user
 
         assertThrows<NotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
+        coVerify(exactly = 0) { readingListRepoMock.createReadingListEntry(any(), any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
@@ -42,13 +42,15 @@ class GetReadingListTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } returns listOf(paper1, paper2)
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper1.id) } returns emptyList()
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
-            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns listOf(paper1.id)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper1.id) } returns emptyList()
-            coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } returns listOf(paper1, paper2)
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns listOf(paper1.id)
 
-            assertThat(mainService.getReadingList().papersList).containsExactlyInAnyOrder(
+            val result = mainService.getReadingList()
+
+            assertThat(result.papersList).containsExactlyInAnyOrder(
                 paper1.toGrpcPaper(emptyList(), emptyList()),
                 paper2.toGrpcPaper(listOf(author.toGrpcAuthor()), listOf(paper1.id.toString())),
             )

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.readinglist
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -19,6 +20,10 @@ class GetReadingListTest : MainServiceTest() {
     fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
         assertThrows<TestSpecificException> { mainService.getReadingList() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { readingListRepoMock.getAllReadingListEntries(any()) }
     }
 
     @Test
@@ -30,6 +35,12 @@ class GetReadingListTest : MainServiceTest() {
         coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getReadingList() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { readingListRepoMock.getAllReadingListEntries(user.id) }
+        coVerify(exactly = 0) { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) }
+        coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }
     }
 
     @Test
@@ -54,6 +65,13 @@ class GetReadingListTest : MainServiceTest() {
                 paper1.toGrpcPaper(emptyList(), emptyList()),
                 paper2.toGrpcPaper(listOf(author.toGrpcAuthor()), listOf(paper1.id.toString())),
             )
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
             coVerify(exactly = 1) { readingListRepoMock.getAllReadingListEntries(user.id) }
+            coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper1.id) }
+            coVerify(exactly = 1) { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) }
+            coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper1.id) }
+            coVerify(exactly = 1) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -47,15 +47,14 @@ class IsPaperOnReadingListTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
-            coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
             coEvery { paperRepoMock.doesPaperExistById(paper1.id) } returns true
             coEvery { paperRepoMock.doesPaperExistById(paper2.id) } returns true
+            coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
+            coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
 
             assertTrue(mainService.isPaperOnReadingList(paper1.id.toGrpcId()).value)
-            coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) }
-
             assertFalse(mainService.isPaperOnReadingList(paper2.id.toGrpcId()).value)
+            coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) }
             coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) }
         }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.readinglist
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,6 +24,11 @@ class IsPaperOnReadingListTest : MainServiceTest() {
         val paperId = Base.Id.getDefaultInstance()
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
         assertThrows<TestSpecificException> { mainService.isPaperOnReadingList(paperId) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { paperRepoMock.doesPaperExistById(any()) }
+        coVerify(exactly = 0) { readingListRepoMock.isPaperOnReadingList(any(), any()) }
     }
 
     @Test
@@ -36,6 +42,11 @@ class IsPaperOnReadingListTest : MainServiceTest() {
         coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paperId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.isPaperOnReadingList(paperId.toGrpcId()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
+        coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paperId) }
     }
 
     @Test
@@ -54,6 +65,11 @@ class IsPaperOnReadingListTest : MainServiceTest() {
 
             assertTrue(mainService.isPaperOnReadingList(paper1.id.toGrpcId()).value)
             assertFalse(mainService.isPaperOnReadingList(paper2.id.toGrpcId()).value)
+
+            verify(exactly = 2) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 2) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paper1.id) }
+            coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paper2.id) }
             coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) }
             coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) }
         }
@@ -71,5 +87,10 @@ class IsPaperOnReadingListTest : MainServiceTest() {
             assertThrows<NotFoundException> {
                 mainService.isPaperOnReadingList(paperId.toGrpcId())
             }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
+            coVerify(exactly = 0) { readingListRepoMock.isPaperOnReadingList(any(), any()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.readinglist
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -22,6 +23,11 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         val paperId = Base.Id.getDefaultInstance()
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
         assertThrows<TestSpecificException> { mainService.removePaperFromReadingList(paperId) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { paperRepoMock.doesPaperExistById(any()) }
+        coVerify(exactly = 0) { readingListRepoMock.removeReadingListEntry(any(), any()) }
     }
 
     @Test
@@ -35,6 +41,11 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.removePaperFromReadingList(paperId.toGrpcId()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
+        coVerify(exactly = 1) { readingListRepoMock.removeReadingListEntry(user.id, paperId) }
     }
 
     @Test
@@ -48,6 +59,10 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } returns Unit
 
         assertDoesNotThrow { mainService.removePaperFromReadingList(paperId.toGrpcId()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
         coVerify(exactly = 1) { readingListRepoMock.removeReadingListEntry(user.id, paperId) }
     }
 
@@ -63,5 +78,10 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         assertThrows<NotFoundException> {
             mainService.removePaperFromReadingList(paperId.toGrpcId())
         }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { paperRepoMock.doesPaperExistById(paperId) }
+        coVerify(exactly = 0) { readingListRepoMock.removeReadingListEntry(any(), any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -23,8 +25,15 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllReviewsForProjectPaperTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
-    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+    private val projectPaperId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(projectPaperId.toString()).build()
+
+    // Test data defined at class level to be accessible in both mock setup and verification
+    private val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private val project = DataBuilder.createExampleProject()
+    private val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+    private val review = DataBuilder.createExampleReview(userId = adminUser.id, projectPaperId = projectPaper.id)
+    private val selectedCriteriaIds = listOf(UUID.randomUUID())
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
@@ -38,23 +47,17 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
 
     @Suppress("ReturnCount")
     private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
-        val review = DataBuilder.createExampleReview(userId = currentUser.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
-
         if (failAt == GrpcContext::getUserIdFromContext) {
             every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
             return
         }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
 
         if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            coEvery { userRepoMock.getUserById(adminUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
@@ -97,8 +100,58 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     @MethodSource("failingFunctions")
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt)
+
         assertThrows<TestSpecificException> {
             mainService.getAllReviewsForProjectPaper(getExampleRequest())
+        }
+
+        // Verification logic for each failure point
+        when (failAt) {
+            GrpcContext::getUserIdFromContext -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+            }
+
+            userRepoMock::getUserById -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 0) { projectPaperRepoMock.getProjectPaperById(any()) }
+            }
+
+            projectPaperRepoMock::getProjectPaperById -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+                coVerify(exactly = 0) { projectRepoMock.getProjectById(any()) }
+            }
+
+            projectRepoMock::getProjectById -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+                coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+                coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+            }
+
+            projectMemberRepoMock::getProjectMembers -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+                coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+                coVerify(exactly = 0) { reviewRepoMock.getAllReviewsForProjectPaper(any()) }
+            }
+
+            reviewRepoMock::getAllReviewsForProjectPaper -> {
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+                coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) }
+                coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
+            }
+
+            reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById -> {
+                coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) }
+                coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
+            }
         }
     }
 
@@ -106,16 +159,24 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
     fun `When a project member retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val review = DataBuilder.createExampleReview(userId = currentUser.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+        val selectedCriteriaIds = listOf(UUID.randomUUID())
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -128,6 +189,14 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         } returns selectedCriteriaIds
 
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
@@ -135,7 +204,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject()
-            val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
+            val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -148,5 +217,13 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
                     getExampleRequest(),
                 )
             }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(projectPaperId) }
+            coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+            coVerify(exactly = 0) { reviewRepoMock.getAllReviewsForProjectPaper(any()) }
+            coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -23,8 +25,15 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetReviewByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
-    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+    private val reviewId = UUID.randomUUID()
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(reviewId.toString()).build()
+
+    // Test data defined at class level to be accessible in both mock setup and verification
+    private val adminUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+    private val review = DataBuilder.createExampleReview(id = reviewId, userId = adminUser.id)
+    private val project = DataBuilder.createExampleProject()
+    private val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
+    private val selectedCriteriaIds = listOf(UUID.randomUUID())
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
@@ -38,23 +47,17 @@ class GetReviewByIdTest : MainServiceTest() {
 
     @Suppress("ReturnCount")
     private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
-
         if (failAt == GrpcContext::getUserIdFromContext) {
             every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
             return
         }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
 
         if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
+            coEvery { userRepoMock.getUserById(adminUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
 
         if (failAt == reviewRepoMock::getReviewById) {
             coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
@@ -98,22 +101,73 @@ class GetReviewByIdTest : MainServiceTest() {
         assertThrows<TestSpecificException> {
             mainService.getReviewById(getExampleRequest())
         }
+
+        // Verification logic for each failure point
+        when (failAt) {
+            GrpcContext::getUserIdFromContext -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+            }
+
+            userRepoMock::getUserById -> {
+                verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 0) { reviewRepoMock.getReviewById(any()) }
+            }
+
+            reviewRepoMock::getReviewById -> {
+                coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+                coVerify(exactly = 1) { reviewRepoMock.getReviewById(reviewId) }
+                coVerify(exactly = 0) { projectPaperRepoMock.getProjectPaperById(any()) }
+            }
+
+            projectPaperRepoMock::getProjectPaperById -> {
+                coVerify(exactly = 1) { reviewRepoMock.getReviewById(reviewId) }
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) }
+                coVerify(exactly = 0) { projectRepoMock.getProjectById(any()) }
+            }
+
+            projectRepoMock::getProjectById -> {
+                coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) }
+                coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+                coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+            }
+
+            projectMemberRepoMock::getProjectMembers -> {
+                coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+                coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
+            }
+
+            reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById -> {
+                coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+                coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
+            }
+        }
     }
 
     @Test
     fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null)
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(adminUser.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getReviewById(reviewId) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
     fun `When a project member retrieves the review, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val review = DataBuilder.createExampleReview(id = reviewId, userId = currentUser.id)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+        val selectedCriteriaIds = listOf(UUID.randomUUID())
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
@@ -126,12 +180,20 @@ class GetReviewByIdTest : MainServiceTest() {
         } returns selectedCriteriaIds
 
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getReviewById(reviewId) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 1) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) }
     }
 
     @Test
     fun `When a non project member retrieves the review, then an unauthorized exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
+        val review = DataBuilder.createExampleReview(id = reviewId, userId = currentUser.id)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
 
@@ -143,5 +205,13 @@ class GetReviewByIdTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.getReviewById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getReviewById(reviewId) }
+        coVerify(exactly = 1) { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) }
+        coVerify(exactly = 1) { projectRepoMock.getProjectById(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(project.id) }
+        coVerify(exactly = 0) { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -24,8 +24,9 @@ class GetAllUsersTest : MainServiceTest() {
 
     @Test
     fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllUsers() }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -20,6 +22,10 @@ class GetAllUsersTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllUsers() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.getAllUsers() }
     }
 
     @Test
@@ -29,6 +35,10 @@ class GetAllUsersTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllUsers() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { userRepoMock.getAllUsers() }
     }
 
     @Test
@@ -39,6 +49,10 @@ class GetAllUsersTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
 
         assertThrows<UnauthorizedException.All> { mainService.getAllUsers() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 0) { userRepoMock.getAllUsers() }
     }
 
     @Test
@@ -50,6 +64,10 @@ class GetAllUsersTest : MainServiceTest() {
         coEvery { userRepoMock.getAllUsers() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllUsers() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getAllUsers() }
     }
 
     @Test
@@ -61,5 +79,9 @@ class GetAllUsersTest : MainServiceTest() {
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllUsers() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getAllUsers() }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -18,6 +20,9 @@ class GetCurrentUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCurrentUser() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
     }
 
     @Test
@@ -27,6 +32,9 @@ class GetCurrentUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(userId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCurrentUser() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(userId) }
     }
 
     @Test
@@ -36,5 +44,8 @@ class GetCurrentUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(user.id) } returns user
 
         assertDoesNotThrow { mainService.getCurrentUser() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -24,7 +24,7 @@ class GetCurrentUserTest : MainServiceTest() {
     fun `When retrieving the user by id fails, then an exception is thrown`() = runTest {
         val userId = UUID.randomUUID()
         every { GrpcContext.getUserIdFromContext() } returns userId
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(userId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCurrentUser() }
     }
@@ -33,7 +33,7 @@ class GetCurrentUserTest : MainServiceTest() {
     fun `When retrieving the current user, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns user
 
         assertDoesNotThrow { mainService.getCurrentUser() }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -26,6 +28,11 @@ class GetInviteCandidatesTest : MainServiceTest() {
 
         val result = mainService.getInviteCandidates(shortSearchQuery)
         assertThat(result.usersList).isEmpty()
+
+        verify(exactly = 0) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+        coVerify(exactly = 0) { userRepoMock.getUsersMatchingSearchQuery(any(), any()) }
     }
 
     @Test
@@ -35,6 +42,11 @@ class GetInviteCandidatesTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(userId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getInviteCandidates(validInviteCandidatesRequest) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(userId) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+        coVerify(exactly = 0) { userRepoMock.getUsersMatchingSearchQuery(any(), any()) }
     }
 
     @Test
@@ -48,6 +60,11 @@ class GetInviteCandidatesTest : MainServiceTest() {
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembers(any()) }
+        coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery("john", setOf(currentUser.id)) }
     }
 
     @Test
@@ -63,6 +80,11 @@ class GetInviteCandidatesTest : MainServiceTest() {
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithNotExistingProject) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(requestedProjectId) }
+        coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery("john", setOf(currentUser.id)) }
     }
 
     @Test
@@ -74,6 +96,11 @@ class GetInviteCandidatesTest : MainServiceTest() {
         coEvery { userRepoMock.getUsersMatchingSearchQuery("john", setOf(currentUser.id)) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(testProjectId) }
+        coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery("john", setOf(currentUser.id)) }
     }
 
     @Test
@@ -94,6 +121,11 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
             assertTrue { inviteCandidates.usersList.size == 1 }
             assertTrue { inviteCandidates.usersList.find { it.id == currentUser.id.toString() } == null }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(testProjectId) }
+            coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery("john", excludedUsers) }
         }
 
     @Test
@@ -112,5 +144,10 @@ class GetInviteCandidatesTest : MainServiceTest() {
 
             val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
             assertTrue { inviteCandidates.usersList.isEmpty() }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getProjectMembers(testProjectId) }
+            coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery("john", excludedUsers) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -16,8 +14,6 @@ import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
 import java.util.UUID
 import kotlin.test.assertTrue
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class GetInviteCandidatesTest : MainServiceTest() {
     private val testProjectId = UUID.randomUUID()
     private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder().setQuery(
@@ -27,7 +23,9 @@ class GetInviteCandidatesTest : MainServiceTest() {
     @Test
     fun `When the search query is too short, then an empty list is returned`() = runTest {
         val shortSearchQuery = InviteCandidatesRequest.newBuilder().setQuery("j").build()
-        assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
+
+        val result = mainService.getInviteCandidates(shortSearchQuery)
+        assertThat(result.usersList).isEmpty()
     }
 
     @Test
@@ -53,7 +51,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     }
 
     @Test
-    fun `When no the project members exist, then no users except for the current user are excluded`() = runTest {
+    fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedProjectId = UUID.randomUUID()
         val requestWithNotExistingProject = InviteCandidatesRequest.newBuilder().setQuery(
@@ -68,12 +66,12 @@ class GetInviteCandidatesTest : MainServiceTest() {
     }
 
     @Test
-    fun `When retrieving the users matching the search query fails, then an empty list is returned`() = runTest {
+    fun `When retrieving the users matching the search query returns no users, a successful call is made`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery("john", setOf(currentUser.id)) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
     }
@@ -82,13 +80,15 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When retrieving the invite candidates is successful, then these are returned except for the current user`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
-            val users = listOf(currentUser, DataBuilder.createExampleUser(email = "another.user@example.com"))
+            val otherUser = DataBuilder.createExampleUser(email = "another.user@example.com")
+            val users = listOf(currentUser, otherUser)
             val excludedUsers = setOf(currentUser.id)
+
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
             coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
             coEvery {
-                userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id))
+                userRepoMock.getUsersMatchingSearchQuery("john", excludedUsers)
             } returns users.filterNot { it.id in excludedUsers }
 
             val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
@@ -100,17 +100,15 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When retrieving the project members is successful, then these members are not returned as invite candidates`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
-            val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
-            val users = listOf(currentUser, projectMember)
-            val excludedUsers = setOf(currentUser.id, projectMember.id)
+            val projectMemberUser = DataBuilder.createExampleUser(email = "project.member@example.com")
+            val projectMember =
+                DataBuilder.createExampleProjectMember(userId = projectMemberUser.id, projectId = testProjectId)
+            val excludedUsers = setOf(currentUser.id, projectMemberUser.id)
+
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery {
-                projectMemberRepoMock.getProjectMembers(testProjectId)
-            } returns listOf(DataBuilder.createExampleProjectMember(userId = projectMember.id))
-            coEvery {
-                userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id, projectMember.id))
-            } returns users.filterNot { it.id in excludedUsers }
+            coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns listOf(projectMember)
+            coEvery { userRepoMock.getUsersMatchingSearchQuery("john", excludedUsers) } returns emptyList()
 
             val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
             assertTrue { inviteCandidates.usersList.isEmpty() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -26,6 +28,10 @@ class GetUserByEmailTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.getUserByEmail(any()) }
     }
 
     @Test
@@ -36,6 +42,10 @@ class GetUserByEmailTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { userRepoMock.getUserByEmail(any()) }
     }
 
     @Test
@@ -47,6 +57,11 @@ class GetUserByEmailTest : MainServiceTest() {
         coEvery { userRepoMock.getUserByEmail(exampleEmail) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(exampleEmail) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
     }
 
     @Test
@@ -60,6 +75,11 @@ class GetUserByEmailTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getUserByEmail(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(exampleEmail) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) }
     }
 
     @Test
@@ -81,6 +101,11 @@ class GetUserByEmailTest : MainServiceTest() {
             assertThrows<NotFoundException>("Should throw NotFoundException for status $status") {
                 mainService.getUserByEmail(getExampleRequest())
             }
+
+            verify(atLeast = 1, atMost = 3) { GrpcContext.getUserIdFromContext() }
+            coVerify(atLeast = 1, atMost = 3) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(atLeast = 1, atMost = 3) { userRepoMock.getUserByEmail(exampleEmail) }
+            coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
         }
     }
 
@@ -104,6 +129,11 @@ class GetUserByEmailTest : MainServiceTest() {
             assertDoesNotThrow("Should succeed for status $status") {
                 mainService.getUserByEmail(getExampleRequest())
             }
+
+            verify(atLeast = 1, atMost = 2) { GrpcContext.getUserIdFromContext() }
+            coVerify(atLeast = 1, atMost = 2) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(atLeast = 1, atMost = 2) { userRepoMock.getUserByEmail(exampleEmail) }
+            coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -30,8 +30,10 @@ class GetUserByEmailTest : MainServiceTest() {
 
     @Test
     fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
     }
@@ -42,7 +44,7 @@ class GetUserByEmailTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserByEmail(any()) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserByEmail(exampleEmail) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -32,6 +33,10 @@ class GetUserByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } returns DataBuilder.createExampleUser()
 
         assertThrows<InvalidIdException> { mainService.getUserById(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
     }
 
     @Test
@@ -42,6 +47,10 @@ class GetUserByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
     }
 
     @Test
@@ -57,6 +66,11 @@ class GetUserByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
 
         assertDoesNotThrow { mainService.getUserById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
     }
 
     @Test
@@ -69,8 +83,9 @@ class GetUserByIdTest : MainServiceTest() {
 
         assertDoesNotThrow { mainService.getUserById(request) }
 
-        // Should not call userRepoMock.getUserById(requestedUserId) again because it's self-request
-        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUser.id) }
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
     }
 
     @Test
@@ -89,6 +104,11 @@ class GetUserByIdTest : MainServiceTest() {
         )
 
         assertDoesNotThrow { mainService.getUserById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) }
     }
 
     @Test
@@ -101,6 +121,10 @@ class GetUserByIdTest : MainServiceTest() {
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> { mainService.getUserById(getExampleRequest()) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) }
         }
 
     @Test
@@ -122,6 +146,10 @@ class GetUserByIdTest : MainServiceTest() {
             assertThrows<NotFoundException>("Should throw NotFoundException for status $status") {
                 mainService.getUserById(getExampleRequest())
             }
+
+            verify(atLeast = 1, atMost = 3) { GrpcContext.getUserIdFromContext() }
+            coVerify(atLeast = 1, atMost = 3) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(atLeast = 1, atMost = 3) { userRepoMock.getUserById(requestedUserId) }
         }
     }
 
@@ -145,6 +173,10 @@ class GetUserByIdTest : MainServiceTest() {
             assertDoesNotThrow("Should succeed for status $status") {
                 mainService.getUserById(getExampleRequest())
             }
+
+            verify(atLeast = 1, atMost = 2) { GrpcContext.getUserIdFromContext() }
+            coVerify(atLeast = 1, atMost = 2) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(atLeast = 1, atMost = 2) { userRepoMock.getUserById(requestedUserId) }
         }
     }
 
@@ -157,5 +189,10 @@ class GetUserByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getMembersInSameProjectsAsUser(any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -26,16 +26,20 @@ class GetUserByIdTest : MainServiceTest() {
     @Test
     fun `When parsing the user ID fails, then InvalidIdException is thrown`() = runTest {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns DataBuilder.createExampleUser()
+        val currentUserId = UUID.randomUUID()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } returns DataBuilder.createExampleUser()
 
         assertThrows<InvalidIdException> { mainService.getUserById(request) }
     }
 
     @Test
     fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }
     }
@@ -57,16 +61,11 @@ class GetUserByIdTest : MainServiceTest() {
 
     @Test
     fun `When current user requests own user, then user is returned without redundant DB call`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(
-            id = currentUser.id,
-            status = UserStatus.USER_STATUS_ACTIVE,
-        )
-        val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
+        val currentUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
+        val request = Base.Id.newBuilder().setId(currentUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
 
         assertDoesNotThrow { mainService.getUserById(request) }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.every
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -12,18 +10,15 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
-import java.util.UUID
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetUserSettingsTest : MainServiceTest() {
     @Test
     fun `When retrieving current user settings fails, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns user
-        coEvery { userRepoMock.getUserSettings(any()) } throws TestSpecificException()
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserSettings(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserSettings() }
     }
@@ -36,8 +31,8 @@ class GetUserSettingsTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
             coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+            coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
 
             assertDoesNotThrow { mainService.getUserSettings() }
         }
@@ -51,8 +46,8 @@ class GetUserSettingsTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
             coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+            coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
 
             assertDoesNotThrow { mainService.getUserSettings() }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -21,6 +23,11 @@ class GetUserSettingsTest : MainServiceTest() {
         coEvery { userRepoMock.getUserSettings(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserSettings() }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserSettings(user.id) }
+        coVerify(exactly = 0) { criterionRepoMock.getCriteriaByIds(any()) }
     }
 
     @Test
@@ -35,6 +42,11 @@ class GetUserSettingsTest : MainServiceTest() {
             coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
 
             assertDoesNotThrow { mainService.getUserSettings() }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserSettings(user.id) }
+            coVerify(exactly = 1) { criterionRepoMock.getCriteriaByIds(emptyList()) }
         }
 
     @Test
@@ -50,5 +62,10 @@ class GetUserSettingsTest : MainServiceTest() {
             coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
 
             assertDoesNotThrow { mainService.getUserSettings() }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserSettings(user.id) }
+            coVerify(exactly = 1) { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
@@ -27,7 +27,7 @@ class LoginTest : MainServiceTest() {
     fun `When a user provides an invalid email, then an exception is thrown`() = runTest {
         val request = LoginRequest.newBuilder().setEmail("wrongEmail").build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } throws SnowballRException.NotFoundException(
+        coEvery { userRepoMock.getUserByEmail("wrongEmail") } throws SnowballRException.NotFoundException(
             EntityType.USER, "wrongEmail",
             identifierType = IdentifierType.EMAIL,
         )
@@ -77,13 +77,12 @@ class LoginTest : MainServiceTest() {
     @Test
     fun `When the password hash cannot be retrieved, then an exception is thrown`() = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
-
         val request = LoginRequest.newBuilder().apply {
             email = testUser.email
             password = "anyPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns testUser
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } throws SnowballRException.NotFoundException(
             EntityType.USER, testUser.email, identifierType = IdentifierType.EMAIL,
         )
@@ -96,43 +95,37 @@ class LoginTest : MainServiceTest() {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
         val userPassword = "AAbb__00"
         val passwordHash = PasswordUtils.hashPassword(userPassword)
-
         val request = LoginRequest.newBuilder().apply {
             email = testUser.email
             password = "wrongPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns testUser
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns passwordHash
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
 
     @Test
-    fun `When an active user provides valid credentials, then the user is logged in successfully`() = runTest {
+    fun `When an active user provides valid credentials, then the user is logged in successfully`(
+        cookiesMap: MutableMap<String, String>,
+    ) = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
         val userPassword = "AAbb__00"
         val passwordHash = PasswordUtils.hashPassword(userPassword)
         val tokens = JwtAuthTokens("accessToken", "refreshToken")
-
         val request = LoginRequest.newBuilder().apply {
             email = testUser.email
             password = userPassword
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns testUser
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns passwordHash
         every { jwtServiceMock.generateAuthTokens(testUser.id) } returns tokens
 
         assertDoesNotThrow { mainService.login(request) }
 
-        assertEquals(
-            tokens.accessToken,
-            GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.ACCESS_TOKEN_COOKIE_NAME],
-        )
-        assertEquals(
-            tokens.refreshToken,
-            GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.REFRESH_TOKEN_COOKIE_NAME],
-        )
+        assertEquals(tokens.accessToken, cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
+        assertEquals(tokens.refreshToken, cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -33,6 +35,10 @@ class LoginTest : MainServiceTest() {
         )
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail("wrongEmail") }
+        coVerify(exactly = 0) { userRepoMock.getPasswordHashByEmail(any()) }
+        verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
     }
 
     @Test
@@ -46,6 +52,10 @@ class LoginTest : MainServiceTest() {
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(testUser.email) }
+        coVerify(exactly = 0) { userRepoMock.getPasswordHashByEmail(any()) }
+        verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
     }
 
     @Test
@@ -59,6 +69,10 @@ class LoginTest : MainServiceTest() {
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(testUser.email) }
+        coVerify(exactly = 0) { userRepoMock.getPasswordHashByEmail(any()) }
+        verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
     }
 
     @Test
@@ -72,6 +86,10 @@ class LoginTest : MainServiceTest() {
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(testUser.email) }
+        coVerify(exactly = 0) { userRepoMock.getPasswordHashByEmail(any()) }
+        verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
     }
 
     @Test
@@ -88,6 +106,10 @@ class LoginTest : MainServiceTest() {
         )
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(testUser.email) }
+        coVerify(exactly = 1) { userRepoMock.getPasswordHashByEmail(testUser.email) }
+        verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
     }
 
     @Test
@@ -104,6 +126,10 @@ class LoginTest : MainServiceTest() {
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns passwordHash
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(testUser.email) }
+        coVerify(exactly = 1) { userRepoMock.getPasswordHashByEmail(testUser.email) }
+        verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
     }
 
     @Test
@@ -127,5 +153,9 @@ class LoginTest : MainServiceTest() {
 
         assertEquals(tokens.accessToken, cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
         assertEquals(tokens.refreshToken, cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
+
+        coVerify(exactly = 1) { userRepoMock.getUserByEmail(testUser.email) }
+        coVerify(exactly = 1) { userRepoMock.getPasswordHashByEmail(testUser.email) }
+        verify(exactly = 1) { jwtServiceMock.generateAuthTokens(testUser.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LogoutTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LogoutTest.kt
@@ -1,5 +1,7 @@
 package se.uulm.snowballr.backend.service.user
 
+import io.mockk.coVerify
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -21,5 +23,9 @@ class LogoutTest : MainServiceTest() {
 
             assertEquals("", cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
             assertEquals("", cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
+
+            coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+            coVerify(exactly = 0) { userRepoMock.getUserByEmail(any()) }
+            verify(exactly = 0) { jwtServiceMock.generateAuthTokens(any()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -1,8 +1,10 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -23,6 +25,11 @@ class RegisterTest : MainServiceTest() {
         coEvery { userRepoMock.doesUserExistByEmail("test@example.com") } returns true
 
         assertThrows<DuplicateEntityException> { mainService.register(request) }
+
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail("test@example.com") }
+        coVerify(exactly = 0) { userRepoMock.createUser(any(), any()) }
+        coVerify(exactly = 0) { verificationTokenRepoMock.saveVerificationToken(any(), any()) }
+        coVerify(exactly = 0) { emailManagerMock.sendVerificationEmail(any(), any()) }
     }
 
     @Test
@@ -33,6 +40,11 @@ class RegisterTest : MainServiceTest() {
         coEvery { userRepoMock.createUser(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.register(request) }
+
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(request.email) }
+        coVerify(exactly = 1) { userRepoMock.createUser(eq(request), any()) }
+        coVerify(exactly = 0) { verificationTokenRepoMock.saveVerificationToken(any(), any()) }
+        coVerify(exactly = 0) { emailManagerMock.sendVerificationEmail(any(), any()) }
     }
 
     @Test
@@ -45,6 +57,11 @@ class RegisterTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.saveVerificationToken(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.register(request) }
+
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(request.email) }
+        coVerify(exactly = 1) { userRepoMock.createUser(eq(request), any()) }
+        coVerify(exactly = 1) { verificationTokenRepoMock.saveVerificationToken(eq(user.id), any()) }
+        coVerify(exactly = 0) { emailManagerMock.sendVerificationEmail(any(), any()) }
     }
 
     @Test
@@ -59,6 +76,12 @@ class RegisterTest : MainServiceTest() {
         coEvery { emailManagerMock.sendVerificationEmail(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.register(request) }
+
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(request.email) }
+        coVerify(exactly = 1) { userRepoMock.createUser(eq(request), any()) }
+        coVerify(exactly = 1) { verificationTokenRepoMock.saveVerificationToken(eq(user.id), any()) }
+        verify(exactly = 1) { emailManagerMock.createVerificationLink(any()) }
+        coVerify(exactly = 1) { emailManagerMock.sendVerificationEmail(eq(user.email), any()) }
     }
 
     @Test
@@ -96,5 +119,11 @@ class RegisterTest : MainServiceTest() {
             assertThat(capturedEmailData.firstName).isEqualTo(user.firstName)
             assertThat(capturedEmailData.lastName).isEqualTo(user.lastName)
             assertThat(capturedEmailData.verificationLink).isEqualTo(expectedVerificationLink)
+
+            coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(request.email) }
+            coVerify(exactly = 1) { userRepoMock.createUser(eq(request), any()) }
+            coVerify(exactly = 1) { verificationTokenRepoMock.saveVerificationToken(user.id, capturedToken) }
+            verify(exactly = 1) { emailManagerMock.createVerificationLink(capturedToken) }
+            coVerify(exactly = 1) { emailManagerMock.sendVerificationEmail(user.email, capturedEmailData) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -18,9 +18,9 @@ import snowballr.Authentication
 class RegisterTest : MainServiceTest() {
     @Test
     fun `When a user with the given email already exists, then an exception is thrown`() = runTest {
-        val request = Authentication.RegisterRequest.newBuilder().build()
+        val request = Authentication.RegisterRequest.newBuilder().setEmail("test@example.com").build()
 
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
+        coEvery { userRepoMock.doesUserExistByEmail("test@example.com") } returns true
 
         assertThrows<DuplicateEntityException> { mainService.register(request) }
     }
@@ -50,7 +50,7 @@ class RegisterTest : MainServiceTest() {
     @Test
     fun `When sending the verification email fails, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
-        val request = Authentication.RegisterRequest.newBuilder().build()
+        val request = Authentication.RegisterRequest.newBuilder().setEmail(user.email).build()
 
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
         coEvery { userRepoMock.createUser(any(), any()) } returns user
@@ -76,16 +76,14 @@ class RegisterTest : MainServiceTest() {
             val tokenSlot = slot<String>()
             val emailDataSlot = slot<EmailData.EmailVerification>()
 
-            coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-            coEvery { userRepoMock.createUser(any(), any()) } returns user
-            coEvery { verificationTokenRepoMock.saveVerificationToken(any(), capture(tokenSlot)) } returns Unit
-
+            coEvery { userRepoMock.doesUserExistByEmail(request.email) } returns false
+            coEvery { userRepoMock.createUser(eq(request), any()) } returns user
+            coEvery { verificationTokenRepoMock.saveVerificationToken(user.id, capture(tokenSlot)) } returns Unit
             every { emailManagerMock.createVerificationLink(any()) } answers {
                 val token = firstArg<String>()
                 "$testFrontendURL/verifyemail?token=$token"
             }
-
-            coEvery { emailManagerMock.sendVerificationEmail(any(), capture(emailDataSlot)) } returns Unit
+            coEvery { emailManagerMock.sendVerificationEmail(user.email, capture(emailDataSlot)) } returns Unit
 
             assertDoesNotThrow { mainService.register(request) }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -30,8 +30,9 @@ class SoftDeleteUserTest : MainServiceTest() {
 
     @Test
     fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
     }
@@ -39,8 +40,10 @@ class SoftDeleteUserTest : MainServiceTest() {
     @Test
     fun `When parsing user ID fails, then InvalidIdException is thrown`() = runTest {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns DataBuilder.createExampleUser()
+        val currentUser = DataBuilder.createExampleUser()
+
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
 
         assertThrows<InvalidIdException> { mainService.softDeleteUser(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -26,6 +28,10 @@ class SoftDeleteUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.softDeleteUser(any()) }
     }
 
     @Test
@@ -35,6 +41,10 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { userRepoMock.softDeleteUser(any()) }
     }
 
     @Test
@@ -46,6 +56,10 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
 
         assertThrows<InvalidIdException> { mainService.softDeleteUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 0) { userRepoMock.softDeleteUser(any()) }
     }
 
     @Test
@@ -57,6 +71,11 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { userRepoMock.softDeleteUser(any()) }
     }
 
     @Test
@@ -69,6 +88,11 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } returns userToDelete
 
         assertThrows<UnauthorizedException.Single> { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { userRepoMock.softDeleteUser(any()) }
     }
 
     @Test
@@ -81,6 +105,11 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } returns userToDelete
 
         assertThrows<FailedPreconditionException> { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { userRepoMock.softDeleteUser(any()) }
     }
 
     @Test
@@ -94,6 +123,11 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { userRepoMock.softDeleteUser(requestedUserId) }
     }
 
     @Test
@@ -107,6 +141,11 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { userRepoMock.softDeleteUser(requestedUserId) }
     }
 
     @Test
@@ -118,6 +157,10 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 2) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.softDeleteUser(currentUser.id) }
     }
 
     @Test
@@ -129,5 +172,9 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 2) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.softDeleteUser(currentUser.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -2,7 +2,9 @@ package se.uulm.snowballr.backend.service.user
 
 import com.google.protobuf.FieldMask
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -44,6 +46,10 @@ class UpdateUserTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -53,6 +59,10 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUserId) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -64,6 +74,11 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -77,6 +92,12 @@ class UpdateUserTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
 
             assertThrows<UnauthorizedException.Single> { mainService.updateUser(getExampleRequest()) }
+
+            verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+            coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+            coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+            coVerify(exactly = 0) { userRepoMock.doesUserExistByEmail(any()) }
+            coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
         }
 
     @Test
@@ -93,6 +114,12 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(otherUser.id) } returns otherUser
 
         assertThrows<UnauthorizedException.Single> { mainService.updateUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(otherUser.id) }
+        coVerify(exactly = 0) { userRepoMock.doesUserExistByEmail(any()) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -106,6 +133,12 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.doesUserExistByEmail(newEmail) } returns true
 
         assertThrows<DuplicateEntityException> { mainService.updateUser(getExampleRequest()) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(newEmail) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -121,6 +154,12 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.updateUser(request) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(newEmail) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(request) }
     }
 
     @Test
@@ -138,6 +177,11 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.updateUser(request) } returns currentUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 2) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(newEmail) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(request) }
     }
 
     @Test
@@ -155,6 +199,12 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.updateUser(request) } returns otherUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(otherUser.id) }
+        coVerify(exactly = 0) { userRepoMock.doesUserExistByEmail(any()) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(request) }
     }
 
     @Test
@@ -170,5 +220,11 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.updateUser(request) } returns requestedUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
+
+        verify(exactly = 1) { GrpcContext.getUserIdFromContext() }
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUserId) }
+        coVerify(exactly = 1) { userRepoMock.doesUserExistByEmail(newEmail) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -19,11 +19,12 @@ import java.util.UUID
 
 class UpdateUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
+    private val newEmail = "newemail@example.com"
 
     private fun getExampleRequest(): UserOuterClass.User.Update {
         val user = UserOuterClass.User.newBuilder()
             .setId(requestedUserId.toString())
-            .setEmail("newemail@example.com")
+            .setEmail(newEmail)
             .setRole(UserRole.USER_ROLE_ADMIN)
             .build()
 
@@ -47,8 +48,9 @@ class UpdateUserTest : MainServiceTest() {
 
     @Test
     fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        val currentUserId = UUID.randomUUID()
+        every { GrpcContext.getUserIdFromContext() } returns currentUserId
+        coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
     }
@@ -99,9 +101,9 @@ class UpdateUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
+        coEvery { userRepoMock.doesUserExistByEmail(newEmail) } returns true
 
         assertThrows<DuplicateEntityException> { mainService.updateUser(getExampleRequest()) }
     }
@@ -110,31 +112,29 @@ class UpdateUserTest : MainServiceTest() {
     fun `When update fails, then exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
+        val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
+        coEvery { userRepoMock.doesUserExistByEmail(newEmail) } returns false
+        coEvery { userRepoMock.updateUser(request) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
+        assertThrows<TestSpecificException> { mainService.updateUser(request) }
     }
 
     @Test
     fun `When user updates own email, then it succeeds`() = runTest {
+        val newEmail = "new-and-shiny@example.com"
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
         val request = UserOuterClass.User.Update.newBuilder()
-            .setUser(
-                UserOuterClass.User.newBuilder()
-                    .setId(currentUser.id.toString())
-                    .setEmail("new-and-shiny@example.com"),
-            )
+            .setUser(UserOuterClass.User.newBuilder().setId(currentUser.id.toString()).setEmail(newEmail))
             .setMask(FieldMask.newBuilder().addPaths("email"))
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.doesUserExistByEmail("new-and-shiny@example.com") } returns false
+        coEvery { userRepoMock.doesUserExistByEmail(newEmail) } returns false
         coEvery { userRepoMock.updateUser(request) } returns currentUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
@@ -145,11 +145,7 @@ class UpdateUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val otherUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
         val request = UserOuterClass.User.Update.newBuilder()
-            .setUser(
-                UserOuterClass.User.newBuilder()
-                    .setId(otherUser.id.toString())
-                    .setRole(UserRole.USER_ROLE_ADMIN),
-            )
+            .setUser(UserOuterClass.User.newBuilder().setId(otherUser.id.toString()).setRole(UserRole.USER_ROLE_ADMIN))
             .setMask(FieldMask.newBuilder().addPaths("role"))
             .build()
 
@@ -165,13 +161,14 @@ class UpdateUserTest : MainServiceTest() {
     fun `When admin updates all fields of another user, then it succeeds`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
+        val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.updateUser(any()) } returns requestedUser
+        coEvery { userRepoMock.doesUserExistByEmail(newEmail) } returns false
+        coEvery { userRepoMock.updateUser(request) } returns requestedUser
 
-        assertDoesNotThrow { mainService.updateUser(getExampleRequest()) }
+        assertDoesNotThrow { mainService.updateUser(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -21,6 +22,11 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue("non-existent-token") } returns null
 
         assertThrows<VerificationTokenNotFoundException> { mainService.verifyEmail(request) }
+
+        coVerify(exactly = 1) { verificationTokenRepoMock.getVerificationTokenByValue("non-existent-token") }
+        coVerify(exactly = 0) { verificationTokenRepoMock.deleteVerificationToken(any()) }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -34,6 +40,11 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.deleteVerificationToken(expiredToken.token) } returns Unit
 
         assertThrows<VerificationTokenNotFoundException> { mainService.verifyEmail(request) }
+
+        coVerify(exactly = 1) { verificationTokenRepoMock.getVerificationTokenByValue(expiredToken.token) }
+        coVerify(exactly = 1) { verificationTokenRepoMock.deleteVerificationToken(expiredToken.token) }
+        coVerify(exactly = 0) { userRepoMock.getUserById(any()) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
     }
 
     @Test
@@ -45,6 +56,11 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(token.userId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
+
+        coVerify(exactly = 1) { verificationTokenRepoMock.getVerificationTokenByValue(token.token) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(token.userId) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
+        coVerify(exactly = 0) { verificationTokenRepoMock.deleteVerificationToken(any()) }
     }
 
     @Test
@@ -58,6 +74,11 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
+
+        coVerify(exactly = 1) { verificationTokenRepoMock.getVerificationTokenByValue(token.token) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(any()) }
+        coVerify(exactly = 0) { verificationTokenRepoMock.deleteVerificationToken(any()) }
     }
 
     @Test
@@ -72,6 +93,11 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.deleteVerificationToken(token.token) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
+
+        coVerify(exactly = 1) { verificationTokenRepoMock.getVerificationTokenByValue(token.token) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(any()) }
+        coVerify(exactly = 1) { verificationTokenRepoMock.deleteVerificationToken(token.token) }
     }
 
     @Test
@@ -87,5 +113,10 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.deleteVerificationToken(token.token) } returns Unit
 
         assertDoesNotThrow { mainService.verifyEmail(request) }
+
+        coVerify(exactly = 1) { verificationTokenRepoMock.getVerificationTokenByValue(token.token) }
+        coVerify(exactly = 1) { userRepoMock.getUserById(user.id) }
+        coVerify(exactly = 1) { userRepoMock.updateUser(userUpdateSlot.captured) }
+        coVerify(exactly = 1) { verificationTokenRepoMock.deleteVerificationToken(token.token) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -18,7 +18,7 @@ class VerifyEmailTest : MainServiceTest() {
     @Test
     fun `When the verification token is not found, then an exception is thrown`() = runTest {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken("non-existent-token").build()
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns null
+        coEvery { verificationTokenRepoMock.getVerificationTokenByValue("non-existent-token") } returns null
 
         assertThrows<VerificationTokenNotFoundException> { mainService.verifyEmail(request) }
     }
@@ -41,7 +41,7 @@ class VerifyEmailTest : MainServiceTest() {
         val token = DataBuilder.createExampleVerificationToken()
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
+        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns token
         coEvery { userRepoMock.getUserById(token.userId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
@@ -53,8 +53,8 @@ class VerifyEmailTest : MainServiceTest() {
         val token = DataBuilder.createExampleVerificationToken(userId = user.id)
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns token
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
@@ -66,10 +66,10 @@ class VerifyEmailTest : MainServiceTest() {
         val token = DataBuilder.createExampleVerificationToken(userId = user.id)
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns token
+        coEvery { userRepoMock.getUserById(user.id) } returns user
         coEvery { userRepoMock.updateUser(any()) } returns user
-        coEvery { verificationTokenRepoMock.deleteVerificationToken(any()) } throws TestSpecificException()
+        coEvery { verificationTokenRepoMock.deleteVerificationToken(token.token) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
     }


### PR DESCRIPTION
Closes #261 

## What I have made

- Removed an unused variable
- Refactored almost all service layer tests
  - mainly as preparation for the following modifications
  - to fix wording, etc.
- Used `assertThat` wherever possible
- Added verification of made calls

It's easiest to go commit-by-commit in order to only see the new changes and refactoring and not everything all at once.

@domienderle, please have a look at your new tests. In my opinion, this new style makes the addition of these verify blocks unfortunate. Maybe we need to find a better way, but currently I don't have any ideas.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~ Mainly refactoring
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ Modified the test code
- [ ] (for reviewer) I have checked the implementation against the requirements
