### PR TITLE
Implement `getNextPaper` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -214,7 +214,7 @@ class SnowballRServer(
             mainService.getPapersToReviewForProject(request)
 
         override suspend fun getNextPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
-            super.getNextPaper(request)
+            mainService.getNextPaper(request)
 
         override suspend fun getNextPaperToReview(request: Base.Id): ProjectOuterClass.Project.Paper =
             super.getNextPaperToReview(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -2,11 +2,13 @@ package se.uulm.snowballr.backend.repository.association
 
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
@@ -69,6 +71,16 @@ interface IProjectPaperTableRepo {
      * @return A list of [ProjectPaper] instances associated with the given project.
      */
     suspend fun getAllProjectPapersForProject(projectId: UUID): List<ProjectPaper>
+
+    /**
+     * Retrieves the succeeding local paper ID for the project paper with the given local paper ID.
+     *
+     * @param projectId The unique identifier of the project for which the next local paper ID is being requested.
+     * @param localPaperId The current local paper ID used as a reference to compute the next ID.
+     * @return A [Result] containing the next available local paper ID as a [Long] or a [FailedPreconditionException]
+     * if it cannot be determined.
+     */
+    suspend fun getNextPaperLocalId(projectId: UUID, localPaperId: Long): Result<Long>
 
     /**
      * Retrieves a list of project papers along with their associated papers for the specified project.
@@ -168,6 +180,28 @@ class ProjectPaperTableRepo(
 
     override suspend fun getAllProjectPapersForProject(projectId: UUID): List<ProjectPaper> = db.query {
         ProjectPaperTable.getEntities(ResultRow::toProjectPaper) { ProjectPaperTable.projectId eq projectId }
+    }
+
+    override suspend fun getNextPaperLocalId(projectId: UUID, localPaperId: Long): Result<Long> = db.query {
+        val nextId = ProjectPaperTable
+            .selectAll()
+            .where {
+                (ProjectPaperTable.projectId eq projectId) and
+                    (ProjectPaperTable.localPaperId greater localPaperId)
+            }
+            .orderBy(ProjectPaperTable.localPaperId, SortOrder.ASC)
+            .map { it[ProjectPaperTable.localPaperId] }
+            .firstOrNull()
+
+        if (nextId != null) {
+            Result.success(nextId)
+        } else {
+            Result.failure(
+                FailedPreconditionException(
+                    "There is no next project paper in the project.",
+                ),
+            )
+        }
     }
 
     override suspend fun getAllProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -65,6 +65,11 @@ interface IProjectPaperService {
      * Service implementation of [SnowballRService.addPaperToProject].
      */
     suspend fun addPaperToProject(request: GrpcProjectPaper.Add): GrpcProjectPaper
+
+    /**
+     * Service implementation of [SnowballRService.getNextPaper].
+     */
+    suspend fun getNextPaper(request: Base.Id): GrpcProjectPaper
 }
 
 /**
@@ -238,4 +243,18 @@ class ProjectPaperService(
 
             projectPaper.toGrpcProjectPaperWithData(paper)
         }
+
+    override suspend fun getNextPaper(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
+        val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
+        val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+
+        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+
+        val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
+        val nextProjectPaperId = repo.getNextPaperLocalId(projectId, projectPaper.localPaperId).getOrThrow()
+        val nextProjectPaper = repo.getProjectPaperByRelativeId(projectId, nextProjectPaperId).getOrThrow()
+        val paper = paperRepo.getPaperById(nextProjectPaper.paperId).getOrThrow()
+
+        nextProjectPaper.toGrpcProjectPaperWithData(paper)
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -42,7 +42,7 @@ fun isProjectActive() = AccessRule<Project> { _, project ->
  * @param projectMemberRepo The project member repository used to retrieve a project member list.
  */
 @CheckReturnValue
-private fun isProjectMember(projectMemberRepo: IProjectMemberTableRepo) = AccessRule<UUID> { requester, targetId ->
+fun isProjectMember(projectMemberRepo: IProjectMemberTableRepo) = AccessRule<UUID> { requester, targetId ->
     val projectMembers = projectMemberRepo.getProjectMembers(targetId)
     projectMembers.any { it.userId == requester.id }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
 import se.uulm.snowballr.backend.repository.PaperTableRepo
@@ -175,6 +176,55 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             assertThat(result).anyMatch { it.id == projectPaperId1 }
             assertThat(result).anyMatch { it.id == projectPaperId2 }
         }
+    }
+
+    @Nested
+    inner class GetNextPaperLocalId {
+        @Test
+        fun `When a project paper with a succeeding local paper ID exists, then the local paper ID of this paper is returned`() =
+            runTest {
+                val projectId =
+                    insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val projectPaperId = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    localPaperId = 1,
+                    createdBy = testUserId,
+                )
+                insertProjectPaperAndGetId(
+                    paperId = paperId2,
+                    projectId = projectId,
+                    localPaperId = 3,
+                    createdBy = testUserId,
+                )
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+
+                val nextPaperLocalId = repo.getNextPaperLocalId(projectId, projectPaper.localPaperId)
+
+                val result = assertResultSuccess(nextPaperLocalId)
+                assertEquals(3, result)
+            }
+
+        @Test
+        fun `When no project paper with a succeeding local paper ID exists, then a FailedPreconditionException is returned`() =
+            runTest {
+                val projectId =
+                    insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val projectPaperId = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    localPaperId = 1,
+                    createdBy = testUserId,
+                )
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+
+                val nextPaperLocalId = repo.getNextPaperLocalId(projectId, projectPaper.localPaperId)
+
+                assertResultFailure<FailedPreconditionException>(nextPaperLocalId)
+            }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -1,0 +1,121 @@
+package se.uulm.snowballr.backend.service.projectpaper
+
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+class GetNextPaperTest : MainServiceTest() {
+    private val projectPaperId = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(projectPaperId.toString()).build()
+
+    @Test
+    fun `When a server admin requests the next project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper =
+            DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id, paperId = paper.id)
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
+        val nextRelativeId = 1L
+        val author = DataBuilder.createExampleAuthor()
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
+        coEvery {
+            projectPaperRepoMock.getNextPaperLocalId(project.id, projectPaper.localPaperId)
+        } returns Result.success(nextRelativeId)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, nextRelativeId)
+        } returns Result.success(nextProjectPaper)
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getNextPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member requests the next project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper =
+            DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id, paperId = paper.id)
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val nextRelativeId = 1L
+        val author = DataBuilder.createExampleAuthor()
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
+        coEvery {
+            projectPaperRepoMock.getNextPaperLocalId(project.id, projectPaper.localPaperId)
+        } returns Result.success(nextRelativeId)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, nextRelativeId)
+        } returns Result.success(nextProjectPaper)
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getNextPaper(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member requests the next project paper, then an UnauthorizedException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.success(projectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+            assertThrows<UnauthorizedException> { mainService.getNextPaper(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When no next paper exists, then a FailedPreconditionException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper =
+            DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id, paperId = paper.id)
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
+        coEvery {
+            projectPaperRepoMock.getNextPaperLocalId(project.id, projectPaper.localPaperId)
+        } returns Result.failure(FailedPreconditionException("No next paper exists"))
+
+        assertThrows<FailedPreconditionException> { mainService.getNextPaper(getExampleRequest()) }
+    }
+}


### PR DESCRIPTION
Closes #100 

## What I have made

I have implemented the service layer and the according tests for the `getNextPaper` call. Additionally, I added a repo method to retrieve the succeeding local paper ID of a given local paper ID as well as tests for the method.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
