### PR TITLE
Use the result type for repo methods that throw specific exceptions

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -126,6 +126,7 @@ complexity:
         active: true
         ignoredLabels:
             - query
+            - withUser
     LargeClass:
         active: true
         threshold: 600

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -115,14 +115,14 @@ class Database(
     private fun seedDummyUserIfEnabled() {
         val seedUserEnabled = envReader.env.database.seedUserEnabled
 
-        val existingId = UserTable
+        val existentId = UserTable
             .select(UserTable.id)
             .where { UserTable.email eq DummyUser.email }
             .map { it[UserTable.id].value }
             .singleOrNull()
 
         if (seedUserEnabled) {
-            if (existingId == null) {
+            if (existentId == null) {
                 // If seeding is enabled and a user doesn't exist, create it.
                 DummyUser.id = UserTable.insertAndGetId {
                     it[email] = DummyUser.email
@@ -135,12 +135,12 @@ class Database(
                 logger.info { "Dummy User seeded with ID: ${DummyUser.id}" }
             } else {
                 // If the user already exists, update the static ID.
-                DummyUser.id = existingId
+                DummyUser.id = existentId
                 logger.info { "Dummy User already exists with ID: ${DummyUser.id}" }
             }
-        } else if (existingId != null) {
+        } else if (existentId != null) {
             // If seeding is disabled and a user exists, delete it.
-            UserTable.deleteWhere { UserTable.id eq existingId }
+            UserTable.deleteWhere { UserTable.id eq existentId }
             logger.info { "Dummy user deleted as seeding is disabled." }
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/AccessType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/AccessType.kt
@@ -10,7 +10,7 @@ enum class AccessType(val description: String) {
     /** Attempt to create a new entity */
     CREATE("create"),
 
-    /** Attempt to update an existing entity */
+    /** Attempt to update an existent entity */
     UPDATE("update"),
 
     /** Attempt to delete an entity */

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepo.kt
@@ -45,6 +45,6 @@ class AuthorTableRepo(
     private fun getAuthorByIdOrNull(id: UUID): Author? = AuthorTable.getEntityByIdOrNull(id, ResultRow::toAuthor)
 
     override suspend fun getAuthorById(id: UUID): Result<Author> = db.query {
-        getEntityByIdAsResult(::getAuthorByIdOrNull, EntityType.AUTHOR, id)
+        getEntityByKeyAsResult(::getAuthorByIdOrNull, EntityType.AUTHOR, id)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepo.kt
@@ -18,9 +18,10 @@ import java.util.UUID
  */
 interface IAuthorTableRepo {
     /**
-     * Returns an author by its ID or throws a [NotFoundException] if the author with the passed [id] doesn't exist.
+     * Returns a [Result] containing the author by its ID or a [NotFoundException] if the author with the passed [id]
+     * doesn't exist.
      */
-    suspend fun getAuthorById(id: UUID): Author
+    suspend fun getAuthorById(id: UUID): Result<Author>
 }
 
 /**
@@ -43,7 +44,7 @@ class AuthorTableRepo(
      */
     private fun getAuthorByIdOrNull(id: UUID): Author? = AuthorTable.getEntityByIdOrNull(id, ResultRow::toAuthor)
 
-    override suspend fun getAuthorById(id: UUID): Author = db.query {
-        getAuthorByIdOrNull(id) ?: throw NotFoundException(EntityType.AUTHOR, id.toString())
+    override suspend fun getAuthorById(id: UUID): Result<Author> = db.query {
+        getEntityByIdAsResult(::getAuthorByIdOrNull, EntityType.AUTHOR, id)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -94,7 +94,7 @@ class CriterionTableRepo(
         CriterionTable.getEntityByIdOrNull(id, ResultRow::toCriterion)
 
     override suspend fun getCriterionById(id: UUID): Result<Criterion> = db.query {
-        getEntityByIdAsResult(::getCriterionByIdOrNull, EntityType.CRITERION, id)
+        getEntityByKeyAsResult(::getCriterionByIdOrNull, EntityType.CRITERION, id)
     }
 
     override suspend fun createCriterion(request: GrpcCriterion.Create, userId: UUID): Criterion = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
-import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
@@ -100,11 +99,10 @@ class CriterionTableRepo(
 
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =
         db.query {
-            val userEntityId = getUserEntityId(userId)
-            var projectEntityId: EntityID<UUID>? = null
-            if (request.projectId.isNotEmpty()) {
-                val projectUUID = parseUUID(request.projectId, EntityType.PROJECT)
-                projectEntityId = getProjectEntityId(projectUUID)
+            val projectId = if (request.projectId.isNotEmpty()) {
+                parseUUID(request.projectId, EntityType.PROJECT)
+            } else {
+                null
             }
 
             CriterionTable.insertAndGet(ResultRow::toCriterion, EntityType.CRITERION) {
@@ -112,8 +110,8 @@ class CriterionTableRepo(
                 it[name] = request.name
                 it[description] = request.description
                 it[category] = request.category
-                it[projectId] = projectEntityId
-                it[createdBy] = userEntityId
+                it[this.projectId] = projectId
+                it[createdBy] = userId
             }
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -47,7 +47,7 @@ interface ICriterionTableRepo {
     suspend fun getAllUserCriteria(userId: UUID): List<Criterion>
 
     /**
-     * Updates an existing criterion in the database with the provided new information.
+     * Updates an existent criterion in the database with the provided new information.
      * The following fields can be updated:
      * - tag
      * - name

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -12,8 +12,8 @@ import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.toCriterion
 import se.uulm.snowballr.backend.table.toProjectCriterion
 import se.uulm.snowballr.backend.table.toUserCriterion
-import snowballr.CriterionOuterClass
 import java.util.UUID
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 /**
  * Defines an interface for repository operations related to the [CriterionTable].
@@ -36,7 +36,7 @@ interface ICriterionTableRepo {
      * @param userId The ID of the user creating the criterion.
      * @return The created [Criterion] object representing the newly created criterion.
      */
-    suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion
+    suspend fun createCriterion(request: GrpcCriterion.Create, userId: UUID): Criterion
 
     /**
      * Retrieves all criteria associated with a specific user.
@@ -57,7 +57,7 @@ interface ICriterionTableRepo {
      * @param request The update request containing the new criterion details, such as the new name.
      * @return The updated [Criterion] object reflecting the changes from the [request].
      */
-    suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): Criterion
+    suspend fun updateCriterion(request: GrpcCriterion.Update): Criterion
 
     /**
      * Retrieves a list of criteria based on their unique identifiers.
@@ -97,25 +97,24 @@ class CriterionTableRepo(
         getEntityByIdAsResult(::getCriterionByIdOrNull, EntityType.CRITERION, id)
     }
 
-    override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =
-        db.query {
-            val projectId = if (request.projectId.isNotEmpty()) {
-                parseUUID(request.projectId, EntityType.PROJECT)
-            } else {
-                null
-            }
-
-            CriterionTable.insertAndGet(ResultRow::toCriterion, EntityType.CRITERION) {
-                it[tag] = request.tag
-                it[name] = request.name
-                it[description] = request.description
-                it[category] = request.category
-                it[this.projectId] = projectId
-                it[createdBy] = userId
-            }
+    override suspend fun createCriterion(request: GrpcCriterion.Create, userId: UUID): Criterion = db.query {
+        val projectId = if (request.projectId.isNotEmpty()) {
+            parseUUID(request.projectId, EntityType.PROJECT)
+        } else {
+            null
         }
 
-    override suspend fun updateCriterion(request: CriterionOuterClass.Criterion.Update): Criterion = db.query {
+        CriterionTable.insertAndGet(ResultRow::toCriterion, EntityType.CRITERION) {
+            it[tag] = request.tag
+            it[name] = request.name
+            it[description] = request.description
+            it[category] = request.category
+            it[this.projectId] = projectId
+            it[createdBy] = userId
+        }
+    }
+
+    override suspend fun updateCriterion(request: GrpcCriterion.Update): Criterion = db.query {
         val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
         val fieldMask = FieldMaskUtil.normalize(request.mask)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -25,9 +25,10 @@ import java.util.UUID
  */
 interface ICriterionTableRepo {
     /**
-     * Returns a criterion by its ID or throws a [NotFoundException] if the criterion with the passed [id] doesn't exist.
+     * Returns a [Result] containing the criterion by its ID or a [NotFoundException] if the criterion with the passed
+     * [id] doesn't exist.
      */
-    suspend fun getCriterionById(id: UUID): Criterion
+    suspend fun getCriterionById(id: UUID): Result<Criterion>
 
     /**
      * Creates a new criterion in the database based on the provided request and user ID.
@@ -93,8 +94,8 @@ class CriterionTableRepo(
     private fun getCriterionByIdOrNull(id: UUID): Criterion? =
         CriterionTable.getEntityByIdOrNull(id, ResultRow::toCriterion)
 
-    override suspend fun getCriterionById(id: UUID): Criterion = db.query {
-        getCriterionByIdOrNull(id) ?: throw NotFoundException(EntityType.CRITERION, id.toString())
+    override suspend fun getCriterionById(id: UUID): Result<Criterion> = db.query {
+        getEntityByIdAsResult(::getCriterionByIdOrNull, EntityType.CRITERION, id)
     }
 
     override suspend fun createCriterion(request: CriterionOuterClass.Criterion.Create, userId: UUID): Criterion =

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepo.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.repository
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
@@ -11,6 +10,7 @@ import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.toCriterion
+import se.uulm.snowballr.backend.table.toProjectCriterion
 import se.uulm.snowballr.backend.table.toUserCriterion
 import snowballr.CriterionOuterClass
 import java.util.UUID
@@ -136,16 +136,14 @@ class CriterionTableRepo(
     }
 
     override suspend fun getAllUserCriteria(userId: UUID): List<Criterion.UserCriterion> = db.query {
-        CriterionTable
-            .selectAll()
-            .where { CriterionTable.createdBy eq userId and CriterionTable.projectId.isNull() }
-            .map { it.toUserCriterion() }
+        CriterionTable.getEntities(ResultRow::toUserCriterion) {
+            CriterionTable.createdBy eq userId and CriterionTable.projectId.isNull()
+        }
     }
 
     override suspend fun getAllProjectCriteria(projectId: UUID): List<Criterion> = db.query {
-        CriterionTable
-            .selectAll()
-            .where { CriterionTable.projectId eq projectId }
-            .map { it.toCriterion() }
+        CriterionTable.getEntities(ResultRow::toProjectCriterion) {
+            CriterionTable.projectId eq projectId
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -17,9 +17,10 @@ import java.util.UUID
  */
 interface IPaperTableRepo {
     /**
-     * Returns a paper by its ID or throws a [NotFoundException] if the paper with the passed [id] doesn't exist.
+     * Returns a [Result] containing the paper by its ID or a [NotFoundException] if the paper with the passed [id]
+     * doesn't exist.
      */
-    suspend fun getPaperById(id: UUID): Paper
+    suspend fun getPaperById(id: UUID): Result<Paper>
 
     /**
      * @return whether the paper with the passed [id] exists.
@@ -41,8 +42,8 @@ class PaperTableRepo(
 ) : IPaperTableRepo {
     private fun getPaperByIdOrNull(id: UUID): Paper? = PaperTable.getEntityByIdOrNull(id, ResultRow::toPaper)
 
-    override suspend fun getPaperById(id: UUID): Paper = db.query {
-        getPaperByIdOrNull(id) ?: throw NotFoundException(EntityType.PAPER, id.toString())
+    override suspend fun getPaperById(id: UUID): Result<Paper> = db.query {
+        getEntityByIdAsResult(::getPaperByIdOrNull, EntityType.PAPER, id)
     }
 
     override suspend fun doesPaperExistById(id: UUID): Boolean = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -43,7 +43,7 @@ class PaperTableRepo(
     private fun getPaperByIdOrNull(id: UUID): Paper? = PaperTable.getEntityByIdOrNull(id, ResultRow::toPaper)
 
     override suspend fun getPaperById(id: UUID): Result<Paper> = db.query {
-        getEntityByIdAsResult(::getPaperByIdOrNull, EntityType.PAPER, id)
+        getEntityByKeyAsResult(::getPaperByIdOrNull, EntityType.PAPER, id)
     }
 
     override suspend fun doesPaperExistById(id: UUID): Boolean = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -32,7 +32,7 @@ interface IPaperTableRepo {
  * Repository implementation for managing the [PaperTable] in the database.
  *
  * This class provides functionality to handle persistence and retrieval operations for papers by leveraging the
- * database abstraction defined in [IDatabase]. It facilitates CRUD operations on free-standing papers and ensures
+ * database abstraction defined in [IDatabase]. It facilitates CRUD operations on freestanding papers and ensures
  * database transactions are handled properly.
  *
  * @param db The database abstraction used for executing queries within a transaction.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -127,8 +127,6 @@ class ProjectTableRepo(
         userId: UUID,
         userSettings: UserSettings,
     ): Project = db.query {
-        val userEntityId = getUserEntityId(userId)
-
         ProjectTable.insertAndGet(ResultRow::toProject, EntityType.PROJECT) {
             it[name] = request.name
             it[status] = ProjectStatus.PROJECT_STATUS_ACTIVE
@@ -139,7 +137,7 @@ class ProjectTableRepo(
             it[reviewMaybeAllowed] = userSettings.reviewMaybeAllowed
             it[reviewDecisionMatrixBinary] = userSettings.decisionMatrix.toByteArray()
             it[fetchers] = emptyMap()
-            it[createdBy] = userEntityId
+            it[createdBy] = userId
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -15,10 +15,10 @@ import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.toProject
-import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ProjectStatus
 import java.time.OffsetDateTime
 import java.util.UUID
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 /**
  * Defines an interface for repository operations related to the [ProjectTable].
@@ -44,14 +44,11 @@ interface IProjectTableRepo {
      *
      * @param request The project creation request containing project details
      * @param userId The ID of the user creating the project.
-     * @param userSettings The user's current settings, such as default criteria IDs, similarity threshold, and other relevant preferences.
+     * @param userSettings The user's current settings, such as default criteria IDs, similarity threshold, and other
+     * relevant preferences.
      * @return The created [Project] object representing the newly created project.
      */
-    suspend fun createProject(
-        request: ProjectOuterClass.Project.Create,
-        userId: UUID,
-        userSettings: UserSettings,
-    ): Project
+    suspend fun createProject(request: GrpcProject.Create, userId: UUID, userSettings: UserSettings): Project
 
     /**
      * Returns all active projects stored in the database.
@@ -96,7 +93,7 @@ interface IProjectTableRepo {
      *  status.
      * @return The updated [Project] object reflecting the changes from the [request].
      */
-    suspend fun updateProject(request: ProjectOuterClass.Project.Update, projectStatus: ProjectStatus): Project
+    suspend fun updateProject(request: GrpcProject.Update, projectStatus: ProjectStatus): Project
 }
 
 /**
@@ -121,24 +118,21 @@ class ProjectTableRepo(
         ProjectTable.doesEntityExistById(id)
     }
 
-    override suspend fun createProject(
-        request: ProjectOuterClass.Project.Create,
-        userId: UUID,
-        userSettings: UserSettings,
-    ): Project = db.query {
-        ProjectTable.insertAndGet(ResultRow::toProject, EntityType.PROJECT) {
-            it[name] = request.name
-            it[status] = ProjectStatus.PROJECT_STATUS_ACTIVE
-            it[currentStage] = 0
-            it[maxStage] = 0
-            it[similarityThreshold] = userSettings.similarityThreshold
-            it[snowballingType] = userSettings.snowballingType
-            it[reviewMaybeAllowed] = userSettings.reviewMaybeAllowed
-            it[reviewDecisionMatrixBinary] = userSettings.decisionMatrix.toByteArray()
-            it[fetchers] = emptyMap()
-            it[createdBy] = userId
+    override suspend fun createProject(request: GrpcProject.Create, userId: UUID, userSettings: UserSettings): Project =
+        db.query {
+            ProjectTable.insertAndGet(ResultRow::toProject, EntityType.PROJECT) {
+                it[name] = request.name
+                it[status] = ProjectStatus.PROJECT_STATUS_ACTIVE
+                it[currentStage] = 0
+                it[maxStage] = 0
+                it[similarityThreshold] = userSettings.similarityThreshold
+                it[snowballingType] = userSettings.snowballingType
+                it[reviewMaybeAllowed] = userSettings.reviewMaybeAllowed
+                it[reviewDecisionMatrixBinary] = userSettings.decisionMatrix.toByteArray()
+                it[fetchers] = emptyMap()
+                it[createdBy] = userId
+            }
         }
-    }
 
     override suspend fun getAllProjects(): List<Project> = db.query {
         ProjectTable.getEntities(ResultRow::toProject) {
@@ -165,10 +159,7 @@ class ProjectTableRepo(
             .map { it.toProject() }
     }
 
-    override suspend fun updateProject(
-        request: ProjectOuterClass.Project.Update,
-        projectStatus: ProjectStatus,
-    ): Project = db.query {
+    override suspend fun updateProject(request: GrpcProject.Update, projectStatus: ProjectStatus): Project = db.query {
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
         val fieldMaskPaths = FieldMaskUtil.normalize(request.mask).pathsList.toSet()
 
@@ -186,22 +177,19 @@ class ProjectTableRepo(
         }
     }
 
-    private fun UpdateStatement.applyProjectNameUpdate(project: ProjectOuterClass.Project, paths: Set<String>) {
+    private fun UpdateStatement.applyProjectNameUpdate(project: GrpcProject, paths: Set<String>) {
         if ("project.name" in paths) {
             this[ProjectTable.name] = project.name
         }
     }
 
-    private fun UpdateStatement.applyProjectStatusUpdate(project: ProjectOuterClass.Project, paths: Set<String>) {
+    private fun UpdateStatement.applyProjectStatusUpdate(project: GrpcProject, paths: Set<String>) {
         if ("project.status" in paths) {
             this[ProjectTable.status] = project.status
         }
     }
 
-    private fun UpdateStatement.applySlrProjectUpdates(
-        settings: ProjectOuterClass.Project.Settings,
-        paths: Set<String>,
-    ) {
+    private fun UpdateStatement.applySlrProjectUpdates(settings: GrpcProject.Settings, paths: Set<String>) {
         if ("project.settings.similarity_threshold" in paths) {
             this[ProjectTable.similarityThreshold] = settings.similarityThreshold
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -111,7 +111,7 @@ class ProjectTableRepo(
     private fun getProjectByIdOrNull(id: UUID): Project? = ProjectTable.getEntityByIdOrNull(id, ResultRow::toProject)
 
     override suspend fun getProjectById(id: UUID): Result<Project> = db.query {
-        getEntityByIdAsResult(::getProjectByIdOrNull, EntityType.PROJECT, id)
+        getEntityByKeyAsResult(::getProjectByIdOrNull, EntityType.PROJECT, id)
     }
 
     override suspend fun doesProjectExistById(id: UUID): Boolean = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.statements.UpdateStatement
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
@@ -142,13 +141,10 @@ class ProjectTableRepo(
     }
 
     override suspend fun getAllProjects(): List<Project> = db.query {
-        ProjectTable
-            .selectAll()
-            .where {
-                (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE) or
-                    (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-            }
-            .map { it.toProject() }
+        ProjectTable.getEntities(ResultRow::toProject) {
+            (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE) or
+                (ProjectTable.status eq ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+        }
     }
 
     override suspend fun getUserProjects(userId: UUID, statusFilters: Set<ProjectStatus>): List<Project> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -79,7 +79,7 @@ interface IProjectTableRepo {
     ): List<Project>
 
     /**
-     * Updates an existing project in the database with the provided new information.
+     * Updates an existent project in the database with the provided new information.
      * The following fields can be updated:
      * - name
      * - status

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -30,9 +30,10 @@ import java.util.UUID
  */
 interface IProjectTableRepo {
     /**
-     * Returns a project by its ID or throws a [NotFoundException] if the project with the passed [id] doesn't exist.
+     * Returns a [Result] containing the project by its ID or a [NotFoundException] if the project with the passed [id]
+     * doesn't exist.
      */
-    suspend fun getProjectById(id: UUID): Project
+    suspend fun getProjectById(id: UUID): Result<Project>
 
     /**
      * Checks whether the project with the passed [id] exists.
@@ -113,9 +114,10 @@ class ProjectTableRepo(
 ) : IProjectTableRepo {
     private fun getProjectByIdOrNull(id: UUID): Project? = ProjectTable.getEntityByIdOrNull(id, ResultRow::toProject)
 
-    override suspend fun getProjectById(id: UUID): Project = db.query {
-        getProjectByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT, id.toString())
+    override suspend fun getProjectById(id: UUID): Result<Project> = db.query {
+        getEntityByIdAsResult(::getProjectByIdOrNull, EntityType.PROJECT, id)
     }
+
     override suspend fun doesProjectExistById(id: UUID): Boolean = db.query {
         ProjectTable.doesEntityExistById(id)
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -12,12 +12,7 @@ import org.jetbrains.exposed.sql.statements.UpdateStatement
 import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedException
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
-import se.uulm.snowballr.backend.table.ProjectTable
-import se.uulm.snowballr.backend.table.UserTable
 import java.util.UUID
-
-// === generic repo helpers === //
 
 /**
  * Returns an entity according to the [where] expression or returns null if the entity couldn't be found.
@@ -47,24 +42,6 @@ fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntityOrNull(
  */
 fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntityByIdOrNull(id: Key, mapper: (ResultRow) -> EntT): EntT? =
     this.getEntityOrNull(mapper) { this@getEntityByIdOrNull.id eq id }
-
-/**
- * Returns the entity ID of the entity with the given [id] or throws a [NotFoundException] if no such entity exists.
- * This can be used to reference the entity in other table rows.
- *
- * Example:
- * Table A stores a reference to this table as `entity_id`. To create a row in table A, we can use this method
- * to get the [EntityID] and then pass it to the `entity_id` column of table A.
- *
- * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
- * @param T The table type as a subtype of [IdTable].
- * @param id The ID of type [Key], which is used to find the entity.
- * @param entityType The type of the entity used for the [NotFoundException].
- * @return The ID of the entity as [EntityID].
- */
-private fun <Key : Any, T : IdTable<Key>> T.getEntityId(id: Key, entityType: EntityType): EntityID<Key> = this
-    .getEntityByIdOrNull(id) { it[this.id] }
-    ?: throw NotFoundException(entityType, id.toString())
 
 /**
  * Checks if an entity exists in the table with the given ID.
@@ -159,20 +136,3 @@ inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntitiesByIds(
         .where { this@getEntitiesByIds.id inList ids }
         .map(mapper)
 }
-
-// === specific repo helpers === //
-
-/**
- * Returns the entity ID of the user with the passed [id] or throws a [NotFoundException] if the user doesn't exist.
- *
- * @see getEntityId
- */
-fun getUserEntityId(id: UUID): EntityID<UUID> = UserTable.getEntityId(id, EntityType.USER)
-
-/**
- * Returns the entity ID of the project with the passed [id] or throws a [NotFoundException] if the project doesn't
- * exist.
- *
- * @see getEntityId
- */
-fun getProjectEntityId(id: UUID): EntityID<UUID> = ProjectTable.getEntityId(id, EntityType.PROJECT)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -138,7 +138,7 @@ inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.updateAndGet(
     crossinline body: T.(UpdateStatement) -> Unit,
 ): EntT {
     this.update(where, body = body)
-    return this.getEntityOrNull(mapper, where) ?: throw EntityNotPersistedException(entityType, id)
+    return this.getEntityOrNull(mapper, where = where) ?: throw EntityNotPersistedException(entityType, id)
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -15,6 +15,38 @@ import se.uulm.snowballr.backend.model.SnowballRException.EntityNotPersistedExce
 import java.util.UUID
 
 /**
+ * Returns a list of entities according to the [where] expression.
+ *
+ * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
+ * @param T The table type as a subtype of [IdTable].
+ * @param EntT The result entity type.
+ * @param mapper Mapping function to map each [ResultRow] to an entity of type [EntT].
+ * @param where The SQL expression that is used to find the entities.
+ */
+fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntities(
+    mapper: (ResultRow) -> EntT,
+    where: SqlExpressionBuilder.() -> Op<Boolean>,
+): List<EntT> = this.selectAll()
+    .where(where)
+    .map(mapper)
+
+/**
+ * Returns a list of entities by their IDs.
+ *
+ * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
+ * @param T The table type as a subtype of [IdTable].
+ * @param EntT The result entity type.
+ * @param ids A list of IDs for the entities to be fetched.
+ * @param mapper Mapping function to map each [ResultRow] to an entity of type [EntT].
+ */
+fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntitiesByIds(
+    ids: List<Key>,
+    mapper: (ResultRow) -> EntT,
+): List<EntT> = this.getEntities(mapper) {
+    this@getEntitiesByIds.id inList ids
+}
+
+/**
  * Returns an entity according to the [where] expression or returns null if the entity couldn't be found.
  *
  * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
@@ -26,9 +58,8 @@ import java.util.UUID
 fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntityOrNull(
     mapper: (ResultRow) -> EntT,
     where: SqlExpressionBuilder.() -> Op<Boolean>,
-): EntT? = this.selectAll()
-    .where(where)
-    .map(mapper)
+): EntT? = this
+    .getEntities(mapper, where)
     .singleOrNull()
 
 /**
@@ -128,23 +159,3 @@ inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.updateByIdAndGet(
     entityType: EntityType,
     crossinline body: T.(UpdateStatement) -> Unit,
 ): EntT = this.updateAndGet(mapper, entityType, id.toString(), { this@updateByIdAndGet.id eq id }, body)
-
-/**
- * Retrieves a list of entities from the table by their primary key IDs.
- *
- * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
- * @param T The table type as a subtype of [IdTable].
- * @param EntT The result entity type.
- * @param ids A list of primary key IDs for the entities to be fetched.
- * @param mapper A function to map each [ResultRow] to an entity of type [EntT].
- * @return A list of entities of type [EntT] corresponding to the provided IDs.
- */
-inline fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntitiesByIds(
-    ids: List<Key>,
-    mapper: (ResultRow) -> EntT,
-): List<EntT> {
-    return this
-        .selectAll()
-        .where { this@getEntitiesByIds.id inList ids }
-        .map(mapper)
-}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoHelper.kt
@@ -44,6 +44,18 @@ fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntityByIdOrNull(id: Key, map
     this.getEntityOrNull(mapper) { this@getEntityByIdOrNull.id eq id }
 
 /**
+ * Checks if an entity exists in the table that matches the specified [where] condition.
+ *
+ * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
+ * @param T The table type as a subtype of [IdTable].
+ * @param where The condition used to filter the entities in the table.
+ *              It is expressed as an [Op] built using the [SqlExpressionBuilder].
+ * @return `true` if an entity matching the condition exists, otherwise `false`.
+ */
+fun <Key : Any, T : IdTable<Key>> T.doesEntityExist(where: SqlExpressionBuilder.() -> Op<Boolean>): Boolean =
+    this.selectAll().where(where).count() > 0
+
+/**
  * Checks if an entity exists in the table with the given ID.
  *
  * @param Key The type of the [IdTable], i.e., the ID type, such as [UUID].
@@ -51,8 +63,8 @@ fun <Key : Any, T : IdTable<Key>, EntT : Any> T.getEntityByIdOrNull(id: Key, map
  * @param id The ID of type [Key], which is used to find the entity.
  * @return True if an entity with the given ID exists, false otherwise.
  */
-fun <Key : Any, T : IdTable<Key>> T.doesEntityExistById(id: Key): Boolean = this
-    .getEntityByIdOrNull(id) { it[this.id] } != null
+fun <Key : Any, T : IdTable<Key>> T.doesEntityExistById(id: Key): Boolean =
+    this.doesEntityExist { this@doesEntityExistById.id eq id }
 
 /**
  * Combination of using [insertAndGetId] and fetching the created entity by its ID.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
@@ -1,44 +1,57 @@
 package se.uulm.snowballr.backend.repository
 
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
-import java.util.UUID
 
 /**
- * Returns an entity by its ID encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
+ * Returns an entity by its key encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
  * returned, containing a [NotFoundException].
  *
- * @param T The type of the entity.
+ * @param Key The type of the key.
+ * @param EntT The type of the entity.
  * @param getter The actual getter method that returns a nullable entity.
  * @param entityType The [EntityType] of the entity.
- * @param id The ID of the entity.
+ * @param key The key of the entity.
+ * @param identifierType The [IdentifierType] of the [key].
  */
-fun <T> getEntityByIdAsResult(getter: (UUID) -> T?, entityType: EntityType, id: UUID): Result<T> {
-    val entity = getter(id)
+fun <Key : Any, EntT> getEntityByKeyAsResult(
+    getter: (Key) -> EntT?,
+    entityType: EntityType,
+    key: Key,
+    identifierType: IdentifierType = IdentifierType.ID,
+): Result<EntT> {
+    val entity = getter(key)
 
     return if (entity != null) {
         Result.success(entity)
     } else {
-        Result.failure(NotFoundException(entityType, id.toString()))
+        Result.failure(NotFoundException(entityType, key.toString(), identifierType = identifierType))
     }
 }
 
 /**
- * Returns an entity by its two IDs encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
+ * Returns an entity by its two keys encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
  * returned, containing a [NotFoundException].
  *
- * @param T The type of the entity.
+ * @param Key The type of the key.
+ * @param EntT The type of the entity.
  * @param getter The actual getter method that returns a nullable entity.
  * @param entityType The [EntityType] of the entity.
- * @param id1 The first ID of the entity.
- * @param id2 The second ID of the entity.
+ * @param key1 The first key of the entity.
+ * @param key2 The second key of the entity.
  */
-fun <T> getEntityByIdsAsResult(getter: (UUID, UUID) -> T?, entityType: EntityType, id1: UUID, id2: UUID): Result<T> {
-    val entity = getter(id1, id2)
+fun <Key : Any, EntT> getEntityByKeysAsResult(
+    getter: (Key, Key) -> EntT?,
+    entityType: EntityType,
+    key1: Key,
+    key2: Key,
+): Result<EntT> {
+    val entity = getter(key1, key2)
 
     return if (entity != null) {
         Result.success(entity)
     } else {
-        Result.failure(NotFoundException(entityType, id1.toString(), id2.toString()))
+        Result.failure(NotFoundException(entityType, key1.toString(), key2.toString()))
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
@@ -5,7 +5,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import java.util.UUID
 
 /**
- * Returns an entity by its ID encapsulated by a [Result]. If the entity couldn't be found a [Result.Failure] is
+ * Returns an entity by its ID encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
  * returned, containing a [NotFoundException].
  *
  * @param T The type of the entity.
@@ -24,7 +24,7 @@ fun <T> getEntityByIdAsResult(getter: (UUID) -> T?, entityType: EntityType, id: 
 }
 
 /**
- * Returns an entity by its two IDs encapsulated by a [Result]. If the entity couldn't be found a [Result.Failure] is
+ * Returns an entity by its two IDs encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
  * returned, containing a [NotFoundException].
  *
  * @param T The type of the entity.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
@@ -1,0 +1,44 @@
+package se.uulm.snowballr.backend.repository
+
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import java.util.UUID
+
+/**
+ * Returns an entity by its ID encapsulated by a [Result]. If the entity couldn't be found a [Result.Failure] is
+ * returned, containing a [NotFoundException].
+ *
+ * @param T The type of the entity.
+ * @param getter The actual getter method that returns a nullable entity.
+ * @param entityType The [EntityType] of the entity.
+ * @param id The ID of the entity.
+ */
+fun <T> getEntityByIdAsResult(getter: (UUID) -> T?, entityType: EntityType, id: UUID): Result<T> {
+    val entity = getter(id)
+
+    return if (entity != null) {
+        Result.success(entity)
+    } else {
+        Result.failure(NotFoundException(entityType, id.toString()))
+    }
+}
+
+/**
+ * Returns an entity by its two IDs encapsulated by a [Result]. If the entity couldn't be found a [Result.Failure] is
+ * returned, containing a [NotFoundException].
+ *
+ * @param T The type of the entity.
+ * @param getter The actual getter method that returns a nullable entity.
+ * @param entityType The [EntityType] of the entity.
+ * @param id1 The first ID of the entity.
+ * @param id2 The second ID of the entity.
+ */
+fun <T> getEntityByIdsAsResult(getter: (UUID, UUID) -> T?, entityType: EntityType, id1: UUID, id2: UUID): Result<T> {
+    val entity = getter(id1, id2)
+
+    return if (entity != null) {
+        Result.success(entity)
+    } else {
+        Result.failure(NotFoundException(entityType, id1.toString(), id2.toString()))
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
@@ -8,17 +8,17 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
  * Returns an entity by its key encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
  * returned, containing a [NotFoundException].
  *
- * @param Key The type of the key.
+ * @param KeyT The type of the key.
  * @param EntT The type of the entity.
  * @param getter The actual getter method that returns a nullable entity.
  * @param entityType The [EntityType] of the entity.
  * @param key The key of the entity.
  * @param identifierType The [IdentifierType] of the [key].
  */
-fun <Key : Any, EntT> getEntityByKeyAsResult(
-    getter: (Key) -> EntT?,
+fun <KeyT : Any, EntT> getEntityByKeyAsResult(
+    getter: (KeyT) -> EntT?,
     entityType: EntityType,
-    key: Key,
+    key: KeyT,
     identifierType: IdentifierType = IdentifierType.ID,
 ): Result<EntT> {
     val entity = getter(key)
@@ -34,18 +34,18 @@ fun <Key : Any, EntT> getEntityByKeyAsResult(
  * Returns an entity by its two keys encapsulated by a [Result]. If the entity couldn't be found, a [Result.Failure] is
  * returned, containing a [NotFoundException].
  *
- * @param Key The type of the key.
+ * @param KeyT The type of the key.
  * @param EntT The type of the entity.
  * @param getter The actual getter method that returns a nullable entity.
  * @param entityType The [EntityType] of the entity.
  * @param key1 The first key of the entity.
  * @param key2 The second key of the entity.
  */
-fun <Key : Any, EntT> getEntityByKeysAsResult(
-    getter: (Key, Key) -> EntT?,
+fun <KeyT : Any, EntT> getEntityByKeysAsResult(
+    getter: (KeyT, KeyT) -> EntT?,
     entityType: EntityType,
-    key1: Key,
-    key2: Key,
+    key1: KeyT,
+    key2: KeyT,
 ): Result<EntT> {
     val entity = getter(key1, key2)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -48,13 +48,7 @@ class ReviewTableRepo(
     private fun getReviewByIdOrNull(id: UUID): Review? = ReviewTable.getEntityByIdOrNull(id, ResultRow::toReview)
 
     override suspend fun getReviewById(id: UUID): Result<Review> = db.query {
-        val review = getReviewByIdOrNull(id)
-
-        if (review != null) {
-            Result.success(review)
-        } else {
-            Result.failure(NotFoundException(EntityType.REVIEW, id.toString()))
-        }
+        getEntityByIdAsResult(::getReviewByIdOrNull, EntityType.REVIEW, id)
     }
 
     override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -47,7 +47,7 @@ class ReviewTableRepo(
     private fun getReviewByIdOrNull(id: UUID): Review? = ReviewTable.getEntityByIdOrNull(id, ResultRow::toReview)
 
     override suspend fun getReviewById(id: UUID): Result<Review> = db.query {
-        getEntityByIdAsResult(::getReviewByIdOrNull, EntityType.REVIEW, id)
+        getEntityByKeyAsResult(::getReviewByIdOrNull, EntityType.REVIEW, id)
     }
 
     override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -19,9 +19,10 @@ import java.util.UUID
  */
 interface IReviewTableRepo {
     /**
-     * Returns a review by its ID or throws a [NotFoundException] if the review with the passed [id] doesn't exist.
+     * Returns a [Result] containing the review by its ID or a [NotFoundException] if the review with the passed [id]
+     * doesn't exist.
      */
-    suspend fun getReviewById(id: UUID): Review
+    suspend fun getReviewById(id: UUID): Result<Review>
 
     /**
      * Retrieves all reviews associated with the specified project paper.
@@ -46,8 +47,14 @@ class ReviewTableRepo(
 ) : IReviewTableRepo {
     private fun getReviewByIdOrNull(id: UUID): Review? = ReviewTable.getEntityByIdOrNull(id, ResultRow::toReview)
 
-    override suspend fun getReviewById(id: UUID): Review = db.query {
-        getReviewByIdOrNull(id) ?: throw NotFoundException(EntityType.REVIEW, id.toString())
+    override suspend fun getReviewById(id: UUID): Result<Review> = db.query {
+        val review = getReviewByIdOrNull(id)
+
+        if (review != null) {
+            Result.success(review)
+        } else {
+            Result.failure(NotFoundException(EntityType.REVIEW, id.toString()))
+        }
     }
 
     override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
@@ -52,9 +51,6 @@ class ReviewTableRepo(
     }
 
     override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {
-        ReviewTable
-            .selectAll()
-            .where { ReviewTable.projectPaperId eq projectPaperId }
-            .map { it.toReview() }
+        ReviewTable.getEntities(ResultRow::toReview) { ReviewTable.projectPaperId eq projectPaperId }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -35,15 +35,16 @@ import java.util.UUID
 @Suppress("ComplexInterface")
 interface IUserTableRepo {
     /**
-     * Returns a user by its id or throws a [NotFoundException] if the user with the passed [id] doesn't exist.
+     * Returns a [Result] containing the user by its id or a [NotFoundException] if the user with the passed [id]
+     * doesn't exist.
      */
-    suspend fun getUserById(id: UUID): User
+    suspend fun getUserById(id: UUID): Result<User>
 
     /**
-     * Returns a user by its email or throws a [NotFoundException] if the user with the passed [email] doesn't
-     * exist.
+     * Returns a [Result] containing the user by its email or a [NotFoundException] if the user with the passed [email]
+     * doesn't exist.
      */
-    suspend fun getUserByEmail(email: String): User
+    suspend fun getUserByEmail(email: String): Result<User>
 
     /**
      * Checks if a user exists in the database by their email address.
@@ -107,7 +108,7 @@ interface IUserTableRepo {
      * @param email The email address of the user whose password hash is to be retrieved.
      * @return The password hash as a [String] for the user with the specified email.
      */
-    suspend fun getPasswordHashByEmail(email: String): String
+    suspend fun getPasswordHashByEmail(email: String): Result<String>
 
     /**
      * Retrieves the user settings associated with a specific user ID.
@@ -115,7 +116,7 @@ interface IUserTableRepo {
      * @param id The unique identifier of the user whose settings are to be fetched.
      * @return The [UserSettings] object containing the settings for the specified user.
      */
-    suspend fun getUserSettings(id: UUID): UserSettings
+    suspend fun getUserSettings(id: UUID): Result<UserSettings>
 }
 
 /**
@@ -156,17 +157,22 @@ class UserTableRepo(
      */
     private fun getUserByIdOrNull(id: UUID): User? = UserTable.getEntityByIdOrNull(id, ResultRow::toUser)
 
-    override suspend fun getUserById(id: UUID): User = db.query {
-        getUserByIdOrNull(id) ?: throw NotFoundException(EntityType.USER, id.toString())
+    override suspend fun getUserById(id: UUID): Result<User> = db.query {
+        getEntityByIdAsResult(::getUserByIdOrNull, EntityType.USER, id)
     }
 
-    override suspend fun getUserByEmail(email: String): User = db.query {
-        UserTable
+    override suspend fun getUserByEmail(email: String): Result<User> = db.query {
+        val user = UserTable
             .selectAll()
             .where { UserTable.email eq email }
             .map { it.toUser() }
             .singleOrNull()
-            ?: throw NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL)
+
+        if (user != null) {
+            Result.success(user)
+        } else {
+            Result.failure(NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL))
+        }
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.query {
@@ -267,20 +273,30 @@ class UserTableRepo(
         }
     }
 
-    override suspend fun getPasswordHashByEmail(email: String): String = db.query {
-        UserTable
+    override suspend fun getPasswordHashByEmail(email: String): Result<String> = db.query {
+        val passwordHash = UserTable
             .select(UserTable.passwordHash)
             .where { UserTable.email eq email }
             .map { it[UserTable.passwordHash] }
             .singleOrNull()
-            ?: throw NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL)
+
+        if (passwordHash != null) {
+            Result.success(passwordHash)
+        } else {
+            Result.failure(NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL))
+        }
     }
 
-    override suspend fun getUserSettings(id: UUID): UserSettings = db.query {
-        UserTable.selectAll()
+    override suspend fun getUserSettings(id: UUID): Result<UserSettings> = db.query {
+        val settings = UserTable.selectAll()
             .where { UserTable.id eq id }
             .map { it.toUserSettings() }
             .singleOrNull()
-            ?: throw NotFoundException(EntityType.USER, id.toString(), identifierType = IdentifierType.ID)
+
+        if (settings != null) {
+            Result.success(settings)
+        } else {
+            Result.failure(NotFoundException(EntityType.USER, id.toString(), identifierType = IdentifierType.ID))
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -154,11 +154,10 @@ class UserTableRepo(
     private fun getUserByEmailOrNull(email: String): User? =
         UserTable.getEntityOrNull(ResultRow::toUser) { UserTable.email eq email }
 
-    private fun getPasswordHashByUserMailOrNull(email: String): String? = UserTable.getEntityOrNull(
-        mapper = { row -> row[UserTable.passwordHash] },
-        select = UserTable.select(UserTable.passwordHash),
-        where = { UserTable.email eq email },
-    )
+    private fun getPasswordHashByUserMailOrNull(email: String): String? = UserTable.select(UserTable.passwordHash)
+        .where { UserTable.email eq email }
+        .map { it[UserTable.passwordHash] }
+        .singleOrNull()
 
     private fun getUserSettingsByUserIdOrNull(userId: UUID): UserSettings? =
         UserTable.getEntityByIdOrNull(userId, ResultRow::toUserSettings)
@@ -263,7 +262,7 @@ class UserTableRepo(
     }
 
     override suspend fun getPasswordHashByEmail(email: String): Result<String> = db.query {
-        getEntityByKeyAsResult(::getPasswordHashByUserMailOrNull, EntityType.USER, email)
+        getEntityByKeyAsResult(::getPasswordHashByUserMailOrNull, EntityType.USER, email, IdentifierType.EMAIL)
     }
 
     override suspend fun getUserSettings(id: UUID): Result<UserSettings> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
 import org.jetbrains.exposed.sql.TextColumnType
 import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.update
@@ -150,27 +149,26 @@ class UserTableRepo(
         }.map { it.toUser() }.toList()
     }
 
-    /**
-     * Requesting a user from the database.
-     *
-     * @param id The id of the requested user.
-     * @return The [User] object or null, if no user with the given [id] was found.
-     */
     private fun getUserByIdOrNull(id: UUID): User? = UserTable.getEntityByIdOrNull(id, ResultRow::toUser)
 
+    private fun getUserByEmailOrNull(email: String): User? =
+        UserTable.getEntityOrNull(ResultRow::toUser) { UserTable.email eq email }
+
+    private fun getPasswordHashByUserMailOrNull(email: String): String? = UserTable.getEntityOrNull(
+        mapper = { row -> row[UserTable.passwordHash] },
+        select = UserTable.select(UserTable.passwordHash),
+        where = { UserTable.email eq email },
+    )
+
+    private fun getUserSettingsByUserIdOrNull(userId: UUID): UserSettings? =
+        UserTable.getEntityByIdOrNull(userId, ResultRow::toUserSettings)
+
     override suspend fun getUserById(id: UUID): Result<User> = db.query {
-        getEntityByIdAsResult(::getUserByIdOrNull, EntityType.USER, id)
+        getEntityByKeyAsResult(::getUserByIdOrNull, EntityType.USER, id)
     }
 
     override suspend fun getUserByEmail(email: String): Result<User> = db.query {
-        val user = UserTable
-            .getEntityOrNull(ResultRow::toUser) { UserTable.email eq email }
-
-        if (user != null) {
-            Result.success(user)
-        } else {
-            Result.failure(NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL))
-        }
+        getEntityByKeyAsResult(::getUserByEmailOrNull, EntityType.USER, email, IdentifierType.EMAIL)
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.query {
@@ -265,26 +263,10 @@ class UserTableRepo(
     }
 
     override suspend fun getPasswordHashByEmail(email: String): Result<String> = db.query {
-        val passwordHash = UserTable
-            .select(UserTable.passwordHash)
-            .where { UserTable.email eq email }
-            .map { it[UserTable.passwordHash] }
-            .singleOrNull()
-
-        if (passwordHash != null) {
-            Result.success(passwordHash)
-        } else {
-            Result.failure(NotFoundException(EntityType.USER, email, identifierType = IdentifierType.EMAIL))
-        }
+        getEntityByKeyAsResult(::getPasswordHashByUserMailOrNull, EntityType.USER, email)
     }
 
     override suspend fun getUserSettings(id: UUID): Result<UserSettings> = db.query {
-        val settings = UserTable.getEntityByIdOrNull(id, ResultRow::toUserSettings)
-
-        if (settings != null) {
-            Result.success(settings)
-        } else {
-            Result.failure(NotFoundException(EntityType.USER, id.toString(), identifierType = IdentifierType.ID))
-        }
+        getEntityByKeyAsResult(::getUserSettingsByUserIdOrNull, EntityType.USER, id)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.neq
 import org.jetbrains.exposed.sql.TextColumnType
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
@@ -163,10 +162,7 @@ class UserTableRepo(
 
     override suspend fun getUserByEmail(email: String): Result<User> = db.query {
         val user = UserTable
-            .selectAll()
-            .where { UserTable.email eq email }
-            .map { it.toUser() }
-            .singleOrNull()
+            .getEntityOrNull(ResultRow::toUser) { UserTable.email eq email }
 
         if (user != null) {
             Result.success(user)
@@ -281,10 +277,7 @@ class UserTableRepo(
     }
 
     override suspend fun getUserSettings(id: UUID): Result<UserSettings> = db.query {
-        val settings = UserTable.selectAll()
-            .where { UserTable.id eq id }
-            .map { it.toUserSettings() }
-            .singleOrNull()
+        val settings = UserTable.getEntityByIdOrNull(id, ResultRow::toUserSettings)
 
         if (settings != null) {
             Result.success(settings)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -17,12 +17,12 @@ import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.toUser
 import se.uulm.snowballr.backend.table.toUserSettings
 import snowballr.Authentication
-import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.sql.ResultSet
 import java.time.OffsetDateTime
 import java.util.UUID
+import snowballr.UserOuterClass.User as GrpcUser
 
 /**
  * Defines an interface for repository operations related to the [UserTable].
@@ -93,11 +93,11 @@ interface IUserTableRepo {
      * @param request The update request containing the new user details, such as the new first name.
      * @return The updated [User] object reflecting the changes from the [request].
      */
-    suspend fun updateUser(request: UserOuterClass.User.Update): User
+    suspend fun updateUser(request: GrpcUser.Update): User
 
     /**
      * Performs a soft delete meaning the user with the given [id] is not removed from the database, but only the
-     * status is set to [UserOuterClass.UserStatus.USER_STATUS_DELETED].
+     * status is set to [UserStatus.USER_STATUS_DELETED].
      */
     suspend fun softDeleteUser(id: UUID)
 
@@ -234,7 +234,7 @@ class UserTableRepo(
         }
     }
 
-    override suspend fun updateUser(request: UserOuterClass.User.Update): User = db.query {
+    override suspend fun updateUser(request: GrpcUser.Update): User = db.query {
         val userId = parseUUID(request.user.id, EntityType.USER)
         val fieldMask = FieldMaskUtil.normalize(request.mask)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -180,10 +180,7 @@ class UserTableRepo(
     }
 
     override suspend fun getAllUsers(): List<User> = db.query {
-        UserTable
-            .selectAll()
-            .where(UserTable.email neq "")
-            .map { it.toUser() }
+        UserTable.getEntities(ResultRow::toUser) { UserTable.email neq "" }
     }
 
     @Suppress("MagicNumber")

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -34,14 +34,14 @@ import snowballr.UserOuterClass.User as GrpcUser
 @Suppress("ComplexInterface")
 interface IUserTableRepo {
     /**
-     * Returns a [Result] containing the user by its id or a [NotFoundException] if the user with the passed [id]
+     * Returns a [Result] containing the user by their id or a [NotFoundException] if the user with the passed [id]
      * doesn't exist.
      */
     suspend fun getUserById(id: UUID): Result<User>
 
     /**
-     * Returns a [Result] containing the user by its email or a [NotFoundException] if the user with the passed [email]
-     * doesn't exist.
+     * Returns a [Result] containing the user by their email or a [NotFoundException] if the user with the passed
+     * [email] doesn't exist.
      */
     suspend fun getUserByEmail(email: String): Result<User>
 
@@ -102,7 +102,8 @@ interface IUserTableRepo {
     suspend fun softDeleteUser(id: UUID)
 
     /**
-     * Retrieves the password hash for a user by their email address.
+     * Returns a [Result] containing the password hash for a user by their email address or a [NotFoundException] if the
+     * user with the passed [email] doesn't exist.
      *
      * @param email The email address of the user whose password hash is to be retrieved.
      * @return The password hash as a [String] for the user with the specified email.
@@ -110,7 +111,8 @@ interface IUserTableRepo {
     suspend fun getPasswordHashByEmail(email: String): Result<String>
 
     /**
-     * Retrieves the user settings associated with a specific user ID.
+     * Returns a [Result] containing the settings of the user with the passed [id] or a [NotFoundException] if the user
+     * with the passed [id] doesn't exist.
      *
      * @param id The unique identifier of the user whose settings are to be fetched.
      * @return The [UserSettings] object containing the settings for the specified user.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -82,7 +82,7 @@ interface IUserTableRepo {
     suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User
 
     /**
-     * Updates an existing user in the database with the provided new information.
+     * Updates an existent user in the database with the provided new information.
      * The following fields can be updated:
      * - first name
      * - last name

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -176,11 +176,7 @@ class UserTableRepo(
     }
 
     override suspend fun doesUserExistByEmail(email: String): Boolean = db.query {
-        UserTable
-            .select(UserTable.email)
-            .where { UserTable.email eq email }
-            .empty()
-            .not()
+        UserTable.doesEntityExist { UserTable.email eq email }
     }
 
     override suspend fun getAllUsers(): List<User> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/VerificationTokenTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/VerificationTokenTableRepo.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.repository
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.VerificationToken
@@ -49,11 +48,7 @@ class VerificationTokenTableRepo(
     }
 
     override suspend fun getVerificationTokenByValue(token: String): VerificationToken? = db.query {
-        VerificationTokenTable
-            .selectAll()
-            .where { VerificationTokenTable.token eq token }
-            .map { it.toVerificationToken() }
-            .singleOrNull()
+        VerificationTokenTable.getEntityOrNull(ResultRow::toVerificationToken) { VerificationTokenTable.token eq token }
     }
 
     override suspend fun deleteVerificationToken(token: String) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -31,9 +31,10 @@ import java.util.UUID
  */
 interface IProjectMemberTableRepo {
     /**
-     * Returns a project member by its composed ID or throws a [NotFoundException] if the project with the passed [projectId] and [userId] doesn't exist.
+     * Returns a [Result] containing the project member by its composed ID or a [NotFoundException] if the project with
+     * the passed [projectId] and [userId] doesn't exist.
      */
-    suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): ProjectMember
+    suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember>
 
     /**
      * Adds a user with the passed [userId] as member to the project with the passed [projectId].
@@ -102,9 +103,14 @@ class ProjectMemberTableRepo(
             (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId)
         }
 
-    override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): ProjectMember = db.query {
-        getProjectMemberByComposedIdOrNull(projectId, userId)
-            ?: throw NotFoundException(EntityType.PROJECT_MEMBER, projectId.toString(), userId.toString())
+    override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember> = db.query {
+        val projectMember = getProjectMemberByComposedIdOrNull(projectId, userId)
+
+        if (projectMember != null) {
+            Result.success(projectMember)
+        } else {
+            Result.failure(NotFoundException(EntityType.PROJECT_MEMBER, projectId.toString(), userId.toString()))
+        }
     }
 
     override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -10,6 +10,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
+import se.uulm.snowballr.backend.repository.getEntities
 import se.uulm.snowballr.backend.repository.getEntityByIdsAsResult
 import se.uulm.snowballr.backend.repository.getEntityOrNull
 import se.uulm.snowballr.backend.repository.insertAndGet
@@ -122,10 +123,7 @@ class ProjectMemberTableRepo(
     }
 
     override suspend fun getProjectMembers(projectId: UUID): List<ProjectMember> = db.query {
-        ProjectMemberTable
-            .selectAll()
-            .where { ProjectMemberTable.projectId eq projectId }
-            .map { it.toProjectMember() }
+        ProjectMemberTable.getEntities(ResultRow::toProjectMember) { ProjectMemberTable.projectId eq projectId }
     }
 
     override suspend fun getMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember> = db.query {
@@ -148,13 +146,10 @@ class ProjectMemberTableRepo(
     }
 
     override suspend fun getAllProjectAdmins(projectId: UUID): List<ProjectMember> = db.query {
-        ProjectMemberTable
-            .selectAll()
-            .where {
-                (ProjectMemberTable.projectId eq projectId) and
-                    (ProjectMemberTable.role eq ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN)
-            }
-            .map { it.toProjectMember() }
+        ProjectMemberTable.getEntities(ResultRow::toProjectMember) {
+            (ProjectMemberTable.projectId eq projectId) and
+                (ProjectMemberTable.role eq ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN)
+        }
     }
 
     override suspend fun promoteProjectMemberToAdmin(projectId: UUID, userId: UUID): ProjectMember = db.query {
@@ -165,10 +160,9 @@ class ProjectMemberTableRepo(
             where = {
                 (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId)
             },
-            body = {
-                it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
-            },
-        )
+        ) {
+            it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
+        }
     }
 
     override suspend fun getProjectMembersWithUsers(projectId: UUID): List<ProjectMemberWithUser> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -11,7 +11,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.repository.getEntities
-import se.uulm.snowballr.backend.repository.getEntityByIdsAsResult
+import se.uulm.snowballr.backend.repository.getEntityByKeysAsResult
 import se.uulm.snowballr.backend.repository.getEntityOrNull
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.repository.updateAndGet
@@ -104,7 +104,7 @@ class ProjectMemberTableRepo(
         }
 
     override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember> = db.query {
-        getEntityByIdsAsResult(::getProjectMemberByComposedIdOrNull, EntityType.PROJECT_MEMBER, projectId, userId)
+        getEntityByKeysAsResult(::getProjectMemberByComposedIdOrNull, EntityType.PROJECT_MEMBER, projectId, userId)
     }
 
     override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -110,9 +110,9 @@ class ProjectMemberTableRepo(
     override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.query {
         // Return when the user is already a project member
         val projectMembers = getProjectMembers(projectId)
-        val existingMember = projectMembers.find { it.userId == userId }
-        if (existingMember != null) {
-            return@query existingMember
+        val existentMember = projectMembers.find { it.userId == userId }
+        if (existentMember != null) {
+            return@query existentMember
         }
 
         ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, EntityType.PROJECT_MEMBER) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -10,6 +10,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
+import se.uulm.snowballr.backend.repository.getEntityByIdsAsResult
 import se.uulm.snowballr.backend.repository.getEntityOrNull
 import se.uulm.snowballr.backend.repository.getProjectEntityId
 import se.uulm.snowballr.backend.repository.getUserEntityId
@@ -104,13 +105,7 @@ class ProjectMemberTableRepo(
         }
 
     override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember> = db.query {
-        val projectMember = getProjectMemberByComposedIdOrNull(projectId, userId)
-
-        if (projectMember != null) {
-            Result.success(projectMember)
-        } else {
-            Result.failure(NotFoundException(EntityType.PROJECT_MEMBER, projectId.toString(), userId.toString()))
-        }
+        getEntityByIdsAsResult(::getProjectMemberByComposedIdOrNull, EntityType.PROJECT_MEMBER, projectId, userId)
     }
 
     override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -12,8 +12,6 @@ import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.repository.getEntityByIdsAsResult
 import se.uulm.snowballr.backend.repository.getEntityOrNull
-import se.uulm.snowballr.backend.repository.getProjectEntityId
-import se.uulm.snowballr.backend.repository.getUserEntityId
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.repository.updateAndGet
 import se.uulm.snowballr.backend.table.UserTable
@@ -109,22 +107,16 @@ class ProjectMemberTableRepo(
     }
 
     override suspend fun addUserToProject(userId: UUID, projectId: UUID) = db.query {
-        // Get user reference
-        val userEntityId = getUserEntityId(userId)
-
-        // Get project reference
-        val projectEntityId = getProjectEntityId(projectId)
-
         // Return when the user is already a project member
         val projectMembers = getProjectMembers(projectId)
-        val existingMember = projectMembers.find { it.userId == userEntityId.value }
+        val existingMember = projectMembers.find { it.userId == userId }
         if (existingMember != null) {
             return@query existingMember
         }
 
         ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, EntityType.PROJECT_MEMBER) {
-            it[this.userId] = userEntityId
-            it[this.projectId] = projectEntityId
+            it[this.userId] = userId
+            it[this.projectId] = projectId
             it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 interface IProjectMemberTableRepo {
     /**
      * Returns a [Result] containing the project member by its composed ID or a [NotFoundException] if the project with
-     * the passed [projectId] and [userId] doesn't exist.
+     * the passed [projectId] or the user with the passed [userId] doesn't exist.
      */
     suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember>
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -19,7 +19,7 @@ import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
 import se.uulm.snowballr.backend.table.association.toProjectMemberWithUser
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.MemberRole
 import java.util.UUID
 
 /**
@@ -118,7 +118,7 @@ class ProjectMemberTableRepo(
         ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, EntityType.PROJECT_MEMBER) {
             it[this.userId] = userId
             it[this.projectId] = projectId
-            it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
+            it[role] = MemberRole.MEMBER_ROLE_DEFAULT
         }
     }
 
@@ -148,7 +148,7 @@ class ProjectMemberTableRepo(
     override suspend fun getAllProjectAdmins(projectId: UUID): List<ProjectMember> = db.query {
         ProjectMemberTable.getEntities(ResultRow::toProjectMember) {
             (ProjectMemberTable.projectId eq projectId) and
-                (ProjectMemberTable.role eq ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN)
+                (ProjectMemberTable.role eq MemberRole.MEMBER_ROLE_ADMIN)
         }
     }
 
@@ -161,7 +161,7 @@ class ProjectMemberTableRepo(
                 (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId)
             },
         ) {
-            it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
+            it[role] = MemberRole.MEMBER_ROLE_ADMIN
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -11,6 +11,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundEx
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.getEntityByIdAsResult
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
 import se.uulm.snowballr.backend.repository.getUserEntityId
 import se.uulm.snowballr.backend.repository.insertAndGet
@@ -122,13 +123,7 @@ class ProjectPaperTableRepo(
     }
 
     override suspend fun getProjectPaperById(id: UUID): Result<ProjectPaper> = db.query {
-        val projectPaper = getProjectPaperByIdOrNull(id)
-
-        if (projectPaper != null) {
-            Result.success(projectPaper)
-        } else {
-            Result.failure(NotFoundException(EntityType.PROJECT_PAPER, id.toString()))
-        }
+        getEntityByIdAsResult(::getProjectPaperByIdOrNull, EntityType.PROJECT_PAPER, id)
     }
 
     override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): ProjectPaper = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -13,7 +13,6 @@ import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.getEntityByIdAsResult
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
-import se.uulm.snowballr.backend.repository.getUserEntityId
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
@@ -158,7 +157,6 @@ class ProjectPaperTableRepo(
     }
 
     override suspend fun addPaperToProject(request: GrpcProjectPaper.Add, userId: UUID): ProjectPaper = db.query {
-        val userEntityId = getUserEntityId(userId)
         val paperId = parseUUID(request.paperId, EntityType.PAPER)
         val projectId = parseUUID(request.projectId, EntityType.PROJECT)
         val localPaperId = getNextLocalIdForProject(projectId)
@@ -170,7 +168,7 @@ class ProjectPaperTableRepo(
                 it[ProjectPaperTable.localPaperId] = localPaperId
                 it[stage] = request.stage
                 it[decision] = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNSPECIFIED
-                it[createdBy] = userEntityId
+                it[createdBy] = userId
             }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.repository.association
 
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
@@ -15,6 +14,7 @@ import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.doesEntityExist
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
 import se.uulm.snowballr.backend.repository.getEntityByKeyAsResult
+import se.uulm.snowballr.backend.repository.getEntityOrNull
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
@@ -128,12 +128,9 @@ class ProjectPaperTableRepo(
 
     override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): Result<ProjectPaper> =
         db.query {
-            val where = (ProjectPaperTable.projectId eq projectId) and (ProjectPaperTable.localPaperId eq relativeId)
-            val projectPaper = ProjectPaperTable
-                .selectAll()
-                .where(where)
-                .map { it.toProjectPaper() }
-                .singleOrNull()
+            val projectPaper = ProjectPaperTable.getEntityOrNull(ResultRow::toProjectPaper) {
+                (ProjectPaperTable.projectId eq projectId) and (ProjectPaperTable.localPaperId eq relativeId)
+            }
 
             if (projectPaper != null) {
                 Result.success(projectPaper)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -106,7 +106,7 @@ class ProjectPaperTableRepo(
         ProjectPaperTable.getEntityByIdOrNull(id, ResultRow::toProjectPaper)
 
     /**
-     * Generates the next available local paper ID for the specified project by checking the existing maximum local
+     * Generates the next available local paper ID for the specified project by checking the existent maximum local
      * paper ID within the project and incrementing it by one. If no local paper IDs exist for the given project, it
      * returns 0.
      *

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.repository.association
 
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
@@ -37,7 +38,8 @@ interface IProjectPaperTableRepo {
     suspend fun getProjectPaperById(id: UUID): Result<ProjectPaper>
 
     /**
-     * Retrieves a project paper by its relative ID in a project.
+     * Returns a [Result] containing the project paper by its relative ID in a project or a
+     * [ProjectPaperNotFoundException] if the project paper with the passed [relativeId] doesn't exist.
      *
      * Therefore, this method searches for a project paper in the project with the [projectId] with
      * the [relativeId] (`localPaperId`).
@@ -45,9 +47,8 @@ interface IProjectPaperTableRepo {
      * @param projectId The unique identifier of the project to which the project paper belongs.
      * @param relativeId The local paper ID of the project paper in the project.
      * @return The [ProjectPaper] matching the given project ID and relative ID.
-     * @throws [NotFoundException] if no matching project paper is found.
      */
-    suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): ProjectPaper
+    suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): Result<ProjectPaper>
 
     /**
      * Checks if a project paper exists in a project, based on the provided paper ID.
@@ -125,20 +126,21 @@ class ProjectPaperTableRepo(
         getEntityByIdAsResult(::getProjectPaperByIdOrNull, EntityType.PROJECT_PAPER, id)
     }
 
-    override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): ProjectPaper = db.query {
-        ProjectPaperTable
-            .selectAll()
-            .where {
-                (
-                    (ProjectPaperTable.projectId eq projectId)
-                        and (ProjectPaperTable.localPaperId eq relativeId)
-                    )
+    override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): Result<ProjectPaper> =
+        db.query {
+            val where = (ProjectPaperTable.projectId eq projectId) and (ProjectPaperTable.localPaperId eq relativeId)
+            val projectPaper = ProjectPaperTable
+                .selectAll()
+                .where(where)
+                .map { it.toProjectPaper() }
+                .singleOrNull()
+
+            if (projectPaper != null) {
+                Result.success(projectPaper)
+            } else {
+                Result.failure(ProjectPaperNotFoundException(relativeId.toString(), projectId.toString()))
             }
-            .map { it.toProjectPaper() }
-            .singleOrNull() ?: throw ProjectPaperNotFoundException(
-            relativeId.toString(), projectId.toString(),
-        )
-    }
+        }
 
     override suspend fun doesProjectPaperExist(projectId: UUID, paperId: UUID): Boolean = db.query {
         ProjectPaperTable

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -31,9 +31,10 @@ import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
  */
 interface IProjectPaperTableRepo {
     /**
-     * Returns a project paper by its ID or throws a [NotFoundException] if the project paper with the passed [id] doesn't exist.
+     * Returns a [Result] containing the project paper by its ID or a [NotFoundException] if the project paper with the
+     * passed [id] doesn't exist.
      */
-    suspend fun getProjectPaperById(id: UUID): ProjectPaper
+    suspend fun getProjectPaperById(id: UUID): Result<ProjectPaper>
 
     /**
      * Retrieves a project paper by its relative ID in a project.
@@ -120,8 +121,14 @@ class ProjectPaperTableRepo(
             ?: 0L
     }
 
-    override suspend fun getProjectPaperById(id: UUID): ProjectPaper = db.query {
-        getProjectPaperByIdOrNull(id) ?: throw NotFoundException(EntityType.PROJECT_PAPER, id.toString())
+    override suspend fun getProjectPaperById(id: UUID): Result<ProjectPaper> = db.query {
+        val projectPaper = getProjectPaperByIdOrNull(id)
+
+        if (projectPaper != null) {
+            Result.success(projectPaper)
+        } else {
+            Result.failure(NotFoundException(EntityType.PROJECT_PAPER, id.toString()))
+        }
     }
 
     override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): ProjectPaper = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -13,8 +13,8 @@ import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.doesEntityExist
-import se.uulm.snowballr.backend.repository.getEntityByIdAsResult
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
+import se.uulm.snowballr.backend.repository.getEntityByKeyAsResult
 import se.uulm.snowballr.backend.repository.insertAndGet
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
@@ -123,7 +123,7 @@ class ProjectPaperTableRepo(
     }
 
     override suspend fun getProjectPaperById(id: UUID): Result<ProjectPaper> = db.query {
-        getEntityByIdAsResult(::getProjectPaperByIdOrNull, EntityType.PROJECT_PAPER, id)
+        getEntityByKeyAsResult(::getProjectPaperByIdOrNull, EntityType.PROJECT_PAPER, id)
     }
 
     override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Long): Result<ProjectPaper> =

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -12,6 +12,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundEx
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.doesEntityExist
 import se.uulm.snowballr.backend.repository.getEntityByIdAsResult
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
 import se.uulm.snowballr.backend.repository.insertAndGet
@@ -101,14 +102,13 @@ interface IProjectPaperTableRepo {
 class ProjectPaperTableRepo(
     private val db: IDatabase,
 ) : IProjectPaperTableRepo {
-    private fun getProjectPaperByIdOrNull(id: UUID): ProjectPaper? = ProjectPaperTable.getEntityByIdOrNull(
-        id,
-        ResultRow::toProjectPaper,
-    )
+    private fun getProjectPaperByIdOrNull(id: UUID): ProjectPaper? =
+        ProjectPaperTable.getEntityByIdOrNull(id, ResultRow::toProjectPaper)
 
     /**
-     * Generates the next available local paper ID for the specified project by checking the existing maximum local paper ID
-     * within the project and incrementing it by one. If no local paper IDs exist for the given project, it returns 0.
+     * Generates the next available local paper ID for the specified project by checking the existing maximum local
+     * paper ID within the project and incrementing it by one. If no local paper IDs exist for the given project, it
+     * returns 0.
      *
      * @param projectId The unique identifier of the project for which the next local paper ID is to be generated.
      * @return The next available local paper ID as a [Long].
@@ -143,11 +143,9 @@ class ProjectPaperTableRepo(
         }
 
     override suspend fun doesProjectPaperExist(projectId: UUID, paperId: UUID): Boolean = db.query {
-        ProjectPaperTable
-            .selectAll()
-            .where { (ProjectPaperTable.paperId eq paperId) and (ProjectPaperTable.projectId eq projectId) }
-            .empty()
-            .not()
+        ProjectPaperTable.doesEntityExist {
+            (ProjectPaperTable.paperId eq paperId) and (ProjectPaperTable.projectId eq projectId)
+        }
     }
 
     override suspend fun getAllProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -20,7 +20,7 @@ import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.toProjectPaper
 import se.uulm.snowballr.backend.table.association.toProjectPaperWithPaper
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
 import java.util.UUID
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
@@ -167,7 +167,7 @@ class ProjectPaperTableRepo(
                 it[ProjectPaperTable.projectId] = projectId
                 it[ProjectPaperTable.localPaperId] = localPaperId
                 it[stage] = request.stage
-                it[decision] = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNSPECIFIED
+                it[decision] = PaperDecision.PAPER_DECISION_UNSPECIFIED
                 it[createdBy] = userId
             }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepo.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.repository.doesEntityExist
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.ReadingListTable
 import se.uulm.snowballr.backend.table.toPaper
@@ -74,9 +75,9 @@ class ReadingListTableRepo(
     }
 
     override suspend fun isPaperOnReadingList(userId: UUID, paperId: UUID): Boolean = db.query {
-        ReadingListTable.selectAll().where {
+        ReadingListTable.doesEntityExist {
             (ReadingListTable.userId eq userId) and (ReadingListTable.paperId eq paperId)
-        }.count() > 0
+        }
     }
 
     override suspend fun getAllReadingListEntries(userId: UUID): List<Paper> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepo.kt
@@ -1,7 +1,7 @@
 package se.uulm.snowballr.backend.repository.association
 
-import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.repository.getEntities
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import java.util.UUID
 
@@ -29,9 +29,8 @@ class ReviewHasCriterionTableRepo(
     private val db: IDatabase,
 ) : IReviewHasCriterionTableRepo {
     override suspend fun getSelectedCriteriaIdsForReviewById(reviewId: UUID): List<UUID> = db.query {
-        ReviewHasCriterionTable
-            .selectAll()
-            .where { ReviewHasCriterionTable.reviewId eq reviewId }
-            .map { it[ReviewHasCriterionTable.criterionId].value }
+        ReviewHasCriterionTable.getEntities(mapper = { it[ReviewHasCriterionTable.criterionId].value }) {
+            ReviewHasCriterionTable.reviewId eq reviewId
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -173,7 +173,7 @@ class CriterionService(
     override suspend fun getCriterionById(request: Base.Id): GrpcCriterion {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val criterionId = parseUUID(request.id, EntityType.CRITERION)
-        val criterion = repo.getCriterionById(criterionId)
+        val criterion = repo.getCriterionById(criterionId).getOrThrow()
 
         checkCriterionPermission(criterion, currentUser, AccessType.READ)
         return criterion.toGrpcCriterion()
@@ -195,7 +195,7 @@ class CriterionService(
     override suspend fun updateCriterion(request: GrpcCriterion.Update): GrpcCriterion {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
-        val criterion = repo.getCriterionById(criterionId)
+        val criterion = repo.getCriterionById(criterionId).getOrThrow()
 
         checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
         return repo.updateCriterion(request).toGrpcCriterion()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -171,7 +171,7 @@ class CriterionService(
     }
 
     override suspend fun getCriterionById(request: Base.Id): GrpcCriterion {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val criterionId = parseUUID(request.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId).getOrThrow()
 
@@ -180,7 +180,7 @@ class CriterionService(
     }
 
     override suspend fun createCriterion(request: GrpcCriterion.Create): GrpcCriterion {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         if (request.projectId.isNotEmpty()) {
             checkProjectCriterionPermission(
                 null,
@@ -193,7 +193,7 @@ class CriterionService(
     }
 
     override suspend fun updateCriterion(request: GrpcCriterion.Update): GrpcCriterion {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId).getOrThrow()
 
@@ -202,7 +202,7 @@ class CriterionService(
     }
 
     override suspend fun getAllCriteriaForProject(request: Base.Id): GrpcCriterion.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.id, EntityType.PROJECT)
         // This call exists to throw a NotFoundException if the project with the given id does not exist
         projectRepo.getProjectById(projectId)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.Criterion.ProjectCriterion
@@ -204,8 +205,11 @@ class CriterionService(
     override suspend fun getAllCriteriaForProject(request: Base.Id): GrpcCriterion.List {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.id, EntityType.PROJECT)
-        // This call exists to throw a NotFoundException if the project with the given id does not exist
-        projectRepo.getProjectById(projectId)
+
+        if (!projectRepo.doesProjectExistById(projectId)) {
+            throw NotFoundException(EntityType.PROJECT, projectId.toString())
+        }
+
         val projectMembers = projectMemberRepo.getProjectMembers(projectId)
 
         if (!projectMembers.any { it.userId == currentUser.id }) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -91,7 +91,7 @@ class CriterionService(
         currentUser: User,
         accessType: AccessType,
     ) {
-        val project = projectRepo.getProjectById(projectId)
+        val project = projectRepo.getProjectById(projectId).getOrThrow()
         val members = when (accessType) {
             AccessType.READ -> projectMemberRepo.getProjectMembers(project.id)
             AccessType.CREATE, AccessType.UPDATE -> projectMemberRepo.getAllProjectAdmins(project.id)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
@@ -167,61 +166,65 @@ class CriterionService(
                 currentUser,
                 accessType,
             )
+
             is UserCriterion -> checkUserCriterionPermission(criterion, currentUser, accessType)
         }
     }
 
-    override suspend fun getCriterionById(request: Base.Id): GrpcCriterion {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun getCriterionById(request: Base.Id): GrpcCriterion = withUser(userRepo) { currentUser ->
         val criterionId = parseUUID(request.id, EntityType.CRITERION)
         val criterion = repo.getCriterionById(criterionId).getOrThrow()
 
         checkCriterionPermission(criterion, currentUser, AccessType.READ)
-        return criterion.toGrpcCriterion()
+
+        criterion.toGrpcCriterion()
     }
 
-    override suspend fun createCriterion(request: GrpcCriterion.Create): GrpcCriterion {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        if (request.projectId.isNotEmpty()) {
-            checkProjectCriterionPermission(
-                null,
-                parseUUID(request.projectId, EntityType.PROJECT),
-                currentUser,
-                AccessType.CREATE,
-            )
-        }
-        return repo.createCriterion(request, currentUser.id).toGrpcCriterion()
-    }
-
-    override suspend fun updateCriterion(request: GrpcCriterion.Update): GrpcCriterion {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
-        val criterion = repo.getCriterionById(criterionId).getOrThrow()
-
-        checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
-        return repo.updateCriterion(request).toGrpcCriterion()
-    }
-
-    override suspend fun getAllCriteriaForProject(request: Base.Id): GrpcCriterion.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val projectId = parseUUID(request.id, EntityType.PROJECT)
-
-        if (!projectRepo.doesProjectExistById(projectId)) {
-            throw NotFoundException(EntityType.PROJECT, projectId.toString())
-        }
-
-        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
-
-        if (!projectMembers.any { it.userId == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
+    override suspend fun createCriterion(request: GrpcCriterion.Create): GrpcCriterion =
+        withUser(userRepo) { currentUser ->
+            if (request.projectId.isNotEmpty()) {
+                checkProjectCriterionPermission(
+                    null,
+                    parseUUID(request.projectId, EntityType.PROJECT),
+                    currentUser,
+                    AccessType.CREATE,
                 )
             }
+
+            repo.createCriterion(request, currentUser.id).toGrpcCriterion()
         }
-        return repo.getAllProjectCriteria(projectId).toGrpcCriteria()
-    }
+
+    override suspend fun updateCriterion(request: GrpcCriterion.Update): GrpcCriterion =
+        withUser(userRepo) { currentUser ->
+            val criterionId = parseUUID(request.criterion.id, EntityType.CRITERION)
+            val criterion = repo.getCriterionById(criterionId).getOrThrow()
+
+            checkCriterionPermission(criterion, currentUser, AccessType.UPDATE)
+
+            repo.updateCriterion(request).toGrpcCriterion()
+        }
+
+    override suspend fun getAllCriteriaForProject(request: Base.Id): GrpcCriterion.List =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+            if (!projectRepo.doesProjectExistById(projectId)) {
+                throw NotFoundException(EntityType.PROJECT, projectId.toString())
+            }
+
+            val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+
+            if (!projectMembers.any { it.userId == currentUser.id }) {
+                verifyServerAdminRole(currentUser) {
+                    throw UnauthorizedException.Single(
+                        EntityType.PROJECT,
+                        projectId.toString(),
+                        AccessType.READ,
+                        it,
+                    )
+                }
+            }
+
+            repo.getAllProjectCriteria(projectId).toGrpcCriteria()
+        }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -4,6 +4,7 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Criterion
@@ -18,9 +19,10 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Base
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 interface ICriterionService {
     /**
@@ -76,7 +78,7 @@ class CriterionService(
      * or when attempting to access a criterion of an inactive project.
      *
      * @param criterion The [ProjectCriterion] to check the permission for or null, if it does not already exist.
-     * @param projectId The projectId of the [ProjectOuterClass.Project] to check the permission for.
+     * @param projectId The projectId of the [GrpcProject] to check the permission for.
      * @param currentUser The user whose permissions are being validated.
      * @param accessType The type of access being requested (e.g., READ, UPDATE).
      *
@@ -109,7 +111,7 @@ class CriterionService(
             }
         }
         if ((accessType == AccessType.UPDATE || accessType == AccessType.CREATE) &&
-            project.status != ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
+            project.status != ProjectStatus.PROJECT_STATUS_ACTIVE
         ) {
             verifyServerAdminRole(currentUser) {
                 val message = if (accessType == AccessType.CREATE) {
@@ -117,7 +119,7 @@ class CriterionService(
                 } else {
                     "Cannot update criterion with the ID: ${criterion?.id ?: "<unknown>"}"
                 }
-                throw SnowballRException.FailedPreconditionException("The project is not active. $message")
+                throw FailedPreconditionException("The project is not active. $message")
             }
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -50,7 +50,7 @@ class PaperService(
 ) : IPaperService {
     override suspend fun getPaperById(request: Base.Id): GrpcPaper {
         val paperId = parseUUID(request.id, EntityType.PAPER)
-        val paper = repo.getPaperById(paperId)
+        val paper = repo.getPaperById(paperId).getOrThrow()
 
         val authors = authorOfPapersRepo.getAuthorsOfPaperById(paperId).map { it.toGrpcAuthor() }
         val backwardReferencedIds = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
@@ -82,7 +82,7 @@ class PaperService(
 
         val referenceIds = function.invoke(paperId)
         val papers = referenceIds.map {
-            val referencedPaper = repo.getPaperById(it)
+            val referencedPaper = repo.getPaperById(it).getOrThrow()
             val authors = authorOfPapersRepo.getAuthorsOfPaperById(referencedPaper.id)
                 .map(Author::toGrpcAuthor)
             val backwardReferences = citationRepo

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -408,7 +408,7 @@ class ProjectService(
 
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper {
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
-        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId)
+        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
         return loadAndAuthorizeProjectPaper(projectPaper, projectPaper.projectId)
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -1,10 +1,10 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
@@ -91,7 +91,7 @@ interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectPaperByRelativeId].
      */
-    suspend fun getProjectPaperByRelativeId(request: GrpcProject.Paper.Get): GrpcProject.Paper
+    suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): GrpcProjectPaper
 
     /**
      * Service implementation of [SnowballRService.getAllProjectPapersForProject].
@@ -194,7 +194,7 @@ class ProjectService(
     ): GrpcProjectPaper.List = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
         if (!repo.doesProjectExistById(projectId)) {
-            throw SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
+            throw NotFoundException(EntityType.PROJECT, projectId.toString())
         }
 
         if (!isProjectMember(projectId, currentUser.id)) {
@@ -300,7 +300,7 @@ class ProjectService(
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        val project = repo.createProject(request, GrpcContext.getUserIdFromContext(), userSettings)
+        val project = repo.createProject(request, currentUser.id, userSettings)
 
         for (criterion in userDefaultCriteria) {
             val criterionRequest = CriterionOuterClass.Criterion.Create
@@ -324,29 +324,26 @@ class ProjectService(
         repo.getAllProjects().toGrpcProjects()
     }
 
-    override suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List {
+    private suspend fun getAllProjectsForUserAndStatus(
+        request: Base.Id,
+        statuses: Set<ProjectStatus>,
+    ): GrpcProject.List = withUser(userRepo) { currentUser ->
         val requestedUserId = parseUUID(request.id, EntityType.USER)
-        authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
+        authorizeAccessTo(currentUser, requestedUserId, userRepo, AccessType.READ)
 
-        val userProjects = repo.getUserProjects(requestedUserId)
-        return userProjects.toGrpcProjects()
+        repo.getUserProjects(requestedUserId, statuses).toGrpcProjects()
     }
 
-    override suspend fun getAllArchivedProjectsForUser(request: Base.Id): GrpcProject.List {
-        val requestedUserId = parseUUID(request.id, EntityType.USER)
-        authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
+    override suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List = getAllProjectsForUserAndStatus(
+        request,
+        setOf(ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED),
+    )
 
-        val archivedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
-        return archivedUserProjects.toGrpcProjects()
-    }
+    override suspend fun getAllArchivedProjectsForUser(request: Base.Id): GrpcProject.List =
+        getAllProjectsForUserAndStatus(request, setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED))
 
-    override suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List {
-        val requestedUserId = parseUUID(request.id, EntityType.USER)
-        authorizeAccessTo(requestedUserId, userRepo, AccessType.READ)
-
-        val deletedUserProjects = repo.getUserProjects(requestedUserId, setOf(ProjectStatus.PROJECT_STATUS_DELETED))
-        return deletedUserProjects.toGrpcProjects()
-    }
+    override suspend fun getAllDeletedProjectsForUser(request: Base.Id): GrpcProject.List =
+        getAllProjectsForUserAndStatus(request, setOf(ProjectStatus.PROJECT_STATUS_DELETED))
 
     override suspend fun updateProject(request: GrpcProject.Update): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
@@ -398,7 +395,7 @@ class ProjectService(
             projectMembersWithUsers.toGrpcProjectMembers()
         }
 
-    override suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper {
+    override suspend fun getProjectPaperById(request: Base.Id): GrpcProjectPaper {
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
         return loadAndAuthorizeProjectPaper(projectPaper, projectPaper.projectId)
@@ -407,7 +404,7 @@ class ProjectService(
     override suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): GrpcProjectPaper {
         val projectId = parseUUID(request.projectId, EntityType.PROJECT)
         if (!repo.doesProjectExistById(projectId)) {
-            throw SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
+            throw NotFoundException(EntityType.PROJECT, projectId.toString())
         }
 
         val relativeId = request.relativeProjectPaperId.toLong()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -192,7 +192,7 @@ class ProjectService(
         request: Base.Id,
         predicate: (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean)? = null,
     ): GrpcProjectPaper.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.id, EntityType.PROJECT)
         if (!repo.doesProjectExistById(projectId)) {
             throw SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
@@ -251,7 +251,7 @@ class ProjectService(
      * @throws UnauthorizedException.Single If the current user does not have the required read access to the project.
      */
     private suspend fun loadAndAuthorizeProjectPaper(projectPaper: ProjectPaper, projectId: UUID): GrpcProject.Paper {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectMembers = projectMemberRepo.getProjectMembers(projectId)
 
         if (projectMembers.none { it.userId == currentUser.id }) {
@@ -285,7 +285,7 @@ class ProjectService(
     }
 
     override suspend fun getProjectById(request: Base.Id): GrpcProject {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
         if (!isProjectMember(projectId, currentUser.id)) {
@@ -302,8 +302,8 @@ class ProjectService(
     }
 
     override suspend fun createProject(request: GrpcProject.Create): GrpcProject {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        val userSettings = userRepo.getUserSettings(currentUser.id)
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+        val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
         val project = repo.createProject(request, GrpcContext.getUserIdFromContext(), userSettings)
@@ -324,7 +324,7 @@ class ProjectService(
     }
 
     override suspend fun getAllProjects(): GrpcProject.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
 
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, it) }
 
@@ -357,7 +357,7 @@ class ProjectService(
     }
 
     override suspend fun updateProject(request: GrpcProject.Update): GrpcProject {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
         val project = repo.getProjectById(projectId).getOrThrow()
         val isProjectAdmin = projectMemberRepo.getAllProjectAdmins(projectId).any { it.userId == currentUser.id }
@@ -388,7 +388,7 @@ class ProjectService(
     }
 
     override suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.id, EntityType.PROJECT)
         repo.getProjectById(projectId)
         val projectMembersWithUsers = projectMemberRepo.getProjectMembersWithUsers(projectId)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -298,7 +298,7 @@ class ProjectService(
                 )
             }
         }
-        return repo.getProjectById(projectId).toGrpcProject()
+        return repo.getProjectById(projectId).getOrThrow().toGrpcProject()
     }
 
     override suspend fun createProject(request: GrpcProject.Create): GrpcProject {
@@ -359,7 +359,7 @@ class ProjectService(
     override suspend fun updateProject(request: GrpcProject.Update): GrpcProject {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
-        val project = repo.getProjectById(projectId)
+        val project = repo.getProjectById(projectId).getOrThrow()
         val isProjectAdmin = projectMemberRepo.getAllProjectAdmins(projectId).any { it.userId == currentUser.id }
         val projectStatus = project.status
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -442,7 +442,7 @@ class ProjectService(
     }
 
     override suspend fun addPaperToProject(request: GrpcProjectPaper.Add): GrpcProjectPaper {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
         if (!isProjectMember(projectId, currentUser.id)) {
@@ -457,8 +457,8 @@ class ProjectService(
         }
 
         val paperId = parseUUID(request.paperId, EntityType.PAPER)
-        val project = repo.getProjectById(projectId)
-        val paper = paperRepo.getPaperById(paperId)
+        val project = repo.getProjectById(projectId).getOrThrow()
+        val paper = paperRepo.getPaperById(paperId).getOrThrow()
         if (projectPaperRepo.doesProjectPaperExist(projectId, paperId)) {
             throw SnowballRException.DuplicateEntityException(
                 EntityType.PROJECT_PAPER,

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -31,12 +31,13 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
 import snowballr.Base
-import snowballr.CriterionOuterClass
-import snowballr.PaperOuterClass
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
+import snowballr.PaperOuterClass.Author as GrpcAuthor
 import snowballr.ProjectOuterClass.Project as GrpcProject
+import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 import snowballr.ReviewOuterClass.Review as GrpcReview
 
@@ -74,16 +75,13 @@ interface IProjectService {
 
     /**
      * Service implementation of [SnowballRService.updateProject].
-     *
-     * @param request The update request containing the project details to be modified.
-     * @return The updated project after the changes have been applied.
      */
     suspend fun updateProject(request: GrpcProject.Update): GrpcProject
 
     /**
      * Service implementation of [SnowballRService.getProjectMembers].
      */
-    suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List
+    suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List
 
     /**
      * Service implementation of [SnowballRService.getProjectPaperById].
@@ -178,15 +176,16 @@ class ProjectService(
     }
 
     /**
-     * Retrieves a list of [ProjectPaper] associated with a specified project id. This method
-     * also ensures access control for the current user. Optionally, a predicate function can be provided to filter
-     * the [ProjectPaper]s based on custom criteria.
+     * Retrieves a list of [ProjectPaper] associated with a specified project id. This method also ensures access
+     * control for the current user. Optionally, a predicate function can be provided to filter the [ProjectPaper]s
+     * based on custom criteria.
      *
      * @param request The request containing the ID of the [Project] for which [ProjectPaper]s are to be retrieved.
-     * @param predicate An optional lambda function that takes a [ProjectPaperWithPaper], a map of [GrpcReview], and a user ID.
-     * This function should return a boolean value to filter the [ProjectPaperWithPaper]s. If null, no filtering is applied.
-     * @return A list of [GrpcProjectPaper] including associated metadata such as authors,
-     * backward references, and reviews.
+     * @param predicate An optional lambda function that takes a [ProjectPaperWithPaper], a map of [GrpcReview], and a
+     * user ID. This function should return a boolean value to filter the [ProjectPaperWithPaper]s. If null, no
+     * filtering is applied.
+     * @return A list of [GrpcProjectPaper] including associated metadata such as authors, backward references, and
+     * reviews.
      * @throws UnauthorizedException If the user does not have the required access to the project.
      */
     private suspend fun getProjectPapers(
@@ -205,7 +204,7 @@ class ProjectService(
         }
 
         var projectPapersWithPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
-        val paperAuthorsMap = mutableMapOf<Paper, List<PaperOuterClass.Author>>()
+        val paperAuthorsMap = mutableMapOf<Paper, List<GrpcAuthor>>()
         val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
         val projectPaperReviewsMap = mutableMapOf<ProjectPaper, List<GrpcReview>>()
         for (projectPaper in projectPapersWithPapers) {
@@ -286,7 +285,7 @@ class ProjectService(
         val project = repo.createProject(request, currentUser.id, userSettings)
 
         for (criterion in userDefaultCriteria) {
-            val criterionRequest = CriterionOuterClass.Criterion.Create
+            val criterionRequest = GrpcCriterion.Create
                 .newBuilder()
                 .setTag(criterion.tag)
                 .setName(criterion.name)
@@ -349,7 +348,7 @@ class ProjectService(
         repo.updateProject(request, projectStatus).toGrpcProject()
     }
 
-    override suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List =
+    override suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
             repo.getProjectById(projectId).getOrThrow()
@@ -390,9 +389,8 @@ class ProjectService(
                 val isAlreadyReviewedByCurrentUser = projectPaperReviewsMap[projectPaper.projectPaper]
                     ?.any { review -> review.userId == currentUserId } == true
                 val isStillUndecided =
-                    projectPaper.projectPaper.decision == ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED ||
-                        projectPaper.projectPaper.decision ==
-                        ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW
+                    projectPaper.projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED ||
+                        projectPaper.projectPaper.decision == PaperDecision.PAPER_DECISION_IN_REVIEW
 
                 !isAlreadyReviewedByCurrentUser && isStillUndecided
             }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -191,8 +191,7 @@ class ProjectService(
     private suspend fun getProjectPapers(
         request: Base.Id,
         predicate: (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean)? = null,
-    ): GrpcProjectPaper.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    ): GrpcProjectPaper.List = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
         if (!repo.doesProjectExistById(projectId)) {
             throw SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
@@ -233,11 +232,7 @@ class ProjectService(
             projectPapersWithPapers.filter { pred(it, projectPaperReviewsMap, currentUser.id.toString()) }
         } ?: projectPapersWithPapers
 
-        return projectPapersWithPapers.toGrpcProjectPapers(
-            paperAuthorsMap,
-            paperBackwardReferencesMap,
-            projectPaperReviewsMap,
-        )
+        projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, projectPaperReviewsMap)
     }
 
     /**
@@ -250,42 +245,41 @@ class ProjectService(
      * @return The gRPC representation of the project's paper, including associated data.
      * @throws UnauthorizedException.Single If the current user does not have the required read access to the project.
      */
-    private suspend fun loadAndAuthorizeProjectPaper(projectPaper: ProjectPaper, projectId: UUID): GrpcProject.Paper {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+    private suspend fun loadAndAuthorizeProjectPaper(projectPaper: ProjectPaper, projectId: UUID): GrpcProjectPaper =
+        withUser(userRepo) { currentUser ->
+            val projectMembers = projectMemberRepo.getProjectMembers(projectId)
 
-        if (projectMembers.none { it.userId == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
+            if (projectMembers.none { it.userId == currentUser.id }) {
+                verifyServerAdminRole(currentUser) {
+                    throw UnauthorizedException.Single(
+                        EntityType.PROJECT,
+                        projectId.toString(),
+                        AccessType.READ,
+                        it,
+                    )
+                }
             }
+
+            val paper = paperRepo.getPaperById(projectPaper.paperId).getOrThrow()
+            val authors = authorOfPaperTableRepo
+                .getAuthorsOfPaperById(paper.id)
+                .map { it.toGrpcAuthor() }
+
+            val backwardReferences = citationTableRepo
+                .getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+                .map { it.toString() }
+
+            val reviews = reviewTableRepo
+                .getAllReviewsForProjectPaper(projectPaper.id)
+                .map {
+                    val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
+                    it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+                }
+
+            ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
         }
 
-        val paper = paperRepo.getPaperById(projectPaper.paperId).getOrThrow()
-        val authors = authorOfPaperTableRepo
-            .getAuthorsOfPaperById(paper.id)
-            .map { it.toGrpcAuthor() }
-
-        val backwardReferences = citationTableRepo
-            .getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            .map { it.toString() }
-
-        val reviews = reviewTableRepo
-            .getAllReviewsForProjectPaper(projectPaper.id)
-            .map {
-                val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
-                it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
-            }
-
-        return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
-    }
-
-    override suspend fun getProjectById(request: Base.Id): GrpcProject {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun getProjectById(request: Base.Id): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
         if (!isProjectMember(projectId, currentUser.id)) {
@@ -298,11 +292,11 @@ class ProjectService(
                 )
             }
         }
-        return repo.getProjectById(projectId).getOrThrow().toGrpcProject()
+
+        repo.getProjectById(projectId).getOrThrow().toGrpcProject()
     }
 
-    override suspend fun createProject(request: GrpcProject.Create): GrpcProject {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun createProject(request: GrpcProject.Create): GrpcProject = withUser(userRepo) { currentUser ->
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
@@ -320,16 +314,14 @@ class ProjectService(
 
             criterionRepo.createCriterion(criterionRequest, currentUser.id)
         }
-        return project.toGrpcProject()
+
+        project.toGrpcProject()
     }
 
-    override suspend fun getAllProjects(): GrpcProject.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-
+    override suspend fun getAllProjects(): GrpcProject.List = withUser(userRepo) { currentUser ->
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, it) }
 
-        val projects = repo.getAllProjects()
-        return projects.toGrpcProjects()
+        repo.getAllProjects().toGrpcProjects()
     }
 
     override suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List {
@@ -356,8 +348,7 @@ class ProjectService(
         return deletedUserProjects.toGrpcProjects()
     }
 
-    override suspend fun updateProject(request: GrpcProject.Update): GrpcProject {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun updateProject(request: GrpcProject.Update): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
         val project = repo.getProjectById(projectId).getOrThrow()
         val isProjectAdmin = projectMemberRepo.getAllProjectAdmins(projectId).any { it.userId == currentUser.id }
@@ -384,27 +375,28 @@ class ProjectService(
             )
         }
 
-        return repo.updateProject(request, projectStatus).toGrpcProject()
+        repo.updateProject(request, projectStatus).toGrpcProject()
     }
 
-    override suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val projectId = parseUUID(request.id, EntityType.PROJECT)
-        repo.getProjectById(projectId)
-        val projectMembersWithUsers = projectMemberRepo.getProjectMembersWithUsers(projectId)
+    override suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.id, EntityType.PROJECT)
+            repo.getProjectById(projectId)
+            val projectMembersWithUsers = projectMemberRepo.getProjectMembersWithUsers(projectId)
 
-        if (!projectMembersWithUsers.any { it.user.id == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
+            if (!projectMembersWithUsers.any { it.user.id == currentUser.id }) {
+                verifyServerAdminRole(currentUser) {
+                    throw UnauthorizedException.Single(
+                        EntityType.PROJECT,
+                        projectId.toString(),
+                        AccessType.READ,
+                        it,
+                    )
+                }
             }
+
+            projectMembersWithUsers.toGrpcProjectMembers()
         }
-        return projectMembersWithUsers.toGrpcProjectMembers()
-    }
 
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProject.Paper {
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
@@ -441,38 +433,38 @@ class ProjectService(
         return getProjectPapers(request, predicate)
     }
 
-    override suspend fun addPaperToProject(request: GrpcProjectPaper.Add): GrpcProjectPaper {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+    override suspend fun addPaperToProject(request: GrpcProjectPaper.Add): GrpcProjectPaper =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-        if (!isProjectMember(projectId, currentUser.id)) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
+            if (!isProjectMember(projectId, currentUser.id)) {
+                verifyServerAdminRole(currentUser) {
+                    throw UnauthorizedException.Single(
+                        EntityType.PROJECT,
+                        projectId.toString(),
+                        AccessType.READ,
+                        it,
+                    )
+                }
+            }
+
+            val paperId = parseUUID(request.paperId, EntityType.PAPER)
+            val project = repo.getProjectById(projectId).getOrThrow()
+            val paper = paperRepo.getPaperById(paperId).getOrThrow()
+            if (projectPaperRepo.doesProjectPaperExist(projectId, paperId)) {
+                throw SnowballRException.DuplicateEntityException(
+                    EntityType.PROJECT_PAPER,
                     projectId.toString(),
-                    AccessType.READ,
-                    it,
+                    paperId.toString(),
                 )
             }
+
+            if (request.stage !in 0..project.maxStage) {
+                throw SnowballRException.OutOfRangeException.Stage(request.stage, project.maxStage)
+            }
+
+            val projectPaper = projectPaperRepo.addPaperToProject(request, currentUser.id)
+
+            getGrpcProjectPaper(paper, projectPaper)
         }
-
-        val paperId = parseUUID(request.paperId, EntityType.PAPER)
-        val project = repo.getProjectById(projectId).getOrThrow()
-        val paper = paperRepo.getPaperById(paperId).getOrThrow()
-        if (projectPaperRepo.doesProjectPaperExist(projectId, paperId)) {
-            throw SnowballRException.DuplicateEntityException(
-                EntityType.PROJECT_PAPER,
-                projectId.toString(),
-                paperId.toString(),
-            )
-        }
-
-        if (request.stage !in 0..project.maxStage) {
-            throw SnowballRException.OutOfRangeException.Stage(request.stage, project.maxStage)
-        }
-
-        val projectPaper = projectPaperRepo.addPaperToProject(request, currentUser.id)
-
-        return getGrpcProjectPaper(paper, projectPaper)
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -265,7 +265,7 @@ class ProjectService(
             }
         }
 
-        val paper = paperRepo.getPaperById(projectPaper.paperId)
+        val paper = paperRepo.getPaperById(projectPaper.paperId).getOrThrow()
         val authors = authorOfPaperTableRepo
             .getAuthorsOfPaperById(paper.id)
             .map { it.toGrpcAuthor() }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -12,6 +12,7 @@ import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
@@ -154,6 +155,14 @@ class ProjectService(
         return projectMembers.any { it.userId == currentUserId }
     }
 
+    private suspend fun ensureCurrentUserIsProjectMember(projectId: UUID, currentUser: User) {
+        if (isProjectMember(projectId, currentUser.id)) return
+
+        verifyServerAdminRole(currentUser) {
+            throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
+        }
+    }
+
     /**
      * Converts a combination of [Paper] and [ProjectPaper] into a gRPC-compatible [GrpcProjectPaper] object.
      * This includes enriching the data with associated authors, backward references, and reviews.
@@ -197,11 +206,7 @@ class ProjectService(
             throw NotFoundException(EntityType.PROJECT, projectId.toString())
         }
 
-        if (!isProjectMember(projectId, currentUser.id)) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
-            }
-        }
+        ensureCurrentUserIsProjectMember(projectId, currentUser)
 
         var projectPapersWithPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
         val paperAuthorsMap = mutableMapOf<Paper, List<GrpcAuthor>>()
@@ -239,13 +244,7 @@ class ProjectService(
      */
     private suspend fun loadAndAuthorizeProjectPaper(projectPaper: ProjectPaper, projectId: UUID): GrpcProjectPaper =
         withUser(userRepo) { currentUser ->
-            val projectMembers = projectMemberRepo.getProjectMembers(projectId)
-
-            if (projectMembers.none { it.userId == currentUser.id }) {
-                verifyServerAdminRole(currentUser) {
-                    throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
-                }
-            }
+            ensureCurrentUserIsProjectMember(projectId, currentUser)
 
             val paper = paperRepo.getPaperById(projectPaper.paperId).getOrThrow()
             val authors = authorOfPaperTableRepo
@@ -269,11 +268,7 @@ class ProjectService(
     override suspend fun getProjectById(request: Base.Id): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-        if (!isProjectMember(projectId, currentUser.id)) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
-            }
-        }
+        ensureCurrentUserIsProjectMember(projectId, currentUser)
 
         repo.getProjectById(projectId).getOrThrow().toGrpcProject()
     }
@@ -401,11 +396,7 @@ class ProjectService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-            if (!isProjectMember(projectId, currentUser.id)) {
-                verifyServerAdminRole(currentUser) {
-                    throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
-                }
-            }
+            ensureCurrentUserIsProjectMember(projectId, currentUser)
 
             val paperId = parseUUID(request.paperId, EntityType.PAPER)
             val project = repo.getProjectById(projectId).getOrThrow()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -3,8 +3,10 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
@@ -165,13 +167,12 @@ class ProjectService(
      */
     private suspend fun getGrpcProjectPaper(paper: Paper, projectPaper: ProjectPaper): GrpcProjectPaper {
         val authors = authorOfPaperTableRepo.getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
-        val backwardReferences = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(
-            paper.id,
-        ).map { it.toString() }
+        val backwardReferences = citationTableRepo
+            .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map(UUID::toString)
         val reviews = reviewTableRepo.getAllReviewsForProjectPaper(projectPaper.id)
             .map {
                 val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
-                it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
+                it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
             }
         return ProjectPaperWithPaper(projectPaper, paper).toGrpcProjectPaper(authors, backwardReferences, reviews)
     }
@@ -199,12 +200,7 @@ class ProjectService(
 
         if (!isProjectMember(projectId, currentUser.id)) {
             verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
+                throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
             }
         }
 
@@ -217,15 +213,12 @@ class ProjectService(
             paperAuthorsMap[paper] = authorOfPaperTableRepo
                 .getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
             paperBackwardReferencesMap[paper] = citationTableRepo
-                .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map {
-                    it.toString()
-                }
+                .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map(UUID::toString)
             projectPaperReviewsMap[projectPaper.projectPaper] = reviewTableRepo
                 .getAllReviewsForProjectPaper(projectPaper.projectPaper.id)
                 .map {
-                    val selectedCriteriaIds = reviewHasCriterionTableRepo
-                        .getSelectedCriteriaIdsForReviewById(it.id)
-                    it.toGrpcReview(selectedCriteriaIds.map { criterion -> criterion.toString() })
+                    val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
+                    it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
                 }
         }
         projectPapersWithPapers = predicate?.let { pred ->
@@ -251,12 +244,7 @@ class ProjectService(
 
             if (projectMembers.none { it.userId == currentUser.id }) {
                 verifyServerAdminRole(currentUser) {
-                    throw UnauthorizedException.Single(
-                        EntityType.PROJECT,
-                        projectId.toString(),
-                        AccessType.READ,
-                        it,
-                    )
+                    throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
                 }
             }
 
@@ -284,12 +272,7 @@ class ProjectService(
 
         if (!isProjectMember(projectId, currentUser.id)) {
             verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
+                throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
             }
         }
 
@@ -353,23 +336,14 @@ class ProjectService(
 
         if (!isProjectAdmin) {
             verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    request.project.id,
-                    AccessType.UPDATE,
-                    it,
-                )
+                throw UnauthorizedException.Single(EntityType.PROJECT, request.project.id, AccessType.UPDATE, it)
             }
         }
         if (project.status == ProjectStatus.PROJECT_STATUS_DELETED) {
-            throw SnowballRException.FailedPreconditionException(
-                "The project with the id ${request.project.id} is deleted.",
-            )
+            throw FailedPreconditionException("The project with the id ${request.project.id} is deleted.")
         }
         if (request.project.status == ProjectStatus.PROJECT_STATUS_DELETED) {
-            throw SnowballRException.FailedPreconditionException(
-                "The project status can not be set to deleted by an update call.",
-            )
+            throw FailedPreconditionException("The project status can not be set to deleted by an update call.")
         }
 
         repo.updateProject(request, projectStatus).toGrpcProject()
@@ -378,17 +352,12 @@ class ProjectService(
     override suspend fun getProjectMembers(request: Base.Id): GrpcProject.Member.List =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
-            repo.getProjectById(projectId)
+            repo.getProjectById(projectId).getOrThrow()
             val projectMembersWithUsers = projectMemberRepo.getProjectMembersWithUsers(projectId)
 
             if (!projectMembersWithUsers.any { it.user.id == currentUser.id }) {
                 verifyServerAdminRole(currentUser) {
-                    throw UnauthorizedException.Single(
-                        EntityType.PROJECT,
-                        projectId.toString(),
-                        AccessType.READ,
-                        it,
-                    )
+                    throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
                 }
             }
 
@@ -408,7 +377,7 @@ class ProjectService(
         }
 
         val relativeId = request.relativeProjectPaperId.toLong()
-        val projectPaper = projectPaperRepo.getProjectPaperByRelativeId(projectId, relativeId)
+        val projectPaper = projectPaperRepo.getProjectPaperByRelativeId(projectId, relativeId).getOrThrow()
         return loadAndAuthorizeProjectPaper(projectPaper, projectId)
     }
 
@@ -436,12 +405,7 @@ class ProjectService(
 
             if (!isProjectMember(projectId, currentUser.id)) {
                 verifyServerAdminRole(currentUser) {
-                    throw UnauthorizedException.Single(
-                        EntityType.PROJECT,
-                        projectId.toString(),
-                        AccessType.READ,
-                        it,
-                    )
+                    throw UnauthorizedException.Single(EntityType.PROJECT, projectId.toString(), AccessType.READ, it)
                 }
             }
 
@@ -449,15 +413,11 @@ class ProjectService(
             val project = repo.getProjectById(projectId).getOrThrow()
             val paper = paperRepo.getPaperById(paperId).getOrThrow()
             if (projectPaperRepo.doesProjectPaperExist(projectId, paperId)) {
-                throw SnowballRException.DuplicateEntityException(
-                    EntityType.PROJECT_PAPER,
-                    projectId.toString(),
-                    paperId.toString(),
-                )
+                throw DuplicateEntityException(EntityType.PROJECT_PAPER, projectId.toString(), paperId.toString())
             }
 
             if (request.stage !in 0..project.maxStage) {
-                throw SnowballRException.OutOfRangeException.Stage(request.stage, project.maxStage)
+                throw OutOfRangeException.Stage(request.stage, project.maxStage)
             }
 
             val projectPaper = projectPaperRepo.addPaperToProject(request, currentUser.id)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
@@ -73,9 +73,9 @@ class ReadingListService(
     override suspend fun getReadingList(): GrpcPaper.List = withUser(userRepo) { currentUser ->
         val papers = repo.getAllReadingListEntries(currentUser.id).map { paper ->
             val authors = authorOfPaperRepo.getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
-            val backwardReferences = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(
-                paper.id,
-            ).map { it.toString() }
+            val backwardReferences = citationRepo
+                .getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+                .map(UUID::toString)
             paper.toGrpcPaper(authors, backwardReferences)
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
@@ -69,7 +69,7 @@ class ReadingListService(
     }
 
     override suspend fun getReadingList(): PaperOuterClass.Paper.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val papers = repo.getAllReadingListEntries(currentUser.id).map { paper ->
             val authors = authorOfPaperRepo.getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
             val backwardReferences = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(
@@ -84,7 +84,7 @@ class ReadingListService(
     }
 
     override suspend fun isPaperOnReadingList(paperId: Base.Id): Base.BoolValue {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val paperUuid = parseUUID(paperId.id, EntityType.PAPER)
         throwIfPaperDoesNotExist(paperUuid)
         return Base.BoolValue
@@ -99,7 +99,7 @@ class ReadingListService(
     }
 
     override suspend fun addPaperToReadingList(paperId: Base.Id): Base.Nothing {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val paperUuid = parseUUID(paperId.id, EntityType.PAPER)
         throwIfPaperDoesNotExist(paperUuid)
         repo.createReadingListEntry(currentUser.id, paperUuid)
@@ -107,7 +107,7 @@ class ReadingListService(
     }
 
     override suspend fun removePaperFromReadingList(paperId: Base.Id): Base.Nothing {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val paperUuid = parseUUID(paperId.id, EntityType.PAPER)
         throwIfPaperDoesNotExist(paperUuid)
         repo.removeReadingListEntry(currentUser.id, paperUuid)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
@@ -1,11 +1,11 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcPapers
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -13,29 +13,31 @@ import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import snowballr.Base
-import snowballr.PaperOuterClass
+import snowballr.boolValue
+import snowballr.nothing
 import java.util.UUID
+import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface IReadingListService {
     /**
      * Service implementation of [SnowballRService.getReadingList].
      */
-    suspend fun getReadingList(): PaperOuterClass.Paper.List
+    suspend fun getReadingList(): GrpcPaper.List
 
     /**
      * Service implementation of [SnowballRService.isPaperOnReadingList].
      */
-    suspend fun isPaperOnReadingList(paperId: Base.Id): Base.BoolValue
+    suspend fun isPaperOnReadingList(request: Base.Id): Base.BoolValue
 
     /**
      * Service implementation of [SnowballRService.addPaperToReadingList].
      */
-    suspend fun addPaperToReadingList(paperId: Base.Id): Base.Nothing
+    suspend fun addPaperToReadingList(request: Base.Id): Base.Nothing
 
     /**
      * Service implementation of [SnowballRService.removePaperFromReadingList].
      */
-    suspend fun removePaperFromReadingList(paperId: Base.Id): Base.Nothing
+    suspend fun removePaperFromReadingList(request: Base.Id): Base.Nothing
 }
 
 /**
@@ -68,8 +70,7 @@ class ReadingListService(
         }
     }
 
-    override suspend fun getReadingList(): PaperOuterClass.Paper.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun getReadingList(): GrpcPaper.List = withUser(userRepo) { currentUser ->
         val papers = repo.getAllReadingListEntries(currentUser.id).map { paper ->
             val authors = authorOfPaperRepo.getAuthorsOfPaperById(paper.id).map { it.toGrpcAuthor() }
             val backwardReferences = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(
@@ -77,40 +78,33 @@ class ReadingListService(
             ).map { it.toString() }
             paper.toGrpcPaper(authors, backwardReferences)
         }
-        return PaperOuterClass.Paper.List
-            .newBuilder()
-            .addAllPapers(papers)
-            .build()
+
+        papers.toGrpcPapers()
     }
 
-    override suspend fun isPaperOnReadingList(paperId: Base.Id): Base.BoolValue {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val paperUuid = parseUUID(paperId.id, EntityType.PAPER)
-        throwIfPaperDoesNotExist(paperUuid)
-        return Base.BoolValue
-            .newBuilder()
-            .setValue(
-                repo.isPaperOnReadingList(
-                    currentUser.id,
-                    paperUuid,
-                ),
-            )
-            .build()
+    override suspend fun isPaperOnReadingList(request: Base.Id): Base.BoolValue = withUser(userRepo) { currentUser ->
+        val paperId = parseUUID(request.id, EntityType.PAPER)
+        throwIfPaperDoesNotExist(paperId)
+
+        boolValue { value = repo.isPaperOnReadingList(currentUser.id, paperId) }
     }
 
-    override suspend fun addPaperToReadingList(paperId: Base.Id): Base.Nothing {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val paperUuid = parseUUID(paperId.id, EntityType.PAPER)
-        throwIfPaperDoesNotExist(paperUuid)
-        repo.createReadingListEntry(currentUser.id, paperUuid)
-        return Base.Nothing.newBuilder().build()
+    override suspend fun addPaperToReadingList(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
+        val paperId = parseUUID(request.id, EntityType.PAPER)
+
+        throwIfPaperDoesNotExist(paperId)
+        repo.createReadingListEntry(currentUser.id, paperId)
+
+        nothing { }
     }
 
-    override suspend fun removePaperFromReadingList(paperId: Base.Id): Base.Nothing {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val paperUuid = parseUUID(paperId.id, EntityType.PAPER)
-        throwIfPaperDoesNotExist(paperUuid)
-        repo.removeReadingListEntry(currentUser.id, paperUuid)
-        return Base.Nothing.newBuilder().build()
-    }
+    override suspend fun removePaperFromReadingList(request: Base.Id): Base.Nothing =
+        withUser(userRepo) { currentUser ->
+            val paperId = parseUUID(request.id, EntityType.PAPER)
+
+            throwIfPaperDoesNotExist(paperId)
+            repo.removeReadingListEntry(currentUser.id, paperId)
+
+            nothing { }
+        }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -59,7 +59,7 @@ class ReviewService(
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val reviewId = parseUUID(request.id, EntityType.REVIEW)
         val review = repo.getReviewById(reviewId)
-        val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId)
+        val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId).getOrThrow()
         val projectId = projectRepo.getProjectById(projectPaper.projectId).id
 
         val projectMembers = projectMemberRepo.getProjectMembers(projectId)
@@ -81,7 +81,7 @@ class ReviewService(
     override suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
-        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId)
+        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
         val projectId = projectRepo.getProjectById(projectPaper.projectId).id
 
         val projectMembers = projectMemberRepo.getProjectMembers(projectId)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -60,7 +60,7 @@ class ReviewService(
     override suspend fun getReviewById(request: Base.Id): GrpcReview {
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val reviewId = parseUUID(request.id, EntityType.REVIEW)
-        val review = repo.getReviewById(reviewId)
+        val review = repo.getReviewById(reviewId).getOrThrow()
         val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId).getOrThrow()
 
         ensureCurrentUserIsProjectMember(projectPaper.projectId, currentUser)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -88,7 +88,7 @@ class ReviewService(
     }
 
     private suspend fun ensureCurrentUserIsProjectMember(projectId: UUID, currentUser: User) {
-        val project = projectRepo.getProjectById(projectId)
+        val project = projectRepo.getProjectById(projectId).getOrThrow()
         val projectMembers = projectMemberRepo.getProjectMembers(project.id)
         val isProjectMember = projectMembers.any { it.userId == currentUser.id }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -6,6 +6,7 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcReview
 import se.uulm.snowballr.backend.model.dto.toGrpcReviews
 import se.uulm.snowballr.backend.model.parseUUID
@@ -16,6 +17,7 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
 import snowballr.Base
+import java.util.UUID
 import snowballr.ReviewOuterClass.Review as GrpcReview
 
 interface IReviewService {
@@ -60,20 +62,9 @@ class ReviewService(
         val reviewId = parseUUID(request.id, EntityType.REVIEW)
         val review = repo.getReviewById(reviewId)
         val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId).getOrThrow()
-        val projectId = projectRepo.getProjectById(projectPaper.projectId).id
 
-        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
+        ensureCurrentUserIsProjectMember(projectPaper.projectId, currentUser)
 
-        if (!projectMembers.any { it.userId == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
-            }
-        }
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(reviewId)
         return review.toGrpcReview(selectedCriteriaIds.map { it.toString() })
     }
@@ -82,20 +73,8 @@ class ReviewService(
         val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
-        val projectId = projectRepo.getProjectById(projectPaper.projectId).id
 
-        val projectMembers = projectMemberRepo.getProjectMembers(projectId)
-
-        if (!projectMembers.any { it.userId == currentUser.id }) {
-            verifyServerAdminRole(currentUser) {
-                throw UnauthorizedException.Single(
-                    EntityType.PROJECT,
-                    projectId.toString(),
-                    AccessType.READ,
-                    it,
-                )
-            }
-        }
+        ensureCurrentUserIsProjectMember(projectPaper.projectId, currentUser)
 
         val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
         val reviewSelectedCriteriaMap = mutableMapOf<Review, List<String>>()
@@ -106,5 +85,17 @@ class ReviewService(
                 }
         }
         return reviews.toGrpcReviews(reviewSelectedCriteriaMap)
+    }
+
+    private suspend fun ensureCurrentUserIsProjectMember(projectId: UUID, currentUser: User) {
+        val project = projectRepo.getProjectById(projectId)
+        val projectMembers = projectMemberRepo.getProjectMembers(project.id)
+        val isProjectMember = projectMembers.any { it.userId == currentUser.id }
+
+        if (!isProjectMember) {
+            verifyServerAdminRole(currentUser) {
+                throw UnauthorizedException.Single(EntityType.PROJECT, project.id.toString(), AccessType.READ, it)
+            }
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
@@ -57,8 +56,7 @@ class ReviewService(
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val reviewHasCriterionRepo: IReviewHasCriterionTableRepo,
 ) : IReviewService {
-    override suspend fun getReviewById(request: Base.Id): GrpcReview {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun getReviewById(request: Base.Id): GrpcReview = withUser(userRepo) { currentUser ->
         val reviewId = parseUUID(request.id, EntityType.REVIEW)
         val review = repo.getReviewById(reviewId).getOrThrow()
         val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId).getOrThrow()
@@ -66,26 +64,28 @@ class ReviewService(
         ensureCurrentUserIsProjectMember(projectPaper.projectId, currentUser)
 
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(reviewId)
-        return review.toGrpcReview(selectedCriteriaIds.map { it.toString() })
+
+        review.toGrpcReview(selectedCriteriaIds.map { it.toString() })
     }
 
-    override suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
-        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
+    override suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List =
+        withUser(userRepo) { currentUser ->
+            val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
+            val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
 
-        ensureCurrentUserIsProjectMember(projectPaper.projectId, currentUser)
+            ensureCurrentUserIsProjectMember(projectPaper.projectId, currentUser)
 
-        val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
-        val reviewSelectedCriteriaMap = mutableMapOf<Review, List<String>>()
-        for (review in reviews) {
-            reviewSelectedCriteriaMap[review] = reviewHasCriterionRepo
-                .getSelectedCriteriaIdsForReviewById(review.id).map {
-                    it.toString()
-                }
+            val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
+            val reviewSelectedCriteriaMap = mutableMapOf<Review, List<String>>()
+            for (review in reviews) {
+                reviewSelectedCriteriaMap[review] = reviewHasCriterionRepo
+                    .getSelectedCriteriaIdsForReviewById(review.id).map {
+                        it.toString()
+                    }
+            }
+
+            reviews.toGrpcReviews(reviewSelectedCriteriaMap)
         }
-        return reviews.toGrpcReviews(reviewSelectedCriteriaMap)
-    }
 
     private suspend fun ensureCurrentUserIsProjectMember(projectId: UUID, currentUser: User) {
         val project = projectRepo.getProjectById(projectId).getOrThrow()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -58,7 +58,7 @@ class ReviewService(
     private val reviewHasCriterionRepo: IReviewHasCriterionTableRepo,
 ) : IReviewService {
     override suspend fun getReviewById(request: Base.Id): GrpcReview {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val reviewId = parseUUID(request.id, EntityType.REVIEW)
         val review = repo.getReviewById(reviewId).getOrThrow()
         val projectPaper = projectPaperRepo.getProjectPaperById(review.projectPaperId).getOrThrow()
@@ -70,7 +70,7 @@ class ReviewService(
     }
 
     override suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -37,8 +37,8 @@ fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRExcepti
  * @param accessType The type of access being attempted, used to construct the exception if unauthorized.
  */
 suspend fun authorizeAccessTo(requestedUserId: UUID, userRepo: IUserTableRepo, accessType: AccessType) {
-    val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-    val requestedUser = userRepo.getUserById(requestedUserId)
+    val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    val requestedUser = userRepo.getUserById(requestedUserId).getOrThrow()
 
     if (currentUser.id != requestedUser.id) {
         verifyServerAdminRole(currentUser) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -12,10 +11,10 @@ import java.util.UUID
 /**
  * Verifies that the [user] has the role [UserRole.USER_ROLE_ADMIN].
  *
- * If the user is not a server admin, a [SnowballRException.UnauthorizedException] is thrown.
+ * If the user is not a server admin, a [UnauthorizedException] is thrown.
  *
  * @param user The user to verify
- * @param getException Getter method for the subtype of [SnowballRException.UnauthorizedException], which is thrown
+ * @param getException Getter method for the subtype of [UnauthorizedException], which is thrown
  * when the user is not a server admin.
  */
 fun verifyServerAdminRole(user: User, getException: (String) -> UnauthorizedException) {
@@ -37,16 +36,11 @@ fun verifyServerAdminRole(user: User, getException: (String) -> UnauthorizedExce
  * @param accessType The type of access being attempted, used to construct the exception if unauthorized.
  */
 suspend fun authorizeAccessTo(currentUser: User, targetUserId: UUID, userRepo: IUserTableRepo, accessType: AccessType) {
-    val requestedUser = userRepo.getUserById(targetUserId).getOrThrow()
+    val targetUser = userRepo.getUserById(targetUserId).getOrThrow()
 
-    if (currentUser.id != requestedUser.id) {
+    if (currentUser.id != targetUser.id) {
         verifyServerAdminRole(currentUser) {
-            UnauthorizedException.Single(
-                EntityType.USER,
-                targetUserId.toString(),
-                accessType,
-                it,
-            )
+            UnauthorizedException.Single(EntityType.USER, targetUserId.toString(), accessType, it)
         }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceChecks.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.service
 
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import snowballr.UserOuterClass.UserRole
@@ -18,7 +18,7 @@ import java.util.UUID
  * @param getException Getter method for the subtype of [SnowballRException.UnauthorizedException], which is thrown
  * when the user is not a server admin.
  */
-fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRException.UnauthorizedException) {
+fun verifyServerAdminRole(user: User, getException: (String) -> UnauthorizedException) {
     if (user.role != UserRole.USER_ROLE_ADMIN) {
         throw getException(user.id.toString())
     }
@@ -27,24 +27,23 @@ fun verifyServerAdminRole(user: User, getException: (String) -> SnowballRExcepti
 /**
  * Authorizes access to a user's resources based on the requesting user's identity and role.
  *
- * This method checks whether the requesting user is the same as the
- * target user identified by [requestedUserId]. If the users differ, the method verifies that the
- * requesting user has the server admin role. If neither condition is met, an
- * [SnowballRException.UnauthorizedException] is thrown.
+ * This method checks whether the requesting user is the same as the target user identified by [targetUserId]. If the
+ * users differ, the method verifies that the requesting user has the server admin role. If neither condition is met, an
+ * [UnauthorizedException] is thrown.
  *
- * @param requestedUserId The ID of the user whose resource is being accessed.
+ * @param currentUser The user who is attempting to access the resource.
+ * @param targetUserId The ID of the user whose resource is being accessed.
  * @param userRepo The user repository used to retrieve user data.
  * @param accessType The type of access being attempted, used to construct the exception if unauthorized.
  */
-suspend fun authorizeAccessTo(requestedUserId: UUID, userRepo: IUserTableRepo, accessType: AccessType) {
-    val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-    val requestedUser = userRepo.getUserById(requestedUserId).getOrThrow()
+suspend fun authorizeAccessTo(currentUser: User, targetUserId: UUID, userRepo: IUserTableRepo, accessType: AccessType) {
+    val requestedUser = userRepo.getUserById(targetUserId).getOrThrow()
 
     if (currentUser.id != requestedUser.id) {
         verifyServerAdminRole(currentUser) {
-            SnowballRException.UnauthorizedException.Single(
+            UnauthorizedException.Single(
                 EntityType.USER,
-                requestedUserId.toString(),
+                targetUserId.toString(),
                 accessType,
                 it,
             )

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceHelper.kt
@@ -1,11 +1,14 @@
 package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 
 /**
  * Fetches the current user using the [userRepo] and executes the [block] with the current user as parameter.
+ *
+ * @throws NotFoundException if the current user does not exist.
  */
 suspend fun <T> withUser(userRepo: IUserTableRepo, block: suspend (User) -> T): T {
     val user = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceHelper.kt
@@ -1,0 +1,13 @@
+package se.uulm.snowballr.backend.service
+
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.repository.IUserTableRepo
+
+/**
+ * Fetches the current user using the [userRepo] and executes the [block] with the current user as parameter.
+ */
+suspend fun <T> withUser(userRepo: IUserTableRepo, block: suspend (User) -> T): T {
+    val user = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    return block(user)
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -35,6 +35,7 @@ import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import snowballr.UserSettingsOuterClass
+import snowballr.nothing
 import java.time.OffsetDateTime
 import java.util.UUID
 import snowballr.UserOuterClass.User as GrpcUser
@@ -157,8 +158,7 @@ class UserService(
         )
     }
 
-    override suspend fun getUserById(request: Base.Id): GrpcUser {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun getUserById(request: Base.Id): GrpcUser = withUser(userRepo) { currentUser ->
         val targetUserId = parseUUID(request.id, EntityType.USER)
 
         verifyUserAccess(currentUser, targetUserId, IdentifierType.ID)
@@ -180,12 +180,10 @@ class UserService(
             throw NotFoundException(EntityType.USER, request.id)
         }
 
-        return result.toGrpcUser()
+        result.toGrpcUser()
     }
 
-    override suspend fun getUserByEmail(request: Base.Email): GrpcUser {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-
+    override suspend fun getUserByEmail(request: Base.Email): GrpcUser = withUser(userRepo) { currentUser ->
         // We have to request the user first to get the ID for the access checks
         val targetUser = userRepo.getUserByEmail(request.email).getOrThrow()
 
@@ -198,17 +196,13 @@ class UserService(
             throw NotFoundException(EntityType.USER, request.email, identifierType = IdentifierType.EMAIL)
         }
 
-        return targetUser.toGrpcUser()
+        targetUser.toGrpcUser()
     }
 
-    override suspend fun getAllUsers(): GrpcUser.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-
+    override suspend fun getAllUsers(): GrpcUser.List = withUser(userRepo) { currentUser ->
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.USER, AccessType.READ, it) }
 
-        val users = userRepo.getAllUsers()
-
-        return users.toGrpcUsers()
+        userRepo.getAllUsers().toGrpcUsers()
     }
 
     override suspend fun getInviteCandidates(
@@ -328,9 +322,7 @@ class UserService(
         return Base.Nothing.getDefaultInstance()
     }
 
-    override suspend fun updateUser(request: GrpcUser.Update): GrpcUser {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-
+    override suspend fun updateUser(request: GrpcUser.Update): GrpcUser = withUser(userRepo) { currentUser ->
         // Check that user to update exists in the database
         val targetUserId = parseUUID(request.user.id, EntityType.USER)
         val targetUser = userRepo.getUserById(targetUserId).getOrThrow()
@@ -348,12 +340,10 @@ class UserService(
             throw DuplicateEntityException(EntityType.USER, request.user.email, identifierType = IdentifierType.EMAIL)
         }
 
-        val updatedUser = userRepo.updateUser(request)
-        return updatedUser.toGrpcUser()
+        userRepo.updateUser(request).toGrpcUser()
     }
 
-    override suspend fun softDeleteUser(request: Base.Id): Base.Nothing {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun softDeleteUser(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
         val targetUser = userRepo.getUserById(parseUUID(request.id, EntityType.USER)).getOrThrow()
         val isSameUser = currentUser.id == targetUser.id
 
@@ -373,14 +363,13 @@ class UserService(
         }
 
         userRepo.softDeleteUser(targetUser.id)
-        return Base.Nothing.getDefaultInstance()
+
+        nothing { }
     }
 
-    override suspend fun getCurrentUser(): GrpcUser =
-        userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow().toGrpcUser()
+    override suspend fun getCurrentUser(): GrpcUser = withUser(userRepo, User::toGrpcUser)
 
-    override suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+    override suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings = withUser(userRepo) { currentUser ->
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val defaultUserCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
@@ -396,6 +385,7 @@ class UserService(
                     .build(),
             )
         }
-        return userSettings.toGrpcUserSettings(criteria)
+
+        userSettings.toGrpcUserSettings(criteria)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -31,7 +31,7 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Authentication
 import snowballr.Base
 import snowballr.CriterionOuterClass
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import snowballr.UserSettingsOuterClass
@@ -62,7 +62,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.getInviteCandidates]
      */
-    suspend fun getInviteCandidates(request: ProjectOuterClass.Project.InviteCandidatesRequest): GrpcUser.List
+    suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): GrpcUser.List
 
     /**
      * Service implementation of [SnowballRService.register].
@@ -205,9 +205,7 @@ class UserService(
         userRepo.getAllUsers().toGrpcUsers()
     }
 
-    override suspend fun getInviteCandidates(
-        request: ProjectOuterClass.Project.InviteCandidatesRequest,
-    ): GrpcUser.List {
+    override suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): GrpcUser.List {
         val searchQuery = request.query.trim()
 
         // Check whether the search query is too short, i.e., 3 or fewer characters long

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -158,7 +158,7 @@ class UserService(
     }
 
     override suspend fun getUserById(request: Base.Id): GrpcUser {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val targetUserId = parseUUID(request.id, EntityType.USER)
 
         verifyUserAccess(currentUser, targetUserId, IdentifierType.ID)
@@ -170,7 +170,7 @@ class UserService(
             if (isRequestedUser) {
                 currentUser
             } else {
-                userRepo.getUserById(targetUserId)
+                userRepo.getUserById(targetUserId).getOrThrow()
             }
 
         // Only active or active unconfirmed users can be retrieved
@@ -184,10 +184,10 @@ class UserService(
     }
 
     override suspend fun getUserByEmail(request: Base.Email): GrpcUser {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
 
         // We have to request the user first to get the ID for the access checks
-        val targetUser = userRepo.getUserByEmail(request.email)
+        val targetUser = userRepo.getUserByEmail(request.email).getOrThrow()
 
         verifyUserAccess(currentUser, targetUser.id, IdentifierType.EMAIL)
 
@@ -202,7 +202,7 @@ class UserService(
     }
 
     override suspend fun getAllUsers(): GrpcUser.List {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
 
         verifyServerAdminRole(currentUser) { UnauthorizedException.All(EntityType.USER, AccessType.READ, it) }
 
@@ -221,7 +221,7 @@ class UserService(
             return GrpcUser.List.getDefaultInstance()
         }
 
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
         val excludedUsersFromSearch = mutableSetOf(currentUser.id)
         try {
             val projectMembers = projectMemberRepo.getProjectMembers(parseUUID(request.projectId, EntityType.PROJECT))
@@ -274,7 +274,7 @@ class UserService(
         }
 
         // Check whether the user exists
-        val user = userRepo.getUserById(verificationToken.userId)
+        val user = userRepo.getUserById(verificationToken.userId).getOrThrow()
 
         // Update the user's status to active
         val updatedUser = user.copy(status = UserStatus.USER_STATUS_ACTIVE)
@@ -300,7 +300,7 @@ class UserService(
         // Check whether a user with the given email exists
         val user =
             try {
-                userRepo.getUserByEmail(request.email)
+                userRepo.getUserByEmail(request.email).getOrThrow()
             } catch (_: NotFoundException) {
                 throw UnauthenticatedException()
             }
@@ -312,7 +312,7 @@ class UserService(
 
         // Verify the password against the stored hash
         val storedPasswordHash = try {
-            userRepo.getPasswordHashByEmail(request.email)
+            userRepo.getPasswordHashByEmail(request.email).getOrThrow()
         } catch (_: NotFoundException) {
             throw UnauthenticatedException()
         }
@@ -329,11 +329,11 @@ class UserService(
     }
 
     override suspend fun updateUser(request: GrpcUser.Update): GrpcUser {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
 
         // Check that user to update exists in the database
         val targetUserId = parseUUID(request.user.id, EntityType.USER)
-        val targetUser = userRepo.getUserById(targetUserId)
+        val targetUser = userRepo.getUserById(targetUserId).getOrThrow()
 
         // Check whether the current user is a server admin if the role is changed or the requested user is different
         // from the current user
@@ -353,8 +353,8 @@ class UserService(
     }
 
     override suspend fun softDeleteUser(request: Base.Id): Base.Nothing {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        val targetUser = userRepo.getUserById(parseUUID(request.id, EntityType.USER))
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+        val targetUser = userRepo.getUserById(parseUUID(request.id, EntityType.USER)).getOrThrow()
         val isSameUser = currentUser.id == targetUser.id
 
         // Checks if the user tries to delete another user without being an admin
@@ -377,11 +377,11 @@ class UserService(
     }
 
     override suspend fun getCurrentUser(): GrpcUser =
-        userRepo.getUserById(GrpcContext.getUserIdFromContext()).toGrpcUser()
+        userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow().toGrpcUser()
 
     override suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings {
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext())
-        val userSettings = userRepo.getUserSettings(currentUser.id)
+        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
+        val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val defaultUserCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
         val criteria = mutableListOf<CriterionOuterClass.Criterion>()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -30,15 +30,15 @@ import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.Authentication
 import snowballr.Base
-import snowballr.CriterionOuterClass
 import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
-import snowballr.UserSettingsOuterClass
 import snowballr.nothing
 import java.time.OffsetDateTime
 import java.util.UUID
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.UserOuterClass.User as GrpcUser
+import snowballr.UserSettingsOuterClass.UserSettings as GrpcUserSettings
 
 val Logger = KotlinLogging.logger { }
 
@@ -97,7 +97,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.getUserSettings].
      */
-    suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings
+    suspend fun getUserSettings(): GrpcUserSettings
 
     /**
      * Service implementation of [SnowballRService.getCurrentUser].
@@ -367,14 +367,14 @@ class UserService(
 
     override suspend fun getCurrentUser(): GrpcUser = withUser(userRepo, User::toGrpcUser)
 
-    override suspend fun getUserSettings(): UserSettingsOuterClass.UserSettings = withUser(userRepo) { currentUser ->
+    override suspend fun getUserSettings(): GrpcUserSettings = withUser(userRepo) { currentUser ->
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val defaultUserCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        val criteria = mutableListOf<CriterionOuterClass.Criterion>()
+        val criteria = mutableListOf<GrpcCriterion>()
         for (criterion in defaultUserCriteria) {
             criteria.add(
-                CriterionOuterClass.Criterion
+                GrpcCriterion
                     .newBuilder()
                     .setTag(criterion.tag)
                     .setName(criterion.name)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -11,9 +11,9 @@ import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthenticatedException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -205,27 +205,27 @@ class UserService(
         userRepo.getAllUsers().toGrpcUsers()
     }
 
-    override suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): GrpcUser.List {
-        val searchQuery = request.query.trim()
+    override suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): GrpcUser.List =
+        withUser(userRepo) { currentUser ->
+            val searchQuery = request.query.trim()
 
-        // Check whether the search query is too short, i.e., 3 or fewer characters long
-        if (searchQuery.length < MINIMUM_LENGTH_OF_SEARCH_QUERY) {
-            return GrpcUser.List.getDefaultInstance()
+            // Check whether the search query is too short, i.e., 3 or fewer characters long
+            if (searchQuery.length < MINIMUM_LENGTH_OF_SEARCH_QUERY) {
+                return@withUser GrpcUser.List.getDefaultInstance()
+            }
+
+            val excludedUsersFromSearch = mutableSetOf(currentUser.id)
+            try {
+                val projectMembers =
+                    projectMemberRepo.getProjectMembers(parseUUID(request.projectId, EntityType.PROJECT))
+                excludedUsersFromSearch += projectMembers.map { it.userId }
+            } catch (_: InvalidIdException.UUID) {
+                Logger.warn { "Invalid project ID in invite candidates request: ${request.projectId}" }
+            }
+
+            val candidates = userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
+            candidates.toGrpcUsers()
         }
-
-        val currentUser = userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()
-        val excludedUsersFromSearch = mutableSetOf(currentUser.id)
-        try {
-            val projectMembers = projectMemberRepo.getProjectMembers(parseUUID(request.projectId, EntityType.PROJECT))
-            excludedUsersFromSearch += projectMembers.map { it.userId }
-        } catch (_: SnowballRException.InvalidIdException.UUID) {
-            Logger.warn { "Invalid project ID in invite candidates request: ${request.projectId}" }
-        }
-
-        val candidates = userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
-
-        return candidates.toGrpcUsers()
-    }
 
     override suspend fun register(request: Authentication.RegisterRequest): Base.Nothing {
         // Check whether a user with the given email already exists

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/CriterionTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/CriterionTable.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.model.dto.Criterion
-import snowballr.CriterionOuterClass
+import snowballr.CriterionOuterClass.CriterionCategory
 import java.time.OffsetDateTime
 
 /**
@@ -15,8 +15,7 @@ import java.time.OffsetDateTime
  * - [tag]: Represents the tag of the criterion as a [String].
  * - [name]: Represents the name of the criterion as a [String].
  * - [description]: Represents the description of the criterion as a [String].
- * - [category]: Represents the category of the criterion as an enumeration value from
- * [CriterionOuterClass.CriterionCategory].
+ * - [category]: Represents the category of the criterion as an enumeration value from [CriterionCategory].
  * - [projectId]: A foreign key referencing the project table, because a criterion always belongs to a project.
  * - [createdAt]: Represents the timestamp of when the criterion was created as an [OffsetDateTime].
  * - [createdBy]: A foreign key referencing the user table, representing the user who created the criterion.
@@ -25,7 +24,7 @@ object CriterionTable : UUIDTable("criterion") {
     val tag = text("tag")
     val name = text("name")
     val description = text("description")
-    val category = enumeration<CriterionOuterClass.CriterionCategory>("category")
+    val category = enumeration<CriterionCategory>("category")
 
     /**
      * Reference to the project, to which the criterion belongs to.

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
@@ -7,9 +7,11 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.json.json
 import org.jetbrains.exposed.sql.kotlin.datetime.timestampWithTimeZone
 import se.uulm.snowballr.backend.model.dto.Project
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
-import snowballr.ReviewOuterClass
+import snowballr.ProjectOuterClass.SnowballingType
+import snowballr.ReviewOuterClass.ReviewDecision
 import java.time.OffsetDateTime
 
 /**
@@ -17,17 +19,18 @@ import java.time.OffsetDateTime
  *
  * Columns:
  * - [name]: Represents the name of the project as a [String].
- * - [status]: Represents the status of the project as an enumeration value from [ProjectOuterClass.ProjectStatus].
+ * - [status]: Represents the status of the project as an enumeration value from [ProjectStatus].
  * - [currentStage]: Represents the current stage of the project as a [Long].
  * - [maxStage]: Represents the maximum stage of the project as a [Long].
  * - [similarityThreshold]: Represents the similarity threshold of the project as a [Float].
  * - [snowballingType]: Represents the type of snowballing used by the project as an enumeration value from
- * [ProjectOuterClass.SnowballingType].
- * - [reviewMaybeAllowed]: Represents whether the project allows reviews with a
- * [ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE] as a [Boolean].
- * - [reviewDecisionMatrixBinary]: Represents the decision matrix on how the [ProjectOuterClass.PaperDecision] for a
- * paper should be determined as a [ByteArray].
- * - [fetchers]: Represents the fetchers used by the project as a json object mapping the fetcher names to their options.
+ * [SnowballingType].
+ * - [reviewMaybeAllowed]: Represents whether the project allows reviews with a [ReviewDecision.REVIEW_DECISION_MAYBE]
+ * as a [Boolean].
+ * - [reviewDecisionMatrixBinary]: Represents the decision matrix on how the [PaperDecision] for a paper should be
+ * determined as a [ByteArray].
+ * - [fetchers]: Represents the fetchers used by the project as a json object mapping the fetcher names to their
+ * options.
  * - [currentStageStartedAt]: Represents the timestamp of when the current stage of the project was started as a
  * [OffsetDateTime].
  * - [createdAt]: Represents the timestamp of when the project was created as an [OffsetDateTime].
@@ -41,11 +44,11 @@ import java.time.OffsetDateTime
  */
 object ProjectTable : UUIDTable("project") {
     val name = text("name")
-    val status = enumeration<ProjectOuterClass.ProjectStatus>("status")
+    val status = enumeration<ProjectStatus>("status")
     val currentStage = long("current_stage")
     val maxStage = long("max_stage")
     val similarityThreshold = float("similarity_threshold")
-    val snowballingType = enumeration<ProjectOuterClass.SnowballingType>("snowballing_type")
+    val snowballingType = enumeration<SnowballingType>("snowballing_type")
     val reviewMaybeAllowed = bool("review_maybe_allowed")
     val reviewDecisionMatrixBinary = binary("review_decision_matrix")
     val fetchers = json<Map<String, Map<String, String>>>("fetchers", Json)

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ReviewTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ReviewTable.kt
@@ -5,12 +5,12 @@ import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
-import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
 import java.time.OffsetDateTime
 
 /**
- * Represents the "review" table, defining the relationship between project papers and users, which is
- * typically used to associate users with reviews of specific project papers.
+ * Represents the "review" table, defining the relationship between project papers and users, which is typically used to
+ * associate users with reviews of specific project papers.
  *
  * Columns:
  * - [projectPaperId]: Foreign key referencing the [ProjectPaperTable], representing the project paper being reviewed.
@@ -40,7 +40,7 @@ object ReviewTable : UUIDTable("review") {
         uniqueIndex(projectPaperId, userId)
     }
 
-    val decision = enumeration<ReviewOuterClass.ReviewDecision>("decision")
+    val decision = enumeration<ReviewDecision>("decision")
 
     // Metadata
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -7,9 +7,10 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.json.json
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
-import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
-import snowballr.UserOuterClass
+import snowballr.ProjectOuterClass.SnowballingType
+import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -19,7 +20,7 @@ private val CRITERIA_IDS_DEFAULT = emptyList<UUID>()
 private const val SIMILARITY_THRESHOLD_DEFAULT = 0F
 private val DECISION_MATRIX_DEFAULT: ByteArray = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
 private val FETCHERS_DEFAULT = emptyMap<String, Map<String, String>>()
-private val SNOWBALLING_TYPE_DEFAULT = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+private val SNOWBALLING_TYPE_DEFAULT = SnowballingType.SNOWBALLING_TYPE_BOTH
 private const val REVIEW_MAYBE_ALLOWED_DEFAULT = true
 
 /**
@@ -30,16 +31,17 @@ private const val REVIEW_MAYBE_ALLOWED_DEFAULT = true
  * - [firstName]: Represents the first name of the user as a [String].
  * - [lastName]: Represents the last name of the user as a [String].
  * - [passwordHash]: Represents the hashed password of the user as a [String].
- * - [role]: Represents the role of the user as an enumeration value from [UserOuterClass.UserRole].
- * - [status]: Represents the status of the user as an enumeration value from [UserOuterClass.UserStatus].
+ * - [role]: Represents the role of the user as an enumeration value from [UserRole].
+ * - [status]: Represents the status of the user as an enumeration value from [UserStatus].
  * - [areHotkeysShown]: Represents whether the user has hotkeys displayed as a [Boolean].
  * - [reviewModeEnabled]: Represents whether the user is in review mode as a [Boolean].
  * - [criteriaIds]: Represents a list of criteria IDs associated with the user as a [List] of [UUID].
  * - [similarityThreshold]: Represents the user's similarity threshold as a [Float].
  * - [decisionMatrix]: Represents the review decision matrix of the user as a binary value.
- * - [fetchers]: Represents the fetchers used by the project as a json object mapping the fetcher names to their options.
+ * - [fetchers]: Represents the fetchers used by the project as a json object mapping the fetcher names to their
+ * options.
  * - [snowballingType]: Represents the snowballing type associated with the user, stored as an enumeration value of
- * [ProjectOuterClass.SnowballingType].
+ * [SnowballingType].
  * - [reviewMaybeAllowed]: Indicates whether "maybe" is allowed in reviews, stored as a [Boolean].
  * - [createdAt]: Represents the timestamp of when the user was created as an [OffsetDateTime].
  * - [modifiedAt]: Represents the timestamp of when the user was last modified as an [OffsetDateTime].
@@ -50,8 +52,8 @@ object UserTable : UUIDTable("user") {
     val firstName = text("first_name")
     val lastName = text("last_name")
     val passwordHash = obfuscatedText("password_hash")
-    val role = enumeration<UserOuterClass.UserRole>("role")
-    val status = enumeration<UserOuterClass.UserStatus>("status")
+    val role = enumeration<UserRole>("role")
+    val status = enumeration<UserStatus>("status")
 
     // User settings
     val areHotkeysShown = bool("show_hotkeys").clientDefault { ARE_HOTKEYS_SHOWN_DEFAULT }
@@ -63,7 +65,7 @@ object UserTable : UUIDTable("user") {
     val decisionMatrix = binary("review_decision_matrix").clientDefault { DECISION_MATRIX_DEFAULT }
     val fetchers = json<Map<String, Map<String, String>>>("fetchers", Json).clientDefault { FETCHERS_DEFAULT }
     val snowballingType =
-        enumeration<ProjectOuterClass.SnowballingType>("snowballing_type").clientDefault { SNOWBALLING_TYPE_DEFAULT }
+        enumeration<SnowballingType>("snowballing_type").clientDefault { SNOWBALLING_TYPE_DEFAULT }
     val reviewMaybeAllowed = bool("review_maybe_allowed").clientDefault { REVIEW_MAYBE_ALLOWED_DEFAULT }
 
     // Metadata

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/association/ProjectMemberTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/association/ProjectMemberTable.kt
@@ -11,7 +11,7 @@ import se.uulm.snowballr.backend.table.createdAt
 import se.uulm.snowballr.backend.table.modifiedAt
 import se.uulm.snowballr.backend.table.toUser
 import se.uulm.snowballr.backend.table.userReference
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.MemberRole
 import java.time.OffsetDateTime
 
 /**
@@ -22,7 +22,7 @@ import java.time.OffsetDateTime
  * Columns:
  * - [projectId]: Foreign key referencing the [ProjectTable], representing the associated project.
  * - [userId]: Foreign key referencing the [UserTable], representing the associated user.
- * - [role]: Enumeration representing the member's role in the project, as defined in [ProjectOuterClass.MemberRole].
+ * - [role]: Enumeration representing the member's role in the project, as defined in [MemberRole].
  * - [createdAt]: Represents the timestamp of when the project member was created as an [OffsetDateTime].
  * - [modifiedAt]: Represents the timestamp of when the project member was last modified as an [OffsetDateTime].
  *
@@ -53,7 +53,7 @@ object ProjectMemberTable : CompositeIdTable("project_member") {
 
     override val primaryKey = PrimaryKey(projectId, userId)
 
-    val role = enumeration<ProjectOuterClass.MemberRole>("role")
+    val role = enumeration<MemberRole>("role")
 
     // Metadata
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/association/ProjectPaperTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/association/ProjectPaperTable.kt
@@ -12,7 +12,7 @@ import se.uulm.snowballr.backend.table.createdBy
 import se.uulm.snowballr.backend.table.modifiedAt
 import se.uulm.snowballr.backend.table.modifiedBy
 import se.uulm.snowballr.backend.table.toPaper
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
 import java.time.OffsetDateTime
 
 /**
@@ -24,7 +24,7 @@ import java.time.OffsetDateTime
  * - [projectId]: Foreign key referencing the [ProjectTable.id] column. Represents the project.
  * - [localPaperId]: Represents the unique identifier for the paper specific to the project as a [Long].
  * - [stage]: Represents the stage of the associated paper within the project as a [Long].
- * - [decision]: Represents the decision related to the paper, as per the [ProjectOuterClass.PaperDecision] enumeration.
+ * - [decision]: Represents the decision related to the paper, as per the [PaperDecision] enumeration.
  * - [createdAt]: Represents the timestamp of when the project paper was created as an [OffsetDateTime].
  * - [createdBy]: A foreign key referencing the user table, representing the user who created the project paper.
  * - [modifiedAt]: Represents the timestamp of when the project paper was last modified as an [OffsetDateTime].
@@ -56,7 +56,7 @@ object ProjectPaperTable : UUIDTable("project_paper") {
 
     val localPaperId = long("local_paper_id")
     val stage = long("stage")
-    val decision = enumeration<ProjectOuterClass.PaperDecision>("decision")
+    val decision = enumeration<PaperDecision>("decision")
 
     // Metadata
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -12,12 +12,12 @@ import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
 import snowballr.Base
 import snowballr.CriterionOuterClass.CriterionCategory
-import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
+import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
-import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import snowballr.id
@@ -201,7 +201,7 @@ object DataBuilder {
         projectId: UUID = UUID.randomUUID(),
         localPaperId: Long = 0,
         stage: Long = 0,
-        decision: ProjectOuterClass.PaperDecision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+        decision: PaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
         createdAt: OffsetDateTime = OffsetDateTime.now(),
         createdBy: UUID = UUID.randomUUID(),
         modifiedAt: OffsetDateTime? = null,
@@ -239,7 +239,7 @@ object DataBuilder {
         id: UUID = UUID.randomUUID(),
         projectPaperId: UUID = UUID.randomUUID(),
         userId: UUID = UUID.randomUUID(),
-        decision: ReviewOuterClass.ReviewDecision = ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED,
+        decision: ReviewDecision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
         createdAt: OffsetDateTime = OffsetDateTime.now(),
         modifiedAt: OffsetDateTime? = null,
     ) = Review(

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -176,6 +176,7 @@ private class NamingConventions {
             .should()
             .haveNameMatching(".*TableRepo.*")
             .orShould(haveNameMatching(".*RepoHelperKt.*")) // exception
+            .orShould(haveNameMatching(".*RepoResultHelperKt.*")) // exception
             .because("All repositories should have the 'TableRepo' suffix")
             .check(classes)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/DummyUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/DummyUserTest.kt
@@ -3,7 +3,8 @@ package se.uulm.snowballr.backend.auth
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
+import snowballr.ProjectOuterClass.SnowballingType
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
@@ -21,13 +22,9 @@ class DummyUserTest {
         assertEquals(false, DummyUser.isReviewModeEnabled)
         assertEquals(emptyList<UUID>(), DummyUser.criteriaIds)
         assertEquals(0F, DummyUser.similarityThreshold)
-        assertTrue(
-            ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray().contentEquals(
-                DummyUser.decisionMatrix,
-            ),
-        )
+        assertTrue(ReviewDecisionMatrix.getDefaultInstance().toByteArray().contentEquals(DummyUser.decisionMatrix))
         assertEquals(emptyMap<String, Map<String, String>>(), DummyUser.fetchers)
-        assertEquals(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH, DummyUser.snowballingType)
+        assertEquals(SnowballingType.SNOWBALLING_TYPE_BOTH, DummyUser.snowballingType)
         assertEquals(true, DummyUser.reviewMaybeAllowed)
 
         assertTrue(

--- a/src/test/kotlin/se/uulm/snowballr/backend/mail/EmailTemplateManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/mail/EmailTemplateManagerTest.kt
@@ -16,7 +16,7 @@ class EmailTemplateManagerTest {
         @Test
         fun `When the path doesn't exist, then a TemplateCompilationFailed exception is thrown`() {
             assertThrows<EmailException.TemplateCompilationFailed> {
-                EmailTemplateManager("foo/bar/not/existing")
+                EmailTemplateManager("foo/bar/not/existent")
             }
         }
 
@@ -34,7 +34,7 @@ class EmailTemplateManagerTest {
     @Nested
     inner class GetTemplate {
         @Test
-        fun `When getTemplate is called with an existing template, then the compiled template is returned`() {
+        fun `When getTemplate is called with an existent template, then the compiled template is returned`() {
             val template = emailTemplateManager.getTemplate(EmailTemplate.EMAIL_VERIFICATION)
 
             assertNotNull(template)

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/ParserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/ParserTest.kt
@@ -16,9 +16,9 @@ class ParserTest {
         }
 
         @Test
-        fun `When an invalid UUID is passed, then an exception is thrown`() {
+        fun `When an invalid UUID is passed, then an InvalidIdException is thrown`() {
             val uuid = "invalid-uuid"
-            assertThrows<InvalidIdException.UUID> { parseUUID(uuid, EntityType.USER) }
+            assertThrows<InvalidIdException> { parseUUID(uuid, EntityType.USER) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepoTest.kt
@@ -31,7 +31,7 @@ class AuthorTableRepoTest : RepositoryTest(arrayOf(AuthorTable), false) {
     @Nested
     inner class GetAuthorById {
         @Test
-        fun `When an author is found, then the correct author is returned`() = runTest {
+        fun `When an author is found, then a successful result with the correct author is returned`() = runTest {
             val authorId = insertTestAuthorAndGetId()
             val result = repo.getAuthorById(authorId)
 
@@ -44,7 +44,7 @@ class AuthorTableRepoTest : RepositoryTest(arrayOf(AuthorTable), false) {
         }
 
         @Test
-        fun `When an author is not found, then an exception is thrown`() = runTest {
+        fun `When an author is not found, then a failed result with a NotFoundException is returned`() = runTest {
             val result = repo.getAuthorById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/AuthorTableRepoTest.kt
@@ -5,9 +5,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.table.AuthorTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import java.util.UUID
 
 class AuthorTableRepoTest : RepositoryTest(arrayOf(AuthorTable), false) {
@@ -32,8 +33,9 @@ class AuthorTableRepoTest : RepositoryTest(arrayOf(AuthorTable), false) {
         @Test
         fun `When an author is found, then the correct author is returned`() = runTest {
             val authorId = insertTestAuthorAndGetId()
-            val author = repo.getAuthorById(authorId)
+            val result = repo.getAuthorById(authorId)
 
+            val author = assertResultSuccess(result)
             with(author) {
                 assertThat(firstName).isEqualTo("First Name")
                 assertThat(lastName).isEqualTo("Last Name")
@@ -43,7 +45,9 @@ class AuthorTableRepoTest : RepositoryTest(arrayOf(AuthorTable), false) {
 
         @Test
         fun `When an author is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getAuthorById(UUID.randomUUID()) }
+            val result = repo.getAuthorById(UUID.randomUUID())
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -128,7 +128,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             }
 
         @Test
-        fun `When a project criterion is created, but the assigned project doesn't exist, then an exception is thrown`() =
+        fun `When a project criterion is created, but the assigned project doesn't exist, then an SQLException is thrown`() =
             runTest {
                 val request =
                     GrpcCriterion.Create
@@ -163,7 +163,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         }
 
         @GrpcEnumSourceTest(CriterionCategory::class)
-        fun `When a criterion is created, but the assigned user doesn't exist, then an exception is thrown`(
+        fun `When a criterion is created, but the assigned user doesn't exist, then an SQLException is thrown`(
             category: CriterionCategory,
         ) = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -25,21 +25,18 @@ import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.CriterionOuterClass.CriterionCategory
-import snowballr.ProjectOuterClass
 import java.sql.SQLException
 import java.util.UUID
 import kotlin.test.assertIs
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTable), true) {
     private val repo = CriterionTableRepo(db)
     private val projectRepo = ProjectTableRepo(db)
 
     private suspend fun createExampleProject(): Project {
-        val request =
-            ProjectOuterClass.Project.Create
-                .newBuilder()
-                .build()
+        val request = GrpcProject.Create.newBuilder().build()
         return projectRepo.createProject(request, testUserId, DataBuilder.createExampleUserSettings())
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -21,6 +21,8 @@ import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndG
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
 import java.util.UUID
@@ -55,22 +57,23 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         fun `When a criterion is found, then the correct criterion is returned`() = runTest {
             val projectId = createExampleProject().id
             val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
-            val criterion = repo.getCriterionById(criterionId)
+            val result = repo.getCriterionById(criterionId)
 
+            val criterion = assertResultSuccess(result)
             assertIs<ProjectCriterion>(criterion)
             assertThat(criterion.id).isEqualTo(criterionId)
             assertThat(criterion.tag).isEqualTo("Test Tag")
             assertThat(criterion.name).isEqualTo("Test Criterion")
             assertThat(criterion.description).isEqualTo("Test Description")
-            assertThat(
-                criterion.category,
-            ).isEqualTo(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
+            assertThat(criterion.category).isEqualTo(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
             assertThat(criterion.projectId).isEqualTo(projectId)
         }
 
         @Test
         fun `When a criterion is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getCriterionById(UUID.randomUUID()) }
+            val result = repo.getCriterionById(UUID.randomUUID())
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 
@@ -293,7 +296,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         ) = runTest {
             val projectId = createExampleProject().id
             val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
-            val originalCriterion = repo.getCriterionById(criterionId)
+            val originalCriterion = repo.getCriterionById(criterionId).getOrThrow()
 
             val updatedCriterionDetails = originalCriterion.toGrpcCriterion().toBuilder()
                 .setTag("Updated Tag")

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -18,6 +18,7 @@ import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
@@ -25,6 +26,7 @@ import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass
+import java.sql.SQLException
 import java.util.UUID
 import kotlin.test.assertIs
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
@@ -138,7 +140,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .setProjectId(UUID.randomUUID().toString())
                         .build()
 
-                assertThrows<NotFoundException> { repo.createCriterion(request, testUserId) }
+                assertThrows<SQLException> { repo.createCriterion(request, testUserId) }
             }
 
         @Test
@@ -164,6 +166,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         fun `When a criterion is created, but the assigned user doesn't exist, then an exception is thrown`(
             category: CriterionCategory,
         ) = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
             val request =
                 GrpcCriterion.Create
                     .newBuilder()
@@ -171,10 +174,10 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                     .setName("Test Criterion")
                     .setDescription("Test Description")
                     .setCategory(category)
-                    .setProjectId(UUID.randomUUID().toString())
+                    .setProjectId(projectId.toString())
                     .build()
 
-            assertThrows<NotFoundException> { repo.createCriterion(request, UUID.randomUUID()) }
+            assertThrows<SQLException> { repo.createCriterion(request, UUID.randomUUID()) }
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -54,7 +54,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
     @Nested
     inner class GetCriterionById {
         @Test
-        fun `When a criterion is found, then the correct criterion is returned`() = runTest {
+        fun `When a criterion is found, then a successful result with the correct criterion is returned`() = runTest {
             val projectId = createExampleProject().id
             val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
             val result = repo.getCriterionById(criterionId)
@@ -70,7 +70,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         }
 
         @Test
-        fun `When a criterion is not found, then an exception is thrown`() = runTest {
+        fun `When a criterion is not found, then a failed result with a NotFoundException is returned`() = runTest {
             val result = repo.getCriterionById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -238,7 +238,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             }
 
         @Test
-        fun `When all criteria of the given ids are requested but not all criteria exist, then only the existing criteria are returned`() =
+        fun `When all criteria of the given ids are requested but not all criteria exist, then only the existent criteria are returned`() =
             runTest {
                 val baseRequestBuilder = GrpcCriterion.Create.newBuilder()
                     .setTag("Test Tag")

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -4,10 +4,11 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.table.PaperTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -20,8 +21,9 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
         @Test
         fun `When a paper is found, then the correct paper is returned`() = runTest {
             val paperId = insertPaperAndGetId(externalId = "ExternalId")
-            val paper = repo.getPaperById(paperId)
+            val result = repo.getPaperById(paperId)
 
+            val paper = assertResultSuccess(result)
             with(paper) {
                 assertThat(title).isEqualTo("Title")
                 assertThat(externalId).isEqualTo("ExternalId")
@@ -36,7 +38,9 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
 
         @Test
         fun `When a paper is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getPaperById(UUID.randomUUID()) }
+            val result = repo.getPaperById(UUID.randomUUID())
+
+            assertResultFailure<NotFoundException>(result)
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -61,17 +61,17 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
         fun `When a paper with the given id exists, then true returned`() = runTest {
             val paperId =
                 insertPaperAndGetId("Test Paper")
-            val isPaperExisting = repo.doesPaperExistById(paperId)
+            val isPaperExistent = repo.doesPaperExistById(paperId)
 
-            assertTrue(isPaperExisting)
+            assertTrue(isPaperExistent)
         }
 
         @Test
         fun `When a paper with the given id does not exist, then false returned`() = runTest {
             val paperId = UUID.randomUUID()
-            val isPaperExisting = repo.doesPaperExistById(paperId)
+            val isPaperExistent = repo.doesPaperExistById(paperId)
 
-            assertFalse(isPaperExisting)
+            assertFalse(isPaperExistent)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -19,7 +19,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
     @Nested
     inner class GetPaperById {
         @Test
-        fun `When a paper is found, then the correct paper is returned`() = runTest {
+        fun `When a paper is found, then a successful result with the correct paper is returned`() = runTest {
             val paperId = insertPaperAndGetId(externalId = "ExternalId")
             val result = repo.getPaperById(paperId)
 
@@ -37,7 +37,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
         }
 
         @Test
-        fun `When a paper is not found, then an exception is thrown`() = runTest {
+        fun `When a paper is not found, then a failed result with a NotFoundException is returned`() = runTest {
             val result = repo.getPaperById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -23,6 +23,7 @@ import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
+import java.sql.SQLException
 import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -123,7 +124,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         fun `When a project is created, but the assigned user doesn't exist, then an exception is thrown`() = runTest {
             val request = Project.Create.newBuilder().setName("Test Project").build()
             val userSettings = DataBuilder.createExampleUserSettings()
-            assertThrows<NotFoundException> { repo.createProject(request, UUID.randomUUID(), userSettings) }
+            assertThrows<SQLException> { repo.createProject(request, UUID.randomUUID(), userSettings) }
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -44,7 +44,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
     @Nested
     inner class GetProjectById {
         @Test
-        fun `When a project is found, then the correct project is returned`() = runTest {
+        fun `When a project is found, then a successful result with the correct project is returned`() = runTest {
             val projectId =
                 insertProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
             val result = repo.getProjectById(projectId)
@@ -63,7 +63,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         }
 
         @Test
-        fun `When a project is not found, then an exception is thrown`() = runTest {
+        fun `When a project is not found, then a failed result with a NotFoundException is returned`() = runTest {
             val result = repo.getProjectById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -77,17 +77,17 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         fun `When a project with the given id exists, then true returned`() = runTest {
             val projectId =
                 insertProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
-            val isProjectExisting = repo.doesProjectExistById(projectId)
+            val isProjectExistent = repo.doesProjectExistById(projectId)
 
-            assertTrue(isProjectExisting)
+            assertTrue(isProjectExistent)
         }
 
         @Test
         fun `When a project with the given id does not exist, then false returned`() = runTest {
             val projectId = UUID.randomUUID()
-            val isProjectExisting = repo.doesProjectExistById(projectId)
+            val isProjectExistent = repo.doesProjectExistById(projectId)
 
-            assertFalse(isProjectExisting)
+            assertFalse(isProjectExistent)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -121,11 +121,12 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         }
 
         @Test
-        fun `When a project is created, but the assigned user doesn't exist, then an exception is thrown`() = runTest {
-            val request = Project.Create.newBuilder().setName("Test Project").build()
-            val userSettings = DataBuilder.createExampleUserSettings()
-            assertThrows<SQLException> { repo.createProject(request, UUID.randomUUID(), userSettings) }
-        }
+        fun `When a project is created, but the assigned user doesn't exist, then an SQLException is thrown`() =
+            runTest {
+                val request = Project.Create.newBuilder().setName("Test Project").build()
+                val userSettings = DataBuilder.createExampleUserSettings()
+                assertThrows<SQLException> { repo.createProject(request, UUID.randomUUID(), userSettings) }
+            }
     }
 
     @Nested
@@ -447,15 +448,16 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         }
 
         @Test
-        fun `When an invalid project status is used to filter user projects, then an exception is thrown`() = runTest {
-            val userId = createExampleUser("userWithActiveProjects@example.com")
+        fun `When an invalid project status is used to filter user projects, then an IllegalArgumentException is thrown`() =
+            runTest {
+                val userId = createExampleUser("userWithActiveProjects@example.com")
 
-            assertThrows<IllegalArgumentException> {
-                repo.getUserProjects(
-                    userId,
-                    setOf(ProjectStatus.PROJECT_STATUS_UNSPECIFIED),
-                )
+                assertThrows<IllegalArgumentException> {
+                    repo.getUserProjects(
+                        userId,
+                        setOf(ProjectStatus.PROJECT_STATUS_UNSPECIFIED),
+                    )
+                }
             }
-        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -17,6 +17,8 @@ import se.uulm.snowballr.backend.repository.RepositoryHelper.createExampleUser
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
@@ -45,8 +47,9 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
         fun `When a project is found, then the correct project is returned`() = runTest {
             val projectId =
                 insertProjectAndGetId("Test Project", ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
-            val project = repo.getProjectById(projectId)
+            val result = repo.getProjectById(projectId)
 
+            val project = assertResultSuccess(result)
             assertThat(project.id).isEqualTo(projectId)
             assertThat(project.name).isEqualTo("Test Project")
             assertThat(project.status).isEqualTo(ProjectStatus.PROJECT_STATUS_ACTIVE)
@@ -61,7 +64,9 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
 
         @Test
         fun `When a project is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getProjectById(UUID.randomUUID()) }
+            val result = repo.getProjectById(UUID.randomUUID())
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 
@@ -173,7 +178,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
             val projectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE
             val projectId =
                 insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
-            val originalProject = repo.getProjectById(projectId)
+            val originalProject = repo.getProjectById(projectId).getOrThrow()
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
                 .setName("Updated Project")
@@ -229,7 +234,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
             val projectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
             val projectId =
                 insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
-            val originalProject = repo.getProjectById(projectId)
+            val originalProject = repo.getProjectById(projectId).getOrThrow()
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
                 .setName("Updated Project")
@@ -273,7 +278,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
             val projectStatus = ProjectStatus.PROJECT_STATUS_ARCHIVED
             val projectId =
                 insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
-            val originalProject = repo.getProjectById(projectId)
+            val originalProject = repo.getProjectById(projectId).getOrThrow()
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
                 .setName("Updated Project")

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -15,12 +15,14 @@ import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
 import snowballr.CriterionOuterClass.CriterionCategory
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.MemberRole
+import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
-import snowballr.ReviewOuterClass
-import snowballr.UserOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
+import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 /**
@@ -42,8 +44,8 @@ object RepositoryHelper {
                 it[firstName] = "Test"
                 it[lastName] = "User"
                 it[passwordHash] = "1234"
-                it[role] = UserOuterClass.UserRole.USER_ROLE_DEFAULT
-                it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+                it[role] = UserRole.USER_ROLE_DEFAULT
+                it[status] = UserStatus.USER_STATUS_ACTIVE
             }.value
     }
 
@@ -58,7 +60,7 @@ object RepositoryHelper {
         ProjectMemberTable.insertAndGet(ResultRow::toProjectMember, EntityType.PROJECT_MEMBER) {
             it[ProjectMemberTable.userId] = userId
             it[ProjectMemberTable.projectId] = projectId
-            it[role] = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
+            it[role] = MemberRole.MEMBER_ROLE_DEFAULT
         }
     }
 
@@ -133,7 +135,7 @@ object RepositoryHelper {
         projectId: UUID,
         localPaperId: Long = 0,
         stage: Long = 0,
-        decision: ProjectOuterClass.PaperDecision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+        decision: PaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
         createdBy: UUID,
     ): UUID = db.query {
         ProjectPaperTable.insertAndGetId {
@@ -150,7 +152,7 @@ object RepositoryHelper {
     suspend fun insertReviewAndGetId(
         projectPaperId: UUID,
         userId: UUID,
-        decision: ReviewOuterClass.ReviewDecision = ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED,
+        decision: ReviewDecision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
     ): UUID = db.query {
         ReviewTable.insertAndGetId {
             it[ReviewTable.projectPaperId] = projectPaperId

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryTest.kt
@@ -22,7 +22,8 @@ import se.uulm.snowballr.backend.db.DatabaseHelper.addExtensions
 import se.uulm.snowballr.backend.db.DatabaseHelper.dropAllTables
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.table.UserTable
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.sql.Connection
 import java.util.UUID
 import javax.sql.DataSource
@@ -133,8 +134,8 @@ open class RepositoryTest(
                 it[firstName] = "Test"
                 it[lastName] = "User"
                 it[passwordHash] = "hashedPassword"
-                it[role] = UserOuterClass.UserRole.USER_ROLE_ADMIN
-                it[status] = UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+                it[role] = UserRole.USER_ROLE_ADMIN
+                it[status] = UserStatus.USER_STATUS_ACTIVE
             }
         testUserId = userId.value
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -40,7 +40,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
         }
 
         @Test
-        fun `When a review is not found, then a failed result with an exception is returned`() = runTest {
+        fun `When a review is not found, then a failed result with a NotFoundException is returned`() = runTest {
             val result = repo.getReviewById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
@@ -16,6 +16,7 @@ import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import snowballr.ReviewOuterClass
 import java.util.UUID
+import kotlin.test.assertIs
 
 class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable), true) {
     private val repo = ReviewTableRepo(db)
@@ -23,14 +24,17 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
     @Nested
     inner class GetReviewById {
         @Test
-        fun `When a review is found, then the correct review is returned`() = runTest {
+        fun `When a review is found, then a successful result with the correct review is returned`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             val paperId = insertPaperAndGetId()
             val projectPaperId =
                 insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
             val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
-            val review = repo.getReviewById(reviewId)
+            val result = repo.getReviewById(reviewId)
 
+            assertThat(result.isSuccess).isTrue()
+            val review = result.getOrNull()
+            assertIs<Review>(review)
             assertThat(review.id).isEqualTo(reviewId)
             assertThat(review.projectPaperId).isEqualTo(projectPaperId)
             assertThat(review.userId).isEqualTo(testUserId)
@@ -38,8 +42,12 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
         }
 
         @Test
-        fun `When a review is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getReviewById(UUID.randomUUID()) }
+        fun `When a review is not found, then a failed result with an exception is returned`() = runTest {
+            val result = repo.getReviewById(UUID.randomUUID())
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertIs<NotFoundException>(exception)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -15,7 +15,7 @@ import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
 import java.util.UUID
 
 class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable), true) {
@@ -36,7 +36,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
             assertThat(review.id).isEqualTo(reviewId)
             assertThat(review.projectPaperId).isEqualTo(projectPaperId)
             assertThat(review.userId).isEqualTo(testUserId)
-            assertThat(review.decision).isEqualTo(ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED)
+            assertThat(review.decision).isEqualTo(ReviewDecision.REVIEW_DECISION_ACCEPTED)
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
-import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
@@ -14,9 +13,10 @@ import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ReviewOuterClass
 import java.util.UUID
-import kotlin.test.assertIs
 
 class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable), true) {
     private val repo = ReviewTableRepo(db)
@@ -32,9 +32,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
             val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
             val result = repo.getReviewById(reviewId)
 
-            assertThat(result.isSuccess).isTrue()
-            val review = result.getOrNull()
-            assertIs<Review>(review)
+            val review = assertResultSuccess(result)
             assertThat(review.id).isEqualTo(reviewId)
             assertThat(review.projectPaperId).isEqualTo(projectPaperId)
             assertThat(review.userId).isEqualTo(testUserId)
@@ -45,9 +43,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
         fun `When a review is not found, then a failed result with an exception is returned`() = runTest {
             val result = repo.getReviewById(UUID.randomUUID())
 
-            assertThat(result.isFailure).isTrue()
-            val exception = result.exceptionOrNull()
-            assertIs<NotFoundException>(exception)
+            assertResultFailure<NotFoundException>(result)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -65,7 +65,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
     @Nested
     inner class GetUserById {
         @Test
-        fun `When a user is found, then a successful result with the correct user is returned`() = runTest {
+        fun `When a user is found by their ID, then a successful result with the correct user is returned`() = runTest {
             val userId = insertTestUserAndGetId()
             val result = repo.getUserById(userId)
 
@@ -79,35 +79,38 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
-            val result = repo.getUserById(UUID.randomUUID())
+        fun `When a user is not found by their ID, then a failed result with a NotFoundException is returned`() =
+            runTest {
+                val result = repo.getUserById(UUID.randomUUID())
 
-            assertResultFailure<NotFoundException>(result)
-        }
+                assertResultFailure<NotFoundException>(result)
+            }
     }
 
     @Nested
     inner class GetUserByEmail {
         @Test
-        fun `When a user is found, then a successful result with the correct user is returned`() = runTest {
-            val userId = insertTestUserAndGetId()
-            val result = repo.getUserByEmail("test.user@example.com")
+        fun `When a user is found by their email, then a successful result with the correct user is returned`() =
+            runTest {
+                val userId = insertTestUserAndGetId()
+                val result = repo.getUserByEmail("test.user@example.com")
 
-            val user = assertResultSuccess(result)
-            assertThat(user.id).isEqualTo(userId)
-            assertThat(user.email).isEqualTo("test.user@example.com")
-            assertThat(user.firstName).isEqualTo("Test")
-            assertThat(user.lastName).isEqualTo("User")
-            assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
-            assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
-        }
+                val user = assertResultSuccess(result)
+                assertThat(user.id).isEqualTo(userId)
+                assertThat(user.email).isEqualTo("test.user@example.com")
+                assertThat(user.firstName).isEqualTo("Test")
+                assertThat(user.lastName).isEqualTo("User")
+                assertThat(user.role).isEqualTo(UserRole.USER_ROLE_DEFAULT)
+                assertThat(user.status).isEqualTo(UserStatus.USER_STATUS_ACTIVE)
+            }
 
         @Test
-        fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
-            val result = repo.getUserByEmail("non-existing email")
+        fun `When a user is not found by their email, then a failed result with a NotFoundException is returned`() =
+            runTest {
+                val result = repo.getUserByEmail("non-existing email")
 
-            assertResultFailure<NotFoundException>(result)
-        }
+                assertResultFailure<NotFoundException>(result)
+            }
     }
 
     @Nested
@@ -334,7 +337,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
     @Nested
     inner class GetUserSettings {
         @Test
-        fun `When a user is found, then the a successful result with the user settings is returned`() = runTest {
+        fun `When a user is found, then a successful result with the user settings is returned`() = runTest {
             val userId = insertTestUserAndGetId()
             val result = repo.getUserSettings(userId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -107,7 +107,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         @Test
         fun `When a user is not found by their email, then a failed result with a NotFoundException is returned`() =
             runTest {
-                val result = repo.getUserByEmail("non-existing email")
+                val result = repo.getUserByEmail("nonexistent email")
 
                 assertResultFailure<NotFoundException>(result)
             }
@@ -144,7 +144,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When permanently deleted users exist, then only the existing users are returned`() = runTest {
+        fun `When permanently deleted users exist, then only the existent users are returned`() = runTest {
             val userId1 = insertTestUserAndGetId(email = "test.user1@example.com", lastName = "User 1")
             val userId2 = insertTestUserAndGetId(email = "", firstName = "", lastName = "")
 
@@ -179,7 +179,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user with an existing email is created, then an SQLException is thrown`() = runTest {
+        fun `When a user with an existent email is created, then an SQLException is thrown`() = runTest {
             val request =
                 Authentication.RegisterRequest
                     .newBuilder()
@@ -273,7 +273,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user's email should be updated to an existing email, then an SQLException is thrown`() = runTest {
+        fun `When a user's email should be updated to an existent email, then an SQLException is thrown`() = runTest {
             insertTestUserAndGetId(email = "alice.smith@example.com")
 
             val user2Id = insertTestUserAndGetId(email = "bob.smith@example.com")
@@ -328,7 +328,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
 
         @Test
         fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
-            val result = repo.getPasswordHashByEmail("non-existing email")
+            val result = repo.getPasswordHashByEmail("nonexistent email")
 
             assertResultFailure<NotFoundException>(result)
         }
@@ -388,7 +388,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         fun `When no user is matching the search query, then an empty list is returned`() = runTest {
             insertTestUserAndGetId(firstName = "johnathan")
 
-            val matchingUsers = repo.getUsersMatchingSearchQuery("non-existing", emptySet())
+            val matchingUsers = repo.getUsersMatchingSearchQuery("nonexistent", emptySet())
 
             assertEquals(0, matchingUsers.size)
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.repository
 import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -24,6 +23,7 @@ import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import java.sql.SQLException
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -175,7 +175,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user with an existing email is created, then an exception is thrown`() = runTest {
+        fun `When a user with an existing email is created, then an SQLException is thrown`() = runTest {
             val request =
                 Authentication.RegisterRequest
                     .newBuilder()
@@ -186,7 +186,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
                     .build()
             repo.createUser(request, "hashedPassword")
 
-            assertThrows<ExposedSQLException> {
+            assertThrows<SQLException> {
                 repo.createUser(request, "hashedPassword2")
             }
         }
@@ -269,7 +269,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user's email should be updated to an existing email, then an exception is thrown`() = runTest {
+        fun `When a user's email should be updated to an existing email, then an SQLException is thrown`() = runTest {
             insertTestUserAndGetId(email = "alice.smith@example.com")
 
             val user2Id = insertTestUserAndGetId(email = "bob.smith@example.com")
@@ -282,7 +282,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
                     .setMask(FieldMaskUtil.fromString("user.email"))
                     .build()
 
-            assertThrows<ExposedSQLException> {
+            assertThrows<SQLException> {
                 repo.updateUser(updateRequest)
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -19,7 +19,8 @@ import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.Authentication
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
+import snowballr.ProjectOuterClass.SnowballingType
 import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
@@ -342,10 +343,9 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             assertThat(userSettings.isReviewModeEnabled).isFalse()
             assertThat(userSettings.criteriaIds).isEmpty()
             assertThat(userSettings.similarityThreshold).isEqualTo(0F)
-            assertThat(userSettings.decisionMatrix)
-                .isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
+            assertThat(userSettings.decisionMatrix).isEqualTo(ReviewDecisionMatrix.getDefaultInstance())
             assertThat(userSettings.fetchers).isEmpty()
-            assertThat(userSettings.snowballingType).isEqualTo(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH)
+            assertThat(userSettings.snowballingType).isEqualTo(SnowballingType.SNOWBALLING_TYPE_BOTH)
             assertThat(userSettings.reviewMaybeAllowed).isTrue()
         }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -16,6 +17,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.table.UserTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.Authentication
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.User
@@ -61,10 +64,11 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
     @Nested
     inner class GetUserById {
         @Test
-        fun `When a user is found, then the correct user is returned`() = runTest {
+        fun `When a user is found, then a successful result with the correct user is returned`() = runTest {
             val userId = insertTestUserAndGetId()
-            val user = repo.getUserById(userId)
+            val result = repo.getUserById(userId)
 
+            val user = assertResultSuccess(result)
             assertThat(user.id).isEqualTo(userId)
             assertThat(user.email).isEqualTo("test.user@example.com")
             assertThat(user.firstName).isEqualTo("Test")
@@ -74,18 +78,21 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getUserById(UUID.randomUUID()) }
+        fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
+            val result = repo.getUserById(UUID.randomUUID())
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 
     @Nested
     inner class GetUserByEmail {
         @Test
-        fun `When a user is found, then the correct user is returned`() = runTest {
+        fun `When a user is found, then a successful result with the correct user is returned`() = runTest {
             val userId = insertTestUserAndGetId()
-            val user = repo.getUserByEmail("test.user@example.com")
+            val result = repo.getUserByEmail("test.user@example.com")
 
+            val user = assertResultSuccess(result)
             assertThat(user.id).isEqualTo(userId)
             assertThat(user.email).isEqualTo("test.user@example.com")
             assertThat(user.firstName).isEqualTo("Test")
@@ -95,8 +102,10 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         }
 
         @Test
-        fun `When a user is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getUserByEmail("non-existing email") }
+        fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
+            val result = repo.getUserByEmail("non-existing email")
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 
@@ -215,7 +224,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             fieldMask: List<String>,
         ) = runTest {
             val userId = insertTestUserAndGetId(email = "test.user@example.com")
-            val originalUser = repo.getUserById(userId)
+            val originalUser = repo.getUserById(userId).getOrThrow()
 
             val updatedUserDetails = originalUser.toGrpcUser().toBuilder()
                 .setEmail("updated.user@example.com")
@@ -264,7 +273,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             insertTestUserAndGetId(email = "alice.smith@example.com")
 
             val user2Id = insertTestUserAndGetId(email = "bob.smith@example.com")
-            val user2Builder = repo.getUserById(user2Id).toGrpcUser().toBuilder()
+            val user2Builder = repo.getUserById(user2Id).getOrThrow().toGrpcUser().toBuilder()
 
             val updateRequest =
                 User.Update
@@ -289,57 +298,62 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             repo.softDeleteUser(userId1)
 
             val after = OffsetDateTime.now()
-            val deletedUser = repo.getUserById(userId1)
+            val deletedUser = repo.getUserById(userId1).getOrThrow()
 
             assertThat(deletedUser.status).isEqualTo(UserStatus.USER_STATUS_DELETED)
             assertThat(deletedUser.deletedAt).isBetween(before, after)
         }
 
         @Test
-        fun `When a user is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getUserById(UUID.randomUUID()) }
+        fun `When a user is not found, then no exception is thrown`() = runTest {
+            assertDoesNotThrow { repo.softDeleteUser(UUID.randomUUID()) }
         }
     }
 
     @Nested
     inner class GetPasswordHashByEmail {
         @Test
-        fun `When a user is found, then the password hash is returned`() = runTest {
+        fun `When a user is found, then a successful result with the password hash is returned`() = runTest {
             val passwordHash = "hashedPassword"
             insertTestUserAndGetId(email = "test.user@example.com", passwordHash = passwordHash)
-            val retrievedPasswordHash = repo.getPasswordHashByEmail("test.user@example.com")
+            val result = repo.getPasswordHashByEmail("test.user@example.com")
 
+            val retrievedPasswordHash = assertResultSuccess(result)
             assertEquals(passwordHash, retrievedPasswordHash)
         }
 
         @Test
-        fun `When a user is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getPasswordHashByEmail("non-existing email") }
+        fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
+            val result = repo.getPasswordHashByEmail("non-existing email")
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 
     @Nested
     inner class GetUserSettings {
         @Test
-        fun `When a user is found, then the user settings are returned`() = runTest {
+        fun `When a user is found, then the a successful result with the user settings is returned`() = runTest {
             val userId = insertTestUserAndGetId()
-            val userSettings = repo.getUserSettings(userId)
+            val result = repo.getUserSettings(userId)
 
+            val userSettings = assertResultSuccess(result)
             assertThat(userSettings.areHotkeysShown).isTrue()
             assertThat(userSettings.isReviewModeEnabled).isFalse()
             assertThat(userSettings.criteriaIds).isEmpty()
             assertThat(userSettings.similarityThreshold).isEqualTo(0F)
-            assertThat(
-                userSettings.decisionMatrix,
-            ).isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
+            assertThat(userSettings.decisionMatrix)
+                .isEqualTo(ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance())
             assertThat(userSettings.fetchers).isEmpty()
             assertThat(userSettings.snowballingType).isEqualTo(ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH)
             assertThat(userSettings.reviewMaybeAllowed).isTrue()
         }
 
         @Test
-        fun `When a user is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> { repo.getUserSettings(UUID.randomUUID()) }
+        fun `When a user is not found, then a failed result with a NotFoundException is returned`() = runTest {
+            val result = repo.getUserSettings(UUID.randomUUID())
+
+            assertResultFailure<NotFoundException>(result)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/VerificationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/VerificationTokenTableRepoTest.kt
@@ -25,7 +25,7 @@ class VerificationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, Verific
     @Nested
     inner class SaveVerificationToken {
         @Test
-        fun `When a token is saved for an existing user, then it can be retrieved by its value`() = runTest {
+        fun `When a token is saved for an existent user, then it can be retrieved by its value`() = runTest {
             val tokenValue = "a-unique-token-for-saving"
 
             repo.saveVerificationToken(testUserId, tokenValue)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/AuthorOfPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/AuthorOfPaperTableRepoTest.kt
@@ -51,7 +51,7 @@ class AuthorOfPaperTableRepoTest : RepositoryTest(arrayOf(AuthorTable, PaperTabl
             addAuthorToPaper(authorId, paperId)
             val actualAuthors = repo.getAuthorsOfPaperById(paperId)
             assertThat(actualAuthors).hasSize(1)
-            assertThat(actualAuthors).containsExactly(authorRepo.getAuthorById(authorId))
+            assertThat(actualAuthors).containsExactly(authorRepo.getAuthorById(authorId).getOrThrow())
         }
 
         @Test
@@ -64,8 +64,8 @@ class AuthorOfPaperTableRepoTest : RepositoryTest(arrayOf(AuthorTable, PaperTabl
             val actualAuthors = repo.getAuthorsOfPaperById(paperId)
             assertThat(actualAuthors).hasSize(2)
             assertThat(actualAuthors).containsExactlyInAnyOrder(
-                authorRepo.getAuthorById(authorId1),
-                authorRepo.getAuthorById(authorId2),
+                authorRepo.getAuthorById(authorId1).getOrThrow(),
+                authorRepo.getAuthorById(authorId2).getOrThrow(),
             )
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -20,6 +20,7 @@ import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
+import java.sql.SQLException
 import java.util.UUID
 
 class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
@@ -109,7 +110,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
 
         @Test
         fun `When a user is added to a non-existing project, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> {
+            assertThrows<SQLException> {
                 repo.addUserToProject(testUserId, UUID.randomUUID())
             }
         }
@@ -118,7 +119,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When a non-existing user is added to a project, then an exception is thrown`() = runTest {
             val project = createExampleProject()
 
-            assertThrows<NotFoundException> {
+            assertThrows<SQLException> {
                 repo.addUserToProject(UUID.randomUUID(), project.id)
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -274,7 +274,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
             runTest {
                 val (project, _) = setupProject()
                 val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
-                val user = userRepo.getUserById(testUserId)
+                val user = userRepo.getUserById(testUserId).getOrThrow()
                 val projectMembersWithUsers = repo.getProjectMembersWithUsers(project.id)
 
                 assertThat(projectMembersWithUsers).hasSize(1)
@@ -286,9 +286,9 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When not all users are project members, then only the correct project members with users are returned`() =
             runTest {
                 val (project, _) = setupProject()
-                val user = userRepo.getUserById(testUserId)
+                val user = userRepo.getUserById(testUserId).getOrThrow()
                 val nonProjectMemberUserId = RepositoryHelper.createExampleUser("test-user@example.com")
-                val nonProjectMemberUser = userRepo.getUserById(nonProjectMemberUserId)
+                val nonProjectMemberUser = userRepo.getUserById(nonProjectMemberUserId).getOrThrow()
                 val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
                 val projectMembersWithUsers = repo.getProjectMembersWithUsers(project.id)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -18,10 +18,10 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import java.sql.SQLException
 import java.util.UUID
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectMemberTableRepo(db)
@@ -29,11 +29,10 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
     private val projectRepo = ProjectTableRepo(db)
 
     private suspend fun createExampleProject(): Project {
-        val request =
-            ProjectOuterClass.Project.Create
-                .newBuilder()
-                .setName("Test Project")
-                .build()
+        val request = GrpcProject.Create
+            .newBuilder()
+            .setName("Test Project")
+            .build()
         val userSettings = DataBuilder.createExampleUserSettings()
         return projectRepo.createProject(request, testUserId, userSettings)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -108,14 +108,14 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         }
 
         @Test
-        fun `When a user is added to a non-existing project, then an SQLException is thrown`() = runTest {
+        fun `When a user is added to a nonexistent project, then an SQLException is thrown`() = runTest {
             assertThrows<SQLException> {
                 repo.addUserToProject(testUserId, UUID.randomUUID())
             }
         }
 
         @Test
-        fun `When a non-existing user is added to a project, then an SQLException is thrown`() = runTest {
+        fun `When a nonexistent user is added to a project, then an SQLException is thrown`() = runTest {
             val project = createExampleProject()
 
             assertThrows<SQLException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -70,11 +70,12 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
             }
 
         @Test
-        fun `When a project member is not found, then a failed result with an exception is returned`() = runTest {
-            val result = repo.getProjectMemberByComposedId(UUID.randomUUID(), UUID.randomUUID())
+        fun `When a project member is not found, then a failed result with a NotFoundException is returned`() =
+            runTest {
+                val result = repo.getProjectMemberByComposedId(UUID.randomUUID(), UUID.randomUUID())
 
-            assertResultFailure<NotFoundException>(result)
-        }
+                assertResultFailure<NotFoundException>(result)
+            }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -109,14 +109,14 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         }
 
         @Test
-        fun `When a user is added to a non-existing project, then an exception is thrown`() = runTest {
+        fun `When a user is added to a non-existing project, then an SQLException is thrown`() = runTest {
             assertThrows<SQLException> {
                 repo.addUserToProject(testUserId, UUID.randomUUID())
             }
         }
 
         @Test
-        fun `When a non-existing user is added to a project, then an exception is thrown`() = runTest {
+        fun `When a non-existing user is added to a project, then an SQLException is thrown`() = runTest {
             val project = createExampleProject()
 
             assertThrows<SQLException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -19,6 +19,7 @@ import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import java.util.UUID
+import kotlin.test.assertIs
 
 class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectMemberTableRepo(db)
@@ -56,23 +57,26 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
     @Nested
     inner class GetProjectMemberByComposedId {
         @Test
-        fun `When a project member is found, then the correct project member is returned`() = runTest {
-            val (project, members) = setupProject()
-            val projectMember = repo.getProjectMemberByComposedId(project.id, members[0].userId)
+        fun `When a project member is found, then a successful result with the correct project member is returned`() =
+            runTest {
+                val (project, members) = setupProject()
+                val result = repo.getProjectMemberByComposedId(project.id, members[0].userId)
 
-            assertThat(projectMember.projectId).isEqualTo(project.id)
-            assertThat(projectMember.userId).isEqualTo(testUserId)
-            assertThat(projectMember.role).isEqualTo(members[0].role)
-        }
+                assertThat(result.isSuccess).isTrue()
+                val projectMember = result.getOrNull()
+                assertIs<ProjectMember>(projectMember)
+                assertThat(projectMember.projectId).isEqualTo(project.id)
+                assertThat(projectMember.userId).isEqualTo(testUserId)
+                assertThat(projectMember.role).isEqualTo(members[0].role)
+            }
 
         @Test
-        fun `When a project member is not found, then an exception is thrown`() = runTest {
-            assertThrows<NotFoundException> {
-                repo.getProjectMemberByComposedId(
-                    UUID.randomUUID(),
-                    UUID.randomUUID(),
-                )
-            }
+        fun `When a project member is not found, then a failed result with an exception is returned`() = runTest {
+            val result = repo.getProjectMemberByComposedId(UUID.randomUUID(), UUID.randomUUID())
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertIs<NotFoundException>(exception)
         }
     }
 
@@ -200,8 +204,8 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When all project members are project admins, then the correct list of project admins is returned`() =
             runTest {
                 val (project, members) = setupProject(1)
-                val firstMember = repo.getProjectMemberByComposedId(project.id, testUserId)
-                val secondMember = repo.getProjectMemberByComposedId(project.id, members[1].userId)
+                val firstMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
+                val secondMember = repo.getProjectMemberByComposedId(project.id, members[1].userId).getOrThrow()
                 assertThat(firstMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
                 assertThat(secondMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
 
@@ -221,8 +225,8 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When not all project members are project admins, then the correct list of project admins is returned`() =
             runTest {
                 val (project, members) = setupProject(1)
-                val firstMember = repo.getProjectMemberByComposedId(project.id, testUserId)
-                val secondMember = repo.getProjectMemberByComposedId(project.id, members[1].userId)
+                val firstMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
+                val secondMember = repo.getProjectMemberByComposedId(project.id, members[1].userId).getOrThrow()
                 assertThat(firstMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
                 assertThat(secondMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
 
@@ -242,7 +246,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When a project member is promoted to admin, then the role of the project member is correctly updated`() =
             runTest {
                 val (project, _) = setupProject()
-                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId)
+                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
                 assertThat(normalMember.role).isEqualTo(MemberRole.MEMBER_ROLE_DEFAULT)
 
                 val promotedMember = repo.promoteProjectMemberToAdmin(project.id, testUserId)
@@ -272,7 +276,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When a project member and the corresponding user exists, then the project member with user is correctly returned`() =
             runTest {
                 val (project, _) = setupProject()
-                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId)
+                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
                 val user = userRepo.getUserById(testUserId)
                 val projectMembersWithUsers = repo.getProjectMembersWithUsers(project.id)
 
@@ -288,7 +292,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 val user = userRepo.getUserById(testUserId)
                 val nonProjectMemberUserId = RepositoryHelper.createExampleUser("test-user@example.com")
                 val nonProjectMemberUser = userRepo.getUserById(nonProjectMemberUserId)
-                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId)
+                val normalMember = repo.getProjectMemberByComposedId(project.id, testUserId).getOrThrow()
                 val projectMembersWithUsers = repo.getProjectMembersWithUsers(project.id)
 
                 assertThat(projectMembersWithUsers).hasSize(1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -16,10 +16,11 @@ import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.repository.UserTableRepo
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import java.util.UUID
-import kotlin.test.assertIs
 
 class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
     private val repo = ProjectMemberTableRepo(db)
@@ -62,9 +63,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 val (project, members) = setupProject()
                 val result = repo.getProjectMemberByComposedId(project.id, members[0].userId)
 
-                assertThat(result.isSuccess).isTrue()
-                val projectMember = result.getOrNull()
-                assertIs<ProjectMember>(projectMember)
+                val projectMember = assertResultSuccess(result)
                 assertThat(projectMember.projectId).isEqualTo(project.id)
                 assertThat(projectMember.userId).isEqualTo(testUserId)
                 assertThat(projectMember.role).isEqualTo(members[0].role)
@@ -74,9 +73,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When a project member is not found, then a failed result with an exception is returned`() = runTest {
             val result = repo.getProjectMemberByComposedId(UUID.randomUUID(), UUID.randomUUID())
 
-            assertThat(result.isFailure).isTrue()
-            val exception = result.exceptionOrNull()
-            assertIs<NotFoundException>(exception)
+            assertResultFailure<NotFoundException>(result)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
-import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.repository.PaperTableRepo
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
@@ -17,13 +16,14 @@ import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.utils.assertResultFailure
+import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.Project
 import java.util.UUID
 import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, ProjectTable, PaperTable), true) {
@@ -42,9 +42,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
 
                 val result = repo.getProjectPaperById(projectPaperId)
 
-                assertThat(result.isSuccess).isTrue()
-                val projectPaper = result.getOrNull()
-                assertIs<ProjectPaper>(projectPaper)
+                val projectPaper = assertResultSuccess(result)
                 assertThat(projectPaper.id).isEqualTo(projectPaperId)
                 assertThat(projectPaper.projectId).isEqualTo(projectId)
                 assertThat(projectPaper.paperId).isEqualTo(paperId)
@@ -58,9 +56,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
         fun `When a project paper is not found, then a failed result with an exception is returned`() = runTest {
             val result = repo.getProjectPaperById(UUID.randomUUID())
 
-            assertThat(result.isFailure).isTrue()
-            val exception = result.exceptionOrNull()
-            assertIs<NotFoundException>(exception)
+            assertResultFailure<NotFoundException>(result)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -117,9 +117,9 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     insertProjectAndGetId(createdBy = testUserId)
                 val paperId = insertPaperAndGetId()
                 insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-                val isProjectPaperExisting = repo.doesProjectPaperExist(projectId, paperId)
+                val isProjectPaperExistent = repo.doesProjectPaperExist(projectId, paperId)
 
-                assertTrue(isProjectPaperExisting)
+                assertTrue(isProjectPaperExistent)
             }
 
         @Test
@@ -127,9 +127,9 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             runTest {
                 val projectId = UUID.randomUUID()
                 val paperId = UUID.randomUUID()
-                val isProjectExisting = repo.doesProjectPaperExist(projectId, paperId)
+                val isProjectExistent = repo.doesProjectPaperExist(projectId, paperId)
 
-                assertFalse(isProjectExisting)
+                assertFalse(isProjectExistent)
             }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -146,7 +146,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
                 val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-                val paper = paperRepo.getPaperById(paperId)
+                val paper = paperRepo.getPaperById(paperId).getOrThrow()
                 val projectPapers = repo.getAllProjectPapersWithPapers(projectId)
 
                 assertThat(projectPapers).hasSize(1)
@@ -166,7 +166,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 val nonProjectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId2, createdBy = testUserId)
 
-                val paper = paperRepo.getPaperById(paperId)
+                val paper = paperRepo.getPaperById(paperId).getOrThrow()
                 val projectPapers = repo.getAllProjectPapersWithPapers(projectId1)
 
                 assertThat(projectPapers).hasSize(1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.repository.PaperTableRepo
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
@@ -22,6 +23,7 @@ import java.util.UUID
 import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, ProjectTable, PaperTable), true) {
@@ -31,25 +33,34 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
     @Nested
     inner class GetProjectPaperById {
         @Test
-        fun `When a project paper is found, then the correct project paper is returned`() = runTest {
-            val projectId = insertProjectAndGetId(createdBy = testUserId)
-            val paperId = insertPaperAndGetId()
-            val projectPaperId =
-                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-            val projectPaper = repo.getProjectPaperById(projectPaperId)
+        fun `When a project paper is found, then a successful result with the correct project paper is returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
 
-            assertThat(projectPaper.id).isEqualTo(projectPaperId)
-            assertThat(projectPaper.projectId).isEqualTo(projectId)
-            assertThat(projectPaper.paperId).isEqualTo(paperId)
-            assertThat(projectPaper.localPaperId).isEqualTo(0)
-            assertThat(projectPaper.stage).isEqualTo(0)
-            assertThat(projectPaper.decision).isEqualTo(ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED)
-            assertThat(projectPaper.createdBy).isEqualTo(testUserId)
-        }
+                val result = repo.getProjectPaperById(projectPaperId)
+
+                assertThat(result.isSuccess).isTrue()
+                val projectPaper = result.getOrNull()
+                assertIs<ProjectPaper>(projectPaper)
+                assertThat(projectPaper.id).isEqualTo(projectPaperId)
+                assertThat(projectPaper.projectId).isEqualTo(projectId)
+                assertThat(projectPaper.paperId).isEqualTo(paperId)
+                assertThat(projectPaper.localPaperId).isEqualTo(0)
+                assertThat(projectPaper.stage).isEqualTo(0)
+                assertThat(projectPaper.decision).isEqualTo(ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED)
+                assertThat(projectPaper.createdBy).isEqualTo(testUserId)
+            }
 
         @Test
-        fun `When a project paper is not found, then an exception is thrown`() = runTest {
-            assertThrows<SnowballRException.NotFoundException> { repo.getProjectPaperById(UUID.randomUUID()) }
+        fun `When a project paper is not found, then a failed result with an exception is returned`() = runTest {
+            val result = repo.getProjectPaperById(UUID.randomUUID())
+
+            assertThat(result.isFailure).isTrue()
+            val exception = result.exceptionOrNull()
+            assertIs<NotFoundException>(exception)
         }
     }
 
@@ -61,7 +72,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             val paperId = insertPaperAndGetId()
             val projectPaperId =
                 insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-            val projectPaper = repo.getProjectPaperById(projectPaperId)
+            val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
             assertThrows<ProjectPaperNotFoundException> {
                 repo.getProjectPaperByRelativeId(UUID.randomUUID(), projectPaper.localPaperId)
@@ -88,7 +99,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 val paperId = insertPaperAndGetId()
                 val projectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-                var projectPaper = repo.getProjectPaperById(projectPaperId)
+                var projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
                 projectPaper = assertDoesNotThrow {
                     repo.getProjectPaperByRelativeId(projectId, projectPaper.localPaperId)
                 }
@@ -137,7 +148,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 val paperId = insertPaperAndGetId()
                 val projectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-                val projectPaper = repo.getProjectPaperById(projectPaperId)
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
                 val paper = paperRepo.getPaperById(paperId)
                 val projectPapers = repo.getAllProjectPapersWithPapers(projectId)
@@ -155,7 +166,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 val paperId = insertPaperAndGetId()
                 val projectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId1, createdBy = testUserId)
-                val projectPaper = repo.getProjectPaperById(projectPaperId)
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
                 val nonProjectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId2, createdBy = testUserId)
 
@@ -175,11 +186,8 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
         fun `When a project paper is added to a project, but the assigned user doesn't exist, then an exception is thrown`() =
             runTest {
                 val request = Project.Paper.Add.newBuilder().build()
-                assertThrows<SnowballRException.NotFoundException> {
-                    repo.addPaperToProject(
-                        request,
-                        UUID.randomUUID(),
-                    )
+                assertThrows<NotFoundException> {
+                    repo.addPaperToProject(request, UUID.randomUUID())
                 }
             }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -18,7 +18,7 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.Project
 import java.sql.SQLException
 import java.util.UUID
@@ -49,7 +49,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 assertThat(projectPaper.paperId).isEqualTo(paperId)
                 assertThat(projectPaper.localPaperId).isEqualTo(0)
                 assertThat(projectPaper.stage).isEqualTo(0)
-                assertThat(projectPaper.decision).isEqualTo(ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED)
+                assertThat(projectPaper.decision).isEqualTo(PaperDecision.PAPER_DECISION_ACCEPTED)
                 assertThat(projectPaper.createdBy).isEqualTo(testUserId)
             }
 
@@ -103,7 +103,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 assertThat(projectPaper.paperId).isEqualTo(paperId)
                 assertThat(projectPaper.localPaperId).isEqualTo(0)
                 assertThat(projectPaper.stage).isEqualTo(0)
-                assertThat(projectPaper.decision).isEqualTo(ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED)
+                assertThat(projectPaper.decision).isEqualTo(PaperDecision.PAPER_DECISION_ACCEPTED)
                 assertThat(projectPaper.createdBy).isEqualTo(testUserId)
             }
     }
@@ -205,7 +205,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 assertEquals(projectId, projectPaper.projectId)
                 assertEquals(0, projectPaper.localPaperId)
                 assertEquals(0, projectPaper.stage)
-                assertEquals(ProjectOuterClass.PaperDecision.PAPER_DECISION_UNSPECIFIED, projectPaper.decision)
+                assertEquals(PaperDecision.PAPER_DECISION_UNSPECIFIED, projectPaper.decision)
                 assertEquals(testUserId, projectPaper.createdBy)
             }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -20,6 +20,7 @@ import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.Project
+import java.sql.SQLException
 import java.util.UUID
 import kotlin.random.Random
 import kotlin.test.assertEquals
@@ -179,10 +180,14 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
     @Nested
     inner class AddPaperToProject {
         @Test
-        fun `When a project paper is added to a project, but the assigned user doesn't exist, then an exception is thrown`() =
+        fun `When a project paper is added to a project, but the assigned user doesn't exist, then a SQLException is thrown`() =
             runTest {
-                val request = Project.Paper.Add.newBuilder().build()
-                assertThrows<NotFoundException> {
+                val request = Project.Paper.Add
+                    .newBuilder()
+                    .setPaperId(UUID.randomUUID().toString())
+                    .setProjectId(UUID.randomUUID().toString())
+                    .build()
+                assertThrows<SQLException> {
                     repo.addPaperToProject(request, UUID.randomUUID())
                 }
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -64,43 +64,40 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
     @Nested
     inner class GetProjectPaperByRelativeId {
         @Test
-        fun `When no project with the given id exists, then a NotFoundException is thrown`() = runTest {
-            val projectId = insertProjectAndGetId(createdBy = testUserId)
-            val paperId = insertPaperAndGetId()
-            val projectPaperId =
-                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-            val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+        fun `When no project with the given id exists, then a failed result with a ProjectPaperNotFoundException is returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-            assertThrows<ProjectPaperNotFoundException> {
-                repo.getProjectPaperByRelativeId(UUID.randomUUID(), projectPaper.localPaperId)
+                val result = repo.getProjectPaperByRelativeId(UUID.randomUUID(), projectPaper.localPaperId)
+
+                assertResultFailure<ProjectPaperNotFoundException>(result)
             }
-        }
 
         @Test
-        fun `When no project paper with the given local id exists in the project, then a NotFoundException is thrown`() =
+        fun `When no project paper with the given local id exists in the project, then a failed result with a ProjectPaperNotFoundException is returned`() =
             runTest {
                 val projectId = insertProjectAndGetId(createdBy = testUserId)
 
-                assertThrows<ProjectPaperNotFoundException> {
-                    repo.getProjectPaperByRelativeId(
-                        projectId,
-                        Random.nextLong(),
-                    )
-                }
+                val result = repo.getProjectPaperByRelativeId(projectId, Random.nextLong())
+
+                assertResultFailure<ProjectPaperNotFoundException>(result)
             }
 
         @Test
-        fun `When a project paper with the given local id in the project is found, then the correct project paper is returned`() =
+        fun `When a project paper with the given local id in the project is found, then a successful result with the correct project paper is returned`() =
             runTest {
                 val projectId = insertProjectAndGetId(createdBy = testUserId)
                 val paperId = insertPaperAndGetId()
                 val projectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
                 var projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
-                projectPaper = assertDoesNotThrow {
-                    repo.getProjectPaperByRelativeId(projectId, projectPaper.localPaperId)
-                }
+                val result = repo.getProjectPaperByRelativeId(projectId, projectPaper.localPaperId)
 
+                projectPaper = assertResultSuccess(result)
                 assertThat(projectPaper.id).isEqualTo(projectPaperId)
                 assertThat(projectPaper.projectId).isEqualTo(projectId)
                 assertThat(projectPaper.paperId).isEqualTo(paperId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -53,7 +53,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             }
 
         @Test
-        fun `When a project paper is not found, then a failed result with an exception is returned`() = runTest {
+        fun `When a project paper is not found, then a failed result with a NotFoundException is returned`() = runTest {
             val result = repo.getProjectPaperById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -64,7 +64,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
     @Nested
     inner class GetProjectPaperByRelativeId {
         @Test
-        fun `When no project with the given id exists, then a not found exception is thrown`() = runTest {
+        fun `When no project with the given id exists, then a NotFoundException is thrown`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             val paperId = insertPaperAndGetId()
             val projectPaperId =
@@ -77,7 +77,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
         }
 
         @Test
-        fun `When no project paper with the given local id exists in the project, then a not found exception is thrown`() =
+        fun `When no project paper with the given local id exists in the project, then a NotFoundException is thrown`() =
             runTest {
                 val projectId = insertProjectAndGetId(createdBy = testUserId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepoTest.kt
@@ -66,7 +66,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             }
 
         @Test
-        fun `When a paper is removed from the reading list of a non-existing user, then no exception is thrown`() =
+        fun `When a paper is removed from the reading list of a nonexistent user, then no exception is thrown`() =
             runTest {
                 val paperId = insertPaperAndGetId()
                 assertDoesNotThrow {
@@ -75,7 +75,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             }
 
         @Test
-        fun `When a non-existing paper is removed from the reading list of a user, then no exception is thrown`() =
+        fun `When a nonexistent paper is removed from the reading list of a user, then no exception is thrown`() =
             runTest {
                 val userId = createExampleUser("test.user@example.com")
                 assertDoesNotThrow {
@@ -102,13 +102,13 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
         }
 
         @Test
-        fun `When a non-existing paper is provided to isPaperOnReadingList, then it returns false`() = runTest {
+        fun `When a nonexistent paper is provided to isPaperOnReadingList, then it returns false`() = runTest {
             val userId = createExampleUser("test.user@example.com")
             assertThat(repo.isPaperOnReadingList(userId, UUID.randomUUID())).isFalse()
         }
 
         @Test
-        fun `When a non-existing user is provided to isPaperOnReadingList, then it returns false`() = runTest {
+        fun `When a nonexistent user is provided to isPaperOnReadingList, then it returns false`() = runTest {
             val paperId = insertPaperAndGetId()
             assertThat(repo.isPaperOnReadingList(UUID.randomUUID(), paperId)).isFalse()
         }
@@ -153,7 +153,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             }
 
         @Test
-        fun `When a non-existing user is provided to getAllReadingListEntries, then it returns an empty list`() =
+        fun `When a nonexistent user is provided to getAllReadingListEntries, then it returns an empty list`() =
             runTest {
                 assertThat(repo.getAllReadingListEntries(UUID.randomUUID())).isEmpty()
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepoTest.kt
@@ -27,7 +27,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             repo.createReadingListEntry(userId, paperId)
             val actualReadingListEntries = repo.getAllReadingListEntries(userId)
             assertThat(actualReadingListEntries).hasSize(1)
-            assertThat(actualReadingListEntries).containsExactly(paperRepo.getPaperById(paperId))
+            assertThat(actualReadingListEntries).containsExactly(paperRepo.getPaperById(paperId).getOrThrow())
         }
 
         @Test
@@ -38,7 +38,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             repo.createReadingListEntry(userId, paperId)
             val actualReadingListEntries = repo.getAllReadingListEntries(userId)
             assertThat(actualReadingListEntries).hasSize(1)
-            assertThat(actualReadingListEntries).containsExactly(paperRepo.getPaperById(paperId))
+            assertThat(actualReadingListEntries).containsExactly(paperRepo.getPaperById(paperId).getOrThrow())
         }
     }
 
@@ -132,7 +132,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
 
                 val actualReadingListEntries = repo.getAllReadingListEntries(userId)
                 assertThat(actualReadingListEntries).hasSize(1)
-                assertThat(actualReadingListEntries).containsExactly(paperRepo.getPaperById(paperId))
+                assertThat(actualReadingListEntries).containsExactly(paperRepo.getPaperById(paperId).getOrThrow())
             }
 
         @Test
@@ -147,8 +147,8 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
                 val actualReadingListEntries = repo.getAllReadingListEntries(userId)
                 assertThat(actualReadingListEntries).hasSize(2)
                 assertThat(actualReadingListEntries).containsExactlyInAnyOrder(
-                    paperRepo.getPaperById(paperId1),
-                    paperRepo.getPaperById(paperId2),
+                    paperRepo.getPaperById(paperId1).getOrThrow(),
+                    paperRepo.getPaperById(paperId2).getOrThrow(),
                 )
             }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -2,6 +2,8 @@ package se.uulm.snowballr.backend.service
 
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import org.junit.jupiter.api.AfterEach
@@ -20,6 +22,7 @@ import se.uulm.snowballr.backend.env.IEnvService
 import se.uulm.snowballr.backend.fetcher.FetcherManager
 import se.uulm.snowballr.backend.mail.EmailTemplateManager
 import se.uulm.snowballr.backend.mail.IEmailManager
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.IAuthorTableRepo
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
@@ -63,12 +66,12 @@ import se.uulm.snowballr.backend.serviceLayerDeps
  *         }
  *
  *     @Test
- *     fun `When an error occurs during example creation, then an exception is thrown`() =
+ *     fun `When an error occurs during example creation, then a TestSpecificException is thrown`() =
  *         runTest {
  *             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
  *
  *             // Mock the behavior of the repositories
- *             coEvery { exampleRepoMock.createExample(any()) } throws TestSpecificException()
+ *             coEvery { exampleRepoMock.createExample(any()) } returns Result.failure(TestSpecificException())
  *
  *             // Assert service behavior
  *             assertThrows<TestSpecificException> { mainService.createExample(request) }
@@ -172,5 +175,13 @@ open class MainServiceTest : KoinTest {
         checkUnnecessaryStub(*allMocks)
         clearAllMocks()
         stopKoin()
+    }
+
+    /**
+     * Mock the current user that is passed through the [withUser] helper.
+     */
+    protected fun mockCurrentUser(currentUser: User) {
+        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceChecksTest.kt
@@ -15,13 +15,13 @@ class ServiceChecksTest {
     @Nested
     inner class VerifyServerAdminRole {
         @GrpcEnumSourceTest(UserRole::class, excludes = ["USER_ROLE_ADMIN"])
-        fun `When the user is not a server admin, then an exception is thrown`(role: UserRole) {
+        fun `When the user is not a server admin, then an UnauthorizedException is thrown`(role: UserRole) {
             val user = DataBuilder.createExampleUser(role = role)
 
-            assertThrows<UnauthorizedException.All> {
-                verifyServerAdminRole(
-                    user,
-                ) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, user.id.toString()) }
+            assertThrows<UnauthorizedException> {
+                verifyServerAdminRole(user) {
+                    UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, user.id.toString())
+                }
             }
         }
 
@@ -30,9 +30,9 @@ class ServiceChecksTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
             assertDoesNotThrow {
-                verifyServerAdminRole(
-                    user,
-                ) { UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, user.id.toString()) }
+                verifyServerAdminRole(user) {
+                    UnauthorizedException.All(EntityType.PROJECT, AccessType.READ, user.id.toString())
+                }
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceHelperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceHelperTest.kt
@@ -1,0 +1,59 @@
+package se.uulm.snowballr.backend.service
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.repository.IUserTableRepo
+import java.util.UUID
+
+class ServiceHelperTest {
+    @Nested
+    inner class WithUser {
+        val userRepoMock = mockk<IUserTableRepo>()
+
+        @BeforeEach
+        fun setupTest() {
+            mockkObject(GrpcContext)
+        }
+
+        @Test
+        fun `When retrieving the user ID fails, then an exception is thrown`() = runTest {
+            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { withUser(userRepoMock) { } }
+        }
+
+        @Test
+        fun `When retrieving the user fails, then an exception is thrown`() = runTest {
+            val currentUserId = UUID.randomUUID()
+            every { GrpcContext.getUserIdFromContext() } returns currentUserId
+            coEvery { userRepoMock.getUserById(currentUserId) } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { withUser(userRepoMock) { } }
+        }
+
+        @Test
+        fun `When the user is retrieved successfully, then the block is executed with the current user`() = runTest {
+            val currenUser = DataBuilder.createExampleUser()
+            every { GrpcContext.getUserIdFromContext() } returns currenUser.id
+            coEvery { userRepoMock.getUserById(currenUser.id) } returns Result.success(currenUser)
+
+            assertDoesNotThrow {
+                withUser(userRepoMock) {
+                    assertThat(it).isEqualTo(currenUser)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -58,7 +58,7 @@ class CreateCriterionTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertDoesNotThrow { mainService.createCriterion(request) }
@@ -77,7 +77,7 @@ class CreateCriterionTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
         assertDoesNotThrow { mainService.createCriterion(request) }
@@ -92,7 +92,7 @@ class CreateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.createCriterion(request) }
@@ -115,7 +115,7 @@ class CreateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.createCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -56,7 +56,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -74,7 +74,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
@@ -91,7 +91,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -114,7 +114,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -129,7 +129,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getUserCriterionRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
@@ -142,7 +142,7 @@ class CreateCriterionTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser(id = userId)
 
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.createCriterion(request) }
@@ -155,7 +155,7 @@ class CreateCriterionTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleProjectCriterion()
 
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -1,13 +1,11 @@
 package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -46,8 +44,7 @@ class CreateCriterionTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -64,8 +61,7 @@ class CreateCriterionTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
@@ -75,20 +71,18 @@ class CreateCriterionTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project admin creates a project criterion, then an UnauthorizedException#Single is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject()
+    fun `When a non project admin creates a project criterion, then an UnauthorizedException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
-            val request = getProjectCriterionRequest(project.id.toString())
+        val request = getProjectCriterionRequest(project.id.toString())
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        mockCurrentUser(user)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-            assertThrows<UnauthorizedException.Single> { mainService.createCriterion(request) }
-        }
+        assertThrows<UnauthorizedException> { mainService.createCriterion(request) }
+    }
 
     @GrpcEnumSourceTest(
         ProjectOuterClass.ProjectStatus::class,
@@ -105,8 +99,7 @@ class CreateCriterionTest : MainServiceTest() {
 
         val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -120,8 +113,7 @@ class CreateCriterionTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleUserCriterion()
         val request = getUserCriterionRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
@@ -133,8 +125,7 @@ class CreateCriterionTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser(id = UUID.randomUUID())
         val criterion = DataBuilder.createExampleProjectCriterion()
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -10,15 +10,15 @@ import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionExce
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
-import snowballr.CriterionOuterClass
 import snowballr.CriterionOuterClass.CriterionCategory
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 class CreateCriterionTest : MainServiceTest() {
-    private fun getProjectCriterionRequest(projectId: String): CriterionOuterClass.Criterion.Create {
-        return CriterionOuterClass.Criterion.Create.newBuilder()
+    private fun getProjectCriterionRequest(projectId: String): GrpcCriterion.Create {
+        return GrpcCriterion.Create.newBuilder()
             .setTag("Tag")
             .setName("Criterion")
             .setDescription("Description")
@@ -27,8 +27,8 @@ class CreateCriterionTest : MainServiceTest() {
             .build()
     }
 
-    private fun getUserCriterionRequest(): CriterionOuterClass.Criterion.Create {
-        return CriterionOuterClass.Criterion.Create.newBuilder()
+    private fun getUserCriterionRequest(): GrpcCriterion.Create {
+        return GrpcCriterion.Create.newBuilder()
             .setTag("Tag")
             .setName("Criterion")
             .setDescription("Description")
@@ -85,11 +85,11 @@ class CreateCriterionTest : MainServiceTest() {
     }
 
     @GrpcEnumSourceTest(
-        ProjectOuterClass.ProjectStatus::class,
+        ProjectStatus::class,
         excludes = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_UNSPECIFIED"],
     )
     fun `When a project admin creates a project criterion for a non active project, then a FailedPreconditionException is thrown`(
-        status: ProjectOuterClass.ProjectStatus,
+        status: ProjectStatus,
     ) = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
@@ -121,7 +121,7 @@ class CreateCriterionTest : MainServiceTest() {
 
     @Test
     fun `When a criterion is correctly created, then no exception is thrown`() = runTest {
-        val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
+        val request = GrpcCriterion.Create.getDefaultInstance()
         val user = DataBuilder.createExampleUser(id = UUID.randomUUID())
         val criterion = DataBuilder.createExampleProjectCriterion()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass
@@ -36,15 +36,6 @@ class CreateCriterionTest : MainServiceTest() {
             .setDescription("Description")
             .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
             .build()
-    }
-
-    @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
-
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.createCriterion(request) }
     }
 
     @Test
@@ -84,25 +75,26 @@ class CreateCriterionTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project admin creates a project criterion, then an unauthorized exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
+    fun `When a non project admin creates a project criterion, then an UnauthorizedException#Single is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        val request = getProjectCriterionRequest(project.id.toString())
+            val request = getProjectCriterionRequest(project.id.toString())
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.createCriterion(request) }
-    }
+            assertThrows<UnauthorizedException.Single> { mainService.createCriterion(request) }
+        }
 
     @GrpcEnumSourceTest(
         ProjectOuterClass.ProjectStatus::class,
         excludes = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_UNSPECIFIED"],
     )
-    fun `When a project admin creates a project criterion for a non active project, then a failed precondition exception is thrown`(
+    fun `When a project admin creates a project criterion for a non active project, then a FailedPreconditionException is thrown`(
         status: ProjectOuterClass.ProjectStatus,
     ) = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
@@ -118,7 +110,7 @@ class CreateCriterionTest : MainServiceTest() {
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
-        assertThrows<SnowballRException.FailedPreconditionException> { mainService.createCriterion(request) }
+        assertThrows<FailedPreconditionException> { mainService.createCriterion(request) }
     }
 
     @Test
@@ -133,19 +125,6 @@ class CreateCriterionTest : MainServiceTest() {
         coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
-    }
-
-    @Test
-    fun `When an error occurs while a criterion is created, then an exception is thrown`() = runTest {
-        val request = CriterionOuterClass.Criterion.Create.getDefaultInstance()
-        val userId = UUID.randomUUID()
-        val user = DataBuilder.createExampleUser(id = userId)
-
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
-        coEvery { criterionRepoMock.createCriterion(any(), any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.createCriterion(request) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -16,11 +16,11 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetAllCriteriaForProjectTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val projectId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(projectId.toString())
         .build()
 
     @Test
@@ -62,12 +62,12 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
     }
@@ -77,12 +77,12 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = adminUser.id, projectId = project.id)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } throws TestSpecificException()
 
@@ -95,16 +95,16 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val criterion = DataBuilder.createExampleProjectCriterion(
-            projectId = requestId,
+            projectId = projectId,
             createdBy = adminUser.id,
         )
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { criterionRepoMock.getAllProjectCriteria(requestId) } returns listOf(criterion)
+        coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
         assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
     }
@@ -116,17 +116,17 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion = DataBuilder.createExampleProjectCriterion(
-                projectId = requestId,
+                projectId = projectId,
                 createdBy = user.id,
             )
-            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = requestId)
-            val project = DataBuilder.createExampleProject(id = requestId)
+            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
+            val project = DataBuilder.createExampleProject(id = projectId)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { projectRepoMock.getProjectById(requestId) } returns project
-            coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns listOf(projectMember)
-            coEvery { criterionRepoMock.getAllProjectCriteria(requestId) } returns listOf(criterion)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
             assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
         }
@@ -137,12 +137,12 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(id = requestId)
+            val project = DataBuilder.createExampleProject(id = projectId)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { projectRepoMock.getProjectById(requestId) } returns project
-            coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -24,69 +25,28 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When an error occurs while user context is retrieved, then an exception is thrown`() = runTest {
-        val request = getExampleRequest()
-
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
-    }
-
-    @Test
-    fun `When an error occurs while user is retrieved, then an exception is thrown`() = runTest {
+    fun `When an error occurs while user is retrieved, then a TestSpecificException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
     }
 
     @Test
-    fun `When an error occurs while project is retrieved, then an exception is thrown`() = runTest {
+    fun `When the project doesn't exist, then a NotFoundException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
-        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
 
-        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
-    }
-
-    @Test
-    fun `When an error occurs while project members are retrieved, then an exception is thrown`() = runTest {
-        val request = getExampleRequest()
-
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = projectId)
-
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
-    }
-
-    @Test
-    fun `When an error occurs while the criteria are retrieved, then an exception is thrown`() = runTest {
-        val request = getExampleRequest()
-
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val projectMember = DataBuilder.createExampleProjectMember(userId = adminUser.id, projectId = project.id)
-
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
+        assertThrows<NotFoundException> { mainService.getAllCriteriaForProject(request) }
     }
 
     @Test
@@ -102,7 +62,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
@@ -124,7 +84,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
@@ -132,7 +92,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the requesting user is a non project member and wants to retrieve all project criteria, then an unauthorized exception is thrown`() =
+    fun `When the requesting user is a non project member and wants to retrieve all project criteria, then a UnauthorizedException#Single is thrown`() =
         runTest {
             val request = getExampleRequest()
 
@@ -141,9 +101,9 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-            assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }
+            assertThrows<UnauthorizedException.Single> { mainService.getAllCriteriaForProject(request) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -51,7 +51,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
@@ -65,7 +65,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
 
@@ -81,7 +81,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(userId = adminUser.id, projectId = project.id)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } throws TestSpecificException()
@@ -101,7 +101,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
@@ -123,7 +123,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
@@ -140,7 +140,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -1,14 +1,11 @@
 package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -25,25 +22,12 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When an error occurs while user is retrieved, then a TestSpecificException is thrown`() = runTest {
-        val request = getExampleRequest()
-
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.failure(TestSpecificException())
-
-        assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(request) }
-    }
-
-    @Test
     fun `When the project doesn't exist, then a NotFoundException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
 
         assertThrows<NotFoundException> { mainService.getAllCriteriaForProject(request) }
@@ -60,8 +44,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         )
         val project = DataBuilder.createExampleProject(id = projectId)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
@@ -82,8 +65,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
             val project = DataBuilder.createExampleProject(id = projectId)
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
@@ -92,18 +74,17 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the requesting user is a non project member and wants to retrieve all project criteria, then a UnauthorizedException#Single is thrown`() =
+    fun `When the requesting user is a non project member and wants to retrieve all project criteria, then an UnauthorizedException is thrown`() =
         runTest {
             val request = getExampleRequest()
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(id = projectId)
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-            assertThrows<UnauthorizedException.Single> { mainService.getAllCriteriaForProject(request) }
+            assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -36,7 +36,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         )
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
@@ -59,7 +59,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
@@ -81,7 +81,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             )
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
-            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
+            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns Result.success(noAccessUser)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
@@ -97,7 +97,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
@@ -112,7 +112,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
@@ -127,7 +127,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
-            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
+            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns Result.success(noAccessUser)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
@@ -140,7 +140,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -68,7 +68,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the requesting user is not a member of the project and wants to retrieve a project criterion, then an unauthorized exception is thrown`() =
+    fun `When the requesting user is not a member of the project and wants to retrieve a project criterion, then an UnauthorizedException#Single is thrown`() =
         runTest {
             val request = getExampleRequest()
 
@@ -119,7 +119,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he did not create himself, then an unauthorized exception is thrown`() =
+    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he did not create himself, then an UnauthorizedException#Single is thrown`() =
         runTest {
             val request = getExampleRequest()
 
@@ -134,14 +134,14 @@ class GetCriterionByIdTest : MainServiceTest() {
         }
 
     @Test
-    fun `When an error occurs while the criterion is retrieved, then an exception is thrown`() = runTest {
+    fun `When an error occurs while the criterion is retrieved, then a TestSpecificException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } throws TestSpecificException()
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -1,14 +1,12 @@
 package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -35,8 +33,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             createdBy = adminUser.id,
         )
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
@@ -58,8 +55,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             )
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
@@ -68,7 +64,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the requesting user is not a member of the project and wants to retrieve a project criterion, then an UnauthorizedException#Single is thrown`() =
+    fun `When the requesting user is not a member of the project and wants to retrieve a project criterion, then an UnauthorizedException is thrown`() =
         runTest {
             val request = getExampleRequest()
 
@@ -80,13 +76,12 @@ class GetCriterionByIdTest : MainServiceTest() {
                 createdBy = noAccessUser.id,
             )
 
-            every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
-            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns Result.success(noAccessUser)
+            mockCurrentUser(noAccessUser)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
-            assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
+            assertThrows<UnauthorizedException> { mainService.getCriterionById(request) }
         }
 
     @Test
@@ -96,8 +91,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
@@ -111,26 +105,24 @@ class GetCriterionByIdTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
         }
 
     @Test
-    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he did not create himself, then an UnauthorizedException#Single is thrown`() =
+    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he did not create himself, then an UnauthorizedException is thrown`() =
         runTest {
             val request = getExampleRequest()
 
             val noAccessUser = DataBuilder.createExampleUser()
             val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
-            every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
-            coEvery { userRepoMock.getUserById(noAccessUser.id) } returns Result.success(noAccessUser)
+            mockCurrentUser(noAccessUser)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
-            assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
+            assertThrows<UnauthorizedException> { mainService.getCriterionById(request) }
         }
 
     @Test
@@ -139,8 +131,7 @@ class GetCriterionByIdTest : MainServiceTest() {
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -16,11 +16,11 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetCriterionByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val criterionId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(criterionId.toString())
         .build()
 
     @Test
@@ -28,18 +28,18 @@ class GetCriterionByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
         val criterion = DataBuilder.createExampleProjectCriterion(
-            id = requestId,
-            projectId = UUID.randomUUID(),
+            id = criterionId,
+            projectId = project.id,
             createdBy = adminUser.id,
         )
-        val project = DataBuilder.createExampleProject(id = requestId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
     }
@@ -52,7 +52,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject()
             val criterion = DataBuilder.createExampleProjectCriterion(
-                id = requestId,
+                id = criterionId,
                 projectId = project.id,
                 createdBy = user.id,
             )
@@ -61,8 +61,8 @@ class GetCriterionByIdTest : MainServiceTest() {
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
         }
@@ -73,18 +73,18 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val noAccessUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
             val criterion = DataBuilder.createExampleProjectCriterion(
-                id = requestId,
-                projectId = UUID.randomUUID(),
+                id = criterionId,
+                projectId = project.id,
                 createdBy = noAccessUser.id,
             )
-            val project = DataBuilder.createExampleProject()
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
             coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
-            coEvery { projectRepoMock.getProjectById(any()) } returns project
-            coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
         }
@@ -94,11 +94,11 @@ class GetCriterionByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion = DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
+        val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
     }
@@ -109,11 +109,11 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleUserCriterion(id = requestId, createdBy = user.id)
+            val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
         }
@@ -124,11 +124,11 @@ class GetCriterionByIdTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val noAccessUser = DataBuilder.createExampleUser()
-            val criterion = DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
+            val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
             coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
         }
@@ -141,7 +141,7 @@ class GetCriterionByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { criterionRepoMock.getCriterionById(requestId) } throws TestSpecificException()
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -39,7 +39,7 @@ class GetCriterionByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
     }
@@ -62,7 +62,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
         }
@@ -84,7 +84,7 @@ class GetCriterionByIdTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
             coEvery { projectRepoMock.getProjectById(any()) } returns project
             coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
         }
@@ -98,7 +98,7 @@ class GetCriterionByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
         assertDoesNotThrow { mainService.getCriterionById(request) }
     }
@@ -113,7 +113,7 @@ class GetCriterionByIdTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
             assertDoesNotThrow { mainService.getCriterionById(request) }
         }
@@ -128,7 +128,7 @@ class GetCriterionByIdTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
             coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
             assertThrows<UnauthorizedException.Single> { mainService.getCriterionById(request) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -55,7 +55,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -80,7 +80,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -106,7 +106,7 @@ class UpdateCriterionTest : MainServiceTest() {
             val request = getExampleRequest()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -129,7 +129,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -145,7 +145,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -161,7 +161,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -178,7 +178,7 @@ class UpdateCriterionTest : MainServiceTest() {
             val request = getExampleRequest()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
@@ -193,7 +193,7 @@ class UpdateCriterionTest : MainServiceTest() {
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
@@ -175,4 +176,15 @@ class UpdateCriterionTest : MainServiceTest() {
 
             assertThrows<UnauthorizedException> { mainService.updateCriterion(request) }
         }
+
+    @Test
+    fun `When an error occurs while the criterion is retrieved, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val request = getExampleRequest()
+
+        mockCurrentUser(user)
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.updateCriterion(request) }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -19,11 +19,11 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class UpdateCriterionTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val criterionId = UUID.randomUUID()
 
     private fun getExampleRequest(): CriterionOuterClass.Criterion.Update {
         val updatedCriterion = DataBuilder.createExampleProjectCriterion(
-            id = requestId,
+            id = criterionId,
             tag = "Updated Tag",
             name = "Updated Criterion",
             description = "Updated Description",
@@ -47,7 +47,7 @@ class UpdateCriterionTest : MainServiceTest() {
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val criterion = DataBuilder.createExampleProjectCriterion(
-            id = requestId,
+            id = criterionId,
             projectId = project.id,
             createdBy = user.id,
         )
@@ -56,9 +56,9 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertDoesNotThrow { mainService.updateCriterion(request) }
@@ -72,7 +72,7 @@ class UpdateCriterionTest : MainServiceTest() {
         )
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
         val criterion = DataBuilder.createExampleProjectCriterion(
-            id = requestId,
+            id = criterionId,
             projectId = project.id,
             createdBy = user.id,
         )
@@ -81,8 +81,8 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -98,7 +98,7 @@ class UpdateCriterionTest : MainServiceTest() {
             )
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
             val criterion = DataBuilder.createExampleProjectCriterion(
-                id = requestId,
+                id = criterionId,
                 projectId = project.id,
                 createdBy = user.id,
             )
@@ -107,8 +107,8 @@ class UpdateCriterionTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
-            coEvery { projectRepoMock.getProjectById(any()) } returns project
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateCriterion(request) }
@@ -121,7 +121,7 @@ class UpdateCriterionTest : MainServiceTest() {
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val criterion = DataBuilder.createExampleProjectCriterion(
-            id = requestId,
+            id = criterionId,
             projectId = project.id,
             createdBy = user.id,
         )
@@ -130,9 +130,9 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
-        coEvery { projectRepoMock.getProjectById(any()) } returns project
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
     }
@@ -140,14 +140,13 @@ class UpdateCriterionTest : MainServiceTest() {
     @Test
     fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion =
-            DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
+        val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertDoesNotThrow { mainService.updateCriterion(request) }
@@ -157,13 +156,13 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When a user updates a user criterion, which he created himself, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val criterion =
-            DataBuilder.createExampleUserCriterion(id = requestId, createdBy = user.id)
+            DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
 
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertDoesNotThrow { mainService.updateCriterion(request) }
@@ -174,13 +173,13 @@ class UpdateCriterionTest : MainServiceTest() {
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion =
-                DataBuilder.createExampleUserCriterion(id = requestId, createdBy = UUID.randomUUID())
+                DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
 
             val request = getExampleRequest()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
         }
@@ -189,13 +188,13 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When an error occurs while the criterion is updated, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val criterion =
-            DataBuilder.createExampleUserCriterion(id = requestId, createdBy = user.id)
+            DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
 
         val request = getExampleRequest()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -11,28 +11,29 @@ import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionExce
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.CriterionOuterClass
-import snowballr.ProjectOuterClass
+import snowballr.CriterionOuterClass.CriterionCategory
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 class UpdateCriterionTest : MainServiceTest() {
     private val criterionId = UUID.randomUUID()
 
-    private fun getExampleRequest(): CriterionOuterClass.Criterion.Update {
+    private fun getExampleRequest(): GrpcCriterion.Update {
         val updatedCriterion = DataBuilder.createExampleProjectCriterion(
             id = criterionId,
             tag = "Updated Tag",
             name = "Updated Criterion",
             description = "Updated Description",
-            category = CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_INCLUSION,
+            category = CriterionCategory.CRITERION_CATEGORY_INCLUSION,
         )
 
         val updateFieldMask = FieldMaskUtil.fromStringList(
             listOf("tag", "name", "description", "category"),
         )
 
-        return CriterionOuterClass.Criterion.Update.newBuilder()
+        return GrpcCriterion.Update.newBuilder()
             .setCriterion(updatedCriterion.toGrpcCriterion())
             .setMask(updateFieldMask)
             .build()
@@ -42,7 +43,7 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When a server admin updates a project criterion, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+            status = ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val criterion = DataBuilder.createExampleProjectCriterion(
             id = criterionId,
@@ -65,7 +66,7 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When a project admin updates a project criterion, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+            status = ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
         val criterion = DataBuilder.createExampleProjectCriterion(
@@ -90,7 +91,7 @@ class UpdateCriterionTest : MainServiceTest() {
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
+                status = ProjectStatus.PROJECT_STATUS_ARCHIVED,
             )
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
             val criterion = DataBuilder.createExampleProjectCriterion(
@@ -113,7 +114,7 @@ class UpdateCriterionTest : MainServiceTest() {
     fun `When a project member updates a project criterion, then an UnauthorizedException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+            status = ProjectStatus.PROJECT_STATUS_ACTIVE,
         )
         val criterion = DataBuilder.createExampleProjectCriterion(
             id = criterionId,

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.CriterionOuterClass
@@ -90,7 +90,7 @@ class UpdateCriterionTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a project admin updates a project criterion of a non-active project, then a failed precondition exception is thrown`() =
+    fun `When a project admin updates a project criterion of a non-active project, then a FailedPreconditionException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
@@ -111,31 +111,32 @@ class UpdateCriterionTest : MainServiceTest() {
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
-            assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateCriterion(request) }
+            assertThrows<FailedPreconditionException> { mainService.updateCriterion(request) }
         }
 
     @Test
-    fun `When a project member updates a project criterion, then an unauthorized exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
-        )
-        val criterion = DataBuilder.createExampleProjectCriterion(
-            id = criterionId,
-            projectId = project.id,
-            createdBy = user.id,
-        )
+    fun `When a project member updates a project criterion, then an UnauthorizedException#Single is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject(
+                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+            )
+            val criterion = DataBuilder.createExampleProjectCriterion(
+                id = criterionId,
+                projectId = project.id,
+                createdBy = user.id,
+            )
 
-        val request = getExampleRequest()
+            val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            every { GrpcContext.getUserIdFromContext() } returns user.id
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
-    }
+            assertThrows<UnauthorizedException.Single> { mainService.updateCriterion(request) }
+        }
 
     @Test
     fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
@@ -181,22 +182,6 @@ class UpdateCriterionTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
-            assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
+            assertThrows<UnauthorizedException> { mainService.updateCriterion(request) }
         }
-
-    @Test
-    fun `When an error occurs while the criterion is updated, then an exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val criterion =
-            DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
-
-        val request = getExampleRequest()
-
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.updateCriterion(request) }
-    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -56,7 +56,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
@@ -81,7 +81,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
@@ -107,7 +107,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
             coEvery { projectRepoMock.getProjectById(any()) } returns project
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -130,7 +130,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(any()) } returns project
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
 
@@ -147,7 +147,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertDoesNotThrow { mainService.updateCriterion(request) }
@@ -163,7 +163,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
         assertDoesNotThrow { mainService.updateCriterion(request) }
@@ -180,7 +180,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+            coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
 
             assertThrows<SnowballRException.UnauthorizedException> { mainService.updateCriterion(request) }
         }
@@ -195,7 +195,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { criterionRepoMock.getCriterionById(requestId) } returns criterion
+        coEvery { criterionRepoMock.getCriterionById(requestId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -2,13 +2,11 @@ package se.uulm.snowballr.backend.service.criterion
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
@@ -54,8 +52,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
@@ -79,8 +76,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -105,8 +101,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
             val request = getExampleRequest()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -115,28 +110,26 @@ class UpdateCriterionTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a project member updates a project criterion, then an UnauthorizedException#Single is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
-            )
-            val criterion = DataBuilder.createExampleProjectCriterion(
-                id = criterionId,
-                projectId = project.id,
-                createdBy = user.id,
-            )
+    fun `When a project member updates a project criterion, then an UnauthorizedException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(
+            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+        )
+        val criterion = DataBuilder.createExampleProjectCriterion(
+            id = criterionId,
+            projectId = project.id,
+            createdBy = user.id,
+        )
 
-            val request = getExampleRequest()
+        val request = getExampleRequest()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        mockCurrentUser(user)
+        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-            assertThrows<UnauthorizedException.Single> { mainService.updateCriterion(request) }
-        }
+        assertThrows<UnauthorizedException> { mainService.updateCriterion(request) }
+    }
 
     @Test
     fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
@@ -145,8 +138,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -161,8 +153,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
         val request = getExampleRequest()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
@@ -170,7 +161,7 @@ class UpdateCriterionTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a user updates a user criterion, which he did not created himself, then no exception is thrown`() =
+    fun `When a user updates a user criterion, which he did not created himself, then an UnauthorizedException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val criterion =
@@ -178,8 +169,7 @@ class UpdateCriterionTest : MainServiceTest() {
 
             val request = getExampleRequest()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
 
             assertThrows<UnauthorizedException> { mainService.updateCriterion(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -6,124 +6,66 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetBackwardReferencedPapersTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val paperId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(paperId.toString())
         .build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(paperRepoMock::doesPaperExistById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-    )
-
-    @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val backwardReferenceId = UUID.randomUUID()
-        val referencedPaper = DataBuilder.createExamplePaper(id = backwardReferenceId)
-        val author = DataBuilder.createExampleAuthor()
-
-        if (failAt == paperRepoMock::doesPaperExistById) {
-            coEvery { paperRepoMock.doesPaperExistById(paper.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            } throws TestSpecificException()
-            return
-        }
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(backwardReferenceId)
-
-        if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(backwardReferenceId) } throws TestSpecificException()
-            return
-        }
-        coEvery { paperRepoMock.getPaperById(backwardReferenceId) } returns Result.success(referencedPaper)
-
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(backwardReferenceId) } throws TestSpecificException()
-            return
-        }
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(backwardReferenceId) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(backwardReferenceId)
-            } throws TestSpecificException()
-            return
-        }
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(backwardReferenceId)
-        } returns listOf(UUID.randomUUID())
-    }
-
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
-        assertThrows<TestSpecificException> {
+    @Test
+    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
+        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+        assertThrows<NotFoundException> {
             mainService.getBackwardReferencedPapers(getExampleRequest())
         }
     }
 
     @Test
-    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
-        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns false
-        assertThrows<SnowballRException.NotFoundException> {
-            mainService.getBackwardReferencedPapers(
-                getExampleRequest(),
-            )
-        }
-    }
-
-    @Test
     fun `When one of the backward references doesn't exist, then a NotFoundException is thrown`() = runTest {
-        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = paperId)
         val backwardReferenceId = UUID.randomUUID()
 
-        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns true
+        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(backwardReferenceId)
-        coEvery { paperRepoMock.getPaperById(backwardReferenceId) } throws SnowballRException.NotFoundException(
-            entityType = EntityType.PAPER, requestId.toString(),
-        )
+        coEvery {
+            paperRepoMock.getPaperById(backwardReferenceId)
+        } throws NotFoundException(entityType = EntityType.PAPER, paperId.toString())
 
-        assertThrows<SnowballRException.NotFoundException> {
-            mainService.getBackwardReferencedPapers(
-                getExampleRequest(),
-            )
+        assertThrows<NotFoundException> {
+            mainService.getBackwardReferencedPapers(getExampleRequest())
         }
     }
 
     @Test
-    fun `When the backward references of an existing paper are retrieved successfully, then no error is thrown`() =
+    fun `When the backward references of an existing paper are retrieved successfully, then no exception is thrown`() =
         runTest {
-            mockHappyPathUntil(null)
+            val paper = DataBuilder.createExamplePaper(id = paperId)
+            val backwardReferenceId = UUID.randomUUID()
+            val referencedPaper = DataBuilder.createExamplePaper(id = backwardReferenceId)
+            val author = DataBuilder.createExampleAuthor()
+
+            coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+            } returns listOf(backwardReferenceId)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(backwardReferenceId) } returns listOf(author)
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(backwardReferenceId)
+            } returns listOf(UUID.randomUUID())
+            coEvery { paperRepoMock.getPaperById(backwardReferenceId) } returns Result.success(referencedPaper)
+
             assertDoesNotThrow { mainService.getBackwardReferencedPapers(getExampleRequest()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -62,7 +62,7 @@ class GetBackwardReferencedPapersTest : MainServiceTest() {
             coEvery { paperRepoMock.getPaperById(backwardReferenceId) } throws TestSpecificException()
             return
         }
-        coEvery { paperRepoMock.getPaperById(backwardReferenceId) } returns referencedPaper
+        coEvery { paperRepoMock.getPaperById(backwardReferenceId) } returns Result.success(referencedPaper)
 
         if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(backwardReferenceId) } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.paper
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -13,7 +12,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetBackwardReferencedPapersTest : MainServiceTest() {
     private val paperId = UUID.randomUUID()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -49,7 +49,7 @@ class GetBackwardReferencedPapersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the backward references of an existing paper are retrieved successfully, then no exception is thrown`() =
+    fun `When the backward references of an existent paper are retrieved successfully, then no exception is thrown`() =
         runTest {
             val paper = DataBuilder.createExamplePaper(id = paperId)
             val backwardReferenceId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -62,7 +62,7 @@ class GetForwardReferencedPapersTest : MainServiceTest() {
             coEvery { paperRepoMock.getPaperById(forwardReferenceId) } throws TestSpecificException()
             return
         }
-        coEvery { paperRepoMock.getPaperById(forwardReferenceId) } returns citingPaper
+        coEvery { paperRepoMock.getPaperById(forwardReferenceId) } returns Result.success(citingPaper)
 
         if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(forwardReferenceId) } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -6,124 +6,66 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetForwardReferencedPapersTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val paperId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(paperId.toString())
         .build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(paperRepoMock::doesPaperExistById),
-        Arguments.of(citationRepoMock::getForwardReferencedPaperIdsOfPaperById),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-    )
-
-    @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val forwardReferenceId = UUID.randomUUID()
-        val citingPaper = DataBuilder.createExamplePaper(id = forwardReferenceId)
-        val author = DataBuilder.createExampleAuthor()
-
-        if (failAt == paperRepoMock::doesPaperExistById) {
-            coEvery { paperRepoMock.doesPaperExistById(paper.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
-
-        if (failAt == citationRepoMock::getForwardReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
-            } throws TestSpecificException()
-            return
-        }
-        coEvery {
-            citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(forwardReferenceId)
-
-        if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(forwardReferenceId) } throws TestSpecificException()
-            return
-        }
-        coEvery { paperRepoMock.getPaperById(forwardReferenceId) } returns Result.success(citingPaper)
-
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(forwardReferenceId) } throws TestSpecificException()
-            return
-        }
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(forwardReferenceId) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(forwardReferenceId)
-            } throws TestSpecificException()
-            return
-        }
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(forwardReferenceId)
-        } returns listOf(UUID.randomUUID())
-    }
-
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
-        assertThrows<TestSpecificException> {
+    @Test
+    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
+        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+        assertThrows<NotFoundException> {
             mainService.getForwardReferencedPapers(getExampleRequest())
         }
     }
 
     @Test
-    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
-        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns false
-        assertThrows<SnowballRException.NotFoundException> {
-            mainService.getForwardReferencedPapers(
-                getExampleRequest(),
-            )
-        }
-    }
-
-    @Test
     fun `When one of the forward references doesn't exist, then a NotFoundException is thrown`() = runTest {
-        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = paperId)
         val forwardReferenceId = UUID.randomUUID()
 
-        coEvery { paperRepoMock.doesPaperExistById(requestId) } returns true
+        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
         coEvery {
             citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(forwardReferenceId)
-        coEvery { paperRepoMock.getPaperById(forwardReferenceId) } throws SnowballRException.NotFoundException(
-            entityType = EntityType.PAPER, requestId.toString(),
-        )
+        coEvery {
+            paperRepoMock.getPaperById(forwardReferenceId)
+        } throws NotFoundException(entityType = EntityType.PAPER, paper.id.toString())
 
-        assertThrows<SnowballRException.NotFoundException> {
-            mainService.getForwardReferencedPapers(
-                getExampleRequest(),
-            )
+        assertThrows<NotFoundException> {
+            mainService.getForwardReferencedPapers(getExampleRequest())
         }
     }
 
     @Test
-    fun `When the forward references of an existing paper are retrieved successfully, then no error is thrown`() =
+    fun `When the forward references of an existing paper are retrieved successfully, then no exception is thrown`() =
         runTest {
-            mockHappyPathUntil(null)
+            val paper = DataBuilder.createExamplePaper(id = paperId)
+            val forwardReferenceId = UUID.randomUUID()
+            val citingPaper = DataBuilder.createExamplePaper(id = forwardReferenceId)
+            val author = DataBuilder.createExampleAuthor()
+
+            coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+            coEvery {
+                citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
+            } returns listOf(forwardReferenceId)
+            coEvery { paperRepoMock.getPaperById(forwardReferenceId) } returns Result.success(citingPaper)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(forwardReferenceId) } returns listOf(author)
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(forwardReferenceId)
+            } returns listOf(UUID.randomUUID())
+
             assertDoesNotThrow { mainService.getForwardReferencedPapers(getExampleRequest()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -49,7 +49,7 @@ class GetForwardReferencedPapersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the forward references of an existing paper are retrieved successfully, then no exception is thrown`() =
+    fun `When the forward references of an existent paper are retrieved successfully, then no exception is thrown`() =
         runTest {
             val paper = DataBuilder.createExamplePaper(id = paperId)
             val forwardReferenceId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.paper
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -13,7 +12,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetForwardReferencedPapersTest : MainServiceTest() {
     private val paperId = UUID.randomUUID()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -42,7 +42,7 @@ class GetPaperByIdTest : MainServiceTest() {
             coEvery { paperRepoMock.getPaperById(paper.id) } throws TestSpecificException()
             return
         }
-        coEvery { paperRepoMock.getPaperById(paper.id) } returns paper
+        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
 
         if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -27,7 +27,7 @@ class GetPaperByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a paper is retrieved, then no exception is thrown`() = runTest {
+    fun `When a paper is retrieved successfully, then no exception is thrown`() = runTest {
         val paper = DataBuilder.createExamplePaper(id = paperId)
         val author = DataBuilder.createExampleAuthor()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -37,7 +37,7 @@ class GetPaperByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a paper is retrieved, then no error is thrown`() = runTest {
+    fun `When a paper is retrieved, then no exception is thrown`() = runTest {
         val paper = DataBuilder.createExamplePaper(id = requestId)
         val author = DataBuilder.createExampleAuthor()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.paper
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -12,7 +11,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPaperByIdTest : MainServiceTest() {
     private val paperId = UUID.randomUUID()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -14,23 +14,23 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPaperByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val paperId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(paperId.toString())
         .build()
 
     @Test
     fun `When fetching the paper fails, then a TestSpecificException is thrown`() = runTest {
-        coEvery { paperRepoMock.getPaperById(any()) } returns Result.failure(TestSpecificException())
+        coEvery { paperRepoMock.getPaperById(paperId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getPaperById(getExampleRequest()) }
     }
 
     @Test
     fun `When a paper is retrieved, then no exception is thrown`() = runTest {
-        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val paper = DataBuilder.createExamplePaper(id = paperId)
         val author = DataBuilder.createExampleAuthor()
 
         coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
@@ -21,13 +20,6 @@ class GetPaperByIdTest : MainServiceTest() {
         .newBuilder()
         .setId(requestId.toString())
         .build()
-
-    @Test
-    fun `When parsing the paper ID fails, then an InvalidIdException is thrown`() = runTest {
-        val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-
-        assertThrows<InvalidIdException> { mainService.getPaperById(request) }
-    }
 
     @Test
     fun `When fetching the paper fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -6,17 +6,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPaperByIdTest : MainServiceTest() {
@@ -27,59 +22,31 @@ class GetPaperByIdTest : MainServiceTest() {
         .setId(requestId.toString())
         .build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(paperRepoMock::getPaperById),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-    )
-
-    @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?) {
-        val paper = DataBuilder.createExamplePaper(id = requestId)
-        val author = DataBuilder.createExampleAuthor()
-
-        if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(paper.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
-
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            } throws TestSpecificException()
-            return
-        }
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-    }
-
     @Test
-    fun `When parsing the paper ID fails, then an exception is thrown`() = runTest {
+    fun `When parsing the paper ID fails, then an InvalidIdException is thrown`() = runTest {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
 
         assertThrows<InvalidIdException> { mainService.getPaperById(request) }
     }
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt)
-        assertThrows<TestSpecificException> {
-            mainService.getPaperById(getExampleRequest())
-        }
+    @Test
+    fun `When fetching the paper fails, then a TestSpecificException is thrown`() = runTest {
+        coEvery { paperRepoMock.getPaperById(any()) } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getPaperById(getExampleRequest()) }
     }
 
     @Test
     fun `When a paper is retrieved, then no error is thrown`() = runTest {
-        mockHappyPathUntil(null)
+        val paper = DataBuilder.createExamplePaper(id = requestId)
+        val author = DataBuilder.createExampleAuthor()
+
+        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery {
+            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
+        } returns listOf(UUID.randomUUID())
+
         assertDoesNotThrow { mainService.getPaperById(getExampleRequest()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
@@ -15,17 +15,17 @@ import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityExcepti
 import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AddPaperToProjectTest : MainServiceTest() {
     private val projectId = UUID.randomUUID()
     private val paperId = UUID.randomUUID()
-    private fun getExampleRequest() = ProjectOuterClass.Project.Paper.Add.newBuilder()
+    private fun getExampleRequest() = GrpcProject.Paper.Add.newBuilder()
         .setProjectId(projectId.toString())
         .setPaperId(paperId.toString())
         .setStage(0)
@@ -40,9 +40,9 @@ class AddPaperToProjectTest : MainServiceTest() {
     private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val project = DataBuilder.createExampleProject(id = projectId)
@@ -112,7 +112,7 @@ class AddPaperToProjectTest : MainServiceTest() {
 
     @Test
     fun `When a non project member adds a paper to a project, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
@@ -123,7 +123,7 @@ class AddPaperToProjectTest : MainServiceTest() {
 
     @Test
     fun `When a project paper already exists, then a DuplicateEntityException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
         val paper = DataBuilder.createExamplePaper(id = paperId)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
@@ -142,12 +142,12 @@ class AddPaperToProjectTest : MainServiceTest() {
     @Test
     fun `When the requested stage is greater than the projects max stage, then an OutOfRangeException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(id = projectId)
             val paper = DataBuilder.createExamplePaper(id = paperId)
             val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
 
-            val request = ProjectOuterClass.Project.Paper.Add.newBuilder()
+            val request = GrpcProject.Paper.Add.newBuilder()
                 .setProjectId(projectId.toString())
                 .setPaperId(paperId.toString())
                 .setStage(1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -33,15 +32,8 @@ class AddPaperToProjectTest : MainServiceTest() {
         .build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(projectRepoMock::getProjectById),
-        Arguments.of(projectPaperRepoMock::doesProjectPaperExist),
         Arguments.of(paperRepoMock::getPaperById),
-        Arguments.of(projectPaperRepoMock::addPaperToProject),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
     )
 
     @Suppress("LongMethod", "ReturnCount", "CyclomaticComplexMethod")
@@ -64,11 +56,6 @@ class AddPaperToProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview()
 
         mockCurrentUser(currentUser)
-
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -77,63 +64,26 @@ class AddPaperToProjectTest : MainServiceTest() {
             }
 
         if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
+            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
-        if (failAt == projectPaperRepoMock::doesProjectPaperExist) {
-            coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
-
-        if (failAt == projectPaperRepoMock::addPaperToProject) {
-            coEvery {
-                projectPaperRepoMock.addPaperToProject(getExampleRequest(), currentUser.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             projectPaperRepoMock.addPaperToProject(getExampleRequest(), currentUser.id)
         } returns projectPaper
-
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
-            return
-        }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
-
-        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -12,8 +11,10 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
+import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
@@ -32,8 +33,6 @@ class AddPaperToProjectTest : MainServiceTest() {
         .build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(projectRepoMock::getProjectById),
         Arguments.of(projectPaperRepoMock::doesProjectPaperExist),
@@ -64,17 +63,7 @@ class AddPaperToProjectTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -152,7 +141,7 @@ class AddPaperToProjectTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.addPaperToProject(getExampleRequest())
@@ -172,38 +161,36 @@ class AddPaperToProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member adds a paper to a project, then an unauthorized exception is thrown`() = runTest {
+    fun `When a non project member adds a paper to a project, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> { mainService.addPaperToProject(getExampleRequest()) }
+        assertThrows<UnauthorizedException> { mainService.addPaperToProject(getExampleRequest()) }
     }
 
     @Test
-    fun `When a project paper already exists, then a duplicate entity exception is thrown`() = runTest {
+    fun `When a project paper already exists, then a DuplicateEntityException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
         val paper = DataBuilder.createExamplePaper(id = paperId)
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns true
 
-        assertThrows<SnowballRException.DuplicateEntityException> {
+        assertThrows<DuplicateEntityException> {
             mainService.addPaperToProject(getExampleRequest())
         }
     }
 
     @Test
-    fun `When the requested stage is greater than the projects max stage, then a out of range exception is thrown`() =
+    fun `When the requested stage is greater than the projects max stage, then an OutOfRangeException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(id = projectId)
@@ -216,13 +203,12 @@ class AddPaperToProjectTest : MainServiceTest() {
                 .setStage(1)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
             coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
 
-            assertThrows<SnowballRException.OutOfRangeException> { mainService.addPaperToProject(request) }
+            assertThrows<OutOfRangeException> { mainService.addPaperToProject(request) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/AddPaperToProjectTest.kt
@@ -74,7 +74,7 @@ class AddPaperToProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -91,13 +91,13 @@ class AddPaperToProjectTest : MainServiceTest() {
             coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         if (failAt == paperRepoMock::getPaperById) {
             coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
             return
         }
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
         if (failAt == projectPaperRepoMock::doesProjectPaperExist) {
             coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } throws TestSpecificException()
@@ -177,7 +177,7 @@ class AddPaperToProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.addPaperToProject(getExampleRequest()) }
@@ -191,10 +191,10 @@ class AddPaperToProjectTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
-        coEvery { paperRepoMock.getPaperById(paper.id) } returns paper
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns true
 
         assertThrows<SnowballRException.DuplicateEntityException> {
@@ -217,10 +217,10 @@ class AddPaperToProjectTest : MainServiceTest() {
                 .build()
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
-            coEvery { paperRepoMock.getPaperById(paper.id) } returns paper
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
             coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
 
             assertThrows<SnowballRException.OutOfRangeException> { mainService.addPaperToProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -10,7 +9,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
@@ -21,19 +19,11 @@ class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
 
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.createProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When an error occurs while a project is created, then an exception is thrown`() = runTest {
+    fun `When an error occurs while a project is created, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val userSettings = DataBuilder.createExampleUserSettings()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
         coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } throws TestSpecificException()
@@ -47,8 +37,7 @@ class CreateProjectTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val userSettings = DataBuilder.createExampleUserSettings()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
         coEvery { projectRepoMock.createProject(any(), any(), userSettings) } returns project
@@ -66,8 +55,7 @@ class CreateProjectTest : MainServiceTest() {
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
             val criteriaIdsSlot = slot<List<UUID>>()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
             coEvery { criterionRepoMock.getCriteriaByIds(capture(criteriaIdsSlot)) } returns listOf(criterion)
             coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } returns project

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -33,8 +33,8 @@ class CreateProjectTest : MainServiceTest() {
         val userSettings = DataBuilder.createExampleUserSettings()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
         coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } throws TestSpecificException()
 
@@ -48,8 +48,8 @@ class CreateProjectTest : MainServiceTest() {
         val userSettings = DataBuilder.createExampleUserSettings()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
         coEvery { projectRepoMock.createProject(any(), any(), userSettings) } returns project
 
@@ -67,8 +67,8 @@ class CreateProjectTest : MainServiceTest() {
             val criteriaIdsSlot = slot<List<UUID>>()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
             coEvery { criterionRepoMock.getCriteriaByIds(capture(criteriaIdsSlot)) } returns listOf(criterion)
             coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } returns project
             coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -6,9 +6,7 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
@@ -17,19 +15,6 @@ import kotlin.test.assertEquals
 
 class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
-
-    @Test
-    fun `When an error occurs while a project is created, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val userSettings = DataBuilder.createExampleUserSettings()
-
-        mockCurrentUser(user)
-        coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
-        coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
-        coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.createProject(getExampleRequest()) }
-    }
 
     @Test
     fun `When a project is correctly created, then no exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -8,13 +8,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import kotlin.test.assertEquals
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class CreateProjectTest : MainServiceTest() {
-    private fun getExampleRequest() = ProjectOuterClass.Project.Create.getDefaultInstance()
+    private fun getExampleRequest() = GrpcProject.Create.getDefaultInstance()
 
     @Test
     fun `When a project is correctly created, then no exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -48,7 +48,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
@@ -61,8 +61,8 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
             assertThrows<UnauthorizedException.Single> {
                 mainService.getAllArchivedProjectsForUser(
@@ -77,8 +77,8 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
@@ -90,8 +90,8 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
@@ -104,7 +104,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -21,7 +21,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
-    fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {
+    fun `When retrieving the requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -1,14 +1,12 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -21,63 +19,46 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
-    fun `When parsing the ID fails, then an exception is thrown`() = runTest {
+    fun `When parsing the ID fails, then an InvalidIdException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
+
+        mockCurrentUser(currentUser)
 
         assertThrows<InvalidIdException> { mainService.getAllArchivedProjectsForUser(request) }
     }
 
     @Test
-    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested user fails, then an exception is thrown`() = runTest {
+    fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When a non-admin retrieves another user's archived projects, then an unauthorized exception is thrown`() =
+    fun `When a non-admin retrieves another user's archived projects, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
-            assertThrows<UnauthorizedException.Single> {
-                mainService.getAllArchivedProjectsForUser(
-                    getExampleRequest(),
-                )
+            assertThrows<UnauthorizedException> {
+                mainService.getAllArchivedProjectsForUser(getExampleRequest())
             }
         }
 
     @Test
-    fun `When retrieving archived projects fails, then an exception is thrown`() = runTest {
+    fun `When retrieving archived projects fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
 
@@ -89,8 +70,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
@@ -103,8 +83,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -20,16 +19,6 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED)
 
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @Test
-    fun `When parsing the ID fails, then an InvalidIdException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-
-        mockCurrentUser(currentUser)
-
-        assertThrows<InvalidIdException> { mainService.getAllArchivedProjectsForUser(request) }
-    }
 
     @Test
     fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -11,11 +11,14 @@ import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
+    private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED)
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
@@ -34,7 +37,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
     }
@@ -48,22 +51,8 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
-            assertThrows<UnauthorizedException> {
-                mainService.getAllArchivedProjectsForUser(getExampleRequest())
-            }
+            assertThrows<UnauthorizedException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
         }
-
-    @Test
-    fun `When retrieving archived projects fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
-    }
 
     @Test
     fun `When archived projects are retrieved by an admin, then they are returned successfully`() = runTest {
@@ -72,7 +61,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
+        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(getExampleRequest()) }
     }
@@ -84,7 +73,7 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
+        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -21,7 +21,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
-    fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {
+    fun `When retrieving the requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -20,16 +19,6 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_DELETED)
 
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @Test
-    fun `When parsing the ID fails, then an InvalidIdException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-
-        mockCurrentUser(currentUser)
-
-        assertThrows<InvalidIdException> { mainService.getAllDeletedProjectsForUser(request) }
-    }
 
     @Test
     fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -48,7 +48,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
@@ -61,8 +61,8 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
             assertThrows<UnauthorizedException.Single> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
         }
@@ -73,8 +73,8 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
@@ -86,8 +86,8 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
@@ -100,7 +100,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -1,14 +1,12 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -21,59 +19,44 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
-    fun `When parsing the ID fails, then an exception is thrown`() = runTest {
+    fun `When parsing the ID fails, then an InvalidIdException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
+
+        mockCurrentUser(currentUser)
 
         assertThrows<InvalidIdException> { mainService.getAllDeletedProjectsForUser(request) }
     }
 
     @Test
-    fun `When retrieving current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested user fails, then an exception is thrown`() = runTest {
+    fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When a non-admin retrieves another user's deleted projects, then an unauthorized exception is thrown`() =
+    fun `When a non-admin retrieves another user's deleted projects, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
-            assertThrows<UnauthorizedException.Single> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
+            assertThrows<UnauthorizedException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
         }
 
     @Test
-    fun `When retrieving deleted projects fails, then an exception is thrown`() = runTest {
+    fun `When retrieving deleted projects fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
 
@@ -85,8 +68,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
@@ -99,8 +81,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -11,11 +11,14 @@ import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
+    private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_DELETED)
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
@@ -34,7 +37,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
     }
@@ -52,25 +55,13 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         }
 
     @Test
-    fun `When retrieving deleted projects fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
     fun `When deleted projects are retrieved by an admin, then they are returned successfully`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
+        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(getExampleRequest()) }
     }
@@ -82,7 +73,7 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getUserProjects(any(), any()) } returns emptyList()
+        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -66,7 +66,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == projectRepoMock::doesProjectExistById) {
             coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
@@ -155,7 +155,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = requestId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -86,7 +86,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non-existing project is requested, then a NotFoundException is thrown`() = runTest {
+    fun `When a nonexistent project is requested, then a NotFoundException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = requestId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -12,8 +11,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -28,8 +27,6 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(projectRepoMock::doesProjectExistById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
@@ -56,17 +53,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == projectRepoMock::doesProjectExistById) {
             coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
@@ -130,7 +117,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getAllProjectPapersForProject(getExampleRequest())
@@ -150,19 +137,16 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member requests the project papers, then an unauthorized exception is thrown`() = runTest {
+    fun `When a non project member requests the project papers, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = requestId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> {
-            mainService.getAllProjectPapersForProject(
-                getExampleRequest(),
-            )
+        assertThrows<UnauthorizedException> {
+            mainService.getAllProjectPapersForProject(getExampleRequest())
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -6,43 +6,27 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllProjectPapersForProjectTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectRepoMock::doesProjectExistById),
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
-        Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
-    )
-
-    @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+    @Suppress("LongMethod")
+    private fun mockHappyPath(isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val project = DataBuilder.createExampleProject(id = requestId)
@@ -54,91 +38,41 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview()
 
         mockCurrentUser(currentUser)
-
-        if (failAt == projectRepoMock::doesProjectExistById) {
-            coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
-
-        if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
-            coEvery {
-                projectPaperRepoMock.getAllProjectPapersWithPapers(any())
-            } throws TestSpecificException()
-            return
-        }
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) } throws TestSpecificException()
-            return
-        }
+        coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
-
-        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
     }
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt, true)
-        assertThrows<TestSpecificException> {
-            mainService.getAllProjectPapersForProject(getExampleRequest())
-        }
-    }
-
     @Test
     fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, true)
+        mockHappyPath(true)
+
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, false)
+        mockHappyPath(false)
+
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a non project member requests the project papers, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = requestId)
 
         mockCurrentUser(currentUser)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectPapersForProjectTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -80,6 +81,19 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> {
+            mainService.getAllProjectPapersForProject(getExampleRequest())
+        }
+    }
+
+    @Test
+    fun `When a non-existing project is requested, then a NotFoundException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+
+        assertThrows<NotFoundException> {
             mainService.getAllProjectPapersForProject(getExampleRequest())
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -20,16 +19,6 @@ class GetAllProjectsForUserTest : MainServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
 
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @Test
-    fun `When parsing the ID of the requested user fails, then an InvalidIdException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-
-        mockCurrentUser(currentUser)
-
-        assertThrows<InvalidIdException> { mainService.getAllProjectsForUser(request) }
-    }
 
     @Test
     fun `When retrieving the requested user fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -11,11 +11,14 @@ import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetAllProjectsForUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
+    private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
@@ -34,33 +37,22 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When all user projects are retrieved by another non-admin user, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
+    fun `When all user projects are retrieved by another non-admin user, then an UnauthorizedException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
-        assertThrows<UnauthorizedException> { mainService.getAllProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving the projects of a user fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
-    }
+            assertThrows<UnauthorizedException> { mainService.getAllProjectsForUser(getExampleRequest()) }
+        }
 
     @Test
     fun `When the user projects are retrieved by an admin, then all user projects are returned successfully`() =
@@ -70,7 +62,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-            coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllProjectsForUser(getExampleRequest()) }
         }
@@ -83,7 +75,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
+        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjectsForUser(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -48,7 +48,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
@@ -60,8 +60,8 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
         assertThrows<UnauthorizedException.Single> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
@@ -72,8 +72,8 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
@@ -86,8 +86,8 @@ class GetAllProjectsForUserTest : MainServiceTest() {
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(any()) } returns currentUser
-            coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
             coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
 
             assertDoesNotThrow { mainService.getAllProjectsForUser(getExampleRequest()) }
@@ -100,8 +100,8 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjectsForUser(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -1,14 +1,12 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -21,58 +19,43 @@ class GetAllProjectsForUserTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
-    fun `When parsing the ID of the requested user fails, then an exception is thrown`() = runTest {
+    fun `When parsing the ID of the requested user fails, then an InvalidIdException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
+
+        mockCurrentUser(currentUser)
 
         assertThrows<InvalidIdException> { mainService.getAllProjectsForUser(request) }
     }
 
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving the requested user fails, then an exception is thrown`() = runTest {
+    fun `When retrieving the requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When all user projects are retrieved by another non-admin user, then an exception is thrown`() = runTest {
+    fun `When all user projects are retrieved by another non-admin user, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
-        assertThrows<UnauthorizedException.Single> { mainService.getAllProjectsForUser(getExampleRequest()) }
+        assertThrows<UnauthorizedException> { mainService.getAllProjectsForUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When retrieving the projects of a user fails, then an exception is thrown`() = runTest {
+    fun `When retrieving the projects of a user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any()) } throws TestSpecificException()
 
@@ -85,8 +68,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
             coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
 
@@ -99,8 +81,7 @@ class GetAllProjectsForUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
         coEvery { projectRepoMock.getUserProjects(any()) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -1,51 +1,31 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 
 class GetAllProjectsTest : MainServiceTest() {
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjects() }
-    }
-
-    @Test
-    fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns Result.failure(TestSpecificException())
-
-        assertThrows<TestSpecificException> { mainService.getAllProjects() }
-    }
-
-    @Test
-    fun `When all projects are retrieved by a non-admin, then an exception is thrown`() = runTest {
+    fun `When all projects are retrieved by a non-admin, then an UnauthorizedException is thrown`() = runTest {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        every { GrpcContext.getUserIdFromContext() } returns nonAdminUser.id
-        coEvery { userRepoMock.getUserById(nonAdminUser.id) } returns Result.success(nonAdminUser)
+        mockCurrentUser(nonAdminUser)
 
-        assertThrows<UnauthorizedException.All> { mainService.getAllProjects() }
+        assertThrows<UnauthorizedException> { mainService.getAllProjects() }
     }
 
     @Test
-    fun `When retrieving all projects fails, then an exception is thrown`() = runTest {
+    fun `When retrieving all projects fails, then a TestSpecificException is thrown`() = runTest {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectRepoMock.getAllProjects() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
@@ -55,8 +35,7 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When all projects are retrieved by an admin, then no exception is thrown`() = runTest {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectRepoMock.getAllProjects() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjects() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
@@ -19,16 +18,6 @@ class GetAllProjectsTest : MainServiceTest() {
         mockCurrentUser(nonAdminUser)
 
         assertThrows<UnauthorizedException> { mainService.getAllProjects() }
-    }
-
-    @Test
-    fun `When retrieving all projects fails, then a TestSpecificException is thrown`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-
-        mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.getAllProjects() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllProjects() }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -25,7 +25,7 @@ class GetAllProjectsTest : MainServiceTest() {
     @Test
     fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(any()) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
     }
@@ -34,8 +34,8 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When all projects are retrieved by a non-admin, then an exception is thrown`() = runTest {
         val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns nonAdminUser
+        every { GrpcContext.getUserIdFromContext() } returns nonAdminUser.id
+        coEvery { userRepoMock.getUserById(nonAdminUser.id) } returns Result.success(nonAdminUser)
 
         assertThrows<UnauthorizedException.All> { mainService.getAllProjects() }
     }
@@ -44,8 +44,8 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When retrieving all projects fails, then an exception is thrown`() = runTest {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getAllProjects() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllProjects() }
@@ -55,8 +55,8 @@ class GetAllProjectsTest : MainServiceTest() {
     fun `When all projects are retrieved by an admin, then no exception is thrown`() = runTest {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns adminUser
+        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getAllProjects() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjects() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -7,12 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -20,26 +15,14 @@ import snowballr.Base
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPapersToReviewForProjectTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectRepoMock::doesProjectExistById),
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
-        Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
-    )
-
-    @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+    @Suppress("LongMethod")
+    private fun mockHappyPath(isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
                 UserOuterClass.UserRole.USER_ROLE_ADMIN
@@ -56,85 +39,37 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview()
 
         mockCurrentUser(currentUser)
-
-        if (failAt == projectRepoMock::doesProjectExistById) {
-            coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
-
-        if (failAt == projectPaperRepoMock::getAllProjectPapersWithPapers) {
-            coEvery {
-                projectPaperRepoMock.getAllProjectPapersWithPapers(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
         } returns listOf(projectPaperWithPaper)
-
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
-
-        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } throws TestSpecificException()
-            return
-        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
     }
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt, true)
-        assertThrows<TestSpecificException> {
-            mainService.getPapersToReviewForProject(getExampleRequest())
-        }
-    }
-
     @Test
     fun `When a server admin requests the project papers to review, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, true)
+        mockHappyPath(true)
+
         assertDoesNotThrow { mainService.getPapersToReviewForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member requests the project papers to review, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, false)
+        mockHappyPath(false)
+
         assertDoesNotThrow { mainService.getPapersToReviewForProject(getExampleRequest()) }
     }
 
@@ -196,8 +131,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         var projectPapers: ProjectOuterClass.Project.Paper.List
         assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
         assertThat(projectPapers.projectPapersList).hasSize(1)
-        assertThat(projectPapers.projectPapersList)
-            .anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
+        assertThat(projectPapers.projectPapersList).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
         assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -192,7 +192,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a non-existing project is requested, then a NotFoundException is thrown`() = runTest {
+    fun `When a nonexistent project is requested, then a NotFoundException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = requestId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -188,4 +189,17 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             assertThat(projectPapers.projectPapersList)
                 .noneMatch { it.id == projectPaperWithCurrentUserReview.id.toString() }
         }
+
+    @Test
+    fun `When a non-existing project is requested, then a NotFoundException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject(id = requestId)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+
+        assertThrows<NotFoundException> {
+            mainService.getPapersToReviewForProject(getExampleRequest())
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -68,7 +68,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == projectRepoMock::doesProjectExistById) {
             coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
@@ -158,7 +158,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = requestId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
@@ -190,7 +190,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery {
@@ -242,7 +242,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             val reviewByOtherUser = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
             coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -13,8 +12,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -30,8 +29,6 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(projectRepoMock::doesProjectExistById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(projectPaperRepoMock::getAllProjectPapersWithPapers),
@@ -58,17 +55,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == projectRepoMock::doesProjectExistById) {
             coEvery { projectRepoMock.doesProjectExistById(any()) } throws TestSpecificException()
@@ -132,7 +119,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getPapersToReviewForProject(getExampleRequest())
@@ -152,20 +139,17 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member requests the project papers to review, then an unauthorized exception is thrown`() =
+    fun `When a non project member requests the project papers to review, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(id = requestId)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-            assertThrows<SnowballRException.UnauthorizedException> {
-                mainService.getPapersToReviewForProject(
-                    getExampleRequest(),
-                )
+            assertThrows<UnauthorizedException> {
+                mainService.getPapersToReviewForProject(getExampleRequest())
             }
         }
 
@@ -189,8 +173,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery {
@@ -213,9 +196,8 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         var projectPapers: ProjectOuterClass.Project.Paper.List
         assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
         assertThat(projectPapers.projectPapersList).hasSize(1)
-        assertThat(
-            projectPapers.projectPapersList,
-        ).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
+        assertThat(projectPapers.projectPapersList)
+            .anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
         assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
     }
 
@@ -241,8 +223,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             val reviewByCurrentUser = DataBuilder.createExampleReview(userId = currentUser.id)
             val reviewByOtherUser = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
             coEvery {
@@ -268,11 +249,9 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             var projectPapers: ProjectOuterClass.Project.Paper.List
             assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
             assertThat(projectPapers.projectPapersList).hasSize(1)
-            assertThat(
-                projectPapers.projectPapersList,
-            ).anyMatch { it.id == projectPaperWithoutCurrentUserReview.id.toString() }
-            assertThat(
-                projectPapers.projectPapersList,
-            ).noneMatch { it.id == projectPaperWithCurrentUserReview.id.toString() }
+            assertThat(projectPapers.projectPapersList)
+                .anyMatch { it.id == projectPaperWithoutCurrentUserReview.id.toString() }
+            assertThat(projectPapers.projectPapersList)
+                .noneMatch { it.id == projectPaperWithCurrentUserReview.id.toString() }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetPapersToReviewForProjectTest.kt
@@ -13,9 +13,10 @@ import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
-import snowballr.ProjectOuterClass
-import snowballr.UserOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPapersToReviewForProjectTest : MainServiceTest() {
@@ -26,9 +27,9 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     private fun mockHappyPath(isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val project = DataBuilder.createExampleProject(id = requestId)
@@ -77,7 +78,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     @Test
     fun `When a non project member requests the project papers to review, then an UnauthorizedException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(id = requestId)
 
             mockCurrentUser(currentUser)
@@ -91,18 +92,18 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
     @Test
     fun `When the project papers to review are requested, then only the undecided papers are returned`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = requestId)
         val paper = DataBuilder.createExamplePaper(id = requestId)
         val projectPaperAlreadyDecided = DataBuilder.createExampleProjectPaper(
             projectId = project.id,
             paperId = paper.id,
-            decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED,
+            decision = PaperDecision.PAPER_DECISION_ACCEPTED,
         )
         val projectPaperNotAlreadyDecided = DataBuilder.createExampleProjectPaper(
             projectId = project.id,
             paperId = paper.id,
-            decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+            decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
         )
         val projectPaperWithPaper1 = ProjectPaperWithPaper(projectPaperAlreadyDecided, paper)
         val projectPaperWithPaper2 = ProjectPaperWithPaper(projectPaperNotAlreadyDecided, paper)
@@ -129,7 +130,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
 
-        var projectPapers: ProjectOuterClass.Project.Paper.List
+        var projectPapers: GrpcProjectPaper.List
         assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
         assertThat(projectPapers.projectPapersList).hasSize(1)
         assertThat(projectPapers.projectPapersList).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
@@ -139,18 +140,18 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     @Test
     fun `When the project papers to review are requested, then only undecided papers that were not already reviewed by the current user are returned`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject(id = requestId)
             val paper = DataBuilder.createExamplePaper(id = requestId)
             val projectPaperWithCurrentUserReview = DataBuilder.createExampleProjectPaper(
                 projectId = project.id,
                 paperId = paper.id,
-                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
             )
             val projectPaperWithoutCurrentUserReview = DataBuilder.createExampleProjectPaper(
                 projectId = project.id,
                 paperId = paper.id,
-                decision = ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED,
+                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
             )
             val projectPaperWithPaper1 = ProjectPaperWithPaper(projectPaperWithCurrentUserReview, paper)
             val projectPaperWithPaper2 = ProjectPaperWithPaper(projectPaperWithoutCurrentUserReview, paper)
@@ -181,7 +182,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
                 reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviewByOtherUser.id)
             } returns listOf(UUID.randomUUID())
 
-            var projectPapers: ProjectOuterClass.Project.Paper.List
+            var projectPapers: GrpcProjectPaper.List
             assertDoesNotThrow { projectPapers = mainService.getPapersToReviewForProject(getExampleRequest()) }
             assertThat(projectPapers.projectPapersList).hasSize(1)
             assertThat(projectPapers.projectPapersList)
@@ -192,7 +193,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
     @Test
     fun `When a non-existing project is requested, then a NotFoundException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = requestId)
 
         mockCurrentUser(currentUser)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -30,7 +30,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val noAccessUser = DataBuilder.createExampleUser()
 
         every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
-        coEvery { userRepoMock.getUserById(noAccessUser.id) } returns noAccessUser
+        coEvery { userRepoMock.getUserById(noAccessUser.id) } returns Result.success(noAccessUser)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
@@ -44,7 +44,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -60,7 +60,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -74,7 +74,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -24,7 +24,6 @@ class GetProjectByIdTest : MainServiceTest() {
     @Test
     fun `When the requesting user is not a member of the project, then an UnauthorizedException is thrown`() = runTest {
         val request = getExampleRequest()
-
         val noAccessUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(noAccessUser)
@@ -36,7 +35,6 @@ class GetProjectByIdTest : MainServiceTest() {
     @Test
     fun `When the requesting user is a server admin, then the project can be retrieved`() = runTest {
         val request = getExampleRequest()
-
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = projectId)
 
@@ -50,7 +48,6 @@ class GetProjectByIdTest : MainServiceTest() {
     @Test
     fun `When the requesting user is a project member, then the project can be retrieved`() = runTest {
         val request = getExampleRequest()
-
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
@@ -65,12 +62,11 @@ class GetProjectByIdTest : MainServiceTest() {
     @Test
     fun `When an error occurs while the project is retrieved, then a TestSpecificException is thrown`() = runTest {
         val request = getExampleRequest()
-
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
+        coEvery { projectRepoMock.getProjectById(any()) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getProjectById(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -1,14 +1,12 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -24,16 +22,15 @@ class GetProjectByIdTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the requesting user is not a member of the project, then an exception is thrown`() = runTest {
+    fun `When the requesting user is not a member of the project, then an UnauthorizedException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val noAccessUser = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns noAccessUser.id
-        coEvery { userRepoMock.getUserById(noAccessUser.id) } returns Result.success(noAccessUser)
+        mockCurrentUser(noAccessUser)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
 
-        assertThrows<UnauthorizedException.Single> { mainService.getProjectById(request) }
+        assertThrows<UnauthorizedException> { mainService.getProjectById(request) }
     }
 
     @Test
@@ -43,8 +40,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = projectId)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -59,8 +55,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -68,13 +63,12 @@ class GetProjectByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When an error occurs while the project is retrieved, then an exception is thrown`() = runTest {
+    fun `When an error occurs while the project is retrieved, then a TestSpecificException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(any()) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -16,11 +16,11 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetProjectByIdTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val projectId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(projectId.toString())
         .build()
 
     @Test
@@ -41,12 +41,12 @@ class GetProjectByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         assertDoesNotThrow { mainService.getProjectById(request) }
     }
@@ -56,13 +56,13 @@ class GetProjectByIdTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
-        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectMemberRepoMock.getProjectMembers(requestId) } returns listOf(projectMember)
-        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         assertDoesNotThrow { mainService.getProjectById(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -73,7 +73,7 @@ class GetProjectMembersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When project members are requested from a non existing project, then a NotFoundException is thrown`() =
+    fun `When project members are requested from a nonexistent project, then a NotFoundException is thrown`() =
         runTest {
             val request = getExampleRequest()
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -18,11 +18,11 @@ import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetProjectMembersTest : MainServiceTest() {
-    private val requestId = UUID.randomUUID()
+    private val projectId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id
         .newBuilder()
-        .setId(requestId.toString())
+        .setId(projectId.toString())
         .build()
 
     @Test
@@ -31,7 +31,7 @@ class GetProjectMembersTest : MainServiceTest() {
 
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val projectMemberUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(
             userId = projectMemberUser.id,
             projectId = project.id,
@@ -40,7 +40,7 @@ class GetProjectMembersTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
         coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
-        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
 
@@ -52,13 +52,13 @@ class GetProjectMembersTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, user)
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
 
@@ -70,11 +70,11 @@ class GetProjectMembersTest : MainServiceTest() {
         val request = getExampleRequest()
 
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = requestId)
+        val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectRepoMock.getProjectById(requestId) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectMembers(request) }
@@ -90,7 +90,7 @@ class GetProjectMembersTest : MainServiceTest() {
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
             coEvery {
-                projectRepoMock.getProjectById(requestId)
+                projectRepoMock.getProjectById(projectId)
             } throws SnowballRException.NotFoundException(EntityType.PROJECT, request.id)
 
             assertThrows<SnowballRException.NotFoundException> { mainService.getProjectMembers(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
@@ -27,7 +26,6 @@ class GetProjectMembersTest : MainServiceTest() {
     @Test
     fun `When a server admin requests the project members, then no exception is thrown`() = runTest {
         val request = getExampleRequest()
-
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val projectMemberUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(id = projectId)
@@ -48,7 +46,6 @@ class GetProjectMembersTest : MainServiceTest() {
     @Test
     fun `When a project member requests the project members, then no exception is thrown`() = runTest {
         val request = getExampleRequest()
-
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
@@ -65,7 +62,6 @@ class GetProjectMembersTest : MainServiceTest() {
     @Test
     fun `When a non project member requests the project members, then an UnauthorizedException is thrown`() = runTest {
         val request = getExampleRequest()
-
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
 
@@ -77,14 +73,16 @@ class GetProjectMembersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When project members are request from a non existing project, then a NotFoundException is thrown`() = runTest {
-        val request = getExampleRequest()
+    fun `When project members are requested from a non existing project, then a NotFoundException is thrown`() =
+        runTest {
+            val request = getExampleRequest()
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            mockCurrentUser(user)
+            coEvery {
+                projectRepoMock.getProjectById(projectId)
+            } returns Result.failure(NotFoundException(EntityType.PROJECT, request.id))
 
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(projectId) } throws NotFoundException(EntityType.PROJECT, request.id)
-
-        assertThrows<NotFoundException> { mainService.getProjectMembers(request) }
-    }
+            assertThrows<NotFoundException> { mainService.getProjectMembers(request) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -39,7 +39,7 @@ class GetProjectMembersTest : MainServiceTest() {
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, projectMemberUser)
 
         every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns adminUser
+        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
@@ -57,7 +57,7 @@ class GetProjectMembersTest : MainServiceTest() {
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, user)
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
@@ -73,7 +73,7 @@ class GetProjectMembersTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns emptyList()
 
@@ -88,7 +88,7 @@ class GetProjectMembersTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery {
                 projectRepoMock.getProjectById(projectId)
             } throws SnowballRException.NotFoundException(EntityType.PROJECT, request.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectMembersTest.kt
@@ -1,15 +1,14 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -38,8 +37,7 @@ class GetProjectMembersTest : MainServiceTest() {
         )
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, projectMemberUser)
 
-        every { GrpcContext.getUserIdFromContext() } returns adminUser.id
-        coEvery { userRepoMock.getUserById(adminUser.id) } returns Result.success(adminUser)
+        mockCurrentUser(adminUser)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
@@ -56,8 +54,7 @@ class GetProjectMembersTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, user)
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns
             listOf(projectMemberWithUser)
@@ -66,14 +63,13 @@ class GetProjectMembersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member requests the project members, then an unauthorized exception is thrown`() = runTest {
+    fun `When a non project member requests the project members, then an UnauthorizedException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(id = projectId)
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns emptyList()
 
@@ -81,18 +77,14 @@ class GetProjectMembersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When project members are request from a non existing project, then a not found exception is thrown`() =
-        runTest {
-            val request = getExampleRequest()
+    fun `When project members are request from a non existing project, then a NotFoundException is thrown`() = runTest {
+        val request = getExampleRequest()
 
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-            coEvery {
-                projectRepoMock.getProjectById(projectId)
-            } throws SnowballRException.NotFoundException(EntityType.PROJECT, request.id)
+        mockCurrentUser(user)
+        coEvery { projectRepoMock.getProjectById(projectId) } throws NotFoundException(EntityType.PROJECT, request.id)
 
-            assertThrows<SnowballRException.NotFoundException> { mainService.getProjectMembers(request) }
-        }
+        assertThrows<NotFoundException> { mainService.getProjectMembers(request) }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -12,8 +11,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
@@ -27,8 +26,6 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(paperRepoMock::getPaperById),
@@ -64,17 +61,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -130,7 +117,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getProjectPaperById(getExampleRequest())
@@ -150,7 +137,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member retrieves the project paper, then an unauthorized exception is thrown`() = runTest {
+    fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -160,11 +147,10 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             paperId = paper.id,
         )
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> { mainService.getProjectPaperById(getExampleRequest()) }
+        assertThrows<UnauthorizedException> { mainService.getProjectPaperById(getExampleRequest()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -23,16 +22,12 @@ import kotlin.reflect.KFunction
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(paperRepoMock::getPaperById),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
     )
 
     @Suppress("LongMethod", "ReturnCount")
@@ -56,17 +51,14 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview()
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
         mockCurrentUser(currentUser)
-
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -75,41 +67,16 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             }
 
         if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
+            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
-            return
-        }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
-
-        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
@@ -119,6 +86,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     @MethodSource("failingFunctions")
     fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
+
         assertThrows<TestSpecificException> {
             mainService.getProjectPaperById(getExampleRequest())
         }
@@ -127,12 +95,14 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     @Test
     fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, true)
+
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, false)
+
         assertDoesNotThrow { mainService.getProjectPaperById(getExampleRequest()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -14,7 +14,7 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
@@ -34,9 +34,9 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val project = DataBuilder.createExampleProject()
@@ -108,7 +108,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
 
     @Test
     fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -74,7 +74,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -161,7 +161,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         )
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -62,7 +62,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
         if (failAt == GrpcContext::getUserIdFromContext) {
             every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
@@ -162,7 +162,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.getProjectPaperById(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByIdTest.kt
@@ -91,7 +91,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
             coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
             return
         }
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
         if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -12,9 +11,9 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
@@ -33,8 +32,6 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         .build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(projectRepoMock::doesProjectExistById),
         Arguments.of(projectPaperRepoMock::getProjectPaperByRelativeId),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
@@ -81,17 +78,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
             projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
         } returns projectPaper
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -147,7 +134,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getProjectPaperByRelativeId(getExampleRequest())
@@ -167,21 +154,19 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the project to retrieve the project paper from doesn't exist, then a not found exception is thrown`() =
+    fun `When the project to retrieve the project paper from doesn't exist, then a NotFoundException is thrown`() =
         runTest {
             coEvery {
                 projectRepoMock.doesProjectExistById(projectId)
-            } throws SnowballRException.NotFoundException(EntityType.PROJECT, projectId.toString())
+            } throws NotFoundException(EntityType.PROJECT, projectId.toString())
 
-            assertThrows<SnowballRException.NotFoundException> {
-                mainService.getProjectPaperByRelativeId(
-                    getExampleRequest(),
-                )
+            assertThrows<NotFoundException> {
+                mainService.getProjectPaperByRelativeId(getExampleRequest())
             }
         }
 
     @Test
-    fun `When a non project member retrieves the project paper, then an unauthorized exception is thrown`() = runTest {
+    fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(projectId)
         val paper = DataBuilder.createExamplePaper()
@@ -191,18 +176,15 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
             localPaperId = localPaperId,
         )
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
+        mockCurrentUser(currentUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery {
             projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
         } returns projectPaper
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> {
-            mainService.getProjectPaperByRelativeId(
-                getExampleRequest(),
-            )
+        assertThrows<UnauthorizedException> {
+            mainService.getProjectPaperByRelativeId(getExampleRequest())
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -15,7 +15,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.Project
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.random.Random
@@ -41,9 +41,9 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val project = DataBuilder.createExampleProject(id = projectId)
@@ -119,7 +119,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
 
     @Test
     fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(projectId)
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -141,7 +141,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non existing project is requested, then a NotFoundException is thrown`() = runTest {
+    fun `When a nonexistent project is requested, then a NotFoundException is thrown`() = runTest {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -15,17 +15,19 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass
 import java.util.UUID
 import java.util.stream.Stream
+import kotlin.random.Random
 import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     private val projectId = UUID.randomUUID()
-    private val localPaperId = kotlin.random.Random.nextLong()
-    private fun getExampleRequest() = ProjectOuterClass.Project.Paper.Get
+    private val localPaperId = Random.nextLong()
+
+    private fun getExampleRequest() = Project.Paper.Get
         .newBuilder()
         .setProjectId(projectId.toString())
         .setRelativeProjectPaperId(localPaperId.toString())
@@ -71,12 +73,12 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         if (failAt == projectPaperRepoMock::getProjectPaperByRelativeId) {
             coEvery {
                 projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
-            } throws TestSpecificException()
+            } returns Result.failure(TestSpecificException())
             return
         }
         coEvery {
             projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
-        } returns projectPaper
+        } returns Result.success(projectPaper)
 
         mockCurrentUser(currentUser)
 
@@ -180,7 +182,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery {
             projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
-        } returns projectPaper
+        } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.Project
@@ -137,5 +138,14 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         assertThrows<UnauthorizedException> {
             mainService.getProjectPaperByRelativeId(getExampleRequest())
         }
+    }
+
+    @Test
+    fun `When a non existing project is requested, then a NotFoundException is thrown`() = runTest {
+        val project = DataBuilder.createExampleProject(id = projectId)
+
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+
+        assertThrows<NotFoundException> { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -91,7 +91,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -108,7 +108,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
             coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
             return
         }
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns paper
+        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
         if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
@@ -196,7 +196,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
         } returns projectPaper
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectPaperByRelativeIdTest.kt
@@ -11,8 +11,6 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.Project
@@ -34,14 +32,8 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         .build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectRepoMock::doesProjectExistById),
         Arguments.of(projectPaperRepoMock::getProjectPaperByRelativeId),
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
         Arguments.of(paperRepoMock::getPaperById),
-        Arguments.of(authorOfPaperRepoMock::getAuthorsOfPaperById),
-        Arguments.of(citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById),
-        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
     )
 
     @Suppress("LongMethod", "ReturnCount")
@@ -64,10 +56,6 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview()
 
-        if (failAt == projectRepoMock::doesProjectExistById) {
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
 
         if (failAt == projectPaperRepoMock::getProjectPaperByRelativeId) {
@@ -81,11 +69,6 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         } returns Result.success(projectPaper)
 
         mockCurrentUser(currentUser)
-
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -94,41 +77,16 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
             }
 
         if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } throws TestSpecificException()
+            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
-        if (failAt == authorOfPaperRepoMock::getAuthorsOfPaperById) {
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } throws TestSpecificException()
-            return
-        }
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
-
-        if (failAt == citationRepoMock::getBackwardsReferencedPaperIdsOfPaperById) {
-            coEvery {
-                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
-
-        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(any())
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
@@ -138,6 +96,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     @MethodSource("failingFunctions")
     fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
+
         assertThrows<TestSpecificException> {
             mainService.getProjectPaperByRelativeId(getExampleRequest())
         }
@@ -146,26 +105,16 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     @Test
     fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, true)
+
         assertDoesNotThrow { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, false)
+
         assertDoesNotThrow { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
     }
-
-    @Test
-    fun `When the project to retrieve the project paper from doesn't exist, then a NotFoundException is thrown`() =
-        runTest {
-            coEvery {
-                projectRepoMock.doesProjectExistById(projectId)
-            } throws NotFoundException(EntityType.PROJECT, projectId.toString())
-
-            assertThrows<NotFoundException> {
-                mainService.getProjectPaperByRelativeId(getExampleRequest())
-            }
-        }
 
     @Test
     fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -26,7 +26,7 @@ class UpdateProjectTest : MainServiceTest() {
             "PROJECT_STATUS_ARCHIVED",
         ],
     )
-    fun `When a server admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
+    fun `When a server admin updates an existent project, then no exception is thrown`(statusName: String) = runTest {
         val status = ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(status = status)
@@ -55,7 +55,7 @@ class UpdateProjectTest : MainServiceTest() {
             "PROJECT_STATUS_ARCHIVED",
         ],
     )
-    fun `When a project admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
+    fun `When a project admin updates an existent project, then no exception is thrown`(statusName: String) = runTest {
         val status = ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(status = status)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
@@ -205,20 +204,5 @@ class UpdateProjectTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
         assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
-    }
-
-    @Test
-    fun `When an error occurs while updating a project, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
-        val project = DataBuilder.createExampleProject(status = status)
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(project.toGrpcProject()).build()
-
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.updateProject(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.service.project
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -11,8 +10,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
@@ -40,8 +40,7 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
@@ -72,8 +71,7 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
@@ -90,7 +88,7 @@ class UpdateProjectTest : MainServiceTest() {
             "PROJECT_STATUS_DELETED",
         ],
     )
-    fun `When a project member updates a project, then an unauthorized exception is thrown`(statusName: String) =
+    fun `When a project member updates a project, then an UnauthorizedException is thrown`(statusName: String) =
         runTest {
             val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
@@ -104,16 +102,15 @@ class UpdateProjectTest : MainServiceTest() {
                 .setMask(updateFieldMask)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-            assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateProject(request) }
+            assertThrows<UnauthorizedException.Single> { mainService.updateProject(request) }
         }
 
     @Test
-    fun `When a server admin updates project to the project status DELETED, then a failed precondition exception is thrown`() =
+    fun `When a server admin updates project to the project status DELETED, then a FailedPreconditionException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject(
@@ -132,16 +129,15 @@ class UpdateProjectTest : MainServiceTest() {
                 .setMask(updateFieldMask)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-            assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
         }
 
     @Test
-    fun `When a project admin updates project to the project status DELETED, then a failed precondition exception is thrown`() =
+    fun `When a project admin updates project to the project status DELETED, then a FailedPreconditionException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
@@ -161,16 +157,15 @@ class UpdateProjectTest : MainServiceTest() {
                 .setMask(updateFieldMask)
                 .build()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
-            assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
         }
 
     @Test
-    fun `When a server admin updates a deleted project, then a failed precondition exception is thrown`() = runTest {
+    fun `When a server admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
@@ -183,16 +178,15 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+        assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
     }
 
     @Test
-    fun `When a project admin updates a deleted project, then a failed precondition exception is thrown`() = runTest {
+    fun `When a project admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
             status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
@@ -207,23 +201,21 @@ class UpdateProjectTest : MainServiceTest() {
             .setMask(updateFieldMask)
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
-        assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
+        assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
     }
 
     @Test
-    fun `When an error occurs while updating a project, then an exception is thrown`() = runTest {
+    fun `When an error occurs while updating a project, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
         val project = DataBuilder.createExampleProject(status = status)
         val request = ProjectOuterClass.Project.Update.newBuilder().setProject(project.toGrpcProject()).build()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -42,7 +42,7 @@ class UpdateProjectTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
@@ -74,7 +74,7 @@ class UpdateProjectTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
 
@@ -106,7 +106,7 @@ class UpdateProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.UnauthorizedException.Single> { mainService.updateProject(request) }
@@ -134,7 +134,7 @@ class UpdateProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
@@ -163,7 +163,7 @@ class UpdateProjectTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
             coEvery { userRepoMock.getUserById(user.id) } returns user
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
             assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
@@ -185,7 +185,7 @@ class UpdateProjectTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
@@ -209,7 +209,7 @@ class UpdateProjectTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(user.id) } returns user
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
         assertThrows<SnowballRException.FailedPreconditionException> { mainService.updateProject(request) }
@@ -219,12 +219,12 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When an error occurs while updating a project, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
-        val updatedProject = DataBuilder.createExampleProject(status = status)
-        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(updatedProject.toGrpcProject()).build()
+        val project = DataBuilder.createExampleProject(status = status)
+        val request = ProjectOuterClass.Project.Update.newBuilder().setProject(project.toGrpcProject()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { userRepoMock.getUserById(any()) } returns user
-        coEvery { projectRepoMock.getProjectById(updatedProject.id) } returns updatedProject
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
         coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -41,7 +41,7 @@ class UpdateProjectTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
@@ -73,7 +73,7 @@ class UpdateProjectTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
@@ -105,7 +105,7 @@ class UpdateProjectTest : MainServiceTest() {
                 .build()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -133,7 +133,7 @@ class UpdateProjectTest : MainServiceTest() {
                 .build()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -162,7 +162,7 @@ class UpdateProjectTest : MainServiceTest() {
                 .build()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -184,7 +184,7 @@ class UpdateProjectTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -208,7 +208,7 @@ class UpdateProjectTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
 
@@ -223,9 +223,9 @@ class UpdateProjectTest : MainServiceTest() {
         val request = ProjectOuterClass.Project.Update.newBuilder().setProject(project.toGrpcProject()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.updateProject(any(), any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -13,8 +13,9 @@ import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionExce
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
+import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class UpdateProjectTest : MainServiceTest() {
     @ParameterizedTest
@@ -26,13 +27,13 @@ class UpdateProjectTest : MainServiceTest() {
         ],
     )
     fun `When a server admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
-        val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
+        val status = ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(status = status)
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-        val request = ProjectOuterClass.Project.Update
+        val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
             .setMask(updateFieldMask)
@@ -55,7 +56,7 @@ class UpdateProjectTest : MainServiceTest() {
         ],
     )
     fun `When a project admin updates an existing project, then no exception is thrown`(statusName: String) = runTest {
-        val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
+        val status = ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(status = status)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
@@ -63,7 +64,7 @@ class UpdateProjectTest : MainServiceTest() {
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-        val request = ProjectOuterClass.Project.Update
+        val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
             .setMask(updateFieldMask)
@@ -88,13 +89,13 @@ class UpdateProjectTest : MainServiceTest() {
     )
     fun `When a project member updates a project, then an UnauthorizedException is thrown`(statusName: String) =
         runTest {
-            val status = ProjectOuterClass.ProjectStatus.valueOf(statusName)
+            val status = ProjectStatus.valueOf(statusName)
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(status = status)
             val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
             val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
-            val request = ProjectOuterClass.Project.Update
+            val request = GrpcProject.Update
                 .newBuilder()
                 .setProject(updatedProject.toGrpcProject())
                 .setMask(updateFieldMask)
@@ -112,16 +113,16 @@ class UpdateProjectTest : MainServiceTest() {
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject(
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+                status = ProjectStatus.PROJECT_STATUS_ACTIVE,
             )
             val updatedProject = DataBuilder.createExampleProject(
                 id = project.id,
                 name = "Updated Project",
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
+                status = ProjectStatus.PROJECT_STATUS_DELETED,
             )
 
             val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-            val request = ProjectOuterClass.Project.Update
+            val request = GrpcProject.Update
                 .newBuilder()
                 .setProject(updatedProject.toGrpcProject())
                 .setMask(updateFieldMask)
@@ -139,17 +140,17 @@ class UpdateProjectTest : MainServiceTest() {
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE,
+                status = ProjectStatus.PROJECT_STATUS_ACTIVE,
             )
             val updatedProject = DataBuilder.createExampleProject(
                 id = project.id,
                 name = "Updated Project",
-                status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
+                status = ProjectStatus.PROJECT_STATUS_DELETED,
             )
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
             val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-            val request = ProjectOuterClass.Project.Update
+            val request = GrpcProject.Update
                 .newBuilder()
                 .setProject(updatedProject.toGrpcProject())
                 .setMask(updateFieldMask)
@@ -166,11 +167,11 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a server admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
+            status = ProjectStatus.PROJECT_STATUS_DELETED,
         )
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
-        val request = ProjectOuterClass.Project.Update
+        val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
             .setMask(updateFieldMask)
@@ -187,13 +188,13 @@ class UpdateProjectTest : MainServiceTest() {
     fun `When a project admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject(
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED,
+            status = ProjectStatus.PROJECT_STATUS_DELETED,
         )
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
         val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
-        val request = ProjectOuterClass.Project.Update
+        val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
             .setMask(updateFieldMask)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.service.readinglist
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -10,27 +9,17 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.Base
 import java.util.UUID
 
 class AddPaperToReadingListTest : MainServiceTest() {
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        val paperId = Base.Id.getDefaultInstance()
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-        assertThrows<TestSpecificException> { mainService.addPaperToReadingList(paperId) }
-    }
-
-    @Test
-    fun `When creating the reading list entry fails, then an exception is thrown`() = runTest {
+    fun `When creating the reading list entry fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } throws TestSpecificException()
 
@@ -42,23 +31,21 @@ class AddPaperToReadingListTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } returns Unit
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
 
         assertDoesNotThrow { mainService.addPaperToReadingList(paperId.toGrpcId()) }
         coVerify(exactly = 1) { readingListRepoMock.createReadingListEntry(user.id, paperId) }
     }
 
     @Test
-    fun `When the user adds a non-existent paper to their reading list, then an exception is thrown`() = runTest {
+    fun `When the user adds a non-existent paper to their reading list, then a NotFoundException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
 
         assertThrows<NotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -30,7 +30,7 @@ class AddPaperToReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } throws TestSpecificException()
 
@@ -45,7 +45,7 @@ class AddPaperToReadingListTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } returns Unit
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
 
         assertDoesNotThrow { mainService.addPaperToReadingList(paperId.toGrpcId()) }
         coVerify(exactly = 1) { readingListRepoMock.createReadingListEntry(user.id, paperId) }
@@ -58,7 +58,7 @@ class AddPaperToReadingListTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
 
         assertThrows<NotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -8,24 +8,11 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
 
 class AddPaperToReadingListTest : MainServiceTest() {
-    @Test
-    fun `When creating the reading list entry fails, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val paperId = UUID.randomUUID()
-
-        mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
-        coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
-    }
-
     @Test
     fun `When the user adds a paper to their reading list, then the request is forwarded correctly`() = runTest {
         val user = DataBuilder.createExampleUser()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -40,13 +40,14 @@ class AddPaperToReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user adds a non-existent paper to their reading list, then a NotFoundException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val paperId = UUID.randomUUID()
+    fun `When the user adds a non-existent paper to their reading list, then a NotFoundException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val paperId = UUID.randomUUID()
 
-        mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+            mockCurrentUser(user)
+            coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
 
-        assertThrows<NotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
-    }
+            assertThrows<NotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
@@ -5,24 +5,12 @@ import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
 
 class GetReadingListTest : MainServiceTest() {
-    @Test
-    fun `When retrieving the reading list entries fails, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-
-        mockCurrentUser(user)
-        coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getReadingList() }
-    }
-
     @Test
     fun `When the user has entries on their reading list, then they are correctly returned by getReadingList`() =
         runTest {
@@ -44,4 +32,18 @@ class GetReadingListTest : MainServiceTest() {
             )
             coVerify(exactly = 1) { readingListRepoMock.getAllReadingListEntries(user.id) }
         }
+
+    @Test
+    fun `When the user has no entries on their reading list, then an empty list is returned`() = runTest {
+        val user = DataBuilder.createExampleUser()
+
+        mockCurrentUser(user)
+        coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } returns emptyList()
+
+        val papers = mainService.getReadingList().papersList
+        assertThat(papers).isEmpty()
+        coVerify(exactly = 1) { readingListRepoMock.getAllReadingListEntries(user.id) }
+        coVerify(exactly = 0) { authorOfPaperRepoMock.getAuthorsOfPaperById(any()) }
+        coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
@@ -26,7 +26,7 @@ class GetReadingListTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getReadingList() }
@@ -41,7 +41,7 @@ class GetReadingListTest : MainServiceTest() {
             val author = DataBuilder.createExampleAuthor()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper1.id) } returns emptyList()
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns listOf(paper1.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
@@ -2,31 +2,22 @@ package se.uulm.snowballr.backend.service.readinglist
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.dto.toGrpcAuthor
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
 import se.uulm.snowballr.backend.service.MainServiceTest
 
 class GetReadingListTest : MainServiceTest() {
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-        assertThrows<TestSpecificException> { mainService.getReadingList() }
-    }
-
-    @Test
-    fun `When retrieving the reading list entries fails, then an exception is thrown`() = runTest {
+    fun `When retrieving the reading list entries fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getReadingList() }
@@ -40,8 +31,7 @@ class GetReadingListTest : MainServiceTest() {
             val paper2 = DataBuilder.createExamplePaper(externalId = "ExternalId2")
             val author = DataBuilder.createExampleAuthor()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper1.id) } returns emptyList()
             coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns listOf(paper1.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -31,7 +31,7 @@ class IsPaperOnReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paperId) } throws TestSpecificException()
 
@@ -46,7 +46,7 @@ class IsPaperOnReadingListTest : MainServiceTest() {
             val paper2 = DataBuilder.createExamplePaper(externalId = "ExternalId2")
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
             coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
             coEvery { paperRepoMock.doesPaperExistById(paper1.id) } returns true
@@ -66,7 +66,7 @@ class IsPaperOnReadingListTest : MainServiceTest() {
             val paperId = UUID.randomUUID()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
 
             assertThrows<NotFoundException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -2,36 +2,25 @@ package se.uulm.snowballr.backend.service.readinglist
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.Base
 import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class IsPaperOnReadingListTest : MainServiceTest() {
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        val paperId = Base.Id.getDefaultInstance()
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-        assertThrows<TestSpecificException> { mainService.isPaperOnReadingList(paperId) }
-    }
-
-    @Test
-    fun `When checking the reading list status fails, then an exception is thrown`() = runTest {
+    fun `When checking the reading list status fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paperId) } throws TestSpecificException()
 
@@ -45,8 +34,7 @@ class IsPaperOnReadingListTest : MainServiceTest() {
             val paper1 = DataBuilder.createExamplePaper()
             val paper2 = DataBuilder.createExamplePaper(externalId = "ExternalId2")
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
             coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
             coEvery { paperRepoMock.doesPaperExistById(paper1.id) } returns true
@@ -60,13 +48,12 @@ class IsPaperOnReadingListTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user checks if a non-existent paper is on their reading list, then an exception is thrown`() =
+    fun `When the user checks if a non-existent paper is on their reading list, then a NotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
 
             assertThrows<NotFoundException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
@@ -15,18 +14,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class IsPaperOnReadingListTest : MainServiceTest() {
-    @Test
-    fun `When checking the reading list status fails, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val paperId = UUID.randomUUID()
-
-        mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
-        coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paperId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.isPaperOnReadingList(paperId.toGrpcId()) }
-    }
-
     @Test
     fun `When the user checks if a paper is on their reading list, then the request is forwarded correctly`() =
         runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.service.readinglist
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -10,27 +9,17 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.Base
 import java.util.UUID
 
 class RemovePaperFromReadingListTest : MainServiceTest() {
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        val paperId = Base.Id.getDefaultInstance()
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-        assertThrows<TestSpecificException> { mainService.removePaperFromReadingList(paperId) }
-    }
-
-    @Test
-    fun `When removing the reading list entry fails, then an exception is thrown`() = runTest {
+    fun `When removing the reading list entry fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } throws TestSpecificException()
 
@@ -42,8 +31,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } returns Unit
 
@@ -52,12 +40,11 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes a non-existent paper on their reading list, then an exception is thrown`() = runTest {
+    fun `When the user removes a non-existent paper on their reading list, then a NotFoundException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
 
         assertThrows<NotFoundException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -8,24 +8,11 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
 
 class RemovePaperFromReadingListTest : MainServiceTest() {
-    @Test
-    fun `When removing the reading list entry fails, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val paperId = UUID.randomUUID()
-
-        mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
-        coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.removePaperFromReadingList(paperId.toGrpcId()) }
-    }
-
     @Test
     fun `When the user removes a paper from their reading list, then the request is forwarded correctly`() = runTest {
         val user = DataBuilder.createExampleUser()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -40,15 +40,16 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes a non-existent paper on their reading list, then a NotFoundException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val paperId = UUID.randomUUID()
+    fun `When the user removes a non-existent paper on their reading list, then a NotFoundException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val paperId = UUID.randomUUID()
 
-        mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+            mockCurrentUser(user)
+            coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
 
-        assertThrows<NotFoundException> {
-            mainService.removePaperFromReadingList(paperId.toGrpcId())
+            assertThrows<NotFoundException> {
+                mainService.removePaperFromReadingList(paperId.toGrpcId())
+            }
         }
-    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -30,7 +30,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } throws TestSpecificException()
 
@@ -43,7 +43,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } returns Unit
 
@@ -57,7 +57,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
 
         assertThrows<NotFoundException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -12,7 +11,6 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -27,8 +25,6 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
         Arguments.of(projectRepoMock::getProjectById),
         Arguments.of(projectMemberRepoMock::getProjectMembers),
@@ -51,17 +47,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview(userId = currentUser.id)
         val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
@@ -107,7 +93,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getAllReviewsForProjectPaper(getExampleRequest())
@@ -127,22 +113,19 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member retrieves all reviews for a project paper, then an unauthorized exception is thrown`() =
+    fun `When a non project member retrieves all reviews for a project paper, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject()
             val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.UnauthorizedException> {
-                mainService.getAllReviewsForProjectPaper(
-                    getExampleRequest(),
-                )
+                mainService.getAllReviewsForProjectPaper(getExampleRequest())
             }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -61,7 +61,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
@@ -134,7 +134,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -14,7 +14,7 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
@@ -34,9 +34,9 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val project = DataBuilder.createExampleProject()
@@ -100,7 +100,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     @Test
     fun `When a non project member retrieves all reviews for a project paper, then an UnauthorizedException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject()
             val projectPaper = DataBuilder.createExampleProjectPaper(id = requestId, projectId = project.id)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -67,7 +67,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
         if (failAt == projectRepoMock::getProjectById) {
             coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
@@ -135,7 +135,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns projectPaper
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
             coEvery { projectRepoMock.getProjectById(project.id) } returns project
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -73,7 +73,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -136,7 +136,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns project
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<SnowballRException.UnauthorizedException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
@@ -22,14 +22,12 @@ import kotlin.reflect.KFunction
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
         Arguments.of(projectRepoMock::getProjectById),
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
-        Arguments.of(reviewRepoMock::getAllReviewsForProjectPaper),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
     )
 
     @Suppress("ReturnCount", "LongMethod")
@@ -50,42 +48,26 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         mockCurrentUser(currentUser)
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } throws TestSpecificException()
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
         if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
-
-        if (failAt == reviewRepoMock::getAllReviewsForProjectPaper) {
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
@@ -95,6 +77,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     @MethodSource("failingFunctions")
     fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
+
         assertThrows<TestSpecificException> {
             mainService.getAllReviewsForProjectPaper(getExampleRequest())
         }
@@ -103,12 +86,14 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     @Test
     fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, true)
+
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, false)
+
         assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(getExampleRequest()) }
     }
 
@@ -124,7 +109,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-            assertThrows<SnowballRException.UnauthorizedException> {
+            assertThrows<UnauthorizedException> {
                 mainService.getAllReviewsForProjectPaper(getExampleRequest())
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -79,7 +79,7 @@ class GetReviewByIdTest : MainServiceTest() {
             coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
             return
         }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         if (failAt == projectMemberRepoMock::getProjectMembers) {
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
@@ -135,7 +135,7 @@ class GetReviewByIdTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
         coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns project
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<SnowballRException.UnauthorizedException> { mainService.getReviewById(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -14,7 +14,7 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
@@ -35,9 +35,9 @@ class GetReviewByIdTest : MainServiceTest() {
     private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
         val currentUser = DataBuilder.createExampleUser(
             role = if (isUserAdmin) {
-                UserOuterClass.UserRole.USER_ROLE_ADMIN
+                UserRole.USER_ROLE_ADMIN
             } else {
-                UserOuterClass.UserRole.USER_ROLE_DEFAULT
+                UserRole.USER_ROLE_DEFAULT
             },
         )
         val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
@@ -105,7 +105,7 @@ class GetReviewByIdTest : MainServiceTest() {
 
     @Test
     fun `When a non project member retrieves the review, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -61,7 +61,7 @@ class GetReviewByIdTest : MainServiceTest() {
             coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
             return
         }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         if (failAt == reviewRepoMock::getReviewById) {
             coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
@@ -132,7 +132,7 @@ class GetReviewByIdTest : MainServiceTest() {
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
         coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -73,7 +73,7 @@ class GetReviewByIdTest : MainServiceTest() {
             coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } throws TestSpecificException()
             return
         }
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
 
         if (failAt == projectRepoMock::getProjectById) {
             coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
@@ -134,7 +134,7 @@ class GetReviewByIdTest : MainServiceTest() {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
         coEvery { reviewRepoMock.getReviewById(review.id) } returns review
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns projectPaper
+        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -67,7 +67,7 @@ class GetReviewByIdTest : MainServiceTest() {
             coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
             return
         }
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
             coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } throws TestSpecificException()
@@ -133,7 +133,7 @@ class GetReviewByIdTest : MainServiceTest() {
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { reviewRepoMock.getReviewById(review.id) } returns review
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
         coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
         coEvery { projectRepoMock.getProjectById(project.id) } returns project
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass
@@ -22,14 +22,13 @@ import kotlin.reflect.KFunction
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetReviewByIdTest : MainServiceTest() {
     private val requestId = UUID.randomUUID()
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(reviewRepoMock::getReviewById),
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
         Arguments.of(projectRepoMock::getProjectById),
-        Arguments.of(projectMemberRepoMock::getProjectMembers),
-        Arguments.of(reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById),
     )
 
     @Suppress("ReturnCount")
@@ -50,40 +49,31 @@ class GetReviewByIdTest : MainServiceTest() {
         mockCurrentUser(currentUser)
 
         if (failAt == reviewRepoMock::getReviewById) {
-            coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
+            coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
 
         if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } throws TestSpecificException()
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(review.projectPaperId)
+            } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
 
         if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(project.id) } throws TestSpecificException()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
-        if (failAt == projectMemberRepoMock::getProjectMembers) {
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } throws TestSpecificException()
-            return
-        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
-
-        if (failAt == reviewHasCriterionRepoMock::getSelectedCriteriaIdsForReviewById) {
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-            } throws TestSpecificException()
-            return
-        }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
@@ -93,6 +83,7 @@ class GetReviewByIdTest : MainServiceTest() {
     @MethodSource("failingFunctions")
     fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
+
         assertThrows<TestSpecificException> {
             mainService.getReviewById(getExampleRequest())
         }
@@ -101,12 +92,14 @@ class GetReviewByIdTest : MainServiceTest() {
     @Test
     fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, true)
+
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member retrieves the review, then no exception is thrown`() = runTest {
         mockHappyPathUntil(null, false)
+
         assertDoesNotThrow { mainService.getReviewById(getExampleRequest()) }
     }
 
@@ -123,6 +116,6 @@ class GetReviewByIdTest : MainServiceTest() {
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-        assertThrows<SnowballRException.UnauthorizedException> { mainService.getReviewById(getExampleRequest()) }
+        assertThrows<UnauthorizedException> { mainService.getReviewById(getExampleRequest()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -12,7 +11,6 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -27,8 +25,6 @@ class GetReviewByIdTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestId.toString()).build()
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(GrpcContext::getUserIdFromContext),
-        Arguments.of(userRepoMock::getUserById),
         Arguments.of(reviewRepoMock::getReviewById),
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
         Arguments.of(projectRepoMock::getProjectById),
@@ -51,17 +47,7 @@ class GetReviewByIdTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
 
-        if (failAt == GrpcContext::getUserIdFromContext) {
-            every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-            return
-        }
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-
-        if (failAt == userRepoMock::getUserById) {
-            coEvery { userRepoMock.getUserById(currentUser.id) } throws TestSpecificException()
-            return
-        }
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         if (failAt == reviewRepoMock::getReviewById) {
             coEvery { reviewRepoMock.getReviewById(review.id) } throws TestSpecificException()
@@ -105,7 +91,7 @@ class GetReviewByIdTest : MainServiceTest() {
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then an exception is thrown`(failAt: KFunction<*>) = runTest {
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockHappyPathUntil(failAt, true)
         assertThrows<TestSpecificException> {
             mainService.getReviewById(getExampleRequest())
@@ -125,14 +111,13 @@ class GetReviewByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non project member retrieves the review, then an unauthorized exception is thrown`() = runTest {
+    fun `When a non project member retrieves the review, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
         val review = DataBuilder.createExampleReview(id = requestId, userId = currentUser.id)
         val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
         coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
@@ -19,16 +18,6 @@ class GetAllUsersTest : MainServiceTest() {
         mockCurrentUser(currentUser)
 
         assertThrows<UnauthorizedException> { mainService.getAllUsers() }
-    }
-
-    @Test
-    fun `When retrieving users fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getAllUsers() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllUsers() }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -1,51 +1,31 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 
 class GetAllUsersTest : MainServiceTest() {
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllUsers() }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getAllUsers() }
-    }
-
-    @Test
-    fun `When current user is not admin, then UnauthorizedException is thrown`() = runTest {
+    fun `When current user is not admin, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
-        assertThrows<UnauthorizedException.All> { mainService.getAllUsers() }
+        assertThrows<UnauthorizedException> { mainService.getAllUsers() }
     }
 
     @Test
-    fun `When retrieving users fails, then exception is thrown`() = runTest {
+    fun `When retrieving users fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getAllUsers() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllUsers() }
@@ -55,8 +35,7 @@ class GetAllUsersTest : MainServiceTest() {
     fun `When user is admin, then all users are returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllUsers() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -35,7 +35,7 @@ class GetAllUsersTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         assertThrows<UnauthorizedException.All> { mainService.getAllUsers() }
     }
@@ -45,7 +45,7 @@ class GetAllUsersTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getAllUsers() } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getAllUsers() }
@@ -56,7 +56,7 @@ class GetAllUsersTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getAllUsers() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllUsers() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -1,39 +1,17 @@
 package se.uulm.snowballr.backend.service.user
 
-import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
-import java.util.UUID
 
 class GetCurrentUserTest : MainServiceTest() {
     @Test
-    fun `When retrieving the user context fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getCurrentUser() }
-    }
-
-    @Test
-    fun `When retrieving the user by id fails, then an exception is thrown`() = runTest {
-        val userId = UUID.randomUUID()
-        every { GrpcContext.getUserIdFromContext() } returns userId
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getCurrentUser() }
-    }
-
-    @Test
     fun `When retrieving the current user, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
+
+        mockCurrentUser(user)
 
         assertDoesNotThrow { mainService.getCurrentUser() }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -33,7 +33,7 @@ class GetCurrentUserTest : MainServiceTest() {
     fun `When retrieving the current user, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns user
+        coEvery { userRepoMock.getUserById(GrpcContext.getUserIdFromContext()) } returns Result.success(user)
 
         assertDoesNotThrow { mainService.getCurrentUser() }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -1,16 +1,12 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
 import java.util.UUID
@@ -31,22 +27,12 @@ class GetInviteCandidatesTest : MainServiceTest() {
     }
 
     @Test
-    fun `When retrieving the current user fails, then an exception is thrown`() = runTest {
-        val userId = UUID.randomUUID()
-        every { GrpcContext.getUserIdFromContext() } returns userId
-        coEvery { userRepoMock.getUserById(userId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getInviteCandidates(validInviteCandidatesRequest) }
-    }
-
-    @Test
     fun `When parsing the project id fails, then only a warning is logged`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestWithInvalidProjectId = InviteCandidatesRequest.newBuilder().setQuery(
             "john",
         ).setProjectId("invalid-uuid").build()
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
@@ -59,8 +45,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
         val requestWithNotExistingProject = InviteCandidatesRequest.newBuilder().setQuery(
             "john",
         ).setProjectId(requestedProjectId.toString()).build()
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(requestedProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
@@ -70,8 +55,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     @Test
     fun `When retrieving the users matching the search query fails, then an empty list is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
@@ -84,8 +68,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
             val users = listOf(currentUser, DataBuilder.createExampleUser(email = "another.user@example.com"))
             val excludedUsers = setOf(currentUser.id)
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
             coEvery {
                 userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id))
@@ -103,8 +86,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
             val users = listOf(currentUser, projectMember)
             val excludedUsers = setOf(currentUser.id, projectMember.id)
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery {
                 projectMemberRepoMock.getProjectMembers(testProjectId)
             } returns listOf(DataBuilder.createExampleProjectMember(userId = projectMember.id))

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -25,6 +25,8 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When the search query is too short, then an empty list is returned`() = runTest {
         val shortSearchQuery = InviteCandidatesRequest.newBuilder().setQuery("j").build()
 
+        mockCurrentUser(DataBuilder.createExampleUser())
+
         assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -16,22 +16,27 @@ import kotlin.test.assertTrue
 @ExperimentalCoroutinesApi
 class GetInviteCandidatesTest : MainServiceTest() {
     private val testProjectId = UUID.randomUUID()
-    private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder().setQuery(
-        "john",
-    ).setProjectId(testProjectId.toString()).build()
+    private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder()
+        .setQuery("john")
+        .setProjectId(testProjectId.toString())
+        .build()
 
     @Test
     fun `When the search query is too short, then an empty list is returned`() = runTest {
         val shortSearchQuery = InviteCandidatesRequest.newBuilder().setQuery("j").build()
+
         assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
     }
 
     @Test
     fun `When parsing the project id fails, then only a warning is logged`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestWithInvalidProjectId = InviteCandidatesRequest.newBuilder().setQuery(
-            "john",
-        ).setProjectId("invalid-uuid").build()
+        val requestWithInvalidProjectId = InviteCandidatesRequest
+            .newBuilder()
+            .setQuery("john")
+            .setProjectId("invalid-uuid")
+            .build()
+
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
@@ -42,9 +47,12 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When no the project members exist, then no users except for the current user are excluded`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedProjectId = UUID.randomUUID()
-        val requestWithNotExistingProject = InviteCandidatesRequest.newBuilder().setQuery(
-            "john",
-        ).setProjectId(requestedProjectId.toString()).build()
+        val requestWithNotExistingProject = InviteCandidatesRequest
+            .newBuilder()
+            .setQuery("john")
+            .setProjectId(requestedProjectId.toString())
+            .build()
+
         mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(requestedProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
@@ -55,6 +63,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     @Test
     fun `When retrieving the users matching the search query fails, then an empty list is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
+
         mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
@@ -68,6 +77,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
             val users = listOf(currentUser, DataBuilder.createExampleUser(email = "another.user@example.com"))
             val excludedUsers = setOf(currentUser.id)
+
             mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
             coEvery {
@@ -86,6 +96,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
             val users = listOf(currentUser, projectMember)
             val excludedUsers = setOf(currentUser.id, projectMember.id)
+
             mockCurrentUser(currentUser)
             coEvery {
                 projectMemberRepoMock.getProjectMembers(testProjectId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -46,7 +46,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             "john",
         ).setProjectId("invalid-uuid").build()
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
@@ -60,7 +60,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             "john",
         ).setProjectId(requestedProjectId.toString()).build()
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(requestedProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
@@ -71,7 +71,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When retrieving the users matching the search query fails, then an empty list is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
@@ -85,7 +85,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val users = listOf(currentUser, DataBuilder.createExampleUser(email = "another.user@example.com"))
             val excludedUsers = setOf(currentUser.id)
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
             coEvery {
                 userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id))
@@ -104,7 +104,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val users = listOf(currentUser, projectMember)
             val excludedUsers = setOf(currentUser.id, projectMember.id)
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery {
                 projectMemberRepoMock.getProjectMembers(testProjectId)
             } returns listOf(DataBuilder.createExampleProjectMember(userId = projectMember.id))

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -12,8 +10,6 @@ import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
 import java.util.UUID
 import kotlin.test.assertTrue
 
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
 class GetInviteCandidatesTest : MainServiceTest() {
     private val testProjectId = UUID.randomUUID()
     private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetInviteCandidatesTest.kt
@@ -49,7 +49,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When no the project members exist, then no users except for the current user are excluded`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedProjectId = UUID.randomUUID()
-        val requestWithNotExistingProject = InviteCandidatesRequest
+        val requestWithNotExistentProject = InviteCandidatesRequest
             .newBuilder()
             .setQuery("john")
             .setProjectId(requestedProjectId.toString())
@@ -59,7 +59,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(requestedProjectId) } returns emptyList()
         coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getInviteCandidates(requestWithNotExistingProject) }
+        assertDoesNotThrow { mainService.getInviteCandidates(requestWithNotExistentProject) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -41,7 +41,7 @@ class GetUserByEmailTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserByEmail(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
@@ -53,8 +53,8 @@ class GetUserByEmailTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(email = exampleEmail)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns Result.success(requestedUser)
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns emptyList()
 
         assertThrows<UnauthorizedException.Single> { mainService.getUserByEmail(getExampleRequest()) }
@@ -65,7 +65,7 @@ class GetUserByEmailTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         val inactiveStatuses = UserStatus.entries.filterNot {
             it == UserStatus.USER_STATUS_ACTIVE || it == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
@@ -74,7 +74,7 @@ class GetUserByEmailTest : MainServiceTest() {
         inactiveStatuses.forEach { status ->
             val requestedUser = DataBuilder.createExampleUser(email = exampleEmail, status = status)
 
-            coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns requestedUser
+            coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns Result.success(requestedUser)
 
             assertThrows<NotFoundException>("Should throw NotFoundException for status $status") {
                 mainService.getUserByEmail(getExampleRequest())
@@ -87,7 +87,7 @@ class GetUserByEmailTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         val activeStatuses = listOf(
             UserStatus.USER_STATUS_ACTIVE,
@@ -97,7 +97,7 @@ class GetUserByEmailTest : MainServiceTest() {
         activeStatuses.forEach { status ->
             val requestedUser = DataBuilder.createExampleUser(email = exampleEmail, status = status)
 
-            coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns requestedUser
+            coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns Result.success(requestedUser)
 
             assertDoesNotThrow("Should succeed for status $status") {
                 mainService.getUserByEmail(getExampleRequest())

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -23,7 +23,7 @@ class GetUserByEmailTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserByEmail(any()) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserByEmail(any()) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -1,71 +1,50 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
-import java.util.UUID
 
 class GetUserByEmailTest : MainServiceTest() {
     private val exampleEmail = "test@example.com"
     private fun getExampleRequest() = Base.Email.newBuilder().setEmail(exampleEmail).build()
 
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving requested user by email fails, then exception is thrown`() = runTest {
+    fun `When retrieving requested user by email fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserByEmail(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
     }
 
     @Test
-    fun `When verifying user access fails, then UnauthorizedException is thrown`() = runTest {
+    fun `When verifying user access fails, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val requestedUser = DataBuilder.createExampleUser(email = exampleEmail)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns Result.success(requestedUser)
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns emptyList()
 
-        assertThrows<UnauthorizedException.Single> { mainService.getUserByEmail(getExampleRequest()) }
+        assertThrows<UnauthorizedException> { mainService.getUserByEmail(getExampleRequest()) }
     }
 
     @Test
-    fun `When requested user is inactive, then NotFoundException is thrown`() = runTest {
+    fun `When requested user is inactive, then a NotFoundException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         val inactiveStatuses = UserStatus.entries.filterNot {
             it == UserStatus.USER_STATUS_ACTIVE || it == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
@@ -86,8 +65,7 @@ class GetUserByEmailTest : MainServiceTest() {
     fun `When all retrievals succeed and user is active, then user is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         val activeStatuses = listOf(
             UserStatus.USER_STATUS_ACTIVE,

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -27,7 +27,7 @@ class GetUserByIdTest : MainServiceTest() {
     fun `When parsing the user ID fails, then InvalidIdException is thrown`() = runTest {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns DataBuilder.createExampleUser()
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(DataBuilder.createExampleUser())
 
         assertThrows<InvalidIdException> { mainService.getUserById(request) }
     }
@@ -49,8 +49,8 @@ class GetUserByIdTest : MainServiceTest() {
         )
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
 
         assertDoesNotThrow { mainService.getUserById(getExampleRequest()) }
     }
@@ -65,8 +65,8 @@ class GetUserByIdTest : MainServiceTest() {
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
         assertDoesNotThrow { mainService.getUserById(request) }
 
@@ -83,8 +83,8 @@ class GetUserByIdTest : MainServiceTest() {
         )
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) } returns listOf(
             DataBuilder.createExampleProjectMember(userId = currentUser.id),
         )
@@ -98,7 +98,7 @@ class GetUserByIdTest : MainServiceTest() {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> { mainService.getUserById(getExampleRequest()) }
@@ -109,7 +109,7 @@ class GetUserByIdTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         val inactiveStatuses = UserStatus.entries.filterNot {
             it == UserStatus.USER_STATUS_ACTIVE || it == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
@@ -118,7 +118,7 @@ class GetUserByIdTest : MainServiceTest() {
         inactiveStatuses.forEach { status ->
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId, status = status)
 
-            coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+            coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
 
             assertThrows<NotFoundException>("Should throw NotFoundException for status $status") {
                 mainService.getUserById(getExampleRequest())
@@ -131,7 +131,7 @@ class GetUserByIdTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
         val activeStatuses = listOf(
             UserStatus.USER_STATUS_ACTIVE,
@@ -141,7 +141,7 @@ class GetUserByIdTest : MainServiceTest() {
         activeStatuses.forEach { status ->
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId, status = status)
 
-            coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+            coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
 
             assertDoesNotThrow("Should succeed for status $status") {
                 mainService.getUserById(getExampleRequest())
@@ -154,7 +154,7 @@ class GetUserByIdTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -2,15 +2,12 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -21,24 +18,8 @@ import java.util.UUID
 
 class GetUserByIdTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
+
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @Test
-    fun `When parsing the user ID fails, then InvalidIdException is thrown`() = runTest {
-        val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(DataBuilder.createExampleUser())
-
-        assertThrows<InvalidIdException> { mainService.getUserById(request) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }
-    }
 
     @Test
     fun `When current user is admin, then requested user is returned successfully`() = runTest {
@@ -48,8 +29,7 @@ class GetUserByIdTest : MainServiceTest() {
             status = UserStatus.USER_STATUS_ACTIVE,
         )
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
 
         assertDoesNotThrow { mainService.getUserById(getExampleRequest()) }
@@ -64,8 +44,7 @@ class GetUserByIdTest : MainServiceTest() {
         )
         val request = Base.Id.newBuilder().setId(requestedUser.id.toString()).build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
         assertDoesNotThrow { mainService.getUserById(request) }
@@ -82,8 +61,7 @@ class GetUserByIdTest : MainServiceTest() {
             status = UserStatus.USER_STATUS_ACTIVE,
         )
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) } returns listOf(
             DataBuilder.createExampleProjectMember(userId = currentUser.id),
@@ -93,23 +71,21 @@ class GetUserByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When current user is not authorized to access requested user, then UnauthorizedException is thrown`() =
+    fun `When current user is not authorized to access requested user, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUserId) } returns emptyList()
 
-            assertThrows<UnauthorizedException.Single> { mainService.getUserById(getExampleRequest()) }
+            assertThrows<UnauthorizedException> { mainService.getUserById(getExampleRequest()) }
         }
 
     @Test
-    fun `When requested user is inactive, then NotFoundException is thrown`() = runTest {
+    fun `When requested user is inactive, then a NotFoundException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         val inactiveStatuses = UserStatus.entries.filterNot {
             it == UserStatus.USER_STATUS_ACTIVE || it == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
@@ -130,8 +106,7 @@ class GetUserByIdTest : MainServiceTest() {
     fun `When requested user is active, then user is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
 
         val activeStatuses = listOf(
             UserStatus.USER_STATUS_ACTIVE,
@@ -150,11 +125,10 @@ class GetUserByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When retrieving requested user fails, then exception is thrown`() = runTest {
+    fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -129,7 +129,7 @@ class GetUserByIdTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getUserById(getExampleRequest()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -10,18 +9,16 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
 class GetUserSettingsTest : MainServiceTest() {
     @Test
-    fun `When retrieving current user settings fails, then an exception is thrown`() = runTest {
+    fun `When retrieving current user settings fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns user.id
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        mockCurrentUser(user)
         coEvery { userRepoMock.getUserSettings(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserSettings() }
@@ -33,8 +30,7 @@ class GetUserSettingsTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser()
             val userSettings = DataBuilder.createExampleUserSettings()
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
             coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
 
@@ -48,8 +44,7 @@ class GetUserSettingsTest : MainServiceTest() {
             val criterion = DataBuilder.createExampleProjectCriterion()
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
 
-            every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            mockCurrentUser(user)
             coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
             coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -12,7 +12,6 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.service.MainServiceTest
-import java.util.UUID
 
 @ExperimentalCoroutinesApi
 @DelicateCoroutinesApi
@@ -21,9 +20,9 @@ class GetUserSettingsTest : MainServiceTest() {
     fun `When retrieving current user settings fails, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns user
-        coEvery { userRepoMock.getUserSettings(any()) } throws TestSpecificException()
+        every { GrpcContext.getUserIdFromContext() } returns user.id
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        coEvery { userRepoMock.getUserSettings(user.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserSettings() }
     }
@@ -35,9 +34,9 @@ class GetUserSettingsTest : MainServiceTest() {
             val userSettings = DataBuilder.createExampleUserSettings()
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
-            coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+            coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
 
             assertDoesNotThrow { mainService.getUserSettings() }
         }
@@ -50,9 +49,9 @@ class GetUserSettingsTest : MainServiceTest() {
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
 
             every { GrpcContext.getUserIdFromContext() } returns user.id
-            coEvery { userRepoMock.getUserById(user.id) } returns user
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
             coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
-            coEvery { userRepoMock.getUserSettings(user.id) } returns userSettings
+            coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
 
             assertDoesNotThrow { mainService.getUserSettings() }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -11,8 +9,6 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.service.MainServiceTest
 
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
 class GetUserSettingsTest : MainServiceTest() {
     @Test
     fun `When retrieving current user settings fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -19,7 +19,7 @@ class GetUserSettingsTest : MainServiceTest() {
         val user = DataBuilder.createExampleUser()
 
         mockCurrentUser(user)
-        coEvery { userRepoMock.getUserSettings(user.id) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserSettings(user.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getUserSettings() }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertEquals
 @ExtendWith(GrpcTestContextExtension::class)
 class LoginTest : MainServiceTest() {
     @Test
-    fun `When a user provides an invalid email, then an exception is thrown`() = runTest {
+    fun `When a user provides an invalid email, then an UnauthenticatedException is thrown`() = runTest {
         val request = LoginRequest.newBuilder().setEmail("wrongEmail").build()
 
         val exception = NotFoundException(EntityType.USER, "wrongEmail", identifierType = IdentifierType.EMAIL)
@@ -34,20 +34,21 @@ class LoginTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a user with an unconfirmed email tries to log in, then an exception is thrown`() = runTest {
-        val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
-        val request = LoginRequest.newBuilder().apply {
-            email = testUser.email
-            password = "anyPassword"
-        }.build()
+    fun `When a user with an unconfirmed email tries to log in, then an UnauthenticatedException is thrown`() =
+        runTest {
+            val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
+            val request = LoginRequest.newBuilder().apply {
+                email = testUser.email
+                password = "anyPassword"
+            }.build()
 
-        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
+            coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
-        assertThrows<UnauthenticatedException> { mainService.login(request) }
-    }
+            assertThrows<UnauthenticatedException> { mainService.login(request) }
+        }
 
     @Test
-    fun `When a deleted user tries to log in, then an exception is thrown`() = runTest {
+    fun `When a deleted user tries to log in, then an UnauthenticatedException is thrown`() = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_DELETED)
         val request = LoginRequest.newBuilder().apply {
             email = testUser.email
@@ -60,20 +61,21 @@ class LoginTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a user with an unspecified status tries to log in, then an exception is thrown`() = runTest {
-        val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_UNSPECIFIED)
-        val request = LoginRequest.newBuilder().apply {
-            email = testUser.email
-            password = "anyPassword"
-        }.build()
+    fun `When a user with an unspecified status tries to log in, then an UnauthenticatedException is thrown`() =
+        runTest {
+            val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_UNSPECIFIED)
+            val request = LoginRequest.newBuilder().apply {
+                email = testUser.email
+                password = "anyPassword"
+            }.build()
 
-        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
+            coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
-        assertThrows<UnauthenticatedException> { mainService.login(request) }
-    }
+            assertThrows<UnauthenticatedException> { mainService.login(request) }
+        }
 
     @Test
-    fun `When the password hash cannot be retrieved, then an exception is thrown`() = runTest {
+    fun `When the password hash cannot be retrieved, then an UnauthenticatedException is thrown`() = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
 
         val request = LoginRequest.newBuilder().apply {
@@ -82,15 +84,14 @@ class LoginTest : MainServiceTest() {
         }.build()
 
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
-        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } throws NotFoundException(
-            EntityType.USER, testUser.email, identifierType = IdentifierType.EMAIL,
-        )
+        val exception = NotFoundException(EntityType.USER, testUser.email, identifierType = IdentifierType.EMAIL)
+        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns Result.failure(exception)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
 
     @Test
-    fun `When a user provides an invalid password, then an exception is thrown`() = runTest {
+    fun `When a user provides an invalid password, then an UnauthenticatedException is thrown`() = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
         val userPassword = "AAbb__00"
         val passwordHash = PasswordUtils.hashPassword(userPassword)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/LoginTest.kt
@@ -13,7 +13,7 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
-import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthenticatedException
 import se.uulm.snowballr.backend.model.jwt.JwtAuthTokens
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -27,10 +27,8 @@ class LoginTest : MainServiceTest() {
     fun `When a user provides an invalid email, then an exception is thrown`() = runTest {
         val request = LoginRequest.newBuilder().setEmail("wrongEmail").build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } throws SnowballRException.NotFoundException(
-            EntityType.USER, "wrongEmail",
-            identifierType = IdentifierType.EMAIL,
-        )
+        val exception = NotFoundException(EntityType.USER, "wrongEmail", identifierType = IdentifierType.EMAIL)
+        coEvery { userRepoMock.getUserByEmail(any()) } returns Result.failure(exception)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
@@ -43,7 +41,7 @@ class LoginTest : MainServiceTest() {
             password = "anyPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
@@ -56,7 +54,7 @@ class LoginTest : MainServiceTest() {
             password = "anyPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
@@ -69,7 +67,7 @@ class LoginTest : MainServiceTest() {
             password = "anyPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns testUser
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
@@ -83,8 +81,8 @@ class LoginTest : MainServiceTest() {
             password = "anyPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns testUser
-        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } throws SnowballRException.NotFoundException(
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
+        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } throws NotFoundException(
             EntityType.USER, testUser.email, identifierType = IdentifierType.EMAIL,
         )
 
@@ -102,8 +100,8 @@ class LoginTest : MainServiceTest() {
             password = "wrongPassword"
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns testUser
-        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns passwordHash
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
+        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns Result.success(passwordHash)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }
@@ -120,8 +118,8 @@ class LoginTest : MainServiceTest() {
             password = userPassword
         }.build()
 
-        coEvery { userRepoMock.getUserByEmail(any()) } returns testUser
-        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns passwordHash
+        coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
+        coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns Result.success(passwordHash)
         every { jwtServiceMock.generateAuthTokens(testUser.id) } returns tokens
 
         assertDoesNotThrow { mainService.login(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -26,29 +26,7 @@ class RegisterTest : MainServiceTest() {
     }
 
     @Test
-    fun `When creating the user fails, then a TestSpecificException is thrown`() = runTest {
-        val request = Authentication.RegisterRequest.newBuilder().build()
-
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.createUser(any(), any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.register(request) }
-    }
-
-    @Test
-    fun `When saving the verification token fails, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val request = Authentication.RegisterRequest.newBuilder().build()
-
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.createUser(any(), any()) } returns user
-        coEvery { verificationTokenRepoMock.saveVerificationToken(any(), any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.register(request) }
-    }
-
-    @Test
-    fun `When sending the verification email fails, then a TestSpecificException is thrown`() = runTest {
+    fun `When sending the verification email fails, then an exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val request = Authentication.RegisterRequest.newBuilder().build()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -17,7 +17,7 @@ import snowballr.Authentication
 
 class RegisterTest : MainServiceTest() {
     @Test
-    fun `When a user with the given email already exists, then an exception is thrown`() = runTest {
+    fun `When a user with the given email already exists, then a DuplicateEntityException is thrown`() = runTest {
         val request = Authentication.RegisterRequest.newBuilder().build()
 
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
@@ -26,7 +26,7 @@ class RegisterTest : MainServiceTest() {
     }
 
     @Test
-    fun `When creating the user fails, then an exception is thrown`() = runTest {
+    fun `When creating the user fails, then a TestSpecificException is thrown`() = runTest {
         val request = Authentication.RegisterRequest.newBuilder().build()
 
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
@@ -36,7 +36,7 @@ class RegisterTest : MainServiceTest() {
     }
 
     @Test
-    fun `When saving the verification token fails, then an exception is thrown`() = runTest {
+    fun `When saving the verification token fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val request = Authentication.RegisterRequest.newBuilder().build()
 
@@ -48,7 +48,7 @@ class RegisterTest : MainServiceTest() {
     }
 
     @Test
-    fun `When sending the verification email fails, then an exception is thrown`() = runTest {
+    fun `When sending the verification email fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val request = Authentication.RegisterRequest.newBuilder().build()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -40,7 +40,7 @@ class SoftDeleteUserTest : MainServiceTest() {
     fun `When parsing user ID fails, then InvalidIdException is thrown`() = runTest {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
         every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns DataBuilder.createExampleUser()
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(DataBuilder.createExampleUser())
 
         assertThrows<InvalidIdException> { mainService.softDeleteUser(request) }
     }
@@ -50,7 +50,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
@@ -62,8 +62,8 @@ class SoftDeleteUserTest : MainServiceTest() {
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns userToDelete
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
 
         assertThrows<UnauthorizedException.Single> { mainService.softDeleteUser(getExampleRequest()) }
     }
@@ -74,8 +74,8 @@ class SoftDeleteUserTest : MainServiceTest() {
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns userToDelete
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
 
         assertThrows<FailedPreconditionException> { mainService.softDeleteUser(getExampleRequest()) }
     }
@@ -86,8 +86,8 @@ class SoftDeleteUserTest : MainServiceTest() {
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns userToDelete
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
@@ -99,8 +99,8 @@ class SoftDeleteUserTest : MainServiceTest() {
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns userToDelete
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
@@ -111,7 +111,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
@@ -122,7 +122,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -1,14 +1,12 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
@@ -22,71 +20,51 @@ class SoftDeleteUserTest : MainServiceTest() {
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
 
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When parsing user ID fails, then InvalidIdException is thrown`() = runTest {
+    fun `When parsing user ID fails, then an InvalidIdException is thrown`() = runTest {
         val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(DataBuilder.createExampleUser())
+        mockCurrentUser(DataBuilder.createExampleUser())
 
         assertThrows<InvalidIdException> { mainService.softDeleteUser(request) }
     }
 
     @Test
-    fun `When retrieving user to delete fails, then exception is thrown`() = runTest {
+    fun `When retrieving user to delete fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When user is not admin and tries to delete another user, then UnauthorizedException is thrown`() = runTest {
+    fun `When user is not admin and tries to delete another user, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
 
-        assertThrows<UnauthorizedException.Single> { mainService.softDeleteUser(getExampleRequest()) }
+        assertThrows<UnauthorizedException> { mainService.softDeleteUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When trying to delete another admin user, then FailedPreconditionException is thrown`() = runTest {
+    fun `When trying to delete another admin user, then a FailedPreconditionException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
 
         assertThrows<FailedPreconditionException> { mainService.softDeleteUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When soft delete fails, then exception is thrown`() = runTest {
+    fun `When soft delete fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } throws TestSpecificException()
 
@@ -98,8 +76,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } returns Unit
 
@@ -110,8 +87,7 @@ class SoftDeleteUserTest : MainServiceTest() {
     fun `When user tries to delete own account, then it succeeds`() = runTest {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
@@ -121,8 +97,7 @@ class SoftDeleteUserTest : MainServiceTest() {
     fun `When admin tries to delete own account, then it succeeds`() = runTest {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -32,7 +32,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
     }
@@ -57,18 +57,6 @@ class SoftDeleteUserTest : MainServiceTest() {
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
 
         assertThrows<FailedPreconditionException> { mainService.softDeleteUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When soft delete fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
-        coEvery { userRepoMock.softDeleteUser(requestedUserId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.softDeleteUser(getExampleRequest()) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
-import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -18,14 +17,6 @@ import java.util.UUID
 class SoftDeleteUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
     private fun getExampleRequest() = Base.Id.newBuilder().setId(requestedUserId.toString()).build()
-
-    @Test
-    fun `When parsing user ID fails, then an InvalidIdException is thrown`() = runTest {
-        val request = Base.Id.newBuilder().setId("invalid-uuid").build()
-        mockCurrentUser(DataBuilder.createExampleUser())
-
-        assertThrows<InvalidIdException> { mainService.softDeleteUser(request) }
-    }
 
     @Test
     fun `When retrieving user to delete fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -58,7 +58,7 @@ class UpdateUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
@@ -71,8 +71,8 @@ class UpdateUserTest : MainServiceTest() {
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-            coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
 
             assertThrows<UnauthorizedException.Single> { mainService.updateUser(getExampleRequest()) }
         }
@@ -87,8 +87,8 @@ class UpdateUserTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(otherUser.id) } returns otherUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
 
         assertThrows<UnauthorizedException.Single> { mainService.updateUser(request) }
     }
@@ -99,8 +99,8 @@ class UpdateUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
 
         assertThrows<DuplicateEntityException> { mainService.updateUser(getExampleRequest()) }
@@ -112,8 +112,8 @@ class UpdateUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
 
@@ -133,7 +133,7 @@ class UpdateUserTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
         coEvery { userRepoMock.doesUserExistByEmail("new-and-shiny@example.com") } returns false
         coEvery { userRepoMock.updateUser(request) } returns currentUser
 
@@ -154,8 +154,8 @@ class UpdateUserTest : MainServiceTest() {
             .build()
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns currentUser
-        coEvery { userRepoMock.getUserById(otherUser.id) } returns otherUser
+        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
         coEvery { userRepoMock.updateUser(request) } returns otherUser
 
         assertDoesNotThrow { mainService.updateUser(request) }
@@ -167,8 +167,8 @@ class UpdateUserTest : MainServiceTest() {
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns currentUser
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns requestedUser
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
         coEvery { userRepoMock.updateUser(any()) } returns requestedUser
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -11,15 +11,15 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import snowballr.UserOuterClass.User as GrpcUser
 
 class UpdateUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
 
-    private fun getExampleRequest(): UserOuterClass.User.Update {
-        val user = UserOuterClass.User.newBuilder()
+    private fun getExampleRequest(): GrpcUser.Update {
+        val user = GrpcUser.newBuilder()
             .setId(requestedUserId.toString())
             .setEmail("newemail@example.com")
             .setRole(UserRole.USER_ROLE_ADMIN)
@@ -30,7 +30,7 @@ class UpdateUserTest : MainServiceTest() {
             .addPaths("role")
             .build()
 
-        return UserOuterClass.User.Update.newBuilder()
+        return GrpcUser.Update.newBuilder()
             .setUser(user)
             .setMask(mask)
             .build()
@@ -62,8 +62,8 @@ class UpdateUserTest : MainServiceTest() {
     fun `When user is not admin and tries to update another user, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val otherUser = DataBuilder.createExampleUser(id = requestedUserId)
-        val request = UserOuterClass.User.Update.newBuilder()
-            .setUser(UserOuterClass.User.newBuilder().setId(otherUser.id.toString()).setFirstName("NewFirstName"))
+        val request = GrpcUser.Update.newBuilder()
+            .setUser(GrpcUser.newBuilder().setId(otherUser.id.toString()).setFirstName("NewFirstName"))
             .setMask(FieldMask.newBuilder().addPaths("first_name"))
             .build()
 
@@ -88,9 +88,9 @@ class UpdateUserTest : MainServiceTest() {
     @Test
     fun `When user updates own email, then it succeeds`() = runTest {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
-        val request = UserOuterClass.User.Update.newBuilder()
+        val request = GrpcUser.Update.newBuilder()
             .setUser(
-                UserOuterClass.User.newBuilder()
+                GrpcUser.newBuilder()
                     .setId(currentUser.id.toString())
                     .setEmail("new-and-shiny@example.com"),
             )
@@ -108,9 +108,9 @@ class UpdateUserTest : MainServiceTest() {
     fun `When admin updates another user's role, then it succeeds`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val otherUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
-        val request = UserOuterClass.User.Update.newBuilder()
+        val request = GrpcUser.Update.newBuilder()
             .setUser(
-                UserOuterClass.User.newBuilder()
+                GrpcUser.newBuilder()
                     .setId(otherUser.id.toString())
                     .setRole(UserRole.USER_ROLE_ADMIN),
             )

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -41,7 +41,7 @@ class UpdateUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
     }
@@ -83,19 +83,6 @@ class UpdateUserTest : MainServiceTest() {
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
 
         assertThrows<DuplicateEntityException> { mainService.updateUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When update fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -74,7 +74,7 @@ class UpdateUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When updating email to existing email, then a DuplicateEntityException is thrown`() = runTest {
+    fun `When updating email to existent email, then a DuplicateEntityException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -2,14 +2,12 @@ package se.uulm.snowballr.backend.service.user
 
 import com.google.protobuf.FieldMask
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -39,46 +37,29 @@ class UpdateUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When retrieving the current user ID fails, then an exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When retrieving current user fails, then exception is thrown`() = runTest {
-        every { GrpcContext.getUserIdFromContext() } returns UUID.randomUUID()
-        coEvery { userRepoMock.getUserById(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When requested user retrieval fails, then exception is thrown`() = runTest {
+    fun `When requested user retrieval fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
     }
 
     @Test
-    fun `When user is not admin and tries to change another user's role, then UnauthorizedException is thrown`() =
+    fun `When user is not admin and tries to change another user's role, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-            every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-            coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+            mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
 
-            assertThrows<UnauthorizedException.Single> { mainService.updateUser(getExampleRequest()) }
+            assertThrows<UnauthorizedException> { mainService.updateUser(getExampleRequest()) }
         }
 
     @Test
-    fun `When user is not admin and tries to update another user, then UnauthorizedException is thrown`() = runTest {
+    fun `When user is not admin and tries to update another user, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val otherUser = DataBuilder.createExampleUser(id = requestedUserId)
         val request = UserOuterClass.User.Update.newBuilder()
@@ -86,20 +67,18 @@ class UpdateUserTest : MainServiceTest() {
             .setMask(FieldMask.newBuilder().addPaths("first_name"))
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
 
-        assertThrows<UnauthorizedException.Single> { mainService.updateUser(request) }
+        assertThrows<UnauthorizedException> { mainService.updateUser(request) }
     }
 
     @Test
-    fun `When updating email to existing email, then DuplicateEntityException is thrown`() = runTest {
+    fun `When updating email to existing email, then a DuplicateEntityException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
 
@@ -107,12 +86,11 @@ class UpdateUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When update fails, then exception is thrown`() = runTest {
+    fun `When update fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
@@ -132,8 +110,7 @@ class UpdateUserTest : MainServiceTest() {
             .setMask(FieldMask.newBuilder().addPaths("email"))
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.doesUserExistByEmail("new-and-shiny@example.com") } returns false
         coEvery { userRepoMock.updateUser(request) } returns currentUser
 
@@ -153,8 +130,7 @@ class UpdateUserTest : MainServiceTest() {
             .setMask(FieldMask.newBuilder().addPaths("role"))
             .build()
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
         coEvery { userRepoMock.updateUser(request) } returns otherUser
 
@@ -166,8 +142,7 @@ class UpdateUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
 
-        every { GrpcContext.getUserIdFromContext() } returns currentUser.id
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(currentUser)
+        mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
         coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
         coEvery { userRepoMock.updateUser(any()) } returns requestedUser

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -11,8 +11,9 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.VerificationTokenNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Authentication
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
+import snowballr.UserOuterClass.User as GrpcUser
 
 class VerifyEmailTest : MainServiceTest() {
     @Test
@@ -49,10 +50,10 @@ class VerifyEmailTest : MainServiceTest() {
 
     @Test
     fun `When a valid token is provided and all operations succeed, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
+        val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
         val token = DataBuilder.createExampleVerificationToken(userId = user.id)
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
-        val userUpdateSlot = slot<UserOuterClass.User.Update>()
+        val userUpdateSlot = slot<GrpcUser.Update>()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns token
         coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -16,7 +16,7 @@ import java.time.OffsetDateTime
 
 class VerifyEmailTest : MainServiceTest() {
     @Test
-    fun `When the verification token is not found, then an exception is thrown`() = runTest {
+    fun `When the verification token is not found, then a TestSpecificException is thrown`() = runTest {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken("non-existent-token").build()
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns null
 
@@ -24,7 +24,7 @@ class VerifyEmailTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the verification token has expired, then an exception is thrown`() = runTest {
+    fun `When the verification token has expired, then a TestSpecificException is thrown`() = runTest {
         val expiredToken = DataBuilder.createExampleVerificationToken(
             expiresAt = OffsetDateTime.now().minusMinutes(1),
         )
@@ -37,39 +37,12 @@ class VerifyEmailTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user associated with the token is not found, then an exception is thrown`() = runTest {
+    fun `When the user associated with the token is not found, then a TestSpecificException is thrown`() = runTest {
         val token = DataBuilder.createExampleVerificationToken()
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(token.userId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
-    }
-
-    @Test
-    fun `When updating the user status fails, then an exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val token = DataBuilder.createExampleVerificationToken(userId = user.id)
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
-
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-        coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
-    }
-
-    @Test
-    fun `When deleting the verification token fails, then an exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val token = DataBuilder.createExampleVerificationToken(userId = user.id)
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
-
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-        coEvery { userRepoMock.updateUser(any()) } returns user
-        coEvery { verificationTokenRepoMock.deleteVerificationToken(any()) } throws TestSpecificException()
+        coEvery { userRepoMock.getUserById(token.userId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -17,7 +17,7 @@ import snowballr.UserOuterClass.User as GrpcUser
 
 class VerifyEmailTest : MainServiceTest() {
     @Test
-    fun `When the verification token is not found, then a TestSpecificException is thrown`() = runTest {
+    fun `When the verification token is not found, then a VerificationTokenNotFoundException is thrown`() = runTest {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken("non-existent-token").build()
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns null
 
@@ -25,7 +25,7 @@ class VerifyEmailTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the verification token has expired, then a TestSpecificException is thrown`() = runTest {
+    fun `When the verification token has expired, then a VerificationTokenNotFoundException is thrown`() = runTest {
         val expiredToken = DataBuilder.createExampleVerificationToken(
             expiresAt = OffsetDateTime.now().minusMinutes(1),
         )

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -54,7 +54,7 @@ class VerifyEmailTest : MainServiceTest() {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(user)
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
@@ -67,7 +67,7 @@ class VerifyEmailTest : MainServiceTest() {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(any()) } returns user
+        coEvery { userRepoMock.getUserById(any()) } returns Result.success(user)
         coEvery { userRepoMock.updateUser(any()) } returns user
         coEvery { verificationTokenRepoMock.deleteVerificationToken(any()) } throws TestSpecificException()
 
@@ -82,7 +82,7 @@ class VerifyEmailTest : MainServiceTest() {
         val userUpdateSlot = slot<UserOuterClass.User.Update>()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns token
-        coEvery { userRepoMock.getUserById(user.id) } returns user
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { userRepoMock.updateUser(capture(userUpdateSlot)) } returns user
         coEvery { verificationTokenRepoMock.deleteVerificationToken(token.token) } returns Unit
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/VerifyEmailTest.kt
@@ -54,7 +54,7 @@ class VerifyEmailTest : MainServiceTest() {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(user)
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { userRepoMock.updateUser(any()) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }
@@ -67,7 +67,7 @@ class VerifyEmailTest : MainServiceTest() {
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
-        coEvery { userRepoMock.getUserById(any()) } returns Result.success(user)
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { userRepoMock.updateUser(any()) } returns user
         coEvery { verificationTokenRepoMock.deleteVerificationToken(any()) } throws TestSpecificException()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/utils/ResultTestHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/utils/ResultTestHelper.kt
@@ -5,7 +5,7 @@ import se.uulm.snowballr.backend.model.SnowballRException
 import kotlin.test.assertIs
 
 /**
- * Assert that the passed [Result] is not a [Result.Failure] and contains the data of type [T].
+ * Assert that the passed [Result] is not a [Result.Failure] and contains the data of type [T]. The data is returned.
  */
 inline fun <reified T> assertResultSuccess(result: Result<T>): T {
     assertThat(result.isSuccess).isTrue()

--- a/src/test/kotlin/se/uulm/snowballr/backend/utils/ResultTestHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/utils/ResultTestHelper.kt
@@ -1,0 +1,24 @@
+package se.uulm.snowballr.backend.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import se.uulm.snowballr.backend.model.SnowballRException
+import kotlin.test.assertIs
+
+/**
+ * Assert that the passed [Result] is not a [Result.Failure] and contains the data of type [T].
+ */
+inline fun <reified T> assertResultSuccess(result: Result<T>): T {
+    assertThat(result.isSuccess).isTrue()
+    val data = result.getOrNull()
+    assertIs<T>(data)
+    return data
+}
+
+/**
+ * Assert that the passed [Result] is a [Result.Failure] and contains the exception of type [T].
+ */
+inline fun <reified T : SnowballRException> assertResultFailure(result: Result<*>) {
+    assertThat(result.isFailure).isTrue()
+    val exception = result.exceptionOrNull()
+    assertIs<T>(exception)
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
@@ -150,10 +150,10 @@ class CriterionValidatorTest {
         }
 
         @Test
-        fun `When a field mask containing a non-existing field is validated, then the 'InvalidFieldMask' issue is returned`() {
+        fun `When a field mask containing a nonexistent field is validated, then the 'InvalidFieldMask' issue is returned`() {
             val request =
                 validUpdateRequestBuilder
-                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existing_field")))
+                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existent_field")))
                     .build()
             val result = validateRequest(request)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -108,10 +108,10 @@ class ProjectValidatorTest {
         }
 
         @Test
-        fun `When a field mask containing a non-existing field is validated, then the 'InvalidFieldMask' issue is returned`() {
+        fun `When a field mask containing a nonexistent field is validated, then the 'InvalidFieldMask' issue is returned`() {
             val request =
                 validUpdateRequestBuilder
-                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existing_field")))
+                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existent_field")))
                     .build()
             val result = validateRequest(request)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
@@ -55,10 +55,10 @@ class UserValidatorTest {
         }
 
         @Test
-        fun `When a field mask containing a non-existing field is validated, then the 'InvalidFieldMask' issue is returned`() {
+        fun `When a field mask containing a nonexistent field is validated, then the 'InvalidFieldMask' issue is returned`() {
             val request =
                 validUpdateRequestBuilder
-                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existing_field")))
+                    .setMask(FieldMaskUtil.fromStringList(listOf("non_existent_field")))
                     .build()
             val result = validateRequest(request)
 


### PR DESCRIPTION
Closes #291

## What I have made

I recommend reviewing this commit-by-commit.
The refactoring was done in the following steps:
1. Search for repo methods that throw an exception and return a result instead (+ adjust tests) -> first 14 commits
2. Search for service tests that mock exception throwing for methods that do not return a result type, remove them, and return a `Result.Failure` for the other methods. -> following 12 commits
3. In between, use `withUser` instead of `userRepo.getUserById(GrpcContext.getUserIdFromContext()).getOrThrow()` (1fce7514a53e179942509861678ec4b262154f50 and 4a1e7a4bd5b774557b040d28b7e9a901c9cea396)
4. Add some repo helpers (following 3 commits)
5. Add some missing tests (following 2 commits)
6. Adjust imports (last commit)

With this, we could delete ~112 unnecessary tests and a lot of boilerplate code.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
