### PR TITLE
Incorrect checks for the status input when updating a project

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -109,7 +109,7 @@ private class ExceptionCall<ReqT, RespT>(
             "gRPC call failed due to unexpected ${e::class.simpleName ?: "<unknown class>"} " +
                 "with message: ${e.message ?: "<no message>"}."
         }
-        return status
+        return status.withDescription(e.message).withCause(e.cause)
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -1,19 +1,25 @@
 package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
+import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.statements.UpdateStatement
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
+import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.toProject
 import snowballr.ProjectOuterClass.ProjectStatus
 import java.time.OffsetDateTime
@@ -91,6 +97,21 @@ interface IProjectTableRepo {
      * @return The updated [Project] object reflecting the changes from the [request].
      */
     suspend fun updateProject(request: GrpcProject.Update): Project
+
+    /**
+     * Checks if the project with the given [projectId] is locked.
+     *
+     * A project is considered **locked** if at least one [ProjectPaper] with at least one [Review]
+     * is associated with this project.
+     *
+     * **Note:** This functions returns `true` or `false` regardless of the project's current state.
+     * However, the result is only meaningful if the project is in an active state
+     * (i.e., [ProjectStatus.PROJECT_STATUS_ACTIVE] or [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED]).
+     *
+     * @param projectId The ID of the project to check for locked status.
+     * @return `true` if the project is locked, `false` otherwise.
+     */
+    suspend fun isProjectLocked(projectId: UUID): Boolean
 }
 
 /**
@@ -102,6 +123,7 @@ interface IProjectTableRepo {
  *
  * @param db The database abstraction used for executing queries within a transaction.
  */
+@Suppress("TooManyFunctions")
 class ProjectTableRepo(
     private val db: IDatabase,
 ) : IProjectTableRepo {
@@ -166,6 +188,15 @@ class ProjectTableRepo(
             it.applySlrProjectUpdates(request.project.settings, fieldMaskPaths)
             it[modifiedAt] = OffsetDateTime.now()
         }
+    }
+
+    override suspend fun isProjectLocked(projectId: UUID): Boolean = db.query {
+        ProjectPaperTable
+            .join(ReviewTable, JoinType.INNER, ProjectPaperTable.id, ReviewTable.projectPaperId)
+            .selectAll()
+            .where { ProjectPaperTable.projectId eq projectId }
+            .limit(1)
+            .any()
     }
 
     private fun UpdateStatement.applyProjectNameUpdate(project: GrpcProject, paths: Set<String>) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -88,12 +88,9 @@ interface IProjectTableRepo {
      * - review_maybe_allowed
      *
      * @param request The update request containing the new project details, such as the new name.
-     * @param projectStatus The current status of the project, which shall be updated. The status is used to check
-     *  whether the project can be updated and which parts are eligible for updates depending on the current project
-     *  status.
      * @return The updated [Project] object reflecting the changes from the [request].
      */
-    suspend fun updateProject(request: GrpcProject.Update, projectStatus: ProjectStatus): Project
+    suspend fun updateProject(request: GrpcProject.Update): Project
 }
 
 /**
@@ -159,20 +156,14 @@ class ProjectTableRepo(
             .map { it.toProject() }
     }
 
-    override suspend fun updateProject(request: GrpcProject.Update, projectStatus: ProjectStatus): Project = db.query {
+    override suspend fun updateProject(request: GrpcProject.Update): Project = db.query {
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
         val fieldMaskPaths = FieldMaskUtil.normalize(request.mask).pathsList.toSet()
 
         ProjectTable.updateByIdAndGet(projectId, ResultRow::toProject, EntityType.PROJECT) {
             it.applyProjectStatusUpdate(request.project, fieldMaskPaths)
-            if (projectStatus == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED ||
-                projectStatus == ProjectStatus.PROJECT_STATUS_ACTIVE
-            ) {
-                it.applyProjectNameUpdate(request.project, fieldMaskPaths)
-            }
-            if (projectStatus == ProjectStatus.PROJECT_STATUS_ACTIVE) {
-                it.applySlrProjectUpdates(request.project.settings, fieldMaskPaths)
-            }
+            it.applyProjectNameUpdate(request.project, fieldMaskPaths)
+            it.applySlrProjectUpdates(request.project.settings, fieldMaskPaths)
             it[modifiedAt] = OffsetDateTime.now()
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -30,6 +30,8 @@ import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.copy
+import java.util.UUID
 import kotlin.getOrThrow
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.ProjectOuterClass.Project as GrpcProject
@@ -186,20 +188,120 @@ class ProjectService(
 
     override suspend fun updateProject(request: GrpcProject.Update): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.project.id, EntityType.PROJECT)
-        val project = repo.getProjectById(projectId).getOrThrow()
 
         isServerOrProjectAdmin(projectMemberRepo, AccessType.UPDATE).checkFor(currentUser, projectId)
 
-        // TODO (see #314): correct status handling: if a project is archived, you should only be able to activate it
-        // and if it is active, you can do everything, but deleting / restoring it never allowed.
-        if (project.status == ProjectStatus.PROJECT_STATUS_DELETED) {
-            throw FailedPreconditionException("The project with the id ${request.project.id} is deleted.")
-        }
-        if (request.project.status == ProjectStatus.PROJECT_STATUS_DELETED) {
-            throw FailedPreconditionException("The project status can not be set to deleted by an update call.")
+        val project = repo.getProjectById(projectId).getOrThrow()
+        val currentStatus = project.status
+
+        val fieldMask = request.mask.pathsList
+        val requestedStatus = request.project.status
+
+        validateProjectUpdate(currentStatus, requestedStatus, fieldMask)
+
+        val finalStatus = determineEffectiveProjectStatus(projectId, requestedStatus)
+        val finalRequest = request.copy {
+            this.project = request.project.copy {
+                this.status = finalStatus
+            }
         }
 
-        repo.updateProject(request, project.status).toGrpcProject()
+        repo.updateProject(finalRequest).toGrpcProject()
+    }
+
+    /**
+     * Validates the update of a project based on the current status and the requested status.
+     *
+     * If the project is `PROJECT_STATUS_DELETED`, nothing can be updated.
+     * If the project is `PROJECT_STATUS_ARCHIVED`, only the status can be updated (back to an active project).
+     * If the project is `PROJECT_STATUS_ACTIVE`, then everything can be updated.
+     * If the project is `PROJECT_STATUS_ACTIVE_LOCKED`, then everything except the slr settings can be updated.
+     *
+     * In addition, the status can never be set to `PROJECT_STATUS_DELETED` via the update method.
+     *
+     * @throws FailedPreconditionException if the update fails for any reason.
+     */
+    @Suppress("ThrowsCount")
+    private fun validateProjectUpdate(
+        currentStatus: ProjectStatus,
+        requestedStatus: ProjectStatus,
+        fieldMask: List<String>,
+    ) {
+        require(!(fieldMask.contains("project.status") && requestedStatus == ProjectStatus.PROJECT_STATUS_DELETED)) {
+            "The project status cannot be set to DELETED via the update method. Use SoftDeleteProject instead."
+        }
+
+        when (currentStatus) {
+            ProjectStatus.PROJECT_STATUS_DELETED -> {
+                throw FailedPreconditionException(
+                    "The project has been deleted and can therefore not be updated anymore.",
+                )
+            }
+
+            ProjectStatus.PROJECT_STATUS_ARCHIVED -> {
+                val isOnlyStatusUpdate = fieldMask.size == 1 && fieldMask.contains("project.status")
+                if (!isOnlyStatusUpdate) {
+                    throw FailedPreconditionException(
+                        "The project is archived and therefore only the 'status' field can be updated.",
+                    )
+                }
+                if (
+                    requestedStatus != ProjectStatus.PROJECT_STATUS_ACTIVE &&
+                    requestedStatus != ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED &&
+                    requestedStatus != ProjectStatus.PROJECT_STATUS_ARCHIVED
+                ) {
+                    throw FailedPreconditionException(
+                        "An archived project can only be unarchived by setting its status to ACTIVE or ACTIVE_LOCKED.",
+                    )
+                }
+            }
+
+            ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED -> {
+                // all project settings are SLR settings
+                val isChangingSettings = fieldMask.any { it.startsWith("project.settings.") }
+                if (isChangingSettings) {
+                    throw FailedPreconditionException(
+                        "The project is locked and therefore no SLR settings can be modified.",
+                    )
+                }
+            }
+
+            ProjectStatus.PROJECT_STATUS_ACTIVE -> {}
+
+            ProjectStatus.PROJECT_STATUS_UNSPECIFIED,
+            ProjectStatus.UNRECOGNIZED,
+            -> {
+                error("Project is an unspecified status: $currentStatus")
+            }
+        }
+    }
+
+    /**
+     * Determines the effective status of a project based on the current status and the requested status.
+     *
+     * If the requested status is ACTIVE or ACTIVE_LOCKED, it checks if the project has any papers with reviews. If so,
+     * the project is ACTIVE_LOCKED; otherwise, it is set to ACTIVE.
+     * If the requested status is not an active status, it is returned unchanged.
+     *
+     * @param projectId The ID of the project to be updated.
+     * @param requestedStatus The status that is requested for the project.
+     * @return The final status of the project.
+     */
+    private suspend fun determineEffectiveProjectStatus(
+        projectId: UUID,
+        requestedStatus: ProjectStatus,
+    ): ProjectStatus {
+        if (requestedStatus != ProjectStatus.PROJECT_STATUS_ACTIVE &&
+            requestedStatus != ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+        ) {
+            return requestedStatus
+        }
+
+        return if (repo.isProjectLocked(projectId)) {
+            ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+        } else {
+            ProjectStatus.PROJECT_STATUS_ACTIVE
+        }
     }
 
     override suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List =

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -178,12 +178,12 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
     inner class UpdateProject {
         @ParameterizedTest(name = "Update the fields {0}")
         @MethodSource("se.uulm.snowballr.backend.repository.ProjectTableRepoTest#validFieldMasks")
-        fun `When a project is active and updated, then only the fields specified in the field mask are updated and the updated project is returned`(
+        fun `When a project is updated, then only the fields specified in the field mask are updated and the updated project is returned`(
             fieldMask: List<String>,
         ) = runTest {
-            val projectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE
+            val originalStatus = ProjectStatus.PROJECT_STATUS_ACTIVE
             val projectId =
-                insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
+                insertProjectAndGetId(name = "Test Project", originalStatus, createdBy = testUserId)
             val originalProject = repo.getProjectById(projectId).getOrThrow()
 
             val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
@@ -203,7 +203,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
                 .setMask(FieldMaskUtil.fromStringList(fieldMask))
                 .build()
 
-            val updatedProject = repo.updateProject(request, projectStatus)
+            val updatedProject = repo.updateProject(request)
 
             if ("project.name" in fieldMask) {
                 assertEquals("Updated Project", updatedProject.name)
@@ -213,7 +213,7 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
             if ("project.status" in fieldMask) {
                 assertEquals(ProjectStatus.PROJECT_STATUS_ARCHIVED, updatedProject.status)
             } else {
-                assertEquals(projectStatus, updatedProject.status)
+                assertEquals(originalStatus, updatedProject.status)
             }
             if ("project.settings.similarity_threshold" in fieldMask) {
                 assertEquals(1F, updatedProject.similarityThreshold)
@@ -230,90 +230,6 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
             } else {
                 assertTrue(updatedProject.reviewMaybeAllowed)
             }
-        }
-
-        @ParameterizedTest(name = "Update the fields {0}")
-        @MethodSource("se.uulm.snowballr.backend.repository.ProjectTableRepoTest#validFieldMasks")
-        fun `When a project is active locked and updated, then only the project name and status are updated and the updated project is returned`(
-            fieldMask: List<String>,
-        ) = runTest {
-            val projectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
-            val projectId =
-                insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
-            val originalProject = repo.getProjectById(projectId).getOrThrow()
-
-            val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
-                .setName("Updated Project")
-                .setStatus(ProjectStatus.PROJECT_STATUS_ARCHIVED)
-                .setSettings(
-                    Project.Settings.newBuilder()
-                        .setSimilarityThreshold(1F)
-                        .setSnowballingType(SnowballingType.SNOWBALLING_TYPE_FORWARD)
-                        .setReviewMaybeAllowed(false)
-                        .build(),
-                )
-                .build()
-
-            val request = Project.Update.newBuilder()
-                .setProject(updatedProjectDetails)
-                .setMask(FieldMaskUtil.fromStringList(fieldMask))
-                .build()
-
-            val updatedProject = repo.updateProject(request, projectStatus)
-
-            if ("project.name" in fieldMask) {
-                assertEquals("Updated Project", updatedProject.name)
-            } else {
-                assertEquals("Test Project", updatedProject.name)
-            }
-            if ("project.status" in fieldMask) {
-                assertEquals(ProjectStatus.PROJECT_STATUS_ARCHIVED, updatedProject.status)
-            } else {
-                assertEquals(projectStatus, updatedProject.status)
-            }
-            assertEquals(0F, updatedProject.similarityThreshold)
-            assertEquals(SnowballingType.SNOWBALLING_TYPE_BOTH, updatedProject.snowballingType)
-            assertTrue(updatedProject.reviewMaybeAllowed)
-        }
-
-        @ParameterizedTest(name = "Update the fields {0}")
-        @MethodSource("se.uulm.snowballr.backend.repository.ProjectTableRepoTest#validFieldMasks")
-        fun `When a project is archived and updated, then only the project status is updated and the updated project is returned`(
-            fieldMask: List<String>,
-        ) = runTest {
-            val projectStatus = ProjectStatus.PROJECT_STATUS_ARCHIVED
-            val projectId =
-                insertProjectAndGetId(name = "Test Project", projectStatus, createdBy = testUserId)
-            val originalProject = repo.getProjectById(projectId).getOrThrow()
-
-            val updatedProjectDetails = originalProject.toGrpcProject().toBuilder()
-                .setName("Updated Project")
-                .setStatus(ProjectStatus.PROJECT_STATUS_ACTIVE)
-                .setSettings(
-                    Project.Settings.newBuilder()
-                        .setSimilarityThreshold(1F)
-                        .setSnowballingType(SnowballingType.SNOWBALLING_TYPE_FORWARD)
-                        .setReviewMaybeAllowed(false)
-                        .build(),
-                )
-                .build()
-
-            val request = Project.Update.newBuilder()
-                .setProject(updatedProjectDetails)
-                .setMask(FieldMaskUtil.fromStringList(fieldMask))
-                .build()
-
-            val updatedProject = repo.updateProject(request, projectStatus)
-
-            assertEquals("Test Project", updatedProject.name)
-            if ("project.status" in fieldMask) {
-                assertEquals(ProjectStatus.PROJECT_STATUS_ACTIVE, updatedProject.status)
-            } else {
-                assertEquals(projectStatus, updatedProject.status)
-            }
-            assertEquals(0F, updatedProject.similarityThreshold)
-            assertEquals(SnowballingType.SNOWBALLING_TYPE_BOTH, updatedProject.snowballingType)
-            assertTrue(updatedProject.reviewMaybeAllowed)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -19,10 +19,16 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertUserAndGetId
+import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
+import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
+import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass.Project
@@ -32,7 +38,8 @@ import snowballr.ProjectOuterClass.SnowballingType
 import java.sql.SQLException
 import java.util.UUID
 
-class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable), true) {
+class ProjectTableRepoTest :
+    RepositoryTest(arrayOf(ProjectTable, ProjectMemberTable, ProjectPaperTable, PaperTable, ReviewTable), true) {
     private val repo = ProjectTableRepo(db)
 
     companion object {
@@ -379,5 +386,38 @@ class ProjectTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectMemberT
                     )
                 }
             }
+    }
+
+    @Nested
+    inner class IsProjectLocked {
+        @Test
+        fun `When a project has no project papers, then the project is not locked`() = runTest {
+            val projectId =
+                insertProjectAndGetId(status = ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+
+            assertFalse(repo.isProjectLocked(projectId))
+        }
+
+        @Test
+        fun `When a project has project papers without reviews, then the project is not locked`() = runTest {
+            val projectId =
+                insertProjectAndGetId(status = ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+
+            assertFalse(repo.isProjectLocked(projectId))
+        }
+
+        @Test
+        fun `When a project has project papers with reviews, then the project is locked`() = runTest {
+            val projectId =
+                insertProjectAndGetId(status = ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            insertReviewAndGetId(projectPaperId, userId = testUserId)
+
+            assertTrue(repo.isProjectLocked(projectId))
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -30,9 +30,9 @@ class UpdateProjectTest : MainServiceTest() {
         val status = ProjectStatus.valueOf(statusName)
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(status = status)
-        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
+        val updatedProject = DataBuilder.createExampleProject(id = project.id)
 
-        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
+        val updateFieldMask = FieldMaskUtil.fromString("project.status")
         val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
@@ -42,7 +42,8 @@ class UpdateProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
+        coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
+        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
         assertDoesNotThrow { mainService.updateProject(request) }
     }
@@ -61,9 +62,9 @@ class UpdateProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(status = status)
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
 
-        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
+        val updatedProject = DataBuilder.createExampleProject(id = project.id)
 
-        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
+        val updateFieldMask = FieldMaskUtil.fromString("project.status")
         val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
@@ -73,7 +74,8 @@ class UpdateProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.updateProject(request, project.status) } returns updatedProject
+        coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
+        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
         assertDoesNotThrow { mainService.updateProject(request) }
     }
@@ -84,7 +86,6 @@ class UpdateProjectTest : MainServiceTest() {
             "PROJECT_STATUS_ACTIVE",
             "PROJECT_STATUS_ACTIVE_LOCKED",
             "PROJECT_STATUS_ARCHIVED",
-            "PROJECT_STATUS_DELETED",
         ],
     )
     fun `When a project member updates a project, then an UnauthorizedException is thrown`(statusName: String) =
@@ -92,9 +93,9 @@ class UpdateProjectTest : MainServiceTest() {
             val status = ProjectStatus.valueOf(statusName)
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject(status = status)
-            val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
+            val updatedProject = DataBuilder.createExampleProject(id = project.id)
 
-            val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
+            val updateFieldMask = FieldMaskUtil.fromString("project.status")
             val request = GrpcProject.Update
                 .newBuilder()
                 .setProject(updatedProject.toGrpcProject())
@@ -102,26 +103,22 @@ class UpdateProjectTest : MainServiceTest() {
                 .build()
 
             mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException.Single> { mainService.updateProject(request) }
         }
 
     @Test
-    fun `When a server admin updates project to the project status DELETED, then a FailedPreconditionException is thrown`() =
+    fun `When a server admin updates project to the project status DELETED, then a IllegalArgumentException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(
-                status = ProjectStatus.PROJECT_STATUS_ACTIVE,
-            )
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
             val updatedProject = DataBuilder.createExampleProject(
                 id = project.id,
-                name = "Updated Project",
                 status = ProjectStatus.PROJECT_STATUS_DELETED,
             )
 
-            val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
+            val updateFieldMask = FieldMaskUtil.fromString("project.status")
             val request = GrpcProject.Update
                 .newBuilder()
                 .setProject(updatedProject.toGrpcProject())
@@ -132,45 +129,16 @@ class UpdateProjectTest : MainServiceTest() {
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
-            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
-        }
-
-    @Test
-    fun `When a project admin updates project to the project status DELETED, then a FailedPreconditionException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(
-                status = ProjectStatus.PROJECT_STATUS_ACTIVE,
-            )
-            val updatedProject = DataBuilder.createExampleProject(
-                id = project.id,
-                name = "Updated Project",
-                status = ProjectStatus.PROJECT_STATUS_DELETED,
-            )
-            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-
-            val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name", "status"))
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-
-            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
+            assertThrows<IllegalArgumentException> { mainService.updateProject(request) }
         }
 
     @Test
     fun `When a server admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectStatus.PROJECT_STATUS_DELETED,
-        )
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_DELETED)
         val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
-        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
+
+        val updateFieldMask = FieldMaskUtil.fromString("project.name")
         val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
@@ -185,15 +153,41 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a project admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectStatus.PROJECT_STATUS_DELETED,
-        )
-        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
-        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+    fun `When a server admin updates an archived project except the status, then a FailedPreconditionException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val updatedProject =
+                DataBuilder.createExampleProject(id = project.id, name = "Updated Project", reviewMaybeAllowed = false)
 
-        val updateFieldMask = FieldMaskUtil.fromStringList(listOf("name"))
+            val updateFieldMask =
+                FieldMaskUtil.fromStringList(listOf("project.name", "project.settings.reviewMaybeAllowed"))
+            val request = GrpcProject.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
+        }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_ACTIVE_LOCKED"],
+    )
+    fun `When a server admin updates an archived project to an active status, then no exception is thrown`(
+        statusName: String,
+    ) = runTest {
+        val status = ProjectStatus.valueOf(statusName)
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+        val updatedProject = DataBuilder.createExampleProject(id = project.id, status = status)
+
+        val updateFieldMask = FieldMaskUtil.fromString("project.status")
         val request = GrpcProject.Update
             .newBuilder()
             .setProject(updatedProject.toGrpcProject())
@@ -202,8 +196,135 @@ class UpdateProjectTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.isProjectLocked(project.id) } returns
+            (updatedProject.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-        assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
+        assertDoesNotThrow { mainService.updateProject(request) }
     }
+
+    @Test
+    fun `When a server admin updates an archived project to the archived status, then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val updatedProject = DataBuilder.createExampleProject(
+                id = project.id,
+                status = ProjectStatus.PROJECT_STATUS_ARCHIVED,
+            )
+
+            val updateFieldMask = FieldMaskUtil.fromString("project.status")
+            val request = GrpcProject.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+
+            assertDoesNotThrow { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When a server admin updates the project settings of an active locked project, then a FailedPreconditionException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            val updatedProject = DataBuilder.createExampleProject(id = project.id, reviewMaybeAllowed = false)
+
+            val updateFieldMask = FieldMaskUtil.fromString("project.settings.reviewMaybeAllowed")
+            val request = GrpcProject.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When a server admin updates an active locked project except the project settings, then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+            val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
+
+            val updateFieldMask = FieldMaskUtil.fromString("project.name")
+            val request = GrpcProject.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
+            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+
+            assertDoesNotThrow { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When a server admin updates active project, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
+        val updatedProject = DataBuilder.createExampleProject(
+            id = project.id,
+            name = "Updated Project",
+            reviewMaybeAllowed = false,
+        )
+
+        val updateFieldMask =
+            FieldMaskUtil.fromStringList(listOf("project.name", "project.settings.reviewMaybeAllowed"))
+        val request = GrpcProject.Update
+            .newBuilder()
+            .setProject(updatedProject.toGrpcProject())
+            .setMask(updateFieldMask)
+            .build()
+
+        mockCurrentUser(user)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
+        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+
+        assertDoesNotThrow { mainService.updateProject(request) }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "PROJECT_STATUS_UNSPECIFIED",
+            "UNRECOGNIZED",
+        ],
+    )
+    fun `When a project has an unspecified status, then an IllegalStateException is thrown`(statusName: String) =
+        runTest {
+            val status = ProjectStatus.valueOf(statusName)
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject(status = status)
+            val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
+
+            val updateFieldMask = FieldMaskUtil.fromString("project.name")
+            val request = GrpcProject.Update
+                .newBuilder()
+                .setProject(updatedProject.toGrpcProject())
+                .setMask(updateFieldMask)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+            assertThrows<IllegalStateException> { mainService.updateProject(request) }
+        }
 }


### PR DESCRIPTION
Closes #314 

## What I have made

- Added `isProjectLocked()` function in `projectTableRepo` + tests
- Updated `updateProject()` function in `projectService` + tests
  - Removed status checks from `projectTableRepo`'s `updateProject()` function

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
