### PR TITLE
Replace any() in service tests by meaningful parameters if possible

### DIFF
--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManagerTest.kt
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import kotlin.test.assertEquals
 
-private val examplePaper = DataBuilder.createExamplePaper()
-
 class FetcherManagerTest {
     private var fetcherManager = FetcherManager()
+    private val examplePaper = DataBuilder.createExamplePaper()
+    private val exampleOptions = mapOf("foo" to "bar")
 
     @BeforeEach
     fun createNewFetcherService() {
@@ -32,6 +32,7 @@ class FetcherManagerTest {
     fun `When a fetcher is removed, then it is no longer listed as available`() = runTest {
         fetcherManager.registerFetcher("foo", mockk())
         assertEquals(setOf("foo"), fetcherManager.getAvailableFetchers())
+
         fetcherManager.removeFetcher("foo")
         assertEquals(emptySet(), fetcherManager.getAvailableFetchers())
     }
@@ -50,36 +51,46 @@ class FetcherManagerTest {
     @Test
     fun `When a fetcher is registered, then searchPapers is delegated properly`() = runTest {
         val fetcherMock = mockk<IFetcher>()
-        coEvery { fetcherMock.searchPapers(any(), any()) } returns setOf(examplePaper)
+        coEvery { fetcherMock.searchPapers("bar", exampleOptions) } returns setOf(examplePaper)
         fetcherManager.registerFetcher("foo", fetcherMock)
 
-        assertEquals(setOf(examplePaper), fetcherManager.searchPapers("foo", "bar", mapOf("x" to "y")))
-        coVerify { fetcherMock.searchPapers("bar", mapOf("x" to "y")) }
+        assertEquals(
+            setOf(examplePaper),
+            fetcherManager.searchPapers("foo", "bar", exampleOptions),
+        )
+        coVerify { fetcherMock.searchPapers("bar", exampleOptions) }
         confirmVerified(fetcherMock)
     }
 
     @Test
     fun `When a fetcher is registered, then fetchForwardReferences is delegated properly`() = runTest {
         val fetcherMock = mockk<IFetcher>()
-        coEvery { fetcherMock.fetchForwardReferences(any(), any()) } returns setOf(examplePaper)
+        val referencingPaper = DataBuilder.createExamplePaper()
+
+        coEvery { fetcherMock.fetchForwardReferences(referencingPaper, exampleOptions) } returns setOf(examplePaper)
         fetcherManager.registerFetcher("foo", fetcherMock)
 
-        assertEquals(setOf(examplePaper), fetcherManager.fetchForwardReferences("foo", examplePaper, mapOf("x" to "y")))
-        coVerify { fetcherMock.fetchForwardReferences(examplePaper, mapOf("x" to "y")) }
+        assertEquals(
+            setOf(examplePaper),
+            fetcherManager.fetchForwardReferences("foo", referencingPaper, exampleOptions),
+        )
+        coVerify { fetcherMock.fetchForwardReferences(referencingPaper, exampleOptions) }
         confirmVerified(fetcherMock)
     }
 
     @Test
     fun `When a fetcher is registered, then fetchBackwardReferences is delegated properly`() = runTest {
         val fetcherMock = mockk<IFetcher>()
-        coEvery { fetcherMock.fetchBackwardReferences(any(), any()) } returns setOf(examplePaper)
+        val paperWithReference = DataBuilder.createExamplePaper()
+
+        coEvery { fetcherMock.fetchBackwardReferences(paperWithReference, exampleOptions) } returns setOf(examplePaper)
         fetcherManager.registerFetcher("foo", fetcherMock)
 
         assertEquals(
             setOf(examplePaper),
-            fetcherManager.fetchBackwardReferences("foo", examplePaper, mapOf("x" to "y")),
+            fetcherManager.fetchBackwardReferences("foo", paperWithReference, exampleOptions),
         )
-        coVerify { fetcherMock.fetchBackwardReferences(examplePaper, mapOf("x" to "y")) }
+        coVerify { fetcherMock.fetchBackwardReferences(paperWithReference, exampleOptions) }
         confirmVerified(fetcherMock)
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -59,7 +59,7 @@ import se.uulm.snowballr.backend.serviceLayerDeps
  *             val example = ExampleOuterClass.Example.getDefaultInstance()
  *
  *             // Mock the behavior of the repositories
- *             coEvery { exampleRepoMock.createExample(any()) } returns example
+ *             coEvery { exampleRepoMock.createExample(...) } returns Result.success(example)
  *
  *             // Assert service behavior
  *             assertDoesNotThrow { mainService.createExample(request) }
@@ -71,7 +71,7 @@ import se.uulm.snowballr.backend.serviceLayerDeps
  *             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
  *
  *             // Mock the behavior of the repositories
- *             coEvery { exampleRepoMock.createExample(any()) } returns Result.failure(TestSpecificException())
+ *             coEvery { exampleRepoMock.createExample(...) } returns Result.failure(TestSpecificException())
  *
  *             // Assert service behavior
  *             assertThrows<TestSpecificException> { mainService.createExample(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
@@ -25,10 +25,11 @@ import kotlin.test.assertEquals
 class LoginTest : MainServiceTest() {
     @Test
     fun `When a user provides an invalid email, then an UnauthenticatedException is thrown`() = runTest {
-        val request = LoginRequest.newBuilder().setEmail("wrongEmail").build()
+        val email = "wrongEmail"
+        val request = LoginRequest.newBuilder().setEmail(email).build()
 
         val exception = NotFoundException(EntityType.USER, "wrongEmail", identifierType = IdentifierType.EMAIL)
-        coEvery { userRepoMock.getUserByEmail(any()) } returns Result.failure(exception)
+        coEvery { userRepoMock.getUserByEmail(email) } returns Result.failure(exception)
 
         assertThrows<UnauthenticatedException> { mainService.login(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
@@ -18,8 +18,10 @@ import snowballr.UserOuterClass.User as GrpcUser
 class VerifyEmailTest : MainServiceTest() {
     @Test
     fun `When the verification token is not found, then a VerificationTokenNotFoundException is thrown`() = runTest {
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken("non-existent-token").build()
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns null
+        val token = "non-existent-token"
+        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token).build()
+
+        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token) } returns null
 
         assertThrows<VerificationTokenNotFoundException> { mainService.verifyEmail(request) }
     }
@@ -42,7 +44,7 @@ class VerifyEmailTest : MainServiceTest() {
         val token = DataBuilder.createExampleVerificationToken()
         val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(any()) } returns token
+        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns token
         coEvery { userRepoMock.getUserById(token.userId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.verifyEmail(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -45,7 +45,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         mockCurrentUser(user)
-        coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
@@ -62,7 +62,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getProjectCriterionRequest(project.id.toString())
 
         mockCurrentUser(user)
-        coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
 
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
@@ -114,7 +114,7 @@ class CreateCriterionTest : MainServiceTest() {
         val request = getUserCriterionRequest()
 
         mockCurrentUser(user)
-        coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
+        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
     }
@@ -126,7 +126,7 @@ class CreateCriterionTest : MainServiceTest() {
         val criterion = DataBuilder.createExampleProjectCriterion()
 
         mockCurrentUser(user)
-        coEvery { criterionRepoMock.createCriterion(any(), any()) } returns criterion
+        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
 
         assertDoesNotThrow { mainService.createCriterion(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -46,7 +46,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
         mockCurrentUser(adminUser)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
         assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetInviteCandidatesTest.kt
@@ -4,17 +4,20 @@ import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertNull
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
 import java.util.UUID
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class GetInviteCandidatesTest : MainServiceTest() {
-    private val testProjectId = UUID.randomUUID()
+    private val searchQuery = "john"
+    private val projectId = UUID.randomUUID()
     private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder()
-        .setQuery("john")
-        .setProjectId(testProjectId.toString())
+        .setQuery(searchQuery)
+        .setProjectId(projectId.toString())
         .build()
 
     @Test
@@ -23,7 +26,8 @@ class GetInviteCandidatesTest : MainServiceTest() {
 
         mockCurrentUser(DataBuilder.createExampleUser())
 
-        assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
+        val candidates = assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
+        assertTrue { candidates.usersList.isEmpty() }
     }
 
     @Test
@@ -31,31 +35,25 @@ class GetInviteCandidatesTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
         val requestWithInvalidProjectId = InviteCandidatesRequest
             .newBuilder()
-            .setQuery("john")
+            .setQuery(searchQuery)
             .setProjectId("invalid-uuid")
             .build()
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id)) } returns emptyList()
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
     }
 
     @Test
-    fun `When no the project members exist, then no users except for the current user are excluded`() = runTest {
+    fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedProjectId = UUID.randomUUID()
-        val requestWithNotExistentProject = InviteCandidatesRequest
-            .newBuilder()
-            .setQuery("john")
-            .setProjectId(requestedProjectId.toString())
-            .build()
 
         mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(requestedProjectId) } returns emptyList()
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id)) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getInviteCandidates(requestWithNotExistentProject) }
+        assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
     }
 
     @Test
@@ -63,28 +61,30 @@ class GetInviteCandidatesTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(any(), any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id)) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
+        val candidates = assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
+        assertTrue { candidates.usersList.isEmpty() }
     }
 
     @Test
     fun `When retrieving the invite candidates is successful, then these are returned except for the current user`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
-            val users = listOf(currentUser, DataBuilder.createExampleUser(email = "another.user@example.com"))
+            val anotherUser = DataBuilder.createExampleUser(email = "another.user@example.com")
+            val users = listOf(currentUser, anotherUser)
             val excludedUsers = setOf(currentUser.id)
 
             mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.getProjectMembers(testProjectId) } returns emptyList()
+            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
             coEvery {
-                userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id))
+                userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id))
             } returns users.filterNot { it.id in excludedUsers }
 
             val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
-            assertTrue { inviteCandidates.usersList.size == 1 }
-            assertTrue { inviteCandidates.usersList.find { it.id == currentUser.id.toString() } == null }
+            assertEquals(1, inviteCandidates.usersList.size)
+            assertNull(inviteCandidates.usersList.find { user -> user.id == currentUser.id.toString() })
         }
 
     @Test
@@ -97,10 +97,10 @@ class GetInviteCandidatesTest : MainServiceTest() {
 
             mockCurrentUser(currentUser)
             coEvery {
-                projectMemberRepoMock.getProjectMembers(testProjectId)
+                projectMemberRepoMock.getProjectMembers(projectId)
             } returns listOf(DataBuilder.createExampleProjectMember(userId = projectMember.id))
             coEvery {
-                userRepoMock.getUsersMatchingSearchQuery(any(), setOf(currentUser.id, projectMember.id))
+                userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id, projectMember.id))
             } returns users.filterNot { it.id in excludedUsers }
 
             val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -11,6 +11,7 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import kotlin.test.assertEquals
+import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class CreateProjectTest : MainServiceTest() {
@@ -25,7 +26,7 @@ class CreateProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
         coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
-        coEvery { projectRepoMock.createProject(any(), any(), userSettings) } returns project
+        coEvery { projectRepoMock.createProject(getExampleRequest(), user.id, userSettings) } returns project
 
         assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
         coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), any()) }
@@ -40,11 +41,19 @@ class CreateProjectTest : MainServiceTest() {
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
             val criteriaIdsSlot = slot<List<UUID>>()
 
+            val criterionCreateRequest = GrpcCriterion.Create.newBuilder()
+                .setProjectId(project.id.toString())
+                .setTag(criterion.tag)
+                .setName(criterion.name)
+                .setDescription(criterion.description)
+                .setCategory(criterion.category)
+                .build()
+
             mockCurrentUser(user)
             coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
             coEvery { criterionRepoMock.getCriteriaByIds(capture(criteriaIdsSlot)) } returns listOf(criterion)
-            coEvery { projectRepoMock.createProject(any(), user.id, userSettings) } returns project
-            coEvery { criterionRepoMock.createCriterion(any(), user.id) } returns criterion
+            coEvery { projectRepoMock.createProject(getExampleRequest(), user.id, userSettings) } returns project
+            coEvery { criterionRepoMock.createCriterion(criterionCreateRequest, user.id) } returns criterion
 
             assertDoesNotThrow { mainService.createProject(getExampleRequest()) }
             assertEquals(listOf(criterion.id), criteriaIdsSlot.captured)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -27,7 +27,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val noAccessUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(noAccessUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectById(request) }
     }
@@ -65,8 +65,8 @@ class GetProjectByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(any()) } returns Result.failure(TestSpecificException())
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getProjectById(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -23,7 +23,7 @@ class GetUserByEmailTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserByEmail(any()) } returns Result.failure(TestSpecificException())
+        coEvery { userRepoMock.getUserByEmail(exampleEmail) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(getExampleRequest()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -11,61 +11,67 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Authentication
 
 class RegisterTest : MainServiceTest() {
+    private fun getExampleRequest(user: User) = Authentication.RegisterRequest.newBuilder()
+        .setEmail(user.email)
+        .setFirstName(user.firstName)
+        .setLastName(user.lastName)
+        .setPassword("VALIDPassword__1234")
+        .build()
+
     @Test
     fun `When a user with the given email already exists, then a DuplicateEntityException is thrown`() = runTest {
-        val request = Authentication.RegisterRequest.newBuilder().build()
+        val existentEmail = "existent-email"
+        val request = Authentication.RegisterRequest.newBuilder()
+            .setEmail(existentEmail)
+            .build()
 
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
+        coEvery { userRepoMock.doesUserExistByEmail(existentEmail) } returns true
 
         assertThrows<DuplicateEntityException> { mainService.register(request) }
     }
 
     @Test
-    fun `When sending the verification email fails, then an exception is thrown`() = runTest {
+    fun `When sending the verification email fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
-        val request = Authentication.RegisterRequest.newBuilder().build()
+        val verificationLink = "verification-link"
+        val userData = EmailData.EmailVerification(user.firstName, user.lastName, verificationLink)
 
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.createUser(any(), any()) } returns user
-        coEvery { verificationTokenRepoMock.saveVerificationToken(any(), any()) } returns Unit
-        every { emailManagerMock.createVerificationLink(any()) } returns "test-token"
-        coEvery { emailManagerMock.sendVerificationEmail(any(), any()) } throws TestSpecificException()
+        coEvery { userRepoMock.doesUserExistByEmail(user.email) } returns false
+        coEvery { userRepoMock.createUser(getExampleRequest(user), any()) } returns user
+        coEvery { verificationTokenRepoMock.saveVerificationToken(user.id, any()) } returns Unit
+        every { emailManagerMock.createVerificationLink(any()) } returns verificationLink
+        coEvery { emailManagerMock.sendVerificationEmail(user.email, userData) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { mainService.register(request) }
+        assertThrows<TestSpecificException> { mainService.register(getExampleRequest(user)) }
     }
 
     @Test
     fun `When a user provides valid registration data, then the user is created and a verification email is sent`() =
         runTest {
             val user = DataBuilder.createExampleUser()
-            val request = Authentication.RegisterRequest.newBuilder()
-                .setEmail(user.email)
-                .setFirstName(user.firstName)
-                .setLastName(user.lastName)
-                .setPassword("VALIDPassword__1234")
-                .build()
             val testFrontendURL = "https://example.com"
 
             val tokenSlot = slot<String>()
             val emailDataSlot = slot<EmailData.EmailVerification>()
 
-            coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-            coEvery { userRepoMock.createUser(any(), any()) } returns user
-            coEvery { verificationTokenRepoMock.saveVerificationToken(any(), capture(tokenSlot)) } returns Unit
+            coEvery { userRepoMock.doesUserExistByEmail(user.email) } returns false
+            coEvery { userRepoMock.createUser(getExampleRequest(user), any()) } returns user
+            coEvery { verificationTokenRepoMock.saveVerificationToken(user.id, capture(tokenSlot)) } returns Unit
 
             every { emailManagerMock.createVerificationLink(any()) } answers {
                 val token = firstArg<String>()
                 "$testFrontendURL/verifyemail?token=$token"
             }
 
-            coEvery { emailManagerMock.sendVerificationEmail(any(), capture(emailDataSlot)) } returns Unit
+            coEvery { emailManagerMock.sendVerificationEmail(user.email, capture(emailDataSlot)) } returns Unit
 
-            assertDoesNotThrow { mainService.register(request) }
+            assertDoesNotThrow { mainService.register(getExampleRequest(user)) }
 
             val capturedToken = tokenSlot.captured
             assertThat(capturedToken).isNotBlank()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -17,11 +17,12 @@ import snowballr.UserOuterClass.User as GrpcUser
 
 class UpdateUserTest : MainServiceTest() {
     private val requestedUserId = UUID.randomUUID()
+    private val requestEmail = "newemail@example.com"
 
     private fun getExampleRequest(): GrpcUser.Update {
         val user = GrpcUser.newBuilder()
             .setId(requestedUserId.toString())
-            .setEmail("newemail@example.com")
+            .setEmail(requestEmail)
             .setRole(UserRole.USER_ROLE_ADMIN)
             .build()
 
@@ -76,11 +77,11 @@ class UpdateUserTest : MainServiceTest() {
     @Test
     fun `When updating email to existent email, then a DuplicateEntityException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
+        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId, email = requestEmail)
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns true
+        coEvery { userRepoMock.doesUserExistByEmail(requestedUser.email) } returns true
 
         assertThrows<DuplicateEntityException> { mainService.updateUser(getExampleRequest()) }
     }
@@ -127,12 +128,12 @@ class UpdateUserTest : MainServiceTest() {
     @Test
     fun `When admin updates all fields of another user, then it succeeds`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
+        val requestedUser = DataBuilder.createExampleUser(id = requestedUserId, email = requestEmail)
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
-        coEvery { userRepoMock.doesUserExistByEmail(any()) } returns false
-        coEvery { userRepoMock.updateUser(any()) } returns requestedUser
+        coEvery { userRepoMock.doesUserExistByEmail(requestedUser.email) } returns false
+        coEvery { userRepoMock.updateUser(getExampleRequest()) } returns requestedUser
 
         assertDoesNotThrow { mainService.updateUser(getExampleRequest()) }
     }


### PR DESCRIPTION
Closes #254

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- Whenever possible, I replaced a `any()` occurrence in a service test by a meaningful parameter.
- However, there are still some `any()`s in the tests, as for example in the register tests it it not necessary to make the tests more complex by creating example password hashes and tokens as they are tested separately; or to verify that a certain function was **not** called, the parameters does not matter.
- Furthermore, I refactored or fixed little problems.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
