### PR TITLE
Prevent updating of non-modifiable fields in `Update...` requests

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -143,6 +143,7 @@ data class InvalidFieldMask(val fieldMask: String?) : ValidationIssue {
     override fun toString(): String = if (fieldMask.isNullOrBlank()) {
         "Field mask must be not blank."
     } else {
-        "Field mask contains invalid fields: $fieldMask."
+        "Field mask $fieldMask contains invalid fields. A field is considered invalid, if it does not exist or " +
+            "corresponds to a field that cannot be changed."
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -127,14 +127,17 @@ data class InvalidPassword(
 }
 
 /**
- * Represents a validation issue where a provided field mask contains invalid fields or is blank.
+ * Represents a validation issue where a provided field mask is invalid.
  *
- * This class is utilized to indicate that some fields in the provided field mask
- * are not valid, i.e., do not exist in the generated gRPC class or the field mask is blank
- * and the entire object would be overwritten. If this is intended, every field should be specified
- * instead of leaving the field mask blank.
+ * This issue occurs when the field mask is not valid, i.e., it is either blank or contains at least one invalid field.
+ * If the field mask is blank the entire object would be overwritten.To prevent unintended overwrites, all intended
+ * fields should be explicitly listed in the field mask rather than leaving the mask empty.
  *
- * @property fieldMask The invalid field mask causing the issue.
+ * A field is considered invalid if:
+ *  - It does not exist in the corresponding generated gRPC class.
+ *  - It corresponds to a field that cannot be modified or set.
+ *
+ * @property fieldMask The invalid or empty field mask that caused the issue.
  */
 data class InvalidFieldMask(val fieldMask: String?) : ValidationIssue {
     override fun toString(): String = if (fieldMask.isNullOrBlank()) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -25,7 +25,11 @@ object ProjectValidator {
     fun validateUpdateRequest(request: Project.Update): EitherNel<ValidationIssue, Unit> = either {
         // Validate the field mask
         val fieldMaskResult = either {
-            ensureFieldMaskIsValid(request.mask, Project.Update.getDescriptor())
+            ensureFieldMaskIsValid(
+                request.mask,
+                Project.Update.getDescriptor(),
+                listOf("project.current_stage", "project.max_stage"),
+            )
         }
 
         // If field mask validation fails, return early

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/UserValidator.kt
@@ -16,7 +16,7 @@ object UserValidator {
     fun validateUpdateRequest(request: User.Update): EitherNel<ValidationIssue, Unit> = either {
         // Validate the field mask
         val fieldMaskResult = either {
-            ensureFieldMaskIsValid(request.mask, User.Update.getDescriptor())
+            ensureFieldMaskIsValid(request.mask, User.Update.getDescriptor(), listOf("user.status"))
         }
 
         // If field mask validation fails, return early

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -125,15 +125,24 @@ fun Raise<ValidationIssue>.ensureLastNameValidity(lastName: String) =
     ensureTextFieldValidity("last_name", lastName, LAST_NAME_MAX_LENGTH)
 
 /**
- * Ensures that the provided field mask contains only valid fields for the given object type and
- * is non-blank.
+ * Ensures that the provided field mask is non-blank and contains only fields that are valid and allowed for the given
+ * object type.
+ * If the field mask is not valid, a [InvalidFieldMask] validation issue is raised.
  *
  * @param fieldMask The [FieldMask] to validate.
  * @param descriptor The object descriptor to validate against.
+ * @param unallowedFields A list of paths that must not appear in the field mask.
  */
-fun Raise<ValidationIssue>.ensureFieldMaskIsValid(fieldMask: FieldMask, descriptor: Descriptor) {
+fun Raise<ValidationIssue>.ensureFieldMaskIsValid(
+    fieldMask: FieldMask,
+    descriptor: Descriptor,
+    unallowedFields: List<String> = emptyList(),
+) {
     ensure(fieldMask.pathsList.isNotEmpty()) { InvalidFieldMask(null) }
     ensure(FieldMaskUtil.isValid(descriptor, fieldMask)) {
+        InvalidFieldMask(fieldMask.toString())
+    }
+    ensure(fieldMask.pathsList.toSet().none { unallowedFields.contains(it) }) {
         InvalidFieldMask(fieldMask.toString())
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ProjectValidatorTest.kt
@@ -120,6 +120,16 @@ class ProjectValidatorTest {
         }
 
         @Test
+        fun `When a field mask contains the 'current_stage' or 'max_stage' field, then the 'InvalidFieldMask' issue is returned`() {
+            val request = validUpdateRequestBuilder
+                .setMask(FieldMaskUtil.fromStringList(listOf("project.current_stage", "project.max_stage")))
+                .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
         fun `When an invalid ID is validated, then the 'InvalidId' issue is returned`() {
             val project = validUpdatedProject.setId("invalid-id").build()
             val request = validUpdateRequestBuilder

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/UserValidatorTest.kt
@@ -66,6 +66,14 @@ class UserValidatorTest {
         }
 
         @Test
+        fun `When a field mask contains the 'status' field, then the 'InvalidFieldMask' issue is returned`() {
+            val request = validUpdateRequestBuilder.setMask(FieldMaskUtil.fromStringList(listOf("user.status"))).build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidFieldMask>(result)
+        }
+
+        @Test
         fun `When an invalid ID is validated, then the 'InvalidId' issue is returned`() {
             val user = validUpdatedUser.setId("invalid-id").build()
             val request = validUpdateRequestBuilder


### PR DESCRIPTION
Closes #318 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I extended the `ensureFieldMaskIsValid` function to optionally check the field mask for fields that are not allowed to be specified in it
- I added blacklists of fields that are not allowed to be modified using the `Update...` call in the `UpdateUser` and `UpdateProject` call

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
