### PR TITLE
Minor refactoring for validation layer and review table

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,6 @@ kover {
                     "se.uulm.snowballr.backend.db", // production database
                     "se.uulm.snowballr.backend.env", // environment variables
                     "se.uulm.snowballr.backend.grpc", // grpc server implementation
-                    "se.uulm.snowballr.backend.model", // model classes, no logic
                 )
             }
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -27,10 +27,12 @@ import se.uulm.snowballr.backend.repository.IAuthorTableRepo
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.repository.PaperTableRepo
 import se.uulm.snowballr.backend.repository.ProjectTableRepo
+import se.uulm.snowballr.backend.repository.ReviewTableRepo
 import se.uulm.snowballr.backend.repository.UserTableRepo
 import se.uulm.snowballr.backend.repository.VerificationTokenTableRepo
 import se.uulm.snowballr.backend.repository.association.AuthorOfPaperTableRepo
@@ -41,12 +43,10 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
-import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.ProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ReadingListTableRepo
 import se.uulm.snowballr.backend.repository.association.ReviewHasCriterionTableRepo
-import se.uulm.snowballr.backend.repository.association.ReviewTableRepo
 import se.uulm.snowballr.backend.service.AuthenticationService
 import se.uulm.snowballr.backend.service.CriterionService
 import se.uulm.snowballr.backend.service.FetcherService

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/DatabaseHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/DatabaseHelper.kt
@@ -8,6 +8,7 @@ import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.PdfTable
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.VerificationTokenTable
 import se.uulm.snowballr.backend.table.association.AuthorOfPaperTable
@@ -17,7 +18,6 @@ import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.ReadingListTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
-import se.uulm.snowballr.backend.table.association.ReviewTable
 
 /**
  * Helper for the [Database] to manage all tables and extensions.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -88,11 +88,11 @@ data class InvalidId(
     override fun toString(): String = "The ID '$id' is invalid for the field '$name'."
 }
 
-data class OutOfRangeValue(
+data class OutOfRangeValue<T : Comparable<T>>(
     val name: String,
-    val value: Number,
-    val from: Number,
-    val to: Number,
+    val value: T,
+    val from: T,
+    val to: T,
 ) : ValidationIssue {
     override fun toString(): String =
         "The value '$value' is not in the allowed range [$from-$to] for the field '$name'."

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -1,10 +1,10 @@
 package se.uulm.snowballr.backend.model
 
-import se.uulm.snowballr.backend.validation.PASSWORD_MIN_LENGTH
-import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_DIGITS
-import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS
-import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_SPECIAL_CHARS
-import se.uulm.snowballr.backend.validation.PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS
+import se.uulm.snowballr.backend.validation.AuthenticationValidator.PASSWORD_MIN_LENGTH
+import se.uulm.snowballr.backend.validation.AuthenticationValidator.PASSWORD_MIN_NUMBER_DIGITS
+import se.uulm.snowballr.backend.validation.AuthenticationValidator.PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS
+import se.uulm.snowballr.backend.validation.AuthenticationValidator.PASSWORD_MIN_NUMBER_SPECIAL_CHARS
+import se.uulm.snowballr.backend.validation.AuthenticationValidator.PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS
 
 /**
  * Represents a validation issue that can occur during the validation process.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Review.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Review.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
-import se.uulm.snowballr.backend.table.association.ReviewTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import snowballr.ReviewOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.repository.association
+package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
@@ -6,7 +6,6 @@ import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Review
-import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
 import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.toReview
 import java.util.UUID

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepo.kt
@@ -7,8 +7,8 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
-import se.uulm.snowballr.backend.table.association.ReviewTable
-import se.uulm.snowballr.backend.table.association.toReview
+import se.uulm.snowballr.backend.table.ReviewTable
+import se.uulm.snowballr.backend.table.toReview
 import java.util.UUID
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -21,13 +21,13 @@ import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
-import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.PaperOuterClass

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -10,11 +10,11 @@ import se.uulm.snowballr.backend.model.dto.toGrpcReview
 import se.uulm.snowballr.backend.model.dto.toGrpcReviews
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
-import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import snowballr.Base
 import snowballr.ReviewOuterClass.Review as GrpcReview
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ReviewTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ReviewTable.kt
@@ -1,12 +1,10 @@
-package se.uulm.snowballr.backend.table.association
+package se.uulm.snowballr.backend.table
 
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.ResultRow
 import se.uulm.snowballr.backend.model.dto.Review
-import se.uulm.snowballr.backend.table.createdAt
-import se.uulm.snowballr.backend.table.modifiedAt
-import se.uulm.snowballr.backend.table.userReference
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import snowballr.ReviewOuterClass
 import java.time.OffsetDateTime
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/association/ReviewHasCriterionTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/association/ReviewHasCriterionTable.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.table.association
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import se.uulm.snowballr.backend.table.CriterionTable
+import se.uulm.snowballr.backend.table.ReviewTable
 
 /**
  * Represents the "review_has_criterion" table, defining the many-to-many relationship between reviews and criteria.

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/association/ReviewHasCriterionTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/association/ReviewHasCriterionTable.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.table.association
 
-import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.dao.id.CompositeIdTable
 import org.jetbrains.exposed.sql.ReferenceOption
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.ReviewTable
@@ -13,8 +13,11 @@ import se.uulm.snowballr.backend.table.ReviewTable
  * Columns:
  * - [reviewId]: Foreign key referencing the [ReviewTable.id], representing the associated review.
  * - [criterionId]: Foreign key referencing the [CriterionTable], representing the associated criterion.
+ *
+ * Primary Key:
+ * - Composite primary key consisting of [reviewId] and [criterionId].
  */
-object ReviewHasCriterionTable : UUIDTable("review_has_criterion") {
+object ReviewHasCriterionTable : CompositeIdTable("review_has_criterion") {
     /**
      * Reference to the associated review.
      *
@@ -32,6 +35,9 @@ object ReviewHasCriterionTable : UUIDTable("review_has_criterion") {
     val criterionId = reference("criterion_id", CriterionTable, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
 
     init {
-        uniqueIndex(reviewId, criterionId)
+        addIdColumn(reviewId)
+        addIdColumn(criterionId)
     }
+
+    override val primaryKey = PrimaryKey(reviewId, criterionId)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/AuthenticationValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/AuthenticationValidator.kt
@@ -12,6 +12,11 @@ import snowballr.Authentication
  * A validator for [Authentication] related requests.
  */
 object AuthenticationValidator {
+    const val PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS = 2
+    const val PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS = 2
+    const val PASSWORD_MIN_NUMBER_DIGITS = 2
+    const val PASSWORD_MIN_NUMBER_SPECIAL_CHARS = 2
+    const val PASSWORD_MIN_LENGTH = 8
     private val SPECIAL_CHAR_REGEX = Regex("[" + Regex.escape("#$%&@^`~.,:;\"'/|_-<>*+!?={[()]}ß") + "]")
 
     fun validateRegisterRequest(request: Authentication.RegisterRequest): EitherNel<ValidationIssue, Unit> = either {

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/AuthenticationValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/AuthenticationValidator.kt
@@ -2,7 +2,9 @@ package se.uulm.snowballr.backend.validation
 
 import arrow.core.EitherNel
 import arrow.core.raise.either
+import arrow.core.raise.ensure
 import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.InvalidPassword
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.Authentication
 
@@ -10,6 +12,8 @@ import snowballr.Authentication
  * A validator for [Authentication] related requests.
  */
 object AuthenticationValidator {
+    private val SPECIAL_CHAR_REGEX = Regex("[" + Regex.escape("#$%&@^`~.,:;\"'/|_-<>*+!?={[()]}ß") + "]")
+
     fun validateRegisterRequest(request: Authentication.RegisterRequest): EitherNel<ValidationIssue, Unit> = either {
         val result1 = either {
             zipOrAccumulate(
@@ -33,4 +37,59 @@ object AuthenticationValidator {
         ensureEmailValidity(request.email)
         ensureFieldNonBlank("password", request.password)
     }.toEitherNel()
+
+    /**
+     * Ensures that the provided password meets the required complexity criteria.
+     *
+     * It checks the following conditions:
+     * - Minimum length of [PASSWORD_MIN_LENGTH]
+     * - Minimum number of lowercase letters defined by [PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS]
+     * - Minimum number of uppercase letters defined by [PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS]
+     * - Minimum number of digits defined by [PASSWORD_MIN_NUMBER_DIGITS]
+     * - Minimum number of special characters defined by [PASSWORD_MIN_NUMBER_SPECIAL_CHARS]
+     *
+     * If any of these conditions are not met, an [se.uulm.snowballr.backend.model.InvalidPassword] validation issue is raised with the appropriate reason.
+     *
+     * @param password The password to validate.
+     * @return An [arrow.core.Either] containing either the validation issues or a success indication.
+     */
+    private fun ensurePasswordValidity(password: String) = either {
+        zipOrAccumulate(
+            {
+                ensure(password.length >= PASSWORD_MIN_LENGTH) {
+                    InvalidPassword(password, InvalidPassword.Reason.TOO_SHORT)
+                }
+            },
+            {
+                ensure(password.count { it.isLowerCase() } >= PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS) {
+                    InvalidPassword(password, InvalidPassword.Reason.NOT_ENOUGH_LOWERCASE_CHARS)
+                }
+            },
+            {
+                ensure(password.count { it.isUpperCase() } >= PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS) {
+                    InvalidPassword(password, InvalidPassword.Reason.NOT_ENOUGH_UPPERCASE_CHARS)
+                }
+            },
+            {
+                ensure(password.count { it.isDigit() } >= PASSWORD_MIN_NUMBER_DIGITS) {
+                    InvalidPassword(password, InvalidPassword.Reason.NOT_ENOUGH_DIGITS)
+                }
+            },
+            {
+                ensure(countSpecialChars(password) >= PASSWORD_MIN_NUMBER_SPECIAL_CHARS) {
+                    InvalidPassword(password, InvalidPassword.Reason.NOT_ENOUGH_SPECIAL_CHARS)
+                }
+            },
+        ) { _, _, _, _, _ -> }
+    }
+
+    /**
+     * Counts the number of special characters in the given password.
+     * Special characters are defined by the [SPECIAL_CHAR_REGEX].
+     *
+     * @param password The password to check for special characters.
+     * @return The count of special characters in the password.
+     */
+    private fun countSpecialChars(password: String): Int =
+        password.count { SPECIAL_CHAR_REGEX.containsMatchIn(it.toString()) }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
@@ -11,9 +11,9 @@ import snowballr.CriterionOuterClass.Criterion
  * A validator for [Criterion] related requests.
  */
 object CriterionValidator {
-    const val CRITERION_TAG_MAX_LENGTH = 10
-    const val CRITERION_NAME_MAX_LENGTH = 50
-    const val CRITERION_DESCRIPTION_MAX_LENGTH = 200
+    const val TAG_MAX_LENGTH = 10
+    const val NAME_MAX_LENGTH = 50
+    const val DESCRIPTION_MAX_LENGTH = 200
 
     private const val FIELD_TAG = "tag"
     private const val FIELD_NAME = "name"
@@ -35,13 +35,13 @@ object CriterionValidator {
                 }
             },
             {
-                ensureTextFieldValidity(FIELD_TAG, request.tag, CRITERION_TAG_MAX_LENGTH)
+                ensureTextFieldValidity(FIELD_TAG, request.tag, TAG_MAX_LENGTH)
             },
             {
-                ensureTextFieldValidity(FIELD_NAME, request.name, CRITERION_NAME_MAX_LENGTH)
+                ensureTextFieldValidity(FIELD_NAME, request.name, NAME_MAX_LENGTH)
             },
             {
-                ensureTextFieldValidity(FIELD_DESCRIPTION, request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
+                ensureTextFieldValidity(FIELD_DESCRIPTION, request.description, DESCRIPTION_MAX_LENGTH)
             },
             {
                 ensureEnumNotUnspecified(FIELD_CATEGORY, request.category)
@@ -61,30 +61,27 @@ object CriterionValidator {
 
         val selectedFields = request.mask.pathsList.toSet()
 
+        val criterion = request.criterion
         zipOrAccumulate(
-            { ensureIdValidity(FIELD_ID, request.criterion.id) },
+            { ensureIdValidity(FIELD_ID, criterion.id) },
             {
                 if (MASK_TAG in selectedFields) {
-                    ensureTextFieldValidity(FIELD_TAG, request.criterion.tag, CRITERION_TAG_MAX_LENGTH)
+                    ensureTextFieldValidity(FIELD_TAG, criterion.tag, TAG_MAX_LENGTH)
                 }
             },
             {
                 if (MASK_NAME in selectedFields) {
-                    ensureTextFieldValidity(FIELD_NAME, request.criterion.name, CRITERION_NAME_MAX_LENGTH)
+                    ensureTextFieldValidity(FIELD_NAME, criterion.name, NAME_MAX_LENGTH)
                 }
             },
             {
                 if (MASK_DESCRIPTION in selectedFields) {
-                    ensureTextFieldValidity(
-                        FIELD_DESCRIPTION,
-                        request.criterion.description,
-                        CRITERION_DESCRIPTION_MAX_LENGTH,
-                    )
+                    ensureTextFieldValidity(FIELD_DESCRIPTION, criterion.description, DESCRIPTION_MAX_LENGTH)
                 }
             },
             {
                 if (MASK_CATEGORY in selectedFields) {
-                    ensureEnumNotUnspecified(FIELD_CATEGORY, request.criterion.category)
+                    ensureEnumNotUnspecified(FIELD_CATEGORY, criterion.category)
                 }
             },
         ) { _, _, _, _, _ -> }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
@@ -7,26 +7,26 @@ import arrow.core.raise.zipOrAccumulate
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.CriterionOuterClass.Criterion
 
-const val CRITERION_TAG_MAX_LENGTH = 10
-const val CRITERION_NAME_MAX_LENGTH = 50
-const val CRITERION_DESCRIPTION_MAX_LENGTH = 200
-
-private const val FIELD_TAG = "tag"
-private const val FIELD_NAME = "name"
-private const val FIELD_DESCRIPTION = "description"
-private const val FIELD_CATEGORY = "category"
-private const val FIELD_PROJECT_ID = "project_id"
-private const val FIELD_ID = "id"
-
-private const val MASK_TAG = "criterion.tag"
-private const val MASK_NAME = "criterion.name"
-private const val MASK_DESCRIPTION = "criterion.description"
-private const val MASK_CATEGORY = "criterion.category"
-
 /**
  * A validator for [Criterion] related requests.
  */
 object CriterionValidator {
+    const val CRITERION_TAG_MAX_LENGTH = 10
+    const val CRITERION_NAME_MAX_LENGTH = 50
+    const val CRITERION_DESCRIPTION_MAX_LENGTH = 200
+
+    private const val FIELD_TAG = "tag"
+    private const val FIELD_NAME = "name"
+    private const val FIELD_DESCRIPTION = "description"
+    private const val FIELD_CATEGORY = "category"
+    private const val FIELD_PROJECT_ID = "project_id"
+    private const val FIELD_ID = "id"
+
+    private const val MASK_TAG = "criterion.tag"
+    private const val MASK_NAME = "criterion.name"
+    private const val MASK_DESCRIPTION = "criterion.description"
+    private const val MASK_CATEGORY = "criterion.category"
+
     fun validateCreateRequest(request: Criterion.Create): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
             {

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/CriterionValidator.kt
@@ -35,16 +35,13 @@ object CriterionValidator {
                 }
             },
             {
-                ensureFieldNonBlank(FIELD_TAG, request.tag)
-                ensureFieldLength(FIELD_TAG, request.tag, CRITERION_TAG_MAX_LENGTH)
+                ensureTextFieldValidity(FIELD_TAG, request.tag, CRITERION_TAG_MAX_LENGTH)
             },
             {
-                ensureFieldNonBlank(FIELD_NAME, request.name)
-                ensureFieldLength(FIELD_NAME, request.name, CRITERION_NAME_MAX_LENGTH)
+                ensureTextFieldValidity(FIELD_NAME, request.name, CRITERION_NAME_MAX_LENGTH)
             },
             {
-                ensureFieldNonBlank(FIELD_DESCRIPTION, request.description)
-                ensureFieldLength(FIELD_DESCRIPTION, request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
+                ensureTextFieldValidity(FIELD_DESCRIPTION, request.description, CRITERION_DESCRIPTION_MAX_LENGTH)
             },
             {
                 ensureEnumNotUnspecified(FIELD_CATEGORY, request.category)
@@ -68,20 +65,17 @@ object CriterionValidator {
             { ensureIdValidity(FIELD_ID, request.criterion.id) },
             {
                 if (MASK_TAG in selectedFields) {
-                    ensureFieldNonBlank(FIELD_TAG, request.criterion.tag)
-                    ensureFieldLength(FIELD_TAG, request.criterion.tag, CRITERION_TAG_MAX_LENGTH)
+                    ensureTextFieldValidity(FIELD_TAG, request.criterion.tag, CRITERION_TAG_MAX_LENGTH)
                 }
             },
             {
                 if (MASK_NAME in selectedFields) {
-                    ensureFieldNonBlank(FIELD_NAME, request.criterion.name)
-                    ensureFieldLength(FIELD_NAME, request.criterion.name, CRITERION_NAME_MAX_LENGTH)
+                    ensureTextFieldValidity(FIELD_NAME, request.criterion.name, CRITERION_NAME_MAX_LENGTH)
                 }
             },
             {
                 if (MASK_DESCRIPTION in selectedFields) {
-                    ensureFieldNonBlank(FIELD_DESCRIPTION, request.criterion.description)
-                    ensureFieldLength(
+                    ensureTextFieldValidity(
                         FIELD_DESCRIPTION,
                         request.criterion.description,
                         CRITERION_DESCRIPTION_MAX_LENGTH,

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -6,6 +6,7 @@ import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.zipOrAccumulate
 import se.uulm.snowballr.backend.model.ValidationIssue
+import se.uulm.snowballr.backend.validation.ProjectValidator.NAME_MAX_LENGTH
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
 
@@ -13,9 +14,9 @@ import snowballr.ProjectOuterClass.Project.Create
  * A validator for [Project] related requests.
  */
 object ProjectValidator {
-    const val PROJECT_NAME_MAX_LENGTH = 100
-    const val PROJECT_SIMILARITY_THRESHOLD_MIN_VALUE = 0.0f
-    const val PROJECT_SIMILARITY_THRESHOLD_MAX_VALUE = 1.0f
+    const val NAME_MAX_LENGTH = 100
+    const val SIMILARITY_THRESHOLD_MIN_VALUE = 0.0f
+    const val SIMILARITY_THRESHOLD_MAX_VALUE = 1.0f
 
     fun validateCreateRequest(request: Create): EitherNel<ValidationIssue, Unit> = either {
         ensureProjectNameValidity(request.name)
@@ -35,30 +36,31 @@ object ProjectValidator {
         // Only proceed with field validation if the mask is valid
         val selectedFields = request.mask.pathsList.toSet()
 
+        val project = request.project
         zipOrAccumulate(
-            { ensureIdValidity("id", request.project.id) },
+            { ensureIdValidity("id", project.id) },
             {
                 if ("project.name" in selectedFields) {
-                    ensureProjectNameValidity(request.project.name)
+                    ensureProjectNameValidity(project.name)
                 }
             },
             {
                 if ("project.status" in selectedFields) {
-                    ensureEnumNotUnspecified("status", request.project.status)
+                    ensureEnumNotUnspecified("status", project.status)
                 }
             },
             {
                 if ("project.settings.snowballing_type" in selectedFields) {
-                    ensureEnumNotUnspecified("snowballing_type", request.project.settings.snowballingType)
+                    ensureEnumNotUnspecified("snowballing_type", project.settings.snowballingType)
                 }
             },
             {
                 if ("project.settings.similarity_threshold" in selectedFields) {
                     ensureNumberFieldInRange(
                         "similarity_threshold",
-                        request.project.settings.similarityThreshold,
-                        PROJECT_SIMILARITY_THRESHOLD_MIN_VALUE,
-                        PROJECT_SIMILARITY_THRESHOLD_MAX_VALUE,
+                        project.settings.similarityThreshold,
+                        SIMILARITY_THRESHOLD_MIN_VALUE,
+                        SIMILARITY_THRESHOLD_MAX_VALUE,
                     )
                 }
             },
@@ -67,10 +69,10 @@ object ProjectValidator {
 
     /**
      * Ensures that the provided project name is valid.
-     * It checks that the project name is not blank and does not exceed the maximum length defined by [PROJECT_NAME_MAX_LENGTH].
+     * It checks that the project name is not blank and does not exceed the maximum length defined by [NAME_MAX_LENGTH].
      *
      * @param name The project name to validate.
      */
     fun Raise<ValidationIssue>.ensureProjectNameValidity(name: String) =
-        ensureTextFieldValidity("name", name, PROJECT_NAME_MAX_LENGTH)
+        ensureTextFieldValidity("name", name, NAME_MAX_LENGTH)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -4,9 +4,7 @@ import arrow.core.Either
 import arrow.core.EitherNel
 import arrow.core.raise.Raise
 import arrow.core.raise.either
-import arrow.core.raise.ensure
 import arrow.core.raise.zipOrAccumulate
-import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
@@ -16,6 +14,8 @@ import snowballr.ProjectOuterClass.Project.Create
  */
 object ProjectValidator {
     const val PROJECT_NAME_MAX_LENGTH = 100
+    const val PROJECT_SIMILARITY_THRESHOLD_MIN_VALUE = 0.0f
+    const val PROJECT_SIMILARITY_THRESHOLD_MAX_VALUE = 1.0f
 
     fun validateCreateRequest(request: Create): EitherNel<ValidationIssue, Unit> = either {
         ensureProjectNameValidity(request.name)
@@ -54,7 +54,12 @@ object ProjectValidator {
             },
             {
                 if ("project.settings.similarity_threshold" in selectedFields) {
-                    ensureSimilarityThresholdValidity(request.project.settings.similarityThreshold)
+                    ensureNumberFieldInRange(
+                        "similarity_threshold",
+                        request.project.settings.similarityThreshold,
+                        PROJECT_SIMILARITY_THRESHOLD_MIN_VALUE,
+                        PROJECT_SIMILARITY_THRESHOLD_MAX_VALUE,
+                    )
                 }
             },
         ) { _, _, _, _, _ -> }
@@ -68,10 +73,4 @@ object ProjectValidator {
      */
     fun Raise<ValidationIssue>.ensureProjectNameValidity(name: String) =
         ensureTextFieldValidity("name", name, PROJECT_NAME_MAX_LENGTH)
-
-    fun Raise<ValidationIssue>.ensureSimilarityThresholdValidity(threshold: Float) {
-        ensure(threshold in 0.0f..1.0f) {
-            OutOfRangeValue("similarity_threshold", threshold, 0.0f, 1.0f)
-        }
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -66,10 +66,8 @@ object ProjectValidator {
      *
      * @param name The project name to validate.
      */
-    fun Raise<ValidationIssue>.ensureProjectNameValidity(name: String) {
-        ensureFieldNonBlank("name", name)
-        ensureFieldLength("name", name, PROJECT_NAME_MAX_LENGTH)
-    }
+    fun Raise<ValidationIssue>.ensureProjectNameValidity(name: String) =
+        ensureTextFieldValidity("name", name, PROJECT_NAME_MAX_LENGTH)
 
     fun Raise<ValidationIssue>.ensureSimilarityThresholdValidity(threshold: Float) {
         ensure(threshold in 0.0f..1.0f) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -15,6 +15,8 @@ import snowballr.ProjectOuterClass.Project.Create
  * A validator for [Project] related requests.
  */
 object ProjectValidator {
+    const val PROJECT_NAME_MAX_LENGTH = 100
+
     fun validateCreateRequest(request: Create): EitherNel<ValidationIssue, Unit> = either {
         ensureProjectNameValidity(request.name)
     }.toEitherNel()

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
@@ -27,26 +27,27 @@ object UserValidator {
         // Only proceed with field validation if the mask is valid
         val selectedFields = request.mask.pathsList.toSet()
 
+        val user = request.user
         zipOrAccumulate(
-            { ensureIdValidity("id", request.user.id) },
+            { ensureIdValidity("id", user.id) },
             {
                 if ("user.email" in selectedFields) {
-                    ensureEmailValidity(request.user.email)
+                    ensureEmailValidity(user.email)
                 }
             },
             {
                 if ("user.first_name" in selectedFields) {
-                    ensureFirstNameValidity(request.user.firstName)
+                    ensureFirstNameValidity(user.firstName)
                 }
             },
             {
                 if ("user.last_name" in selectedFields) {
-                    ensureLastNameValidity(request.user.lastName)
+                    ensureLastNameValidity(user.lastName)
                 }
             },
             {
                 if ("user.role" in selectedFields) {
-                    ensureEnumNotUnspecified("role", request.user.role)
+                    ensureEnumNotUnspecified("role", user.role)
                 }
             },
         ) { _, _, _, _, _ -> }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -39,6 +39,22 @@ fun Raise<ValidationIssue>.ensureFieldLength(name: String, value: String, maxLen
     ensure(value.length <= maxLength) { TooLongField(name, maxLength) }
 
 /**
+ * Ensures that the given text field value is valid.
+ *
+ * Validity is defined as follows:
+ * - The field value must not be blank.
+ * - The field value must not exceed the specified maximum length.
+ *
+ * @param name The name of the field being validated.
+ * @param value The value of the field to check for validity.
+ * @param maxLength The maximum allowed length for the field value.
+ */
+fun Raise<ValidationIssue>.ensureTextFieldValidity(name: String, value: String, maxLength: Int) {
+    ensureFieldNonBlank(name, value)
+    ensureFieldLength(name, value, maxLength)
+}
+
+/**
  * Ensures that the provided enum value is not the `UNSPECIFIED` value.
  * If the value is `UNSPECIFIED`, an [EnumUnspecified] validation issue is raised.
  *
@@ -83,10 +99,8 @@ fun Raise<ValidationIssue>.ensureStageValidity(stage: Long) =
  *
  * @param firstName The first name to validate.
  */
-fun Raise<ValidationIssue>.ensureFirstNameValidity(firstName: String) {
-    ensureFieldNonBlank("first_name", firstName)
-    ensureFieldLength("first_name", firstName, FIRST_NAME_MAX_LENGTH)
-}
+fun Raise<ValidationIssue>.ensureFirstNameValidity(firstName: String) =
+    ensureTextFieldValidity("first_name", firstName, FIRST_NAME_MAX_LENGTH)
 
 /**
  * Ensures that the provided last name is valid.
@@ -94,10 +108,8 @@ fun Raise<ValidationIssue>.ensureFirstNameValidity(firstName: String) {
  *
  * @param lastName The last name to validate.
  */
-fun Raise<ValidationIssue>.ensureLastNameValidity(lastName: String) {
-    ensureFieldNonBlank("last_name", lastName)
-    ensureFieldLength("last_name", lastName, LAST_NAME_MAX_LENGTH)
-}
+fun Raise<ValidationIssue>.ensureLastNameValidity(lastName: String) =
+    ensureTextFieldValidity("last_name", lastName, LAST_NAME_MAX_LENGTH)
 
 /**
  * Ensures that the provided field mask contains only valid fields for the given object type and

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -18,6 +18,19 @@ import se.uulm.snowballr.backend.model.ValidationIssue
 import java.util.UUID
 
 /**
+ * Email regex.
+ *
+ * See: https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression/201378#201378
+ */
+@Suppress("MaxLineLength", "StringShouldBeRawString")
+private val EMAIL_REGEX =
+    Regex(
+        "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)])",
+    )
+private const val FIRST_NAME_MAX_LENGTH = 100
+private const val LAST_NAME_MAX_LENGTH = 100
+
+/**
  * Ensures that the given field value is not blank (i.e., it contains at least one non-whitespace character).
  * If the value is blank, a [BlankField] validation issue is raised.
  *

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -124,3 +124,20 @@ fun Raise<ValidationIssue>.ensureFieldMaskIsValid(fieldMask: FieldMask, descript
         InvalidFieldMask(fieldMask.toString())
     }
 }
+
+/**
+ * Ensures that the given number field is within the specified range.
+ *
+ * If the value is outside the range, an [OutOfRangeValue] validation issue is raised.
+ *
+ * @param T The type of the number field. Must be a subtype of [Comparable].
+ * @param name The name of the field being validated.
+ * @param value The value of the field to check for validity.
+ * @param min The minimum allowed value for the field.
+ * @param max The maximum allowed value for the field.
+ */
+fun <T : Comparable<T>> Raise<ValidationIssue>.ensureNumberFieldInRange(name: String, value: T, min: T, max: T) {
+    ensure(value in min..max) {
+        OutOfRangeValue(name, value, min, max)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -3,9 +3,7 @@
 package se.uulm.snowballr.backend.validation
 
 import arrow.core.raise.Raise
-import arrow.core.raise.either
 import arrow.core.raise.ensure
-import arrow.core.raise.zipOrAccumulate
 import com.google.protobuf.Descriptors.Descriptor
 import com.google.protobuf.FieldMask
 import com.google.protobuf.util.FieldMaskUtil
@@ -14,8 +12,6 @@ import se.uulm.snowballr.backend.model.EnumUnspecified
 import se.uulm.snowballr.backend.model.InvalidEmail
 import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
-import se.uulm.snowballr.backend.model.InvalidPassword
-import se.uulm.snowballr.backend.model.InvalidPassword.Reason
 import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.TooLongField
 import se.uulm.snowballr.backend.model.ValidationIssue
@@ -73,51 +69,6 @@ fun Raise<ValidationIssue>.ensureEmailValidity(email: String) =
     ensure(EMAIL_REGEX.matches(email)) { InvalidEmail(email) }
 
 /**
- * Ensures that the provided password meets the required complexity criteria.
- *
- * It checks the following conditions:
- * - Minimum length of [PASSWORD_MIN_LENGTH]
- * - Minimum number of lowercase letters defined by [PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS]
- * - Minimum number of uppercase letters defined by [PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS]
- * - Minimum number of digits defined by [PASSWORD_MIN_NUMBER_DIGITS]
- * - Minimum number of special characters defined by [PASSWORD_MIN_NUMBER_SPECIAL_CHARS]
- *
- * If any of these conditions are not met, an [InvalidPassword] validation issue is raised with the appropriate reason.
- *
- * @param password The password to validate.
- * @return An [arrow.core.Either] containing either the validation issues or a success indication.
- */
-fun ensurePasswordValidity(password: String) = either {
-    zipOrAccumulate(
-        {
-            ensure(password.length >= PASSWORD_MIN_LENGTH) {
-                InvalidPassword(password, Reason.TOO_SHORT)
-            }
-        },
-        {
-            ensure(password.count { it.isLowerCase() } >= PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS) {
-                InvalidPassword(password, Reason.NOT_ENOUGH_LOWERCASE_CHARS)
-            }
-        },
-        {
-            ensure(password.count { it.isUpperCase() } >= PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS) {
-                InvalidPassword(password, Reason.NOT_ENOUGH_UPPERCASE_CHARS)
-            }
-        },
-        {
-            ensure(password.count { it.isDigit() } >= PASSWORD_MIN_NUMBER_DIGITS) {
-                InvalidPassword(password, Reason.NOT_ENOUGH_DIGITS)
-            }
-        },
-        {
-            ensure(countSpecialChars(password) >= PASSWORD_MIN_NUMBER_SPECIAL_CHARS) {
-                InvalidPassword(password, Reason.NOT_ENOUGH_SPECIAL_CHARS)
-            }
-        },
-    ) { _, _, _, _, _ -> }
-}
-
-/**
  * Ensures that the provided stage is positive or null.
  * If the stage is negative, an [OutOfRangeValue] validation issue is raised.
  *
@@ -125,16 +76,6 @@ fun ensurePasswordValidity(password: String) = either {
  */
 fun Raise<ValidationIssue>.ensureStageValidity(stage: Long) =
     ensure(stage >= 0) { OutOfRangeValue("stage", stage, 0, Long.MAX_VALUE) }
-
-/**
- * Counts the number of special characters in the given password.
- * Special characters are defined by the [SPECIAL_CHAR_REGEX].
- *
- * @param password The password to check for special characters.
- * @return The count of special characters in the password.
- */
-private fun countSpecialChars(password: String): Int =
-    password.count { SPECIAL_CHAR_REGEX.containsMatchIn(it.toString()) }
 
 /**
  * Ensures that the provided first name is valid.

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -13,24 +13,6 @@ import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 
 /**
- * Email regex.
- *
- * See: https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression/201378#201378
- */
-@Suppress("MaxLineLength", "StringShouldBeRawString")
-val EMAIL_REGEX =
-    Regex(
-        "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)])",
-    )
-const val PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS = 2
-const val PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS = 2
-const val PASSWORD_MIN_NUMBER_DIGITS = 2
-const val PASSWORD_MIN_NUMBER_SPECIAL_CHARS = 2
-const val PASSWORD_MIN_LENGTH = 8
-const val FIRST_NAME_MAX_LENGTH = 100
-const val LAST_NAME_MAX_LENGTH = 100
-
-/**
  * Validates a given request object and returns either a collection of validation issues
  * or an indication that the validation was successful.
  *

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -22,7 +22,6 @@ val EMAIL_REGEX =
     Regex(
         "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)])",
     )
-val SPECIAL_CHAR_REGEX = Regex("[" + Regex.escape("#$%&@^`~.,:;\"'/|_-<>*+!?={[()]}ß") + "]")
 const val PASSWORD_MIN_NUMBER_LOWERCASE_LETTERS = 2
 const val PASSWORD_MIN_NUMBER_UPPERCASE_LETTERS = 2
 const val PASSWORD_MIN_NUMBER_DIGITS = 2

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -29,7 +29,6 @@ const val PASSWORD_MIN_NUMBER_SPECIAL_CHARS = 2
 const val PASSWORD_MIN_LENGTH = 8
 const val FIRST_NAME_MAX_LENGTH = 100
 const val LAST_NAME_MAX_LENGTH = 100
-const val PROJECT_NAME_MAX_LENGTH = 100
 
 /**
  * Validates a given request object and returns either a collection of validation issues

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -8,11 +8,11 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
-import se.uulm.snowballr.backend.table.association.ReviewTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.repository.association
+package se.uulm.snowballr.backend.repository
 
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -10,7 +10,6 @@ import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetId
-import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.ReviewTable

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewHasCriterionTableRepoTest.kt
@@ -14,9 +14,9 @@ import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
-import se.uulm.snowballr.backend.table.association.ReviewTable
 
 class ReviewHasCriterionTableRepoTest : RepositoryTest(
     arrayOf(

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReviewTableRepoTest.kt
@@ -13,8 +13,8 @@ import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetI
 import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
-import se.uulm.snowballr.backend.table.association.ReviewTable
 import snowballr.ReviewOuterClass
 import java.util.UUID
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -24,6 +24,7 @@ import se.uulm.snowballr.backend.repository.IAuthorTableRepo
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.repository.association.IAuthorOfPaperTableRepo
@@ -32,7 +33,6 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
-import se.uulm.snowballr.backend.repository.association.IReviewTableRepo
 import se.uulm.snowballr.backend.service.criterion.CreateCriterionTest
 import se.uulm.snowballr.backend.serviceLayerDeps
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
@@ -13,6 +13,9 @@ import se.uulm.snowballr.backend.model.EnumUnspecified
 import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.TooLongField
+import se.uulm.snowballr.backend.validation.CriterionValidator.CRITERION_DESCRIPTION_MAX_LENGTH
+import se.uulm.snowballr.backend.validation.CriterionValidator.CRITERION_NAME_MAX_LENGTH
+import se.uulm.snowballr.backend.validation.CriterionValidator.CRITERION_TAG_MAX_LENGTH
 import snowballr.CriterionOuterClass.Criterion
 import snowballr.CriterionOuterClass.Criterion.Create
 import snowballr.CriterionOuterClass.Criterion.Update

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/CriterionValidatorTest.kt
@@ -13,9 +13,9 @@ import se.uulm.snowballr.backend.model.EnumUnspecified
 import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.TooLongField
-import se.uulm.snowballr.backend.validation.CriterionValidator.CRITERION_DESCRIPTION_MAX_LENGTH
-import se.uulm.snowballr.backend.validation.CriterionValidator.CRITERION_NAME_MAX_LENGTH
-import se.uulm.snowballr.backend.validation.CriterionValidator.CRITERION_TAG_MAX_LENGTH
+import se.uulm.snowballr.backend.validation.CriterionValidator.DESCRIPTION_MAX_LENGTH
+import se.uulm.snowballr.backend.validation.CriterionValidator.NAME_MAX_LENGTH
+import se.uulm.snowballr.backend.validation.CriterionValidator.TAG_MAX_LENGTH
 import snowballr.CriterionOuterClass.Criterion
 import snowballr.CriterionOuterClass.Criterion.Create
 import snowballr.CriterionOuterClass.Criterion.Update
@@ -73,9 +73,9 @@ class CriterionValidatorTest {
         @ParameterizedTest
         @CsvSource(
             value = [
-                "tag:${CRITERION_TAG_MAX_LENGTH}",
-                "name:${CRITERION_NAME_MAX_LENGTH}",
-                "description:${CRITERION_DESCRIPTION_MAX_LENGTH}",
+                "tag:${TAG_MAX_LENGTH}",
+                "name:${NAME_MAX_LENGTH}",
+                "description:${DESCRIPTION_MAX_LENGTH}",
             ],
             delimiter = ':',
         )
@@ -220,9 +220,9 @@ class CriterionValidatorTest {
         @ParameterizedTest
         @CsvSource(
             value = [
-                "tag:${CRITERION_TAG_MAX_LENGTH}",
-                "name:${CRITERION_NAME_MAX_LENGTH}",
-                "description:${CRITERION_DESCRIPTION_MAX_LENGTH}",
+                "tag:${TAG_MAX_LENGTH}",
+                "name:${NAME_MAX_LENGTH}",
+                "description:${DESCRIPTION_MAX_LENGTH}",
             ],
             delimiter = ':',
         )

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectPaperValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectPaperValidatorTest.kt
@@ -105,7 +105,7 @@ class ProjectPaperValidatorTest {
             val request = validAddRequestBuilder.setStage(-1).build()
             val result = validateRequest(request)
 
-            assertInvalidResult<OutOfRangeValue>(result)
+            assertInvalidResult<OutOfRangeValue<Long>>(result)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -216,7 +216,7 @@ class ProjectValidatorTest {
                 .build()
             val result = validateRequest(request)
 
-            assertInvalidResult<OutOfRangeValue>(result)
+            assertInvalidResult<OutOfRangeValue<Float>>(result)
         }
 
         @Test
@@ -229,7 +229,7 @@ class ProjectValidatorTest {
                 .build()
             val result = validateRequest(request)
 
-            assertInvalidResult<OutOfRangeValue>(result)
+            assertInvalidResult<OutOfRangeValue<Float>>(result)
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -11,6 +11,7 @@ import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.TooLongField
+import se.uulm.snowballr.backend.validation.ProjectValidator.PROJECT_NAME_MAX_LENGTH
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
 import snowballr.ProjectOuterClass.Project.Update

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -11,7 +11,7 @@ import se.uulm.snowballr.backend.model.InvalidFieldMask
 import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.TooLongField
-import se.uulm.snowballr.backend.validation.ProjectValidator.PROJECT_NAME_MAX_LENGTH
+import se.uulm.snowballr.backend.validation.ProjectValidator.NAME_MAX_LENGTH
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
 import snowballr.ProjectOuterClass.Project.Update
@@ -50,7 +50,7 @@ class ProjectValidatorTest {
         fun `When a too long name is validated, then the 'TooLongField' issue is returned`() {
             val request =
                 validCreateRequestBuilder
-                    .setName("a".repeat(PROJECT_NAME_MAX_LENGTH + 1))
+                    .setName("a".repeat(NAME_MAX_LENGTH + 1))
                     .build()
             val result = validateRequest(request)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ValidationAssertions.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ValidationAssertions.kt
@@ -27,10 +27,15 @@ inline fun <reified T : ValidationIssue> assertInvalidResult(result: EitherNel<V
     val issues = (result as Either.Left).value
 
     val matchingIssue = issues.find { it is T }
-    assertThat(
-        matchingIssue,
-    ).withFailMessage("Expected issue of type ${T::class} but found: ${issues.map { it::class }}")
+    assertThat(matchingIssue)
+        .withFailMessage(
+            "Expected issue of type ${T::class} but found: [${
+                issues.map { it::class }.joinToString(", ")
+            }]",
+        )
         .isNotNull()
     assertInstanceOf<T>(matchingIssue)
+    @Suppress("NullableToStringCall")
+    assertThat(matchingIssue.toString()).isNotEmpty()
     return matchingIssue
 }


### PR DESCRIPTION
Closes #294
Closes #150 

## What I have made

I recommend reviewing commit-by-commit.
The following refactorings were made:
- moved `ensure*` methods that were only used in a single validator from `ValidationHelper` to said validator
- did the same with constants
- moved `ReviewTable` out of the `association.table` package to `table`
- `ReviewHasCriterionTable` now has a `CompositeId` because it doesn't require a not-composite ID
- added `ensureTextFieldValidity`, which replaces the combination of `ensureFieldNonBlank` and `ensureFieldLength`
- added `ensureNumberFieldInRange`, which is later used for the `updatePaper` implementation

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only minor refactoring)
- [x] (for reviewer) I have checked the implementation against the requirements
