### PR TITLE
Implement `updateProjectmemberRole`

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -305,7 +305,7 @@ class SnowballRServer(
         ): ProjectOuterClass.Project.Information.DecisionStatistics = super.getDecisionStatisticsForStage(request)
 
         override suspend fun updateProjectMemberRole(request: ProjectOuterClass.Project.Member.Update): Base.Nothing =
-            super.updateProjectMemberRole(request)
+            mainService.updateProjectMemberRole(request)
 
         override suspend fun getCriterionById(request: Base.Id): CriterionOuterClass.Criterion =
             mainService.getCriterionById(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -61,13 +61,14 @@ interface IProjectMemberTableRepo {
     suspend fun getAllProjectAdmins(projectId: UUID): List<ProjectMember>
 
     /**
-     * Promotes a project member to an admin role in the specified project.
+     * Updates the role of a project member.
      *
      * @param projectId The unique identifier of the project to which the member belongs.
-     * @param userId The unique identifier of the user to be promoted to admin.
-     * @return The updated [ProjectMember] including the new role as an admin.
+     * @param userId The unique identifier of the user whose role is to be updated.
+     * @param role The new role to be assigned to the project member.
+     * @return The updated [ProjectMember] with the new role.
      */
-    suspend fun promoteProjectMemberToAdmin(projectId: UUID, userId: UUID): ProjectMember
+    suspend fun updateProjectMemberRole(projectId: UUID, userId: UUID, role: MemberRole): ProjectMember
 
     /**
      * Retrieves a list of all project members along with their associated user details for a given project.
@@ -152,18 +153,19 @@ class ProjectMemberTableRepo(
         }
     }
 
-    override suspend fun promoteProjectMemberToAdmin(projectId: UUID, userId: UUID): ProjectMember = db.query {
-        ProjectMemberTable.updateAndGet(
-            mapper = ResultRow::toProjectMember,
-            entityType = EntityType.PROJECT_MEMBER,
-            id = projectId.toString(),
-            where = {
-                (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId)
-            },
-        ) {
-            it[role] = MemberRole.MEMBER_ROLE_ADMIN
+    override suspend fun updateProjectMemberRole(projectId: UUID, userId: UUID, role: MemberRole): ProjectMember =
+        db.query {
+            ProjectMemberTable.updateAndGet(
+                mapper = ResultRow::toProjectMember,
+                entityType = EntityType.PROJECT_MEMBER,
+                id = projectId.toString(),
+                where = {
+                    (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId)
+                },
+            ) {
+                it[ProjectMemberTable.role] = role
+            }
         }
-    }
 
     override suspend fun getProjectMembersWithUsers(projectId: UUID): List<ProjectMemberWithUser> = db.query {
         ProjectMemberTable

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -6,6 +6,7 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
@@ -27,12 +28,14 @@ import se.uulm.snowballr.backend.service.accessrules.isServerAdminOrSameUser
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
+import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.ProjectStatus
 import kotlin.getOrThrow
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
+@Suppress("ComplexInterface")
 interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectById].
@@ -78,6 +81,11 @@ interface IProjectService {
      * Service implementation of [SnowballRService.getProjectInformation].
      */
     suspend fun getProjectInformation(request: GrpcProject.Information.Get): GrpcProject.Information
+
+    /**
+     * Service implementation of [SnowballRService.updateProjectMemberRole].
+     */
+    suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update): Base.Nothing
 }
 
 /**
@@ -93,6 +101,7 @@ interface IProjectService {
  * @param projectPaperRepo The repository responsible for managing persistence operations for project papers.
  * @param criterionRepo The repository responsible for managing persistence operations for criteria.
  */
+@Suppress("TooManyFunctions")
 class ProjectService(
     private val repo: IProjectTableRepo,
     private val userRepo: IUserTableRepo,
@@ -237,4 +246,35 @@ class ProjectService(
 
             builder.build()
         }
+
+    override suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update): Base.Nothing {
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+            val userId = parseUUID(request.userId, EntityType.USER)
+
+            isServerOrProjectAdmin(projectMemberRepo, AccessType.UPDATE).checkFor(currentUser, projectId)
+
+            repo.getProjectById(projectId).getOrThrow()
+            userRepo.getUserById(userId).getOrThrow()
+
+            val currentMember = try {
+                projectMemberRepo.getProjectMemberByComposedId(projectId, userId).getOrThrow()
+            } catch (_: NotFoundException) {
+                throw FailedPreconditionException(
+                    "User with ID '$userId' is not a member of project with ID '$projectId'.",
+                )
+            }
+
+            if (currentMember.role == MemberRole.MEMBER_ROLE_ADMIN && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
+                val projectAdmins = projectMemberRepo.getAllProjectAdmins(projectId)
+                if (projectAdmins.size <= 1) {
+                    throw FailedPreconditionException("Cannot demote the last admin of a project.")
+                }
+            }
+
+            projectMemberRepo.updateProjectMemberRole(projectId, userId, request.newRole)
+        }
+
+        return Base.Nothing.getDefaultInstance()
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -129,7 +129,7 @@ class ProjectService(
         }
 
         projectMemberRepo.addUserToProject(currentUser.id, project.id)
-        projectMemberRepo.promoteProjectMemberToAdmin(project.id, currentUser.id)
+        projectMemberRepo.updateProjectMemberRole(project.id, currentUser.id, MemberRole.MEMBER_ROLE_ADMIN)
 
         project.toGrpcProject()
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -13,6 +13,7 @@ import snowballr.ProjectOuterClass.Project.Create
 /**
  * A validator for [Project] related requests.
  */
+@Suppress("StringLiteralDuplication")
 object ProjectValidator {
     const val NAME_MAX_LENGTH = 100
     const val SIMILARITY_THRESHOLD_MIN_VALUE = 0.0f
@@ -93,6 +94,12 @@ object ProjectValidator {
 
         either { ensureIdValidity("project_id", request.projectId) }.toEitherNel().bind()
     }
+
+    fun validateMemberUpdateRequest(request: Project.Member.Update): EitherNel<ValidationIssue, Unit> = either {
+        ensureIdValidity("project_id", request.projectId)
+        ensureIdValidity("user_id", request.userId)
+        ensureEnumNotUnspecified("new_role", request.newRole)
+    }.toEitherNel()
 
     /**
      * Ensures that the provided project name is valid.

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -73,7 +73,7 @@ object ProjectValidator {
     }
 
     fun validateInviteRequest(request: Project.Member.Invite): EitherNel<ValidationIssue, Unit> = either {
-        ensureFieldNonBlank("projectId", request.projectId)
+        ensureIdValidity("project_id", request.projectId)
         ensureEmailValidity(request.userEmail)
     }.toEitherNel()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -43,6 +43,8 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is ProjectOuterClass.Project.Member.Invite -> ProjectValidator.validateInviteRequest(request)
     is ProjectOuterClass.Project.Member.Accept -> ProjectValidator.validateAcceptRequest(request)
     is ProjectOuterClass.Project.Information.Get -> ProjectValidator.validateGetInformationRequest(request)
+    // Project Member
+    is ProjectOuterClass.Project.Member.Update -> ProjectValidator.validateMemberUpdateRequest(request)
     // Project Paper
     is ProjectOuterClass.Project.Paper.Get -> ProjectPaperValidator.validateGetRequest(request)
     is ProjectOuterClass.Project.Paper.Add -> ProjectPaperValidator.validateAddRequest(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -195,8 +195,8 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, firstMember.role)
                 assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, secondMember.role)
 
-                repo.promoteProjectMemberToAdmin(projectId, firstMember.userId)
-                repo.promoteProjectMemberToAdmin(projectId, secondMember.userId)
+                repo.updateProjectMemberRole(projectId, firstMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
+                repo.updateProjectMemberRole(projectId, secondMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
 
                 val projectAdmins = repo.getAllProjectAdmins(projectId)
 
@@ -216,7 +216,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, firstMember.role)
                 assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, secondMember.role)
 
-                repo.promoteProjectMemberToAdmin(projectId, firstMember.userId)
+                repo.updateProjectMemberRole(projectId, firstMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
 
                 val projectAdmins = repo.getAllProjectAdmins(projectId)
 
@@ -235,7 +235,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 val normalMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
                 assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, normalMember.role)
 
-                val promotedMember = repo.promoteProjectMemberToAdmin(projectId, testUserId)
+                val promotedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
 
                 assertEquals(projectId, promotedMember.projectId)
                 assertEquals(testUserId, promotedMember.userId)
@@ -245,14 +245,30 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         @Test
         fun `When a project admin is promoted, then the role of the project admin does not change`() = runTest {
             val (projectId, _) = setupProject()
-            var promotedMember = repo.promoteProjectMemberToAdmin(projectId, testUserId)
+            var promotedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
             assertEquals(MemberRole.MEMBER_ROLE_ADMIN, promotedMember.role)
 
-            promotedMember = repo.promoteProjectMemberToAdmin(projectId, testUserId)
+            promotedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
 
             assertEquals(projectId, promotedMember.projectId)
             assertEquals(testUserId, promotedMember.userId)
             assertEquals(MemberRole.MEMBER_ROLE_ADMIN, promotedMember.role)
+        }
+    }
+
+    @Nested
+    inner class UpdateProjectMemberRole {
+        @Test
+        fun `When a project member is updated, then the role of the project member is correctly updated`() = runTest {
+            val (projectId, _) = setupProject()
+            val normalMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
+            assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, normalMember.role)
+
+            val updatedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
+
+            assertEquals(projectId, updatedMember.projectId)
+            assertEquals(testUserId, updatedMember.userId)
+            assertEquals(MemberRole.MEMBER_ROLE_ADMIN, updatedMember.role)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -25,7 +25,13 @@ class CreateProjectTest : MainServiceTest() {
         val projectAdmin = DataBuilder.createExampleProjectMember(project.id, user.id, MemberRole.MEMBER_ROLE_ADMIN)
 
         coEvery { projectMemberRepoMock.addUserToProject(user.id, project.id) } returns projectMember
-        coEvery { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, user.id) } returns projectAdmin
+        coEvery {
+            projectMemberRepoMock.updateProjectMemberRole(
+                project.id,
+                user.id,
+                MemberRole.MEMBER_ROLE_ADMIN,
+            )
+        } returns projectAdmin
     }
 
     @Test
@@ -44,7 +50,13 @@ class CreateProjectTest : MainServiceTest() {
 
         coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), user.id) }
         coVerify(exactly = 1) { projectMemberRepoMock.addUserToProject(user.id, project.id) }
-        coVerify(exactly = 1) { projectMemberRepoMock.promoteProjectMemberToAdmin(project.id, user.id) }
+        coVerify(exactly = 1) {
+            projectMemberRepoMock.updateProjectMemberRole(
+                project.id,
+                user.id,
+                MemberRole.MEMBER_ROLE_ADMIN,
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectMemberRoleTest.kt
@@ -1,0 +1,265 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.IdentifierType
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.MemberRole
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+class UpdateProjectMemberRoleTest : MainServiceTest() {
+    @Test
+    fun `When a server admin updates a member role of a user in a non-existent project, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val nonExistentProjectId = UUID.randomUUID()
+
+            val request = ProjectOuterClass.Project.Member.Update
+                .newBuilder()
+                .setProjectId(nonExistentProjectId.toString())
+                .setUserId(userToBeUpdated.id.toString())
+                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(nonExistentProjectId) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(nonExistentProjectId) } returns
+                Result.failure(TestSpecificException())
+
+            assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
+        }
+
+    @Test
+    fun `When a server admin updates a member role of a non-existent user, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val nonExistentUserId = UUID.randomUUID()
+            val project = DataBuilder.createExampleProject()
+
+            val request = ProjectOuterClass.Project.Member.Update
+                .newBuilder()
+                .setProjectId(project.id.toString())
+                .setUserId(nonExistentUserId.toString())
+                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { userRepoMock.getUserById(nonExistentUserId) } returns
+                Result.failure(TestSpecificException())
+
+            assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
+        }
+
+    @Test
+    fun `When a server admin updates another member's role, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectMemberToBeUpdated =
+            DataBuilder.createExampleProjectMember(userId = userToBeUpdated.id, projectId = project.id)
+
+        val newRole = MemberRole.MEMBER_ROLE_ADMIN
+        val updatedUser = DataBuilder.createExampleProjectMember(
+            userId = userToBeUpdated.id,
+            projectId = project.id,
+            role = newRole,
+        )
+
+        val request = ProjectOuterClass.Project.Member.Update
+            .newBuilder()
+            .setProjectId(project.id.toString())
+            .setUserId(userToBeUpdated.id.toString())
+            .setNewRole(newRole)
+            .build()
+
+        mockCurrentUser(user)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
+        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
+            Result.success(projectMemberToBeUpdated)
+        coEvery { projectMemberRepoMock.updateProjectMemberRole(project.id, userToBeUpdated.id, newRole) } returns
+            updatedUser
+
+        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
+    }
+
+    @Test
+    fun `When a project admin updates another member's role, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val projectAdminMember = DataBuilder.createExampleProjectMember(
+            role = MemberRole.MEMBER_ROLE_ADMIN,
+            userId = user.id,
+        )
+        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectMemberToBeUpdated = DataBuilder.createExampleProjectMember(
+            userId = userToBeUpdated.id,
+            projectId = project.id,
+        )
+
+        val newRole = MemberRole.MEMBER_ROLE_ADMIN
+        val updatedUser = DataBuilder.createExampleProjectMember(
+            userId = userToBeUpdated.id,
+            projectId = project.id,
+            role = newRole,
+        )
+
+        val request = ProjectOuterClass.Project.Member.Update
+            .newBuilder()
+            .setProjectId(project.id.toString())
+            .setUserId(userToBeUpdated.id.toString())
+            .setNewRole(newRole)
+            .build()
+
+        mockCurrentUser(user)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
+        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
+            Result.success(projectMemberToBeUpdated)
+        coEvery { projectMemberRepoMock.updateProjectMemberRole(project.id, userToBeUpdated.id, newRole) } returns
+            updatedUser
+
+        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
+    }
+
+    @Test
+    fun `When a project member updates another member's role, then an UnauthorizedException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+
+        val request = ProjectOuterClass.Project.Member.Update
+            .newBuilder()
+            .setProjectId(project.id.toString())
+            .setUserId(userToBeUpdated.id.toString())
+            .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+            .build()
+
+        mockCurrentUser(user)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+
+        assertThrows<UnauthorizedException> { mainService.updateProjectMemberRole(request) }
+    }
+
+    @Test
+    fun `When an admin updates the member role of a user who is not a member of the project, then a FailedPrecondition is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+
+            val request = ProjectOuterClass.Project.Member.Update
+                .newBuilder()
+                .setProjectId(project.id.toString())
+                .setUserId(userToBeUpdated.id.toString())
+                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+                .build()
+
+            mockCurrentUser(user)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
+            coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
+                Result.failure(
+                    NotFoundException(
+                        EntityType.PROJECT_MEMBER,
+                        user.id.toString(),
+                        project.id.toString(),
+                        identifierType = IdentifierType.ID,
+                    ),
+                )
+
+            assertThrows<FailedPreconditionException> { mainService.updateProjectMemberRole(request) }
+        }
+
+    @Test
+    fun `When a server admin demotes the last project admin, then a FailedPreconditionException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectAdminMember = DataBuilder.createExampleProjectMember(
+            role = MemberRole.MEMBER_ROLE_ADMIN,
+            userId = userToBeUpdated.id,
+        )
+
+        val request = ProjectOuterClass.Project.Member.Update
+            .newBuilder()
+            .setProjectId(project.id.toString())
+            .setUserId(userToBeUpdated.id.toString())
+            .setNewRole(MemberRole.MEMBER_ROLE_DEFAULT)
+            .build()
+
+        mockCurrentUser(user)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
+        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
+            Result.success(projectAdminMember)
+
+        assertThrows<FailedPreconditionException> { mainService.updateProjectMemberRole(request) }
+    }
+
+    @Test
+    fun `When multiple admins exist and one is demoted, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val user1ToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val user2ToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectAdminMember1 = DataBuilder.createExampleProjectMember(
+            role = MemberRole.MEMBER_ROLE_ADMIN,
+            userId = user1ToBeUpdated.id,
+        )
+        val projectAdminMember2 = DataBuilder.createExampleProjectMember(
+            role = MemberRole.MEMBER_ROLE_ADMIN,
+            userId = user2ToBeUpdated.id,
+        )
+
+        val newRole = MemberRole.MEMBER_ROLE_DEFAULT
+        val updatedUser = DataBuilder.createExampleProjectMember(
+            userId = user1ToBeUpdated.id,
+            projectId = project.id,
+            role = newRole,
+        )
+
+        val request = ProjectOuterClass.Project.Member.Update
+            .newBuilder()
+            .setProjectId(project.id.toString())
+            .setUserId(user1ToBeUpdated.id.toString())
+            .setNewRole(newRole)
+            .build()
+
+        mockCurrentUser(user)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(
+            projectAdminMember1, projectAdminMember2,
+        )
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { userRepoMock.getUserById(user1ToBeUpdated.id) } returns Result.success(user1ToBeUpdated)
+        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, user1ToBeUpdated.id) } returns
+            Result.success(projectAdminMember1)
+        coEvery {
+            projectMemberRepoMock.updateProjectMemberRole(
+                project.id,
+                user1ToBeUpdated.id,
+                newRole,
+            )
+        } returns updatedUser
+
+        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -292,7 +292,16 @@ class ProjectValidatorTest {
 
             val result = validateRequest(request)
 
-            assertInvalidResult<BlankField>(result)
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When the project ID is invalid, then the 'InvalidId' issue is returned`() {
+            val request = validInviteRequestBuilder.setProjectId("invalid-id").build()
+
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -13,6 +13,7 @@ import se.uulm.snowballr.backend.model.InvalidId
 import se.uulm.snowballr.backend.model.OutOfRangeValue
 import se.uulm.snowballr.backend.model.TooLongField
 import se.uulm.snowballr.backend.validation.ProjectValidator.NAME_MAX_LENGTH
+import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Create
 import snowballr.ProjectOuterClass.Project.Update
@@ -367,6 +368,68 @@ class ProjectValidatorTest {
             val result = validateRequest(request)
 
             assertInvalidResult<InvalidId>(result)
+        }
+    }
+
+    @Nested
+    inner class MemberUpdateRequest {
+        private val validMemberUpdateRequestBuilder = Project.Member.Update.newBuilder()
+            .setProjectId(UUID.randomUUID().toString())
+            .setUserId(UUID.randomUUID().toString())
+            .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+
+        @Test
+        fun `When a valid request is validated, the no issue is returned`() {
+            val request = validMemberUpdateRequestBuilder.build()
+
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When the project ID is blank, then the 'InvalidId' issue is returned`() {
+            val request = validMemberUpdateRequestBuilder.setProjectId("").build()
+
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When the project ID is invalid, then the 'InvalidId' issue is returned`() {
+            val request = validMemberUpdateRequestBuilder.setProjectId("invalid-id").build()
+
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When the user ID is blank, then the 'InvalidId' issue is returned`() {
+            val request = validMemberUpdateRequestBuilder.setUserId("").build()
+
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When the user ID is invalid, then the 'InvalidId' issue is returned`() {
+            val request = validMemberUpdateRequestBuilder.setUserId("invalid-id").build()
+
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When the new role is unspecified, then the 'EnumUnspecified' issue is returned`() {
+            val request = validMemberUpdateRequestBuilder.setNewRole(MemberRole.MEMBER_ROLE_UNSPECIFIED).build()
+
+            val result = validateRequest(request)
+
+            assertInvalidResult<EnumUnspecified>(result)
         }
     }
 }


### PR DESCRIPTION
Closes #80 

## What I have made

- Added `updateProjectMemberRole()` in `ProjectTableRepo` + tests
  - Refactored `promoteProjectMember()` to use the new update function
- Added `updateProjectMemberRole()` in `ProjectService` + tests

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
