### PR TITLE
Implement `getProjectPaperByRelativeId` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -328,7 +328,7 @@ class SnowballRServer(
 
         override suspend fun getProjectPaperByRelativeId(
             request: ProjectOuterClass.Project.Paper.Get,
-        ): ProjectOuterClass.Project.Paper = super.getProjectPaperByRelativeId(request)
+        ): ProjectOuterClass.Project.Paper = mainService.getProjectPaperByRelativeId(request)
 
         override suspend fun getAllProjectPapersForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
             mainService.getAllProjectPapersForProject(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/IdentifierType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/IdentifierType.kt
@@ -8,4 +8,5 @@ package se.uulm.snowballr.backend.model
 enum class IdentifierType(val displayName: String) {
     ID("ID"),
     EMAIL("email"),
+    LOCAL_ID("local ID"),
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.model
 
 import org.simplejavamail.MailException
 import se.uulm.snowballr.backend.mail.EmailManager
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import java.io.IOException
 
 /**
@@ -23,13 +24,32 @@ sealed class SnowballRException(
      * @param entityType The type of the entity that could not be found.
      * @param entityIds The missing entity's ID(s).
      * @param identifierType The type of the entity's identifier. Defaults to [IdentifierType.ID].
+     * @param location The location where the entity could not be found, e.g., the project or paper. Should start with " in ...".
      */
     open class NotFoundException(
         entityType: EntityType,
         vararg entityIds: String,
         identifierType: IdentifierType = IdentifierType.ID,
+        location: String = "",
     ) : SnowballRException(
-        "${entityType.singularUpper()} ${displayEntityIds(entityIds.toList(), identifierType)} not found.",
+        "${entityType.singularUpper()} ${displayEntityIds(entityIds.toList(), identifierType)} not found$location.",
+    )
+
+    /**
+     * Represents an exception indicating that a [ProjectPaper] entity could not be found within the context of a
+     * specific project.
+     *
+     * @param localProjectPaperId The local identifier of the missing [ProjectPaper] entity.
+     * @param projectId The identifier of the project in which the [ProjectPaper] could not be found.
+     */
+    open class ProjectPaperNotFoundException(
+        localProjectPaperId: String,
+        projectId: String,
+    ) : NotFoundException(
+        EntityType.PROJECT_PAPER,
+        localProjectPaperId,
+        identifierType = IdentifierType.LOCAL_ID,
+        location = " in project with ID $projectId",
     )
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_DIGITS
 import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS
 import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_SPECIAL_CHARS
 import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS
+import kotlin.reflect.KClass
 
 /**
  * Represents a validation issue that can occur during the validation process.
@@ -96,6 +97,22 @@ data class OutOfRangeValue(
 ) : ValidationIssue {
     override fun toString(): String =
         "The value '$value' is not in the allowed range [$from-$to] for the field '$name'."
+}
+
+/**
+ * Represents a validation issue where a given value cannot be converted to the expected type.
+ *
+ * This class encapsulates the problematic value and the expected type, enabling detailed error
+ * reporting in validation workflows.
+ *
+ * @property value The value that failed conversion.
+ * @property type The expected target type for the conversion.
+ */
+data class NotConvertableValue(
+    val value: String,
+    val type: KClass<*>,
+) : ValidationIssue {
+    override fun toString(): String = "The value '$value' is not a valid '$type'."
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -2,10 +2,12 @@ package se.uulm.snowballr.backend.repository.association
 
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
@@ -27,6 +29,19 @@ interface IProjectPaperTableRepo {
      * Returns a project paper by its ID or throws a [NotFoundException] if the project paper with the passed [id] doesn't exist.
      */
     suspend fun getProjectPaperById(id: UUID): ProjectPaper
+
+    /**
+     * Retrieves a project paper by its relative ID in a project.
+     *
+     * Therefore, this method searches for a project paper in the project with the [projectId] with
+     * the [relativeId] (`localPaperId`).
+     *
+     * @param projectId The unique identifier of the project to which the project paper belongs.
+     * @param relativeId The local paper ID of the project paper in the project.
+     * @return The [ProjectPaper] matching the given project ID and relative ID.
+     * @throws [NotFoundException] if no matching project paper is found.
+     */
+    suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): ProjectPaper
 
     /**
      * Retrieves a list of project papers along with their associated papers for the specified project.
@@ -62,6 +77,21 @@ class ProjectPaperTableRepo(
 
     override suspend fun getProjectPaperById(id: UUID): ProjectPaper = db.query {
         getProjectPaperByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT_PAPER, id.toString())
+    }
+
+    override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): ProjectPaper = db.query {
+        ProjectPaperTable
+            .selectAll()
+            .where {
+                (
+                    (ProjectPaperTable.projectId eq projectId)
+                        and (ProjectPaperTable.localPaperId eq relativeId)
+                    )
+            }
+            .map { it.toProjectPaper() }
+            .singleOrNull() ?: throw ProjectPaperNotFoundException(
+            relativeId.toString(), projectId.toString(),
+        )
     }
 
     override suspend fun getAllProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -33,6 +33,7 @@ import snowballr.CriterionOuterClass
 import snowballr.PaperOuterClass
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
+import java.util.UUID
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 import snowballr.ReviewOuterClass.Review as GrpcReview
@@ -86,6 +87,11 @@ interface IProjectService {
      * Service implementation of [SnowballRService.getProjectPaperById].
      */
     suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper
+
+    /**
+     * Service implementation of [SnowballRService.getProjectPaperByRelativeId].
+     */
+    suspend fun getProjectPaperByRelativeId(request: GrpcProject.Paper.Get): GrpcProject.Paper
 
     /**
      * Service implementation of [SnowballRService.getAllProjectPapersForProject].
@@ -194,6 +200,50 @@ class ProjectService(
             paperBackwardReferencesMap,
             projectPaperReviewsMap,
         )
+    }
+
+    /**
+     * Retrieves the gRPC representation of a project's paper, including associated data such as authors,
+     * backward references, and reviews. Furthermore, it ensures that the current user has the necessary permissions to access
+     * the project's paper.
+     *
+     * @param projectPaper The project paper, containing the ids linking to the associated data.
+     * @param projectId The unique identifier of the project to which the paper belongs.
+     * @return The gRPC representation of the project's paper, including associated data.
+     * @throws UnauthorizedException.Single If the current user does not have the required read access to the project.
+     */
+    private suspend fun loadAndAuthorizeProjectPaper(projectPaper: ProjectPaper, projectId: UUID): GrpcProject.Paper {
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+        if (projectMembers.none { it.userId == currentUser.id }) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(
+                    EntityType.PROJECT,
+                    projectId.toString(),
+                    AccessType.READ,
+                    it,
+                )
+            }
+        }
+
+        val paper = paperRepo.getPaperById(projectPaper.paperId)
+        val authors = authorOfPaperTableRepo
+            .getAuthorsOfPaperById(paper.id)
+            .map { it.toGrpcAuthor() }
+
+        val backwardReferences = citationTableRepo
+            .getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            .map { it.toString() }
+
+        val reviews = reviewTableRepo
+            .getAllReviewsForProjectPaper(projectPaper.id)
+            .map {
+                val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
+                it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+            }
+
+        return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
     }
 
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
@@ -321,35 +371,20 @@ class ProjectService(
     }
 
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId)
-        val projectId = projectPaper.projectId
-        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+        return loadAndAuthorizeProjectPaper(projectPaper, projectPaper.projectId)
+    }
 
-        if (!projectMembers.any { it.userId == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
-            }
+    override suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): GrpcProjectPaper {
+        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+        if (!repo.doesProjectExistById(projectId)) {
+            throw SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
         }
 
-        val paper = paperRepo.getPaperById(projectPaper.paperId)
-        val authors = authorOfPaperTableRepo.getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
-        val backwardReferences = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(
-            paper.id,
-        ).map { it.toString() }
-        val reviews = reviewTableRepo.getAllReviewsForProjectPaper(projectPaperId)
-            .map {
-                val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
-                it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
-            }
-
-        return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
+        val relativeId = request.relativeProjectPaperId.toLong()
+        val projectPaper = projectPaperRepo.getProjectPaperByRelativeId(projectId, relativeId)
+        return loadAndAuthorizeProjectPaper(projectPaper, projectId)
     }
 
     override suspend fun getAllProjectPapersForProject(request: Base.Id): GrpcProjectPaper.List =

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectPaperValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectPaperValidator.kt
@@ -1,0 +1,36 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.Raise
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+
+/**
+ * A validator for [GrpcProjectPaper] related requests.
+ */
+object ProjectPaperValidator {
+    fun validateGetRequest(request: GrpcProjectPaper.Get): EitherNel<ValidationIssue, Unit> = either {
+        zipOrAccumulate(
+            { ensureIdValidity("id", request.projectId) },
+            {
+                ensureRelativeProjectPaperIdValidity(request.relativeProjectPaperId)
+            },
+        ) { _, _ -> }
+    }
+
+    /**
+     * Ensures the validity of a given relative project paper ID.
+     *
+     * This function performs the following validations:
+     * - Ensures the ID is non-blank.
+     * - Ensures the ID can be converted to a `Long`.
+     *
+     * @param relativeId The relative project paper ID to validate.
+     */
+    fun Raise<ValidationIssue>.ensureRelativeProjectPaperIdValidity(relativeId: String) {
+        ensureFieldNonBlank("relative_project_paper_id", relativeId)
+        ensureStringIsLongConvertible(relativeId)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package se.uulm.snowballr.backend.validation
 
 import arrow.core.raise.Raise
@@ -14,6 +16,7 @@ import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.InvalidPassword
 import se.uulm.snowballr.backend.model.InvalidPassword.Reason
+import se.uulm.snowballr.backend.model.NotConvertableValue
 import se.uulm.snowballr.backend.model.TooLongField
 import se.uulm.snowballr.backend.model.ValidationIssue
 import java.util.UUID
@@ -157,5 +160,19 @@ fun Raise<ValidationIssue>.ensureFieldMaskIsValid(fieldMask: FieldMask, descript
     ensure(fieldMask.pathsList.isNotEmpty()) { InvalidFieldMask(null) }
     ensure(FieldMaskUtil.isValid(descriptor, fieldMask)) {
         InvalidFieldMask(fieldMask.toString())
+    }
+}
+
+/**
+ * Ensures that the given string value can be converted to a `Long`.
+ *
+ * If the value cannot be converted to a `Long`, this function raises a validation issue
+ * of type [NotConvertableValue].
+ *
+ * @param value The string value to check for `Long` convertibility.
+ */
+fun Raise<ValidationIssue>.ensureStringIsLongConvertible(value: String) {
+    ensure(value.toLongOrNull() != null) {
+        NotConvertableValue(value, Long::class)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -60,6 +60,8 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
     is ProjectOuterClass.Project.Update -> ProjectValidator.validateUpdateRequest(request)
     is ProjectOuterClass.Project.InviteCandidatesRequest -> Either.Right(Unit)
+    // Project Paper
+    is ProjectOuterClass.Project.Paper.Get -> ProjectPaperValidator.validateGetRequest(request)
     // Criterion
     is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
     is CriterionOuterClass.Criterion.Update -> CriterionValidator.validateUpdateRequest(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -4,8 +4,10 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
 import se.uulm.snowballr.backend.repository.PaperTableRepo
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
@@ -16,6 +18,7 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import snowballr.ProjectOuterClass
 import java.util.UUID
+import kotlin.random.Random
 
 class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, ProjectTable, PaperTable), true) {
     private val repo = ProjectPaperTableRepo(db)
@@ -42,8 +45,58 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
 
         @Test
         fun `When a project paper is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getProjectPaperById(UUID.randomUUID()) }
+            assertThrows<SnowballRException.NotFoundException> { repo.getProjectPaperById(UUID.randomUUID()) }
         }
+    }
+
+    @Nested
+    inner class GetProjectPaperByRelativeId {
+        @Test
+        fun `When no project with the given id exists, then a not found exception is thrown`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val projectPaper = repo.getProjectPaperById(projectPaperId)
+
+            assertThrows<ProjectPaperNotFoundException> {
+                repo.getProjectPaperByRelativeId(UUID.randomUUID(), projectPaper.localPaperId)
+            }
+        }
+
+        @Test
+        fun `When no project paper with the given local id exists in the project, then a not found exception is thrown`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+
+                assertThrows<ProjectPaperNotFoundException> {
+                    repo.getProjectPaperByRelativeId(
+                        projectId,
+                        Random.nextLong(),
+                    )
+                }
+            }
+
+        @Test
+        fun `When a project paper with the given local id in the project is found, then the correct project paper is returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+                var projectPaper = repo.getProjectPaperById(projectPaperId)
+                projectPaper = assertDoesNotThrow {
+                    repo.getProjectPaperByRelativeId(projectId, projectPaper.localPaperId)
+                }
+
+                assertThat(projectPaper.id).isEqualTo(projectPaperId)
+                assertThat(projectPaper.projectId).isEqualTo(projectId)
+                assertThat(projectPaper.paperId).isEqualTo(paperId)
+                assertThat(projectPaper.localPaperId).isEqualTo(0)
+                assertThat(projectPaper.stage).isEqualTo(0)
+                assertThat(projectPaper.decision).isEqualTo(ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED)
+                assertThat(projectPaper.createdBy).isEqualTo(testUserId)
+            }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -13,23 +13,30 @@ import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.Base
+import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class GetProjectPaperByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
-    private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
+class GetProjectPaperByRelativeIdTest : MainServiceTest() {
+    private val projectId = UUID.randomUUID()
+    private val localPaperId = kotlin.random.Random.nextLong()
+    private fun getExampleRequest() = ProjectOuterClass.Project.Paper.Get
+        .newBuilder()
+        .setProjectId(projectId.toString())
+        .setRelativeProjectPaperId(localPaperId.toString())
+        .build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(GrpcContext::getUserIdFromContext),
         Arguments.of(userRepoMock::getUserById),
-        Arguments.of(projectPaperRepoMock::getProjectPaperById),
+        Arguments.of(projectRepoMock::doesProjectExistById),
+        Arguments.of(projectPaperRepoMock::getProjectPaperByRelativeId),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(paperRepoMock::getPaperById),
         Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
@@ -47,22 +54,32 @@ class GetProjectPaperByIdTest : MainServiceTest() {
                 UserOuterClass.UserRole.USER_ROLE_DEFAULT
             },
         )
-        val project = DataBuilder.createExampleProject()
+        val project = DataBuilder.createExampleProject(id = projectId)
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
             projectId = project.id,
             paperId = paper.id,
+            localPaperId = localPaperId,
         )
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
-        if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
+        if (failAt == projectRepoMock::doesProjectExistById) {
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+
+        if (failAt == projectPaperRepoMock::getProjectPaperByRelativeId) {
+            coEvery {
+                projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
+        } returns projectPaper
 
         if (failAt == GrpcContext::getUserIdFromContext) {
             every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
@@ -133,38 +150,59 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
-            mainService.getProjectPaperById(getExampleRequest())
+            mainService.getProjectPaperByRelativeId(getExampleRequest())
         }
     }
 
     @Test
     fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, true)
-        assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
+        assertDoesNotThrow { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, false)
-        assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
+        assertDoesNotThrow { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
     }
+
+    @Test
+    fun `When the project to retrieve the project paper from doesn't exist, then a not found exception is thrown`() =
+        runTest {
+            coEvery {
+                projectRepoMock.doesProjectExistById(projectId)
+            } throws SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
+
+            assertThrows<SnowballRException.NotFoundException> {
+                mainService.getProjectPaperByRelativeId(
+                    getExampleRequest(),
+                )
+            }
+        }
 
     @Test
     fun `When a non project member retrieves the project paper, then an unauthorized exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
+        val project = DataBuilder.createExampleProject(projectId)
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = requestId,
             projectId = project.id,
             paperId = paper.id,
+            localPaperId = localPaperId,
         )
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery {
+            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
+        } returns projectPaper
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> { mainService.getProjectPaperById(getExampleRequest()) }
+        assertThrows<SnowballRException.UnauthorizedException> {
+            mainService.getProjectPaperByRelativeId(
+                getExampleRequest(),
+            )
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectPaperValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectPaperValidatorTest.kt
@@ -1,0 +1,59 @@
+package se.uulm.snowballr.backend.validation
+
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.InvalidId
+import se.uulm.snowballr.backend.model.NotConvertableValue
+import snowballr.ProjectOuterClass.Project
+import java.util.UUID
+
+class ProjectPaperValidatorTest {
+    @Nested
+    inner class GetRequest {
+        private val validGetRequestBuilder: Project.Paper.Get.Builder =
+            Project.Paper.Get
+                .newBuilder()
+                .setProjectId(UUID.randomUUID().toString())
+                .setRelativeProjectPaperId(kotlin.random.Random.nextLong().toString())
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validGetRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid project ID is validated, then the 'InvalidId' issue is returned`() {
+            val request = validGetRequestBuilder.setProjectId("invalid-id").build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When a blank relative project paper ID is validated, then the 'BlankField' issue is returned`() {
+            val request =
+                validGetRequestBuilder
+                    .setRelativeProjectPaperId("")
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<BlankField>(result)
+        }
+
+        @Test
+        fun `When the relative project paper ID can not be converted to a Long, then the 'NotConvertableValue' issue is returned`() {
+            val request =
+                validGetRequestBuilder
+                    .setRelativeProjectPaperId("a")
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<NotConvertableValue>(result)
+        }
+    }
+}


### PR DESCRIPTION
Closes #171 

## What I have made

I have implemented the call `getProjectPaperByRelativeId` on repository, service, grpc and validation layer. 

Therefore I refactored the methods `getProjectPaperById` and `getProjectPaperByRelativeId` to prevent duplicated code. Additionally, I had to implement a new validation class for project papers.

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
