### PR TITLE
Implement `getPendingInvitationsForProject` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -255,7 +255,7 @@ class SnowballRServer(
             mainService.acceptProjectInvitation(request)
 
         override suspend fun getPendingInvitationsForProject(request: Base.Id): UserOuterClass.User.List =
-            super.getPendingInvitationsForProject(request)
+            mainService.getPendingInvitationsForProject(request)
 
         override suspend fun getProjectMembers(request: Base.Id): ProjectOuterClass.Project.Member.List =
             mainService.getProjectMembers(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepo.kt
@@ -10,6 +10,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.InvitationTokenNotFoun
 import se.uulm.snowballr.backend.model.dto.InvitationToken
 import se.uulm.snowballr.backend.table.InvitationTokenTable
 import se.uulm.snowballr.backend.table.toInvitationToken
+import java.time.OffsetDateTime
 import java.util.UUID
 
 interface IInvitationTokenTableRepo {
@@ -40,6 +41,15 @@ interface IInvitationTokenTableRepo {
      * [InvitationTokenNotFoundException] if the token doesn't exist.
      */
     suspend fun getInvitationTokenByEmailAndProjectId(email: String, projectId: UUID): Result<InvitationToken>
+
+    /**
+     * Retrieves all invitation tokens for a given project.
+     * Only invitation tokens that are still active and not yet expired will be returned.
+     *
+     * @param projectId The ID of the project for which to retrieve the invitation tokens.
+     * @return A list of active [InvitationToken]s associated with the given project.
+     */
+    suspend fun getActiveInvitationTokenForProject(projectId: UUID): List<InvitationToken>
 
     /**
      * Deletes an invitation token by its value.
@@ -86,6 +96,14 @@ class InvitationTokenTableRepo(
         } else {
             Result.failure(InvitationTokenNotFoundException())
         }
+    }
+
+    override suspend fun getActiveInvitationTokenForProject(projectId: UUID): List<InvitationToken> = db.query {
+        val allToken = InvitationTokenTable.getEntities(ResultRow::toInvitationToken) {
+            InvitationTokenTable.projectId eq projectId
+        }
+
+        allToken.filter { token -> OffsetDateTime.now().isBefore(token.expiresAt) }
     }
 
     override suspend fun deleteInvitationToken(token: String) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepo.kt
@@ -49,7 +49,7 @@ interface IInvitationTokenTableRepo {
      * @param projectId The ID of the project for which to retrieve the invitation tokens.
      * @return A list of active [InvitationToken]s associated with the given project.
      */
-    suspend fun getActiveInvitationTokenForProject(projectId: UUID): List<InvitationToken>
+    suspend fun getActiveInvitationTokensForProject(projectId: UUID): List<InvitationToken>
 
     /**
      * Deletes an invitation token by its value.
@@ -98,12 +98,12 @@ class InvitationTokenTableRepo(
         }
     }
 
-    override suspend fun getActiveInvitationTokenForProject(projectId: UUID): List<InvitationToken> = db.query {
-        val allToken = InvitationTokenTable.getEntities(ResultRow::toInvitationToken) {
+    override suspend fun getActiveInvitationTokensForProject(projectId: UUID): List<InvitationToken> = db.query {
+        val allTokens = InvitationTokenTable.getEntities(ResultRow::toInvitationToken) {
             InvitationTokenTable.projectId eq projectId
         }
 
-        allToken.filter { token -> OffsetDateTime.now().isBefore(token.expiresAt) }
+        allTokens.filter { token -> OffsetDateTime.now().isBefore(token.expiresAt) }
     }
 
     override suspend fun deleteInvitationToken(token: String) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -4,7 +4,6 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.toGrpcCriteria
@@ -14,12 +13,14 @@ import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forTarget
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isCreatorOfCriterion
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import se.uulm.snowballr.backend.service.accessrules.isProjectAdmin
+import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isUserAdminInProjectOfCriterion
 import se.uulm.snowballr.backend.service.accessrules.isUserInProjectOfCriterion
@@ -154,11 +155,9 @@ class CriterionService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-            if (!projectRepo.doesProjectExistById(projectId)) {
-                throw NotFoundException(EntityType.PROJECT, projectId.toString())
-            }
-
-            isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
+            isAllowedToReadProject(projectMemberRepo)
+                .andAlso(isProjectExistent(projectRepo))
+                .checkFor(currentUser, projectId)
 
             repo.getAllProjectCriteria(projectId).toGrpcCriteria()
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -11,6 +11,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionExce
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.InvitationTokenNotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.parseUUID
@@ -18,12 +19,16 @@ import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
+import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
+import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.Project
+import snowballr.UserOuterClass.User
 import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
 import snowballr.ProjectOuterClass.Project as GrpcProject
@@ -44,6 +49,11 @@ interface IInvitationService {
      * Service implementation of [SnowballRService.acceptProjectInvitation].
      */
     suspend fun acceptProjectInvitation(request: GrpcProject.Member.Accept): Base.Nothing
+
+    /**
+     * Service implementation of [SnowballRService.getPendingInvitationsForProject].
+     */
+    suspend fun getPendingInvitationsForProject(request: Base.Id): GrpcUser.List
 }
 
 private const val INVITATION_TOKEN_LENGTH = 48
@@ -160,5 +170,27 @@ class InvitationService(
         invitationTokenRepo.deleteInvitationToken(invitationToken.token)
 
         return Base.Nothing.getDefaultInstance()
+    }
+
+    override suspend fun getPendingInvitationsForProject(request: Base.Id): GrpcUser.List = withUser(
+        userRepo,
+    ) { currentUser ->
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+        isAllowedToReadProject(projectMemberRepo)
+            .andAlso(isProjectExistent(projectRepo))
+            .checkFor(currentUser, projectId)
+
+        val tokens = invitationTokenRepo.getActiveInvitationTokenForProject(projectId)
+
+        val invitees = tokens.map { token ->
+            try {
+                userRepo.getUserByEmail(token.email).getOrThrow().toGrpcUser()
+            } catch (_: NotFoundException) {
+                User.newBuilder().setEmail(token.email).build()
+            }
+        }
+
+        User.List.newBuilder().addAllUsers(invitees).build()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -181,7 +181,7 @@ class InvitationService(
             .andAlso(isProjectExistent(projectRepo))
             .checkFor(currentUser, projectId)
 
-        val tokens = invitationTokenRepo.getActiveInvitationTokenForProject(projectId)
+        val tokens = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
 
         val invitees = tokens.map { token ->
             try {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -5,7 +5,6 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Author
@@ -26,9 +25,11 @@ import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
+import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
@@ -141,11 +142,9 @@ class ProjectPaperService(
     ): GrpcProjectPaper.List = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
-
-        if (!projectRepo.doesProjectExistById(projectId)) {
-            throw NotFoundException(EntityType.PROJECT, projectId.toString())
-        }
+        isAllowedToReadProject(projectMemberRepo)
+            .andAlso(isProjectExistent(projectRepo))
+            .checkFor(currentUser, projectId)
 
         var projectPapersWithPapers = repo.getAllProjectPapersWithPapers(projectId)
         val paperAuthorsMap = mutableMapOf<Paper, List<GrpcAuthor>>()
@@ -187,11 +186,9 @@ class ProjectPaperService(
     ) { currentUser ->
         val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
-
-        if (!projectRepo.doesProjectExistById(projectId)) {
-            throw NotFoundException(EntityType.PROJECT, projectId.toString())
-        }
+        isAllowedToReadProject(projectMemberRepo)
+            .andAlso(isProjectExistent(projectRepo))
+            .checkFor(currentUser, projectId)
 
         val relativeId = request.relativeProjectPaperId.toLong()
         val projectPaper = repo.getProjectPaperByRelativeId(projectId, relativeId).getOrThrow()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -4,7 +4,6 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
-import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
@@ -15,9 +14,11 @@ import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forProperty
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
+import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isServerAdminOrSameUser
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
@@ -186,11 +187,9 @@ class ProjectService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-            isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
-
-            if (!repo.doesProjectExistById(projectId)) {
-                throw NotFoundException(EntityType.PROJECT, projectId.toString())
-            }
+            isAllowedToReadProject(projectMemberRepo)
+                .andAlso(isProjectExistent(repo))
+                .checkFor(currentUser, projectId)
 
             val projectMembersWithUsers = projectMemberRepo.getProjectMembersWithUsers(projectId)
             projectMembersWithUsers.toGrpcProjectMembers()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -4,12 +4,28 @@ package se.uulm.snowballr.backend.service.accessrules
 
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
 import javax.annotation.CheckReturnValue
+
+/**
+ * Check whether a project with the given ID exists; otherwise, throws a [NotFoundException].
+ *
+ * @param projectRepo The repository used to verify project existence.
+ */
+@CheckReturnValue
+fun isProjectExistent(projectRepo: IProjectTableRepo): AccessRule<UUID> {
+    return AccessRule<UUID> { _, projectId ->
+        projectRepo.doesProjectExistById(projectId)
+    }.orElseThrow { _, projectId ->
+        NotFoundException(EntityType.PROJECT, projectId.toString())
+    }
+}
 
 /**
  * Check whether the project is active (or active, but settings are locked).

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.repository
 
 import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -144,7 +144,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             insertInactiveTestToken(projectId)
 
             val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(projectId)
-            assertEquals(1, activeInvitationTokenInProject.size)
+            assertThat(activeInvitationTokenInProject).hasSize(1)
             assertEquals("an-active-token", activeInvitationTokenInProject.first().token)
         }
 
@@ -154,7 +154,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             insertInactiveTestToken(projectId)
 
             val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(projectId)
-            assertTrue(activeInvitationTokenInProject.isEmpty())
+            assertThat(activeInvitationTokenInProject).isEmpty()
         }
 
         @Test
@@ -163,7 +163,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             insertActiveTestToken(projectId, "token-in-another-project")
 
             val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(UUID.randomUUID())
-            assertTrue(activeInvitationTokenInProject.isEmpty())
+            assertThat(activeInvitationTokenInProject).isEmpty()
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
@@ -143,7 +143,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             insertActiveTestToken(projectId2, "token-in-another-project")
             insertInactiveTestToken(projectId)
 
-            val activeInvitationTokenInProject = repo.getActiveInvitationTokenForProject(projectId)
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(projectId)
             assertEquals(1, activeInvitationTokenInProject.size)
             assertEquals("an-active-token", activeInvitationTokenInProject.first().token)
         }
@@ -153,7 +153,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             insertInactiveTestToken(projectId)
 
-            val activeInvitationTokenInProject = repo.getActiveInvitationTokenForProject(projectId)
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(projectId)
             assertTrue(activeInvitationTokenInProject.isEmpty())
         }
 
@@ -162,7 +162,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             insertActiveTestToken(projectId, "token-in-another-project")
 
-            val activeInvitationTokenInProject = repo.getActiveInvitationTokenForProject(UUID.randomUUID())
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(UUID.randomUUID())
             assertTrue(activeInvitationTokenInProject.isEmpty())
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.repository
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,6 +14,7 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTable, InvitationTokenTable), true) {
@@ -116,6 +118,53 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
                     ),
                 )
             }
+    }
+
+    @Nested
+    inner class GetActiveInvitationTokenForProject {
+        private fun getRandomTestEmail() = "${UUID.randomUUID().toString().substring(0, 5)}@example.com"
+
+        private suspend fun insertActiveTestToken(projectId: UUID, token: String) =
+            insertTestToken(getRandomTestEmail(), projectId, token)
+
+        private suspend fun insertInactiveTestToken(projectId: UUID) = insertTestToken(
+            getRandomTestEmail(),
+            projectId,
+            "an-inactive-token",
+            expiresAt = OffsetDateTime.now().minusDays(1),
+        )
+
+        @Test
+        fun `When active tokens exist, then they are returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val projectId2 = insertProjectAndGetId(createdBy = testUserId)
+
+            insertActiveTestToken(projectId, "an-active-token")
+            insertActiveTestToken(projectId2, "token-in-another-project")
+            insertInactiveTestToken(projectId)
+
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokenForProject(projectId)
+            assertEquals(1, activeInvitationTokenInProject.size)
+            assertEquals("an-active-token", activeInvitationTokenInProject.first().token)
+        }
+
+        @Test
+        fun `When tokens exist but none are active, then an empty list is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            insertInactiveTestToken(projectId)
+
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokenForProject(projectId)
+            assertTrue(activeInvitationTokenInProject.isEmpty())
+        }
+
+        @Test
+        fun `When no token exist for the project, then an empty list is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            insertActiveTestToken(projectId, "token-in-another-project")
+
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokenForProject(UUID.randomUUID())
+            assertTrue(activeInvitationTokenInProject.isEmpty())
+        }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -26,6 +26,7 @@ import snowballr.ProjectOuterClass.SnowballingType
 import snowballr.ReviewOuterClass.ReviewDecision
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
+import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
@@ -258,12 +259,18 @@ object RepositoryHelper {
      * Creates a test invitation token (default "secure-random-invitation-token-123") in the database
      * with the specified properties.
      */
-    suspend fun insertTestToken(email: String, projectId: UUID, token: String = "secure-random-invitation-token-123") {
+    suspend fun insertTestToken(
+        email: String,
+        projectId: UUID,
+        token: String = "secure-random-invitation-token-123",
+        expiresAt: OffsetDateTime = OffsetDateTime.now().plusDays(1),
+    ) {
         db.query {
             InvitationTokenTable.insert {
                 it[InvitationTokenTable.email] = email
                 it[InvitationTokenTable.projectId] = projectId
                 it[InvitationTokenTable.token] = token
+                it[InvitationTokenTable.expiresAt] = expiresAt
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -25,9 +25,11 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
     fun `When the project doesn't exist, then a NotFoundException is thrown`() = runTest {
         val request = getExampleRequest()
 
+        val project = DataBuilder.createExampleProject(id = projectId)
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
 
         assertThrows<NotFoundException> { mainService.getAllCriteriaForProject(request) }
@@ -45,8 +47,8 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
         assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
@@ -66,8 +68,8 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(user)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
             assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
@@ -82,7 +84,6 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(user)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
@@ -29,7 +29,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
         mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-        coEvery { invitationTokenRepoMock.getActiveInvitationTokenForProject(projectId) } returns emptyList()
+        coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns emptyList()
 
         assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
     }
@@ -43,7 +43,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
             mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
             coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-            coEvery { invitationTokenRepoMock.getActiveInvitationTokenForProject(projectId) } returns emptyList()
+            coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns emptyList()
 
             assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
         }
@@ -69,7 +69,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
             mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
             coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-            coEvery { invitationTokenRepoMock.getActiveInvitationTokenForProject(projectId) } returns listOf(
+            coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns listOf(
                 invitationTokenForRegisteredUser,
                 invitationTokenForNotRegisteredUser,
             )

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
@@ -1,0 +1,127 @@
+package se.uulm.snowballr.backend.service.invitations
+
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
+import java.util.UUID
+
+class GetPendingInvitationsForProjectTest : MainServiceTest() {
+    private val projectId = UUID.randomUUID()
+
+    private fun createRequest(id: UUID = projectId) = Base.Id.newBuilder().setId(id.toString()).build()
+
+    @Test
+    fun `When a server admin requests the pending invitations for a project, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+        coEvery { invitationTokenRepoMock.getActiveInvitationTokenForProject(projectId) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
+    }
+
+    @Test
+    fun `When a project member requests the pending invitations for a project, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val projectMember = DataBuilder.createExampleProjectMember(userId = currentUser.id, projectId = projectId)
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
+            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+            coEvery { invitationTokenRepoMock.getActiveInvitationTokenForProject(projectId) } returns emptyList()
+
+            assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
+        }
+
+    @Test
+    fun `When a non registered user is invited, then they appear as well in the list of pending invitations but without complete user details`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val registeredUser = DataBuilder.createExampleUser(
+                email = "registered@example.com",
+                status = UserStatus.USER_STATUS_ACTIVE,
+            )
+            val invitationTokenForRegisteredUser = DataBuilder.createExampleInvitationToken(
+                projectId = projectId,
+                email = registeredUser.email,
+            )
+            val notRegisteredEmail = "unregistered@example.com"
+            val invitationTokenForNotRegisteredUser = DataBuilder.createExampleInvitationToken(
+                projectId = projectId,
+                email = notRegisteredEmail,
+            )
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+            coEvery { invitationTokenRepoMock.getActiveInvitationTokenForProject(projectId) } returns listOf(
+                invitationTokenForRegisteredUser,
+                invitationTokenForNotRegisteredUser,
+            )
+            coEvery { userRepoMock.getUserByEmail(registeredUser.email) } returns Result.success(registeredUser)
+            coEvery {
+                userRepoMock.getUserByEmail(notRegisteredEmail)
+            } returns Result.failure(NotFoundException(EntityType.USER, notRegisteredEmail))
+
+            val pendingInvitations = assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
+
+            val invitationForRegisteredUser = pendingInvitations.usersList.find { it.email == registeredUser.email }
+            val invitationForNotRegisteredUser = pendingInvitations.usersList.find { it.email == notRegisteredEmail }
+            assertEquals(2, pendingInvitations.usersList.size)
+            assertNotNull(invitationForRegisteredUser)
+            assertNotNull(invitationForNotRegisteredUser)
+
+            // Registered user should have user details
+            assertEquals(registeredUser.id.toString(), invitationForRegisteredUser?.id)
+            assertEquals(UserStatus.USER_STATUS_ACTIVE, invitationForRegisteredUser?.status)
+            assertEquals(registeredUser.firstName, invitationForRegisteredUser?.firstName)
+
+            // Not registered user should not have user details
+            assertEquals("", invitationForNotRegisteredUser?.id)
+            assertEquals(UserStatus.USER_STATUS_UNSPECIFIED, invitationForNotRegisteredUser?.status)
+            assertEquals("", invitationForNotRegisteredUser?.firstName)
+        }
+
+    @Test
+    fun `When a non project member requests the pending invitations for a project, then an UnauthorizedException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+
+            assertThrows<UnauthorizedException> { mainService.getPendingInvitationsForProject(createRequest()) }
+        }
+
+    @Test
+    fun `When the pending invitations for a nonexistent project are requested, then a NotFoundException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val nonExistentProjectId = UUID.randomUUID()
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getProjectMembers(nonExistentProjectId) } returns emptyList()
+            coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
+
+            assertThrows<NotFoundException> {
+                mainService.getPendingInvitationsForProject(
+                    createRequest(nonExistentProjectId),
+                )
+            }
+        }
+}


### PR DESCRIPTION
Closes #77

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I added a function on the repository layer that retrieves all active invitation token for a project
- I added the service layer function for getting the pending invitations for a project
  - users that are invited but not registered only have an email and no name, id, role or status

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
