### PR TITLE
Implement `removeProjectMember` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -261,7 +261,7 @@ class SnowballRServer(
             mainService.getProjectMembers(request)
 
         override suspend fun removeProjectMember(request: ProjectOuterClass.Project.Member.Remove): Base.Nothing =
-            super.removeProjectMember(request)
+            mainService.removeProjectMember(request)
 
         override suspend fun getAllProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
             mainService.getAllProjects()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -55,7 +55,7 @@ sealed class SnowballRException(
     )
 
     /**
-     * Represents a [NotFoundException] indicating that a [User] could not be found by its identifier, i.e., UUID or email address.
+     * Represents a [NotFoundException] indicating that a [User] could not be found by its identifier, i.e., UUID, or email address.
      *
      * @param entityId The identifier of the missing [User].
      * @param identifierType The type of the entity's identifier. Defaults to [IdentifierType.ID].
@@ -148,6 +148,33 @@ sealed class SnowballRException(
             accessType: AccessType = AccessType.READ,
             currentUserId: String,
         ) : UnauthorizedException(currentUserId, "all ${accessedEntityType.plural}.", accessType)
+
+        /**
+         * Represents an [UnauthorizedException] that occurs when the current user performs an action on an entity.
+         *
+         * @param accessedEntityType The type of entity that the action was attempted on, represented as [EntityType].
+         * @param accessedEntityId The unique identifier of the entity being accessed.
+         * @param accessType The type of access being attempted, such as READ, CREATE, UPDATE, or DELETE.
+         *                   Defaults to [AccessType.DELETE].
+         * @param currentUserId The identifier of the user attempting the unauthorized action.
+         * @param identifierType The type of identifier used for the entity, typically from [IdentifierType].
+         *                       Defaults to [IdentifierType.ID].
+         */
+        class Action(
+            accessedEntityType: EntityType,
+            accessedEntityId: String,
+            accessType: AccessType = AccessType.DELETE,
+            currentUserId: String,
+            identifierType: IdentifierType = IdentifierType.ID,
+        ) : UnauthorizedException(
+            currentUserId,
+            "something ${if (accessType in listOf(AccessType.DELETE, AccessType.READ)) {
+                "from"
+            } else {
+                "in"
+            }} ${accessedEntityType.singular} with ${identifierType.displayName} '$accessedEntityId'.",
+            accessType,
+        )
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -30,7 +30,7 @@ import snowballr.UserOuterClass.User as GrpcUser
  * abstraction over the underlying database implementation. By using this interface, the logic
  * for creating and managing users can remain decoupled from the specifics of the database layer.
  */
-@Suppress("ComplexInterface")
+@Suppress("ComplexInterface", "TooManyFunctions")
 interface IUserTableRepo {
     /**
      * Returns a [Result] containing the user by their id or a [NotFoundException] if the user with the passed [id]
@@ -51,6 +51,14 @@ interface IUserTableRepo {
      * @return True if a user with the given email exists, false otherwise.
      */
     suspend fun doesUserExistByEmail(email: String): Boolean
+
+    /**
+     * Checks if a user exists in the database by their id.
+     *
+     * @param id The unique identifier to check for existence.
+     * @return True if a user with the given id exists, false otherwise.
+     */
+    suspend fun doesUserExistById(id: UUID): Boolean
 
     /**
      * Returns all users stored on the server.
@@ -168,6 +176,10 @@ class UserTableRepo(
 
     override suspend fun getUserByEmail(email: String): Result<User> = db.query {
         getEntityByKeyAsResult(::getUserByEmailOrNull, EntityType.USER, email, IdentifierType.EMAIL)
+    }
+
+    override suspend fun doesUserExistById(id: UUID): Boolean = db.query {
+        UserTable.doesEntityExistById(id)
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -2,8 +2,10 @@ package se.uulm.snowballr.backend.repository.association
 
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
@@ -77,6 +79,14 @@ interface IProjectMemberTableRepo {
      * @return A list of [ProjectMemberWithUser] objects, each containing a project member and the corresponding user information.
      */
     suspend fun getProjectMembersWithUsers(projectId: UUID): List<ProjectMemberWithUser>
+
+    /**
+     * Removes a project member with the given [userId] from the project with the given [projectId].
+     *
+     * @param projectId The unique identifier of the project whose member should be removed.
+     * @param userId The unique identifier of the user, who should be removed.
+     */
+    suspend fun removeProjectMember(projectId: UUID, userId: UUID)
 }
 
 /**
@@ -173,5 +183,12 @@ class ProjectMemberTableRepo(
             .selectAll()
             .where { ProjectMemberTable.projectId eq projectId }
             .map { it.toProjectMemberWithUser() }
+    }
+
+    override suspend fun removeProjectMember(projectId: UUID, userId: UUID) {
+        db.query {
+            ProjectMemberTable
+                .deleteWhere { (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId) }
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -19,14 +19,20 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+import se.uulm.snowballr.backend.service.accessrules.AccessRuleCompoundObject
 import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forProperty
+import se.uulm.snowballr.backend.service.accessrules.forTarget
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
+import se.uulm.snowballr.backend.service.accessrules.isProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
+import se.uulm.snowballr.backend.service.accessrules.isProjectMember
+import se.uulm.snowballr.backend.service.accessrules.isSameUserById
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isServerAdminOrSameUser
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
+import se.uulm.snowballr.backend.service.accessrules.orElse
 import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.MemberRole
@@ -34,7 +40,6 @@ import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.copy
 import java.util.UUID
-import kotlin.getOrThrow
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.ProjectOuterClass.Project.Information.DecisionStatistics as GrpcProjectDecisionStatistics
@@ -96,6 +101,11 @@ interface IProjectService {
      * Service implementation of [SnowballRService.getDecisionStatisticsForStage].
      */
     suspend fun getDecisionStatisticsForStage(request: GrpcProjectDecisionStatistics.Get): GrpcProjectDecisionStatistics
+
+    /**
+     * Service implementation of [SnowballRService.removeProjectMember]
+     */
+    suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing
 }
 
 /**
@@ -438,4 +448,52 @@ class ProjectService(
             PaperDecision.PAPER_DECISION_IN_REVIEW,
         ).map(::createStatistic)
     }
+
+    override suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+            val requestedUserId = parseUUID(request.userId, EntityType.USER)
+
+            val userProjectCompound = AccessRuleCompoundObject(requestedUserId, projectId)
+
+            isSameUserById()
+                .forProperty(AccessRuleCompoundObject::firstTargetId)
+                .andAlso(isProjectMember(projectMemberRepo).forProperty(AccessRuleCompoundObject::secondTargetId))
+                .orElse(
+                    isProjectAdmin(projectMemberRepo)
+                        .orElse(isServerAdmin().forTarget())
+                        .orElseThrow { user, targetId ->
+                            UnauthorizedException.Action(
+                                EntityType.PROJECT,
+                                targetId.toString(),
+                                AccessType.DELETE,
+                                user.id.toString(),
+                            )
+                        }
+                        .forProperty(AccessRuleCompoundObject::secondTargetId),
+                )
+                .checkFor(currentUser, userProjectCompound)
+
+            when {
+                !repo.doesProjectExistById(projectId)
+                -> throw NotFoundException(EntityType.PROJECT, projectId.toString())
+
+                !userRepo.doesUserExistById(requestedUserId)
+                -> throw NotFoundException(EntityType.USER, projectId.toString())
+            }
+
+            val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+            val projectAdmins = projectMemberRepo.getAllProjectAdmins(projectId)
+            if (projectMembers.size == 1 && projectMembers.any { it.userId == requestedUserId }) {
+                // TODO soft delete the project asa the call is implemented in #87.
+            } else if (projectAdmins.size == 1 && projectAdmins.any { it.userId == requestedUserId }) {
+                throw FailedPreconditionException(
+                    "The user can not be removed from the project, because this user is the last " +
+                        "project admin.",
+                )
+            }
+
+            projectMemberRepo.removeProjectMember(projectId, requestedUserId)
+            Base.Nothing.newBuilder().build()
+        }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/AccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/AccessRule.kt
@@ -150,3 +150,17 @@ suspend fun <T> AccessRule<T>.checkFor(requester: User, target: T) {
  *         without throwing a specific exception while evaluating the chain.
  */
 suspend fun AccessRule<Unit>.checkFor(requester: User) = checkFor(requester, Unit)
+
+/**
+ * Represents a compound object containing two target identifiers for access rule checks.
+ *
+ * This class is typically used in scenarios where access control requires validation involving
+ * two related targets, such as ensuring permissions across multiple associated entities.
+ *
+ * @property firstTargetId The unique identifier of the first target.
+ * @property secondTargetId The unique identifier of the second target.
+ */
+data class AccessRuleCompoundObject(
+    val firstTargetId: UUID,
+    val secondTargetId: UUID,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectMemberValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectMemberValidator.kt
@@ -1,0 +1,42 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.ProjectOuterClass.Project
+import snowballr.ProjectOuterClass.Project.Member
+import snowballr.ProjectOuterClass.Project.Member.Remove
+
+private const val FIELD_PROJECT_ID = "project_id"
+private const val FIELD_USER_ID = "user_id"
+private const val FIELD_TOKEN = "token"
+private const val FIELD_NEW_ROLE = "new_role"
+
+/**
+ * A validator for [Member] related requests.
+ */
+object ProjectMemberValidator {
+    fun validateRemoveRequest(request: Remove): EitherNel<ValidationIssue, Unit> = either {
+        zipOrAccumulate(
+            { ensureIdValidity(FIELD_PROJECT_ID, request.projectId) },
+            { ensureIdValidity(FIELD_USER_ID, request.userId) },
+        ) { _, _ -> }
+    }
+
+    fun validateInviteRequest(request: Member.Invite): EitherNel<ValidationIssue, Unit> = either {
+        ensureFieldNonBlank(FIELD_PROJECT_ID, request.projectId)
+        ensureIdValidity(FIELD_PROJECT_ID, request.projectId)
+        ensureEmailValidity(request.userEmail)
+    }.toEitherNel()
+
+    fun validateAcceptRequest(request: Member.Accept): EitherNel<ValidationIssue, Unit> = either {
+        ensureFieldNonBlank(FIELD_TOKEN, request.token)
+    }.toEitherNel()
+
+    fun validateMemberUpdateRequest(request: Project.Member.Update): EitherNel<ValidationIssue, Unit> = either {
+        ensureIdValidity(FIELD_PROJECT_ID, request.projectId)
+        ensureIdValidity(FIELD_USER_ID, request.userId)
+        ensureEnumNotUnspecified(FIELD_NEW_ROLE, request.newRole)
+    }.toEitherNel()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -72,15 +72,6 @@ object ProjectValidator {
         ) { _, _, _, _, _ -> }
     }
 
-    fun validateInviteRequest(request: Project.Member.Invite): EitherNel<ValidationIssue, Unit> = either {
-        ensureIdValidity("project_id", request.projectId)
-        ensureEmailValidity(request.userEmail)
-    }.toEitherNel()
-
-    fun validateAcceptRequest(request: Project.Member.Accept): EitherNel<ValidationIssue, Unit> = either {
-        ensureFieldNonBlank("token", request.token)
-    }.toEitherNel()
-
     fun validateGetInformationRequest(request: Project.Information.Get): EitherNel<ValidationIssue, Unit> = either {
         // Validate the field mask
         val fieldMaskResult = either {
@@ -94,12 +85,6 @@ object ProjectValidator {
 
         either { ensureIdValidity("project_id", request.projectId) }.toEitherNel().bind()
     }
-
-    fun validateMemberUpdateRequest(request: Project.Member.Update): EitherNel<ValidationIssue, Unit> = either {
-        ensureIdValidity("project_id", request.projectId)
-        ensureIdValidity("user_id", request.userId)
-        ensureEnumNotUnspecified("new_role", request.newRole)
-    }.toEitherNel()
 
     fun validateGetDecisionStatisticsRequest(
         request: Project.Information.DecisionStatistics.Get,

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -41,16 +41,17 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is ProjectOuterClass.Project.Create -> ProjectValidator.validateCreateRequest(request)
     is ProjectOuterClass.Project.Update -> ProjectValidator.validateUpdateRequest(request)
     is ProjectOuterClass.Project.InviteCandidatesRequest -> Either.Right(Unit)
-    is ProjectOuterClass.Project.Member.Invite -> ProjectValidator.validateInviteRequest(request)
-    is ProjectOuterClass.Project.Member.Accept -> ProjectValidator.validateAcceptRequest(request)
     is ProjectOuterClass.Project.Information.Get -> ProjectValidator.validateGetInformationRequest(request)
     is ProjectOuterClass.Project.Information.DecisionStatistics.Get ->
         ProjectValidator.validateGetDecisionStatisticsRequest(request)
-    // Project Member
-    is ProjectOuterClass.Project.Member.Update -> ProjectValidator.validateMemberUpdateRequest(request)
     // Project Paper
     is ProjectOuterClass.Project.Paper.Get -> ProjectPaperValidator.validateGetRequest(request)
     is ProjectOuterClass.Project.Paper.Add -> ProjectPaperValidator.validateAddRequest(request)
+    // Project Member
+    is ProjectOuterClass.Project.Member.Invite -> ProjectMemberValidator.validateInviteRequest(request)
+    is ProjectOuterClass.Project.Member.Accept -> ProjectMemberValidator.validateAcceptRequest(request)
+    is ProjectOuterClass.Project.Member.Remove -> ProjectMemberValidator.validateRemoveRequest(request)
+    is ProjectOuterClass.Project.Member.Update -> ProjectMemberValidator.validateMemberUpdateRequest(request)
     // Criterion
     is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
     is CriterionOuterClass.Criterion.Update -> CriterionValidator.validateUpdateRequest(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -98,6 +98,21 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
     }
 
     @Nested
+    inner class DoesUserExitsById {
+        @Test
+        fun `When a user with the given id exists, then true is returned`() = runTest {
+            val userId = insertUserAndGetId()
+
+            assertTrue(repo.doesUserExistById(userId))
+        }
+
+        @Test
+        fun `When a user with the given id does not exist, then false is returned`() = runTest {
+            assertFalse(repo.doesUserExistByEmail(UUID.randomUUID().toString()))
+        }
+    }
+
+    @Nested
     inner class DoesUserExistByEmail {
         @Test
         fun `When a user with the given email exists, then true is returned`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -3,8 +3,10 @@ package se.uulm.snowballr.backend.repository.association
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
@@ -302,5 +304,25 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 assertThat(projectMembersWithUsers).anyMatch { it.user == user }
                 assertThat(projectMembersWithUsers).noneMatch { it.projectMember.userId == nonProjectMemberUser.id }
             }
+    }
+
+    @Nested
+    inner class RemoveProjectMember {
+        @Test
+        fun `When a project member is found, then the correct project member is removed`() = runTest {
+            val (projectId, members) = setupProject()
+            repo.removeProjectMember(projectId, members[0].userId)
+
+            assertTrue(repo.getProjectMemberByComposedId(projectId, members[0].userId).isFailure)
+        }
+
+        @Test
+        fun `When a project member is not found, nothing happens`() = runTest {
+            val (projectId, members) = setupProject()
+
+            assertDoesNotThrow { repo.removeProjectMember(projectId, UUID.randomUUID()) }
+            assertDoesNotThrow { repo.removeProjectMember(UUID.randomUUID(), members[0].userId) }
+            assertTrue(repo.getProjectMemberByComposedId(projectId, members[0].userId).isSuccess)
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/RemoveProjectMemberTest.kt
@@ -1,0 +1,176 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass
+import java.util.UUID
+
+class RemoveProjectMemberTest : MainServiceTest() {
+    private val projectId = UUID.randomUUID()
+    private val userId = UUID.randomUUID()
+    private fun getExampleRequest() = ProjectOuterClass.Project.Member.Remove.newBuilder()
+        .setProjectId(projectId.toString())
+        .setUserId(userId.toString())
+        .build()
+
+    @Test
+    fun `When a server admin removes a project member, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(id = projectId)
+        val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
+        val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = UUID.randomUUID())
+
+        mockCurrentUser(currentUser)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { userRepoMock.doesUserExistById(userId) } returns true
+        coEvery {
+            projectMemberRepoMock.getProjectMembers(project.id)
+        } returns listOf(projectMember1, projectMember2)
+        coEvery { projectMemberRepoMock.removeProjectMember(project.id, userId) } returns Unit
+
+        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project admin removes another project member, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = projectId)
+        val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
+        val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = UUID.randomUUID())
+
+        mockCurrentUser(currentUser)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { userRepoMock.doesUserExistById(userId) } returns true
+        coEvery {
+            projectMemberRepoMock.getProjectMembers(project.id)
+        } returns listOf(projectMember1, projectMember2)
+        coEvery { projectMemberRepoMock.removeProjectMember(project.id, userId) } returns Unit
+
+        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project admin removes themselves and they are not the last project admin, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(id = userId)
+            val otherUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(id = projectId)
+            val projectAdmin1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
+            val projectAdmin2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = otherUser.id)
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectMemberRepoMock.getProjectMembers(project.id)
+            } returns listOf(projectAdmin1, projectAdmin2)
+            coEvery {
+                projectMemberRepoMock.getAllProjectAdmins(project.id)
+            } returns listOf(projectAdmin1, projectAdmin2)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { userRepoMock.doesUserExistById(currentUser.id) } returns true
+            coEvery {
+                projectMemberRepoMock.removeProjectMember(project.id, currentUser.id)
+            } returns Unit
+
+            assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When a non project admin removes themselves and they are not the last project member, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(id = userId)
+            val otherUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(id = projectId)
+            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
+            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = otherUser.id)
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectMemberRepoMock.getProjectMembers(project.id)
+            } returns listOf(projectMember, projectAdmin)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { userRepoMock.doesUserExistById(currentUser.id) } returns true
+            coEvery {
+                projectMemberRepoMock.removeProjectMember(project.id, currentUser.id)
+            } returns Unit
+
+            assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When a project admin removes a project member from a nonexisting project, then a NotFoundException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = projectId, userId = currentUser.id)
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns listOf(projectAdmin)
+            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+
+            assertThrows<SnowballRException.NotFoundException> {
+                mainService.removeProjectMember(getExampleRequest())
+            }
+        }
+
+    @Test
+    fun `When a project admin removes a nonexisting project member, then a NotFoundException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = projectId)
+        val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { userRepoMock.doesUserExistById(userId) } returns false
+
+        assertThrows<SnowballRException.NotFoundException> {
+            mainService.removeProjectMember(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When a normal project member removes another project member, then an UnauthorizedException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(id = projectId)
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+            assertThrows<SnowballRException.UnauthorizedException> {
+                mainService.removeProjectMember(getExampleRequest())
+            }
+        }
+
+    @Test
+    fun `When a project admin removes themselves, but is the last project admin in the project, then a FailedPreconditionException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(id = userId)
+            val otherUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(id = projectId)
+            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = otherUser.id)
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectMemberRepoMock.getProjectMembers(project.id)
+            } returns listOf(projectAdmin, projectMember)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { userRepoMock.doesUserExistById(userId) } returns true
+
+            assertThrows<SnowballRException.FailedPreconditionException> {
+                mainService.removeProjectMember(getExampleRequest())
+            }
+        }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectMemberValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectMemberValidatorTest.kt
@@ -1,0 +1,43 @@
+package se.uulm.snowballr.backend.validation
+
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.InvalidId
+import snowballr.ProjectOuterClass.Project.Member.Remove
+import java.util.UUID
+
+class ProjectMemberValidatorTest {
+    @Nested
+    inner class RemoveRequest {
+        private val validRemoveRequestBuilder: Remove.Builder =
+            Remove
+                .newBuilder()
+                .setProjectId(UUID.randomUUID().toString())
+                .setUserId(UUID.randomUUID().toString())
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validRemoveRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a request with an invalid project ID is validated, then the 'InvalidId' issue is returned`() {
+            val request = validRemoveRequestBuilder.setProjectId("invalid-id").build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When a request with an invalid user ID is validated, then the 'InvalidId' issue is returned`() {
+            val request = validRemoveRequestBuilder.setUserId("invalid-id").build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -292,7 +292,7 @@ class ProjectValidatorTest {
 
             val result = validateRequest(request)
 
-            assertInvalidResult<InvalidId>(result)
+            assertInvalidResult<BlankField>(result)
         }
 
         @Test


### PR DESCRIPTION
Closes #79 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

I have implemented the repository, service, grpc and validation layer for the `removeProjectMember` call. 

At the moment it is implemented as a hard delete, since the `ProjectMember` should be deletable without any side effects. For the reviewer: Please check, if I am correct with this assumption or if I have overseen something. In this case we would have to change the project member removal to a soft delete, too.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
