### PR TITLE
Trim `frontendBaseUrl` and remove trailing slashes

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
@@ -23,6 +23,7 @@ data class Env(
     data class Miscellaneous(
         val logLevel: String,
         val authBypassEnabled: Boolean,
+        // Guaranteed to not contain a trailing slash
         val frontendBaseUrl: String,
     )
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -64,7 +64,10 @@ class EnvReader(
         val port = envService.getRequiredOrDefault(PORT, defaults.port?.toString()).toInt()
         val host = envService.getRequiredOrDefault(DATABASE_HOST, defaults.databaseHost)
         val logLevel = envService.getOrDefault(LOG_LEVEL, defaults.logLevel)
-        val frontendBaseUrl = envService.getRequiredOrDefault(FRONTEND_BASE_URL, defaults.frontendBaseUrl)
+        val frontendBaseUrl = envService.getRequiredOrDefault(
+            FRONTEND_BASE_URL,
+            defaults.frontendBaseUrl,
+        ).trim().trimEnd('/')
         val smtpTransportLoggingOnlyEnabled =
             envService.getBooleanOrDefault(
                 SMTP_TRANSPORT_LOGGING_ONLY_ENABLED,


### PR DESCRIPTION
Closes #297 

## What I have made

- trim spaces and trailing slashes from `frontendBaseUrl` after being read from the environment or defaults.

## Checklist

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have manually tested the behavior
- [ ] (for reviewer) I have checked the implementation against the requirements
