### PR TITLE
Add creator of project as project admin to the newly created project

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -93,6 +93,7 @@ class ProjectService(
 
         val project = repo.createProject(request, currentUser.id, userSettings)
 
+        // Additionally, clone user default criteria into the project as project criteria and add creator as project member
         for (criterion in userDefaultCriteria) {
             val criterionRequest = GrpcCriterion.Create
                 .newBuilder()
@@ -105,6 +106,9 @@ class ProjectService(
 
             criterionRepo.createCriterion(criterionRequest, currentUser.id)
         }
+
+        projectMemberRepo.addUserToProject(currentUser.id, project.id)
+        projectMemberRepo.promoteProjectMemberToAdmin(project.id, currentUser.id)
 
         project.toGrpcProject()
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -7,7 +7,10 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.ProjectOuterClass.MemberRole
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -16,6 +19,14 @@ import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class CreateProjectTest : MainServiceTest() {
     private fun getExampleRequest() = GrpcProject.Create.getDefaultInstance()
+
+    private fun mockProjectAdminCreation(project: Project, user: User) {
+        val projectMember = DataBuilder.createExampleProjectMember(project.id, user.id, MemberRole.MEMBER_ROLE_DEFAULT)
+        val projectAdmin = DataBuilder.createExampleProjectMember(project.id, user.id, MemberRole.MEMBER_ROLE_ADMIN)
+
+        coEvery { projectMemberRepoMock.addUserToProject(user.id, project.id) } returns projectMember
+        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, user.id) } returns projectAdmin
+    }
 
     @Test
     fun `When a project is correctly created, then no exception is thrown`() = runTest {
@@ -27,9 +38,13 @@ class CreateProjectTest : MainServiceTest() {
         coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
         coEvery { projectRepoMock.createProject(getExampleRequest(), user.id, userSettings) } returns project
+        mockProjectAdminCreation(project, user)
 
         assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
-        coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
+
+        coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), user.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.addUserToProject(user.id, project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, user.id) }
     }
 
     @Test
@@ -54,6 +69,7 @@ class CreateProjectTest : MainServiceTest() {
             coEvery { criterionRepoMock.getCriteriaByIds(capture(criteriaIdsSlot)) } returns listOf(criterion)
             coEvery { projectRepoMock.createProject(getExampleRequest(), user.id, userSettings) } returns project
             coEvery { criterionRepoMock.createCriterion(criterionCreateRequest, user.id) } returns criterion
+            mockProjectAdminCreation(project, user)
 
             assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
             assertEquals(listOf(criterion.id), criteriaIdsSlot.captured)


### PR DESCRIPTION
Closes #300

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I added the creator of a project as project admin
- I adapted the tests to ensure, that the calls to add and promote the user as project admin are called

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
