### PR TITLE
Fix accept project invation issues

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -50,6 +50,7 @@ private val PUBLIC_METHODS =
         SnowballRGrpcKt.loginMethod.fullMethodName,
         SnowballRGrpcKt.requestPasswordResetMethod.fullMethodName,
         SnowballRGrpcKt.resetPasswordMethod.fullMethodName,
+        SnowballRGrpcKt.acceptProjectInvitationMethod.fullMethodName,
     )
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -79,8 +79,8 @@ private class ExceptionCall<ReqT, RespT>(
             when (e) {
                 is SnowballRException.InvalidIdException -> Status.INVALID_ARGUMENT
                 is SnowballRException.OutOfRangeException -> Status.INVALID_ARGUMENT
-                is SnowballRException.VerificationTokenNotFoundException -> Status.DEADLINE_EXCEEDED
-                is SnowballRException.InvitationTokenNotFoundException -> Status.DEADLINE_EXCEEDED
+                is SnowballRException.VerificationTokenNotFoundException -> Status.NOT_FOUND
+                is SnowballRException.InvitationTokenNotFoundException -> Status.NOT_FOUND
                 is SnowballRException.NotFoundException -> Status.NOT_FOUND
                 is SnowballRException.DuplicateEntityException -> Status.ALREADY_EXISTS
                 is SnowballRException.UnauthorizedException -> Status.PERMISSION_DENIED

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -150,12 +150,12 @@ class InvitationService(
 
         // Check if the user is registered and verified
         val user = try {
-            userRepo.getUserByEmail(invitationToken.email)
+            userRepo.getUserByEmail(invitationToken.email).getOrThrow()
         } catch (_: NotFoundException) {
             throw FailedPreconditionException(
                 "The user with the email ${invitationToken.email} is not registered.",
             )
-        }.getOrThrow()
+        }
 
         if (user.status != UserStatus.USER_STATUS_ACTIVE) {
             throw FailedPreconditionException(


### PR DESCRIPTION
Closes #319 

## What I have made

- Use `NOT_FOUND` instead of `DEADLINE_EXCEEDED` when a email verification token / acceptance token is not found
- Add `acceptProjectInvitation` as public call
- Throw a `FAILED_PRECONDITION` instead of `NOT_FOUND` if the invited user is not registered yet

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] (for reviewer) I have checked the implementation against the requirements
