### PR TITLE
Use `cookiesMap` instead of `GrpcContext`

### DIFF
--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/AuthenticateTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/AuthenticateTest.kt
@@ -39,7 +39,9 @@ class AuthenticateTest {
     }
 
     @Test
-    fun `When access token is invalid but refresh token is valid, then token is refreshed and authentication succeeds`() {
+    fun `When access token is invalid but refresh token is valid, then token is refreshed and authentication succeeds`(
+        cookiesMap: MutableMap<String, String?>,
+    ) {
         val parsedRefreshClaims = ParsedJwtAuthClaims(UUID.randomUUID(), Date(), Date())
         every { jwtManagerMock.parseAuthToken("invalidAccessToken") } throws JwtException("Invalid access token")
         every { jwtManagerMock.parseAuthToken("validRefreshToken") } returns parsedRefreshClaims
@@ -56,12 +58,14 @@ class AuthenticateTest {
         )
         assertEquals(
             "newAccessToken",
-            GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.ACCESS_TOKEN_COOKIE_NAME],
+            cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME],
         )
     }
 
     @Test
-    fun `When access token is invalid, refresh token is valid, and skipRefresh is true, then auth succeeds without refresh`() {
+    fun `When access token is invalid, refresh token is valid, and skipRefresh is true, then auth succeeds without refresh`(
+        cookiesMap: MutableMap<String, String?>,
+    ) {
         val parsedRefreshClaims = ParsedJwtAuthClaims(UUID.randomUUID(), Date(), Date())
         every { jwtManagerMock.parseAuthToken("invalidAccessToken") } throws JwtException("Invalid access token")
         every { jwtManagerMock.parseAuthToken("validRefreshToken") } returns parsedRefreshClaims
@@ -75,11 +79,13 @@ class AuthenticateTest {
             Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED,
             GrpcContext.getAuthenticationStatusFromContext(),
         )
-        assertTrue(GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get().isEmpty())
+        assertTrue(cookiesMap.isEmpty())
     }
 
     @Test
-    fun `When both access and refresh tokens are invalid, then authentication fails and cookies are cleared`() {
+    fun `When both access and refresh tokens are invalid, then authentication fails and cookies are cleared`(
+        cookiesMap: MutableMap<String, String?>,
+    ) {
         every { jwtManagerMock.parseAuthToken("invalidAccessToken") } throws JwtException("Invalid access token")
         every { jwtManagerMock.parseAuthToken("invalidRefreshToken") } throws JwtException("Invalid refresh token")
 
@@ -91,12 +97,14 @@ class AuthenticateTest {
             Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED,
             GrpcContext.getAuthenticationStatusFromContext(),
         )
-        assertNull(GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
-        assertNull(GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
+        assertNull(cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
+        assertNull(cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
     }
 
     @Test
-    fun `When access token is invalid and refresh token is missing, then authentication fails`() {
+    fun `When access token is invalid and refresh token is missing, then authentication fails`(
+        cookiesMap: MutableMap<String, String?>,
+    ) {
         every { jwtManagerMock.parseAuthToken("invalidAccessToken") } throws JwtException("Invalid access token")
 
         val authResult = authenticationManager.authenticate("invalidAccessToken", null, false)
@@ -107,12 +115,14 @@ class AuthenticateTest {
             Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED,
             GrpcContext.getAuthenticationStatusFromContext(),
         )
-        assertNull(GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
-        assertNull(GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
+        assertNull(cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
+        assertNull(cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
     }
 
     @Test
-    fun `When both tokens are invalid and skipRefresh is true, then authentication fails and cookies are not cleared`() {
+    fun `When both tokens are invalid and skipRefresh is true, then authentication fails and cookies are not cleared`(
+        cookiesMap: MutableMap<String, String?>,
+    ) {
         every { jwtManagerMock.parseAuthToken("invalidAccessToken") } throws JwtException("Invalid access token")
         every { jwtManagerMock.parseAuthToken("invalidRefreshToken") } throws JwtException("Invalid refresh token")
 
@@ -124,6 +134,6 @@ class AuthenticateTest {
             Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED,
             GrpcContext.getAuthenticationStatusFromContext(),
         )
-        assertTrue(GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get().isEmpty())
+        assertTrue(cookiesMap.isEmpty())
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
@@ -109,7 +109,9 @@ class LoginTest : MainServiceTest() {
     }
 
     @Test
-    fun `When an active user provides valid credentials, then the user is logged in successfully`() = runTest {
+    fun `When an active user provides valid credentials, then the user is logged in successfully`(
+        cookiesMap: MutableMap<String, String?>,
+    ) = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
         val userPassword = "AAbb__00"
         val passwordHash = PasswordUtils.hashPassword(userPassword)
@@ -126,13 +128,7 @@ class LoginTest : MainServiceTest() {
 
         assertDoesNotThrow { mainService.login(request) }
 
-        assertEquals(
-            tokens.accessToken,
-            GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.ACCESS_TOKEN_COOKIE_NAME],
-        )
-        assertEquals(
-            tokens.refreshToken,
-            GrpcContext.COOKIES_TO_SET_CONTEXT_KEY.get()[GrpcContext.REFRESH_TOKEN_COOKIE_NAME],
-        )
+        assertEquals(tokens.accessToken, cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
+        assertEquals(tokens.refreshToken, cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])
     }
 }


### PR DESCRIPTION
Closes 307

## What I have made

- Refactored `AuthenticateTest` to assert against an injected `cookiesMap` instead of directly accessing `GrpcContext.COOKIES_TO_SET_CONTEXT_KEY`.

Note: I explicitly did not refactor the assertions (e.g., `assertTrue(cookiesMap.isEmpty())` to `assertThat(cookiesMap).isEmpty()`) as this will be done in #305.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] (for reviewer) I have checked the implementation against the requirements
