### PR TITLE
Missing env vars in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,38 @@ services:
         networks:
             - grpc_network
 
+    # Backend only (profile: backend-only)
+    backend:
+        profiles: [ "backend-only" ]
+        build:
+            context: .
+        environment:
+            PROFILE: ${PROFILE:-}
+            PORT: ${PORT:-8080}
+            DATABASE_HOST: ${DATABASE_HOST:-db}
+            LOG_LEVEL: ${LOG_LEVEL:-}
+            AUTH_BYPASS_ENABLED: ${AUTH_BYPASS_ENABLED:-}
+            FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-}
+            DATABASE_SEED_USER_ENABLED: ${DATABASE_SEED_USER_ENABLED:-}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD:-}
+            JWT_PRIVATE_KEY_BASE64: ${JWT_PRIVATE_KEY_BASE64:-}
+            JWT_PUBLIC_KEY_BASE64: ${JWT_PUBLIC_KEY_BASE64:-}
+            SMTP_HOST: ${SMTP_HOST:-}
+            SMTP_PORT: ${SMTP_PORT:-}
+            SMTP_USER: ${SMTP_USER:-}
+            SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+            SMTP_TRANSPORT_LOGGING_ONLY_ENABLED: ${SMTP_TRANSPORT_LOGGING_ONLY_ENABLED:-}
+            SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-}
+            SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
+        ports:
+            - ${PORT:-8080}:${PORT:-8080}
+        healthcheck:
+            start_period: 4s # wait 4s to let backend get ready for accepting connections
+            start_interval: 2s # start first healthcheck after 2s
+        networks:
+            - db_network
+            - grpc_network
+
     # Proxy only (profile: proxy-only)
     proxy:
         profiles: [ "proxy-only" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
-    # PostgreSQL Database
+    # PostgreSQL Database (profile: default, db-only, registry)
     db:
+        profiles: [ "", "db-only", "registry" ]
         image: postgres:16.1-alpine3.19
         restart: always
         environment:
@@ -15,10 +16,10 @@ services:
             start_interval: 2s # start first healthcheck after 2s
         networks:
             - db_network
-        profiles: [ "", "db-only", "registry" ]
 
-    # Use local backend
+    # Local Backend + Proxy (profile: default)
     backend-local:
+        profiles: [ "" ]
         build:
             context: .
         environment:
@@ -50,9 +51,9 @@ services:
         networks:
             - db_network
             - grpc_network
-        profiles: [ "" ]
 
     proxy-local:
+        profiles: [ "" ]
         build:
             context: .
             dockerfile: Dockerfile.proxy
@@ -69,10 +70,10 @@ services:
                 condition: service_healthy
         networks:
             - grpc_network
-        profiles: [ "" ]
 
-    # Use the published backend with the specified tag
+    # Registry Backend + Proxy (profile: registry)
     backend-registry:
+        profiles: [ "registry" ]
         image: ghcr.io/se-uulm/snowballr-backend:${BACKEND_TAG:-latest-dev}
         environment:
             PROFILE: ${PROFILE:-}
@@ -103,9 +104,9 @@ services:
         networks:
             - db_network
             - grpc_network
-        profiles: [ "registry" ]
 
     proxy-registry:
+        profiles: [ "registry" ]
         build:
             context: .
             dockerfile: Dockerfile.proxy
@@ -122,10 +123,10 @@ services:
                 condition: service_healthy
         networks:
             - grpc_network
-        profiles: [ "registry" ]
 
-    # Proxy that listens to localhost instead of a service; can be used for local development
+    # Proxy only (profile: proxy-only)
     proxy:
+        profiles: [ "proxy-only" ]
         build:
             context: .
             dockerfile: Dockerfile.proxy
@@ -137,7 +138,6 @@ services:
             - --allow_all_origins # Crucial for local dev where frontend is on different origin
             - --run_tls_server=false # Don't require TLS
             - --server_http_debug_port=${WEB_PORT:-8081} # Proxy listens on this port inside the container
-        profiles: [ "proxy-only" ]
 
 networks:
     db_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
             test: "pg_isready -U postgres"
             start_period: 4s # wait 4s to let db get ready for accepting connections
             start_interval: 2s # start first healthcheck after 2s
-        networks:
-            - db_network
 
     # Local Backend + Proxy (profile: default)
     backend-local:
@@ -48,9 +46,6 @@ services:
         healthcheck:
             start_period: 4s # wait 4s to let backend get ready for accepting connections
             start_interval: 2s # start first healthcheck after 2s
-        networks:
-            - db_network
-            - grpc_network
 
     proxy-local:
         profiles: [ "" ]
@@ -68,8 +63,6 @@ services:
         depends_on:
             backend-local:
                 condition: service_healthy
-        networks:
-            - grpc_network
 
     # Registry Backend + Proxy (profile: registry)
     backend-registry:
@@ -101,9 +94,6 @@ services:
         healthcheck:
             start_period: 4s # wait 4s to let backend get ready for accepting connections
             start_interval: 2s # start first healthcheck after 2s
-        networks:
-            - db_network
-            - grpc_network
 
     proxy-registry:
         profiles: [ "registry" ]
@@ -121,8 +111,6 @@ services:
         depends_on:
             backend-registry:
                 condition: service_healthy
-        networks:
-            - grpc_network
 
     # Backend only (profile: backend-only)
     backend:
@@ -152,9 +140,6 @@ services:
         healthcheck:
             start_period: 4s # wait 4s to let backend get ready for accepting connections
             start_interval: 2s # start first healthcheck after 2s
-        networks:
-            - db_network
-            - grpc_network
 
     # Proxy only (profile: proxy-only)
     proxy:
@@ -166,7 +151,7 @@ services:
             - "${WEB_PORT:-8081}:${WEB_PORT:-8081}"
         command:
             # Point to the backend on the machine's host
-            - --backend_addr=host.docker.internal:${PORT:-8080}
+            - --backend_addr=backend:${PORT:-8080}
             - --allow_all_origins # Crucial for local dev where frontend is on different origin
             - --run_tls_server=false # Don't require TLS
             - --server_http_debug_port=${WEB_PORT:-8081} # Proxy listens on this port inside the container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,23 @@ services:
         build:
             context: .
         environment:
+            PROFILE: ${PROFILE:-}
             PORT: ${PORT:-8080}
-            LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
-            DATABASE_PASSWORD: ${DATABASE_PASSWORD}
             DATABASE_HOST: db # use db service as db host
-            JWT_PRIVATE_KEY_BASE64: ${JWT_PRIVATE_KEY_BASE64}
-            JWT_PUBLIC_KEY_BASE64: ${JWT_PUBLIC_KEY_BASE64}
+            LOG_LEVEL: ${LOG_LEVEL:-}
+            AUTH_BYPASS_ENABLED: ${AUTH_BYPASS_ENABLED:-}
+            FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-}
+            DATABASE_SEED_USER_ENABLED: ${DATABASE_SEED_USER_ENABLED:-}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD:-}
+            JWT_PRIVATE_KEY_BASE64: ${JWT_PRIVATE_KEY_BASE64:-}
+            JWT_PUBLIC_KEY_BASE64: ${JWT_PUBLIC_KEY_BASE64:-}
+            SMTP_HOST: ${SMTP_HOST:-}
+            SMTP_PORT: ${SMTP_PORT:-}
+            SMTP_USER: ${SMTP_USER:-}
+            SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+            SMTP_TRANSPORT_LOGGING_ONLY_ENABLED: ${SMTP_TRANSPORT_LOGGING_ONLY_ENABLED:-}
+            SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-}
+            SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         depends_on:
@@ -64,12 +75,23 @@ services:
     backend-registry:
         image: ghcr.io/se-uulm/snowballr-backend:${BACKEND_TAG:-latest-dev}
         environment:
+            PROFILE: ${PROFILE:-}
             PORT: ${PORT:-8080}
-            LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
-            DATABASE_PASSWORD: ${DATABASE_PASSWORD}
             DATABASE_HOST: db # use db service as db host
-            JWT_PRIVATE_KEY_BASE64: ${JWT_PRIVATE_KEY_BASE64}
-            JWT_PUBLIC_KEY_BASE64: ${JWT_PUBLIC_KEY_BASE64}
+            LOG_LEVEL: ${LOG_LEVEL:-}
+            AUTH_BYPASS_ENABLED: ${AUTH_BYPASS_ENABLED:-}
+            FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-}
+            DATABASE_SEED_USER_ENABLED: ${DATABASE_SEED_USER_ENABLED:-}
+            DATABASE_PASSWORD: ${DATABASE_PASSWORD:-}
+            JWT_PRIVATE_KEY_BASE64: ${JWT_PRIVATE_KEY_BASE64:-}
+            JWT_PUBLIC_KEY_BASE64: ${JWT_PUBLIC_KEY_BASE64:-}
+            SMTP_HOST: ${SMTP_HOST:-}
+            SMTP_PORT: ${SMTP_PORT:-}
+            SMTP_USER: ${SMTP_USER:-}
+            SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+            SMTP_TRANSPORT_LOGGING_ONLY_ENABLED: ${SMTP_TRANSPORT_LOGGING_ONLY_ENABLED:-}
+            SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-}
+            SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         depends_on:

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
@@ -4,38 +4,56 @@ import io.github.cdimascio.dotenv.dotenv
 
 interface IEnvService {
     /**
-     * Returns the value of the env variable with the specified [key] or throws an
-     * [EnvVariableNotFoundException] if the env variable couldn't be found.
+     * Returns the value of the environment variable with the specified [key].
+     *
+     * @param key Name of the environment variable to read.
+     * @return The value of the environment variable.
+     * @throws EnvVariableNotFoundException if the environment variable is not set.
      */
     operator fun get(key: String): String
 
     /**
-     * Returns the value of the env variable with the specified [key] or returns the [default]
-     * value if the env variable couldn't be found.
+     * Returns the value of the environment variable with the specified [key].
+     *
+     * @param key Name of the environment variable to read.
+     * @param default The value to return if the environment variable is not set.
+     * @return The value of the environment variable, or [default] if not found.
      */
     fun getOrDefault(key: String, default: String): String
 
     /**
-     * Returns the value of the env variable with the specified [key] or null if the env variable
-     * couldn't be found.
+     * Returns the value of the environment variable with the specified [key].
+     *
+     * @param key Name of the environment variable to read.
+     * @return The value of the environment variable, or `null` if not found.
      */
     fun getOrNull(key: String): String?
 
     /**
-     * Returns the boolean value of the env variable with the specified [key] or throws an
-     * [EnvVariableNotFoundException] if the env variable couldn't be found or is not a valid boolean.
+     * Returns the boolean value of the environment variable with the specified [key].
+     *
+     * @param key Name of the environment variable to read.
+     * @return The boolean value of the environment variable.
+     * @throws EnvVariableNotFoundException if the variable is not found or is not a valid boolean.
      */
     fun getBoolean(key: String): Boolean
 
     /**
-     * Returns the boolean value of the env variable with the specified [key] or returns the [default]
-     * value if the env variable couldn't be found or is not a valid boolean.
+     * Returns the boolean value of the environment variable with the specified [key].
+     *
+     * @param key Name of the environment variable to read.
+     * @param default The value to return if the environment variable is not set.
+     * @return The boolean value of the environment variable, or [default] if not found.
      */
     fun getBooleanOrDefault(key: String, default: Boolean): Boolean
 
     /**
-     * Retrieves the value of the environment variable identified by [key], or returns [default] if [default]
-     * is non-null. If [default] is null, throws [EnvVariableNotFoundException] if the environment variable is not set.
+     * Retrieves the value of the environment variable identified by [key].
+     *
+     * @param key Name of the environment variable to read.
+     * @param default An optional value to return if the environment variable is not set.
+     * @return The value of the environment variable, or [default] if provided and the variable is not found.
+     * @throws EnvVariableNotFoundException if the environment variable is not set and [default] is `null`.
      */
     fun getRequiredOrDefault(key: String, default: String?): String
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
@@ -46,11 +46,24 @@ interface IEnvService {
 class EnvService : IEnvService {
     private val dotenv = getEnv()
 
-    override fun get(key: String): String = dotenv[key] ?: throw EnvVariableNotFoundException(key)
+    /**
+     * Returns the raw value of the env variable or `null` if it couldn't be found or is empty.
+     * It is checked whether the value is `null` or empty because the docker-compose file
+     * may provide an empty string for a variable that is defined but not assigned a value.
+     *
+     * @param key Name of the environment variable to read
+     * @return Value of the environment variable or `null` if not found or empty
+     */
+    private fun getRaw(key: String): String? {
+        val value = dotenv[key]
+        return if (value.isNullOrEmpty()) null else value
+    }
 
-    override fun getOrDefault(key: String, default: String): String = dotenv[key] ?: default
+    override fun get(key: String): String = getRaw(key) ?: throw EnvVariableNotFoundException(key)
 
-    override fun getOrNull(key: String): String? = dotenv[key]
+    override fun getOrDefault(key: String, default: String): String = getRaw(key) ?: default
+
+    override fun getOrNull(key: String): String? = getRaw(key)
 
     override fun getBoolean(key: String): Boolean {
         val value = get(key)
@@ -59,18 +72,13 @@ class EnvService : IEnvService {
     }
 
     override fun getBooleanOrDefault(key: String, default: Boolean): Boolean {
-        val value = dotenv[key] ?: return default
+        val value = getRaw(key) ?: return default
         return value.toBooleanStrictOrNull()
             ?: throw EnvVariableNotFoundException("Invalid boolean value for key '$key': '$value'")
     }
 
-    override fun getRequiredOrDefault(key: String, default: String?): String {
-        if (default != null) {
-            return getOrDefault(key, default)
-        }
-
-        return dotenv[key] ?: throw EnvVariableNotFoundException(key)
-    }
+    override fun getRequiredOrDefault(key: String, default: String?): String =
+        getRaw(key) ?: default ?: throw EnvVariableNotFoundException(key)
 
     companion object {
         private fun getEnv() = dotenv {

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvService.kt
@@ -7,7 +7,6 @@ interface IEnvService {
      * Returns the value of the env variable with the specified [key] or throws an
      * [EnvVariableNotFoundException] if the env variable couldn't be found.
      */
-    @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     operator fun get(key: String): String
 
     /**
@@ -26,7 +25,6 @@ interface IEnvService {
      * Returns the boolean value of the env variable with the specified [key] or throws an
      * [EnvVariableNotFoundException] if the env variable couldn't be found or is not a valid boolean.
      */
-    @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     fun getBoolean(key: String): Boolean
 
     /**
@@ -48,14 +46,12 @@ interface IEnvService {
 class EnvService : IEnvService {
     private val dotenv = getEnv()
 
-    @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     override fun get(key: String): String = dotenv[key] ?: throw EnvVariableNotFoundException(key)
 
     override fun getOrDefault(key: String, default: String): String = dotenv[key] ?: default
 
     override fun getOrNull(key: String): String? = dotenv[key]
 
-    @kotlin.jvm.Throws(EnvVariableNotFoundException::class)
     override fun getBoolean(key: String): Boolean {
         val value = get(key)
         return value.toBooleanStrictOrNull()


### PR DESCRIPTION
Closes #339 

## What I have made

- Added missing env vars to all relevant sections in the docker compose file
- Updated the `EnvService` to no longer accept empty values
  - Since docker compose files are not able to ignore not set env vars but simply set an empty value if the var is not specified in the env file, the `EnvService` needs to compensate this.
- Added a new `backend-only` profile

Note: The docker compose should work out of the box with the `env.example` file!

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ `EnvService` is not being tested -> but executed all docker compose profiles
- [ ] (for reviewer) I have checked the implementation against the requirements
