### PR TITLE
Implement `getForwardReferencedPapers` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -368,7 +368,7 @@ class SnowballRServer(
             super.updatePaper(request)
 
         override suspend fun getForwardReferencedPapers(request: Base.Id): PaperOuterClass.Paper.List =
-            super.getForwardReferencedPapers(request)
+            mainService.getForwardReferencedPapers(request)
 
         override suspend fun getBackwardReferencedPapers(request: Base.Id): PaperOuterClass.Paper.List =
             mainService.getBackwardReferencedPapers(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -49,23 +49,9 @@ fun Paper.toGrpcPaper(
 }
 
 /**
- * Converts a list of [Paper] objects into a gRPC list of papers.
- *
- * @return A [PaperOuterClass.Paper.List] containing the gRPC representation of the papers.
+ * Converts a list of [PaperOuterClass.Paper] objects into a [PaperOuterClass.Paper.List].
  */
-fun List<Paper>.toGrpcPapers(
-    paperAuthorsMap: Map<Paper, List<PaperOuterClass.Author>>,
-    paperBackwardReferencesMap: Map<Paper, List<String>>,
-): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List
+fun List<PaperOuterClass.Paper>.toGrpcPapers(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List
     .newBuilder()
-    .addAllPapers(
-        this.map { paper ->
-            val authors = paperAuthorsMap[paper].orEmpty()
-            val backwardRefs = paperBackwardReferencesMap[paper].orEmpty()
-            paper.toGrpcPaper(
-                authors = authors,
-                backwardReferencedIds = backwardRefs,
-            )
-        },
-    )
+    .addAllPapers(this)
     .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.model.dto
 
-import kotlinx.datetime.Instant
 import se.uulm.snowballr.backend.table.PaperTable
 import snowballr.PaperOuterClass
+import snowballr.paper
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -14,10 +14,10 @@ data class Paper(
     val title: String,
     val externalId: String?,
     val abstract: String,
-    val publishedAt: Instant?,
-    val publisher: String?,
-    val publicationType: String?,
-    val publicationName: String?,
+    val year: Int,
+    val publisher: String,
+    val publicationType: String,
+    val publicationName: String,
     val pdfId: UUID?,
     val fetcherMetadata: Map<String, String>,
     val createdAt: OffsetDateTime,
@@ -29,21 +29,24 @@ data class Paper(
  * Creates a [PaperOuterClass.Paper] from this [Paper].
  */
 fun Paper.toGrpcPaper(
-    authors: List<PaperOuterClass.Author>,
-    backwardReferencedIds: List<String>,
-): PaperOuterClass.Paper = PaperOuterClass.Paper
-    .newBuilder()
-    .setId(id.toString())
-    .setTitle(title)
-    .setExternalId(externalId)
-    .setAbstrakt(abstract)
-    .setPublisher(publisher)
-    .setPublicationType(publicationType)
-    .setPublicationName(publicationName)
-    .setHasPdf(pdfId != null)
-    .addAllAuthors(authors)
-    .addAllBackwardReferencedIds(backwardReferencedIds)
-    .build()
+    authorList: List<PaperOuterClass.Author>,
+    backwardReferencedIdsList: List<String>,
+): PaperOuterClass.Paper {
+    val paper = this
+    return paper {
+        id = paper.id.toString()
+        title = paper.title
+        if (paper.externalId != null) externalId = paper.externalId
+        abstrakt = paper.abstract
+        year = paper.year
+        publisher = paper.publisher
+        publicationType = paper.publicationType
+        publicationName = paper.publicationName
+        hasPdf = paper.pdfId != null
+        authors.addAll(authorList)
+        backwardReferencedIds.addAll(backwardReferencedIdsList)
+    }
+}
 
 /**
  * Converts a list of [Paper] objects into a gRPC list of papers.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepo.kt
@@ -16,6 +16,11 @@ interface ICitationTableRepo {
      * Returns the backward references of a paper by its ID.
      */
     suspend fun getBackwardsReferencedPaperIdsOfPaperById(id: UUID): List<UUID>
+
+    /**
+     * Returns the forward references of a paper by its ID.
+     */
+    suspend fun getForwardReferencedPaperIdsOfPaperById(id: UUID): List<UUID>
 }
 
 /**
@@ -35,6 +40,14 @@ class CitationTableRepo(
             .select(CitationTable.citedPaperId)
             .where { CitationTable.paperId eq id }
             .map { it[CitationTable.citedPaperId].value }
+            .toList()
+    }
+
+    override suspend fun getForwardReferencedPaperIdsOfPaperById(id: UUID): List<UUID> = db.query {
+        CitationTable
+            .select(CitationTable.paperId)
+            .where { CitationTable.citedPaperId eq id }
+            .map { it[CitationTable.paperId].value }
             .toList()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -3,7 +3,7 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
-import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcPapers
@@ -12,7 +12,7 @@ import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import snowballr.Base
-import snowballr.PaperOuterClass
+import java.util.UUID
 import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface IPaperService {
@@ -25,6 +25,11 @@ interface IPaperService {
      * Service implementation of [SnowballRService.getBackwardReferencedPapers].
      */
     suspend fun getBackwardReferencedPapers(request: Base.Id): GrpcPaper.List
+
+    /**
+     * Service implementation of [SnowballRService.getForwardReferencedPapers].
+     */
+    suspend fun getForwardReferencedPapers(request: Base.Id): GrpcPaper.List
 }
 
 /**
@@ -53,27 +58,38 @@ class PaperService(
         return paper.toGrpcPaper(authors, backwardReferencedIds)
     }
 
-    override suspend fun getBackwardReferencedPapers(request: Base.Id): GrpcPaper.List {
+    override suspend fun getBackwardReferencedPapers(request: Base.Id): GrpcPaper.List =
+        getReferencePapers(request, citationRepo::getBackwardsReferencedPaperIdsOfPaperById)
+
+    override suspend fun getForwardReferencedPapers(request: Base.Id): GrpcPaper.List =
+        getReferencePapers(request, citationRepo::getForwardReferencedPaperIdsOfPaperById)
+
+    /**
+     * Retrieves a list of reference papers based on the provided paper ID and a specified function for fetching
+     * references. This method ensures the validity of the paper ID and retrieves the associated metadata for each
+     * reference paper, including authors and backward references.
+     *
+     * @param request The request containing the ID of the paper for which references are to be retrieved.
+     * @param function A function that takes a paper ID and returns a list of UUIDs of the references.
+     * @return A list of gRPC-compatible paper objects containing reference information.
+     * @throws SnowballRException.NotFoundException If the paper specified in the request does not exist.
+     */
+    private suspend fun getReferencePapers(request: Base.Id, function: suspend (UUID) -> List<UUID>): GrpcPaper.List {
         val paperId = parseUUID(request.id, EntityType.PAPER)
         if (!repo.doesPaperExistById(paperId)) {
             throw SnowballRException.NotFoundException(EntityType.PAPER, paperId.toString())
         }
 
-        val backwardReferencedIds = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
-        val papers: MutableList<Paper> = mutableListOf()
-        val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
-        val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
-        backwardReferencedIds.forEach {
+        val referenceIds = function.invoke(paperId)
+        val papers = referenceIds.map {
             val referencedPaper = repo.getPaperById(it)
-            papers.add(referencedPaper)
-            paperAuthorsMap[referencedPaper] = authorOfPapersRepo
-                .getAuthorsOfPaperById(referencedPaper.id).map { author -> author.toGrpcAuthor() }
-            paperBackwardReferencesMap[referencedPaper] = citationRepo
-                .getBackwardsReferencedPaperIdsOfPaperById(referencedPaper.id).map { reference ->
-                    reference.toString()
-                }
+            val authors = authorOfPapersRepo.getAuthorsOfPaperById(referencedPaper.id)
+                .map(Author::toGrpcAuthor)
+            val backwardReferences = citationRepo
+                .getBackwardsReferencedPaperIdsOfPaperById(referencedPaper.id)
+                .map(UUID::toString)
+            referencedPaper.toGrpcPaper(authors, backwardReferences)
         }
-
-        return papers.toGrpcPapers(paperAuthorsMap, paperBackwardReferencesMap)
+        return papers.toGrpcPapers()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/PaperTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/PaperTable.kt
@@ -3,9 +3,7 @@ package se.uulm.snowballr.backend.table
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 import se.uulm.snowballr.backend.model.dto.Paper
-import java.time.Instant
 import java.time.OffsetDateTime
 
 /**
@@ -15,7 +13,7 @@ import java.time.OffsetDateTime
  * - [title]: Represents the title of the paper as a [String].
  * - [externalId]: Represents an optional unique external identifier of the paper as a nullable [String].
  * - [abstract]: Represents the abstract of the paper as a [String].
- * - [publishedAt]: Represents the publication timestamp of the paper as an [Instant].
+ * - [year]: Represents the publication year of the paper as an [Int].
  * - [publisher]: Represents the publisher of the paper as a nullable [String].
  * - [publicationType]: Represents the type of publication as a nullable [String].
  * - [publicationName]: Represents the name of the publication where the paper is published, as a nullable [String].
@@ -28,10 +26,10 @@ object PaperTable : UUIDTable("paper") {
     val title = text("title")
     val externalId = text("external_id").uniqueIndex().nullable()
     val abstract = text("abstract")
-    val publishedAt = timestamp("published_at").nullable()
-    val publisher = text("publisher").nullable()
-    val publicationType = text("publication_type").nullable()
-    val publicationName = text("publication_name").nullable()
+    val year = integer("year")
+    val publisher = text("publisher")
+    val publicationType = text("publication_type")
+    val publicationName = text("publication_name")
 
     /**
      * Optional reference to the PDF of the paper.
@@ -57,7 +55,7 @@ fun ResultRow.toPaper() = Paper(
     title = this[PaperTable.title],
     externalId = this[PaperTable.externalId],
     abstract = this[PaperTable.abstract],
-    publishedAt = this[PaperTable.publishedAt],
+    year = this[PaperTable.year],
     publisher = this[PaperTable.publisher],
     publicationType = this[PaperTable.publicationType],
     publicationName = this[PaperTable.publicationName],

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend
 
-import kotlinx.datetime.Instant
 import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.Paper
@@ -21,6 +20,7 @@ import snowballr.ProjectOuterClass.SnowballingType
 import snowballr.ReviewOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import snowballr.id
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -170,10 +170,10 @@ object DataBuilder {
         title: String = "Title",
         externalId: String? = "ExternalId",
         abstract: String = "Abstract",
-        publishedAt: Instant? = Instant.fromEpochSeconds(0),
-        publisher: String? = "Publisher",
-        publicationType: String? = "PublicationType",
-        publicationName: String? = "PublicationName",
+        year: Int = 2025,
+        publisher: String = "Publisher",
+        publicationType: String = "PublicationType",
+        publicationName: String = "PublicationName",
         pdfId: UUID? = UUID.randomUUID(),
         fetcherMetadata: Map<String, String> = emptyMap(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
@@ -184,7 +184,7 @@ object DataBuilder {
         title,
         externalId,
         abstract,
-        publishedAt,
+        year,
         publisher,
         publicationType,
         publicationName,

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -27,7 +26,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
                 assertThat(title).isEqualTo("Title")
                 assertThat(externalId).isEqualTo("ExternalId")
                 assertThat(abstract).isEqualTo("Abstract")
-                assertThat(publishedAt).isEqualTo(Instant.fromEpochSeconds(0))
+                assertThat(year).isEqualTo(2025)
                 assertThat(publisher).isEqualTo("Publisher")
                 assertThat(publicationType).isEqualTo("PublicationType")
                 assertThat(publicationName).isEqualTo("PublicationName")

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import kotlinx.datetime.Instant
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
@@ -82,7 +81,7 @@ object RepositoryHelper {
         title: String = "Title",
         externalId: String = UUID.randomUUID().toString(),
         abstract: String = "Abstract",
-        publishedAt: Instant = Instant.fromEpochSeconds(0),
+        year: Int = 2025,
         publisher: String = "Publisher",
         publicationType: String = "PublicationType",
         publicationName: String = "PublicationName",
@@ -92,7 +91,7 @@ object RepositoryHelper {
             it[PaperTable.title] = title
             it[PaperTable.externalId] = externalId
             it[PaperTable.abstract] = abstract
-            it[PaperTable.publishedAt] = publishedAt
+            it[PaperTable.year] = year
             it[PaperTable.publisher] = publisher
             it[PaperTable.publicationType] = publicationType
             it[PaperTable.publicationName] = publicationName

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
@@ -51,4 +51,35 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
             assertThat(actualReferences).containsExactlyInAnyOrder(paperId2, paperId3)
         }
     }
+
+    @Nested
+    inner class GetForwardReferencedPaperIdsOfPaperById {
+        @Test
+        fun `When a paper has no forward references, then none are returned`() = runTest {
+            val paperId = insertPaperAndGetId()
+            assertThat(repo.getForwardReferencedPaperIdsOfPaperById(paperId)).isEmpty()
+        }
+
+        @Test
+        fun `When a paper has one forward reference, then it is returned`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val citedPaperId = insertPaperAndGetId(externalId = "ExternalId2")
+            addCitation(paperId, citedPaperId)
+            val actualReferences = repo.getForwardReferencedPaperIdsOfPaperById(citedPaperId)
+            assertThat(actualReferences).hasSize(1)
+            assertThat(actualReferences).containsExactly(paperId)
+        }
+
+        @Test
+        fun `When a paper has two forward references, then they are returned`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val paperId2 = insertPaperAndGetId(externalId = "ExternalId2")
+            val citedPaperId = insertPaperAndGetId(externalId = "ExternalId3")
+            addCitation(paperId, citedPaperId)
+            addCitation(paperId2, citedPaperId)
+            val actualReferences = repo.getForwardReferencedPaperIdsOfPaperById(citedPaperId)
+            assertThat(actualReferences).hasSize(2)
+            assertThat(actualReferences).containsExactlyInAnyOrder(paperId, paperId2)
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -1,0 +1,129 @@
+package se.uulm.snowballr.backend.service.paper
+
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GetForwardReferencedPapersTest : MainServiceTest() {
+    private val requestId = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id
+        .newBuilder()
+        .setId(requestId.toString())
+        .build()
+
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(paperRepoMock::doesPaperExistById),
+        Arguments.of(citationRepoMock::getForwardReferencedPaperIdsOfPaperById),
+        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
+        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
+    )
+
+    @Suppress("ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val forwardReferenceId = UUID.randomUUID()
+        val citingPaper = DataBuilder.createExamplePaper(id = forwardReferenceId)
+        val author = DataBuilder.createExampleAuthor()
+
+        if (failAt == paperRepoMock::doesPaperExistById) {
+            coEvery { paperRepoMock.doesPaperExistById(paper.id) } throws TestSpecificException()
+            return
+        }
+        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+
+        if (failAt == citationRepoMock::getForwardReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(forwardReferenceId)
+
+        if (failAt == paperRepoMock::getPaperById) {
+            coEvery { paperRepoMock.getPaperById(forwardReferenceId) } throws TestSpecificException()
+            return
+        }
+        coEvery { paperRepoMock.getPaperById(forwardReferenceId) } returns citingPaper
+
+        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(forwardReferenceId) } throws TestSpecificException()
+            return
+        }
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(forwardReferenceId) } returns listOf(author)
+
+        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(forwardReferenceId)
+            } throws TestSpecificException()
+            return
+        }
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(forwardReferenceId)
+        } returns listOf(UUID.randomUUID())
+    }
+
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt)
+        assertThrows<TestSpecificException> {
+            mainService.getForwardReferencedPapers(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
+        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns false
+        assertThrows<SnowballRException.NotFoundException> {
+            mainService.getForwardReferencedPapers(
+                getExampleRequest(),
+            )
+        }
+    }
+
+    @Test
+    fun `When one of the forward references doesn't exist, then a NotFoundException is thrown`() = runTest {
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val forwardReferenceId = UUID.randomUUID()
+
+        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns true
+        coEvery {
+            citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(forwardReferenceId)
+        coEvery { paperRepoMock.getPaperById(forwardReferenceId) } throws SnowballRException.NotFoundException(
+            entityType = EntityType.PAPER, requestId.toString(),
+        )
+
+        assertThrows<SnowballRException.NotFoundException> {
+            mainService.getForwardReferencedPapers(
+                getExampleRequest(),
+            )
+        }
+    }
+
+    @Test
+    fun `When the forward references of an existing paper are retrieved successfully, then no error is thrown`() =
+        runTest {
+            mockHappyPathUntil(null)
+            assertDoesNotThrow { mainService.getForwardReferencedPapers(getExampleRequest()) }
+        }
+}


### PR DESCRIPTION
Closes #169 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

**Note:** Only the last three commits need to be review, because this branch is rebased onto #168.

I have added the repository, service and grpc layer for the `getForwardReferencedPapers` call. Since this call is very similar to the `getBackwardReferencedPapers` call I refactored this call to prevent duplicated code and used it for the current call as well (on the service layer).

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
