### PR TITLE
Implement `RenewSession` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -180,7 +180,7 @@ class SnowballRServer(
         ): Authentication.AuthenticationStatusResponse = Authentication.AuthenticationStatusResponse.newBuilder()
             .setAuthenticationStatus(GrpcContext.getAuthenticationStatusFromContext()).build()
 
-        override suspend fun renewSession(request: Base.Nothing): Base.Nothing = super.renewSession(request)
+        override suspend fun renewSession(request: Base.Nothing): Base.Nothing = Base.Nothing.getDefaultInstance()
 
         override suspend fun requestPasswordReset(request: Authentication.RequestPasswordResetRequest): Base.Nothing =
             super.requestPasswordReset(request)


### PR DESCRIPTION
Closes #176 

## What I have made

Since the `AuthenticationInterceptor` handles the whole authentication including the session renewal, there is nothing needed in order to use the renew session functionality.

This can be tested very easily by simply reducing the access token TTL in the JWT Service to 1 minute or less.
Then you can test this behaviour by login in in the frontend, wait for a minute and then click on the reading list e.g.
Even the hover over the button should trigger the renew session event and the user should notice nothing in the frontend.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~ Already implemented
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ Already tested
- [x] (for reviewer) I have checked the implementation against the requirements
