### PR TITLE
Implement `getPreviousPaper` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -220,7 +220,7 @@ class SnowballRServer(
             super.getNextPaperToReview(request)
 
         override suspend fun getPreviousPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
-            super.getPreviousPaper(request)
+            mainService.getPreviousPaper(request)
 
         override suspend fun getUserSettings(request: Base.Nothing): UserSettingsOuterClass.UserSettings =
             mainService.getUserSettings()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/PaperNavigationDirection.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/PaperNavigationDirection.kt
@@ -1,0 +1,11 @@
+package se.uulm.snowballr.backend.model
+
+/**
+ * Represents the navigation direction within a collection of papers.
+ *
+ * @property displayName A human-readable representation of the navigation direction.
+ */
+enum class PaperNavigationDirection(val displayName: String) {
+    NEXT("next"),
+    PREVIOUS("previous"),
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.PaperNavigationDirection
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
@@ -74,14 +75,20 @@ interface IProjectPaperTableRepo {
     suspend fun getAllProjectPapersForProject(projectId: UUID): List<ProjectPaper>
 
     /**
-     * Retrieves the succeeding local paper ID for the project paper with the given local paper ID.
+     * Retrieves the preceding local paper ID for the project paper with the given local paper ID.
      *
-     * @param projectId The unique identifier of the project for which the next local paper ID is being requested.
-     * @param localPaperId The current local paper ID used as a reference to compute the next ID.
-     * @return A [Result] containing the next available local paper ID as a [Long] or a [FailedPreconditionException]
-     * if it cannot be determined.
+     * @param projectId The unique identifier of the project for which the previous local paper ID is being requested.
+     * @param localPaperId The current local paper ID used as a reference to compute the previous ID.
+     * @param direction The navigation direction indicating whether to retrieve the next or previous paper.
+     * Must be one of the values from [PaperNavigationDirection].
+     * @return A [Result] containing the previous available local paper ID as a [Long] or a
+     * [FailedPreconditionException] if it cannot be determined.
      */
-    suspend fun getNextPaperLocalId(projectId: UUID, localPaperId: Long): Result<Long>
+    suspend fun getAdjacentPaper(
+        projectId: UUID,
+        localPaperId: Long,
+        direction: PaperNavigationDirection,
+    ): Result<ProjectPaper>
 
     /**
      * Retrieves a list of project papers along with their associated papers for the specified project.
@@ -165,6 +172,49 @@ class ProjectPaperTableRepo(
             ?: 0L
     }
 
+    /**
+     * Retrieves the local paper ID for a project based on the specified conditions and order.
+     *
+     * @param projectId The unique identifier of the project.
+     * @param localPaperId The reference local paper ID used in the condition.
+     * @param direction The direction to navigate for finding the adjacent paper, either NEXT or PREVIOUS.
+     * @return A [Result] containing the local paper ID if found, or a failure if the specified conditions do not match
+     * any paper.
+     */
+    override suspend fun getAdjacentPaper(
+        projectId: UUID,
+        localPaperId: Long,
+        direction: PaperNavigationDirection,
+    ): Result<ProjectPaper> = db.query {
+        val isNext = direction == PaperNavigationDirection.NEXT
+        val paperId = ProjectPaperTable
+            .selectAll()
+            .where {
+                (ProjectPaperTable.projectId eq projectId) and
+                    if (isNext) {
+                        ProjectPaperTable.localPaperId greater localPaperId
+                    } else {
+                        ProjectPaperTable.localPaperId less localPaperId
+                    }
+            }
+            .orderBy(
+                ProjectPaperTable.localPaperId to if (isNext) SortOrder.ASC else SortOrder.DESC,
+            )
+            .map { it.toProjectPaper() }
+            .firstOrNull()
+
+        if (paperId != null) {
+            Result.success(paperId)
+        } else {
+            Result.failure(
+                FailedPreconditionException(
+                    "There is no $direction project paper " +
+                        "in the project.",
+                ),
+            )
+        }
+    }
+
     override suspend fun getProjectPaperById(id: UUID): Result<ProjectPaper> = db.query {
         getEntityByKeyAsResult(::getProjectPaperByIdOrNull, EntityType.PROJECT_PAPER, id)
     }
@@ -192,31 +242,14 @@ class ProjectPaperTableRepo(
         ProjectPaperTable.getEntities(ResultRow::toProjectPaper) { ProjectPaperTable.projectId eq projectId }
     }
 
-    override suspend fun getNextPaperLocalId(projectId: UUID, localPaperId: Long): Result<Long> = db.query {
-        val nextId = ProjectPaperTable
-            .selectAll()
-            .where {
-                (ProjectPaperTable.projectId eq projectId) and
-                    (ProjectPaperTable.localPaperId greater localPaperId)
-            }
-            .orderBy(ProjectPaperTable.localPaperId, SortOrder.ASC)
-            .map { it[ProjectPaperTable.localPaperId] }
-            .firstOrNull()
-
-        if (nextId != null) {
-            Result.success(nextId)
-        } else {
-            Result.failure(
-                FailedPreconditionException(
-                    "There is no next project paper in the project.",
-                ),
-            )
-        }
-    }
-
     override suspend fun getAllProjectPapersWithPapers(projectId: UUID): List<ProjectPaperWithPaper> = db.query {
         ProjectPaperTable
-            .join(PaperTable, JoinType.INNER, onColumn = ProjectPaperTable.paperId, otherColumn = PaperTable.id)
+            .join(
+                PaperTable,
+                JoinType.INNER,
+                onColumn = ProjectPaperTable.paperId,
+                otherColumn = PaperTable.id,
+            )
             .selectAll()
             .where { ProjectPaperTable.projectId eq projectId }
             .map { it.toProjectPaperWithPaper() }
@@ -239,13 +272,15 @@ class ProjectPaperTableRepo(
     }
 
     override suspend fun getProjectProgress(projectId: UUID): Float = db.query {
-        val allPapersCount = ProjectPaperTable.selectAll().where { ProjectPaperTable.projectId eq projectId }.count()
+        val allPapersCount =
+            ProjectPaperTable.selectAll().where { ProjectPaperTable.projectId eq projectId }.count()
         if (allPapersCount == 0L) {
             0.0f
         } else {
             val fullyReviewedPapersCount = ProjectPaperTable.selectAll().where {
-                val paperReviewedOp = (ProjectPaperTable.decision eq PaperDecision.PAPER_DECISION_ACCEPTED) or
-                    (ProjectPaperTable.decision eq PaperDecision.PAPER_DECISION_DECLINED)
+                val paperReviewedOp =
+                    (ProjectPaperTable.decision eq PaperDecision.PAPER_DECISION_ACCEPTED) or
+                        (ProjectPaperTable.decision eq PaperDecision.PAPER_DECISION_DECLINED)
 
                 paperReviewedOp and (ProjectPaperTable.projectId eq projectId)
             }.count()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -75,13 +75,13 @@ interface IProjectPaperTableRepo {
     suspend fun getAllProjectPapersForProject(projectId: UUID): List<ProjectPaper>
 
     /**
-     * Retrieves the preceding local paper ID for the project paper with the given local paper ID.
+     * Retrieves the adjacent local paper ID for the project paper with the given local paper ID.
      *
-     * @param projectId The unique identifier of the project for which the previous local paper ID is being requested.
-     * @param localPaperId The current local paper ID used as a reference to compute the previous ID.
+     * @param projectId The unique identifier of the project for which the adjacent local paper ID is requested.
+     * @param localPaperId The current local paper ID used as a reference to compute the adjacent ID.
      * @param direction The navigation direction indicating whether to retrieve the next or previous paper.
      * Must be one of the values from [PaperNavigationDirection].
-     * @return A [Result] containing the previous available local paper ID as a [Long] or a
+     * @return A [Result] containing the adjacent available local paper ID as a [Long] or a
      * [FailedPreconditionException] if it cannot be determined.
      */
     suspend fun getAdjacentPaper(
@@ -172,15 +172,6 @@ class ProjectPaperTableRepo(
             ?: 0L
     }
 
-    /**
-     * Retrieves the local paper ID for a project based on the specified conditions and order.
-     *
-     * @param projectId The unique identifier of the project.
-     * @param localPaperId The reference local paper ID used in the condition.
-     * @param direction The direction to navigate for finding the adjacent paper, either NEXT or PREVIOUS.
-     * @return A [Result] containing the local paper ID if found, or a failure if the specified conditions do not match
-     * any paper.
-     */
     override suspend fun getAdjacentPaper(
         projectId: UUID,
         localPaperId: Long,

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -3,7 +3,10 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.PaperNavigationDirection
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
+import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Author
@@ -68,6 +71,11 @@ interface IProjectPaperService {
      * Service implementation of [SnowballRService.getNextPaper].
      */
     suspend fun getNextPaper(request: Base.Id): GrpcProjectPaper
+
+    /**
+     * Service implementation of [SnowballRService.getPreviousPaper].
+     */
+    suspend fun getPreviousPaper(request: Base.Id): GrpcProjectPaper
 }
 
 /**
@@ -175,6 +183,34 @@ class ProjectPaperService(
         projectPapersWithPapers.toGrpcProjectPapers(paperAuthorsMap, paperBackwardReferencesMap, projectPaperReviewsMap)
     }
 
+    /**
+     * Retrieves the following project paper based on the provided project paper ID and the following paper computation
+     * logic.
+     *
+     * @param id The unique identifier of the current project paper as a string.
+     * @param adjacentPaper A suspend function that takes the project ID and the local paper ID and returns the result
+     * containing the relative ID of the following paper.
+     * @return The gRPC representation of the following project paper, including its associated metadata.
+     * @throws NotFoundException If the project, project paper, or associated paper cannot be found.
+     * @throws InvalidIdException.UUID If the given project paper ID is not a valid UUID.
+     * @throws UnauthorizedException If the user does not have the required access to the project.
+     */
+    private suspend fun getAdjacentPaper(
+        id: String,
+        adjacentPaper: suspend ((UUID, Long) -> Result<ProjectPaper>),
+    ): GrpcProjectPaper = withUser(userRepo) { currentUser ->
+        val projectPaperId = parseUUID(id, EntityType.PROJECT_PAPER)
+        val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+
+        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+
+        val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
+        val nextProjectPaper = adjacentPaper(projectId, projectPaper.localPaperId).getOrThrow()
+        val paper = paperRepo.getPaperById(nextProjectPaper.paperId).getOrThrow()
+
+        nextProjectPaper.toGrpcProjectPaperWithData(paper)
+    }
+
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
@@ -240,17 +276,21 @@ class ProjectPaperService(
             projectPaper.toGrpcProjectPaperWithData(paper)
         }
 
-    override suspend fun getNextPaper(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
-        val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
-        val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+    override suspend fun getNextPaper(request: Base.Id): GrpcProjectPaper =
+        getAdjacentPaper(request.id) { projectId, localPaperId ->
+            repo.getAdjacentPaper(
+                projectId,
+                localPaperId,
+                PaperNavigationDirection.NEXT,
+            )
+        }
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
-
-        val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
-        val nextProjectPaperId = repo.getNextPaperLocalId(projectId, projectPaper.localPaperId).getOrThrow()
-        val nextProjectPaper = repo.getProjectPaperByRelativeId(projectId, nextProjectPaperId).getOrThrow()
-        val paper = paperRepo.getPaperById(nextProjectPaper.paperId).getOrThrow()
-
-        nextProjectPaper.toGrpcProjectPaperWithData(paper)
-    }
+    override suspend fun getPreviousPaper(request: Base.Id): GrpcProjectPaper =
+        getAdjacentPaper(request.id) { projectId, localPaperId ->
+            repo.getAdjacentPaper(
+                projectId,
+                localPaperId,
+                PaperNavigationDirection.PREVIOUS,
+            )
+        }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -188,28 +188,26 @@ class ProjectPaperService(
      * logic.
      *
      * @param id The unique identifier of the current project paper as a string.
-     * @param adjacentPaper A suspend function that takes the project ID and the local paper ID and returns the result
-     * containing the relative ID of the following paper.
+     * @param direction The navigation direction indicating whether to retrieve the next or previous paper.
+     * Containing the relative ID of the following paper.
      * @return The gRPC representation of the following project paper, including its associated metadata.
      * @throws NotFoundException If the project, project paper, or associated paper cannot be found.
      * @throws InvalidIdException.UUID If the given project paper ID is not a valid UUID.
      * @throws UnauthorizedException If the user does not have the required access to the project.
      */
-    private suspend fun getAdjacentPaper(
-        id: String,
-        adjacentPaper: suspend ((UUID, Long) -> Result<ProjectPaper>),
-    ): GrpcProjectPaper = withUser(userRepo) { currentUser ->
-        val projectPaperId = parseUUID(id, EntityType.PROJECT_PAPER)
-        val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+    private suspend fun getAdjacentPaper(id: String, direction: PaperNavigationDirection): GrpcProjectPaper =
+        withUser(userRepo) { currentUser ->
+            val projectPaperId = parseUUID(id, EntityType.PROJECT_PAPER)
+            val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+            isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
 
-        val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
-        val nextProjectPaper = adjacentPaper(projectId, projectPaper.localPaperId).getOrThrow()
-        val paper = paperRepo.getPaperById(nextProjectPaper.paperId).getOrThrow()
+            val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
+            val adjacentPaper = repo.getAdjacentPaper(projectId, projectPaper.localPaperId, direction).getOrThrow()
+            val paper = paperRepo.getPaperById(adjacentPaper.paperId).getOrThrow()
 
-        nextProjectPaper.toGrpcProjectPaperWithData(paper)
-    }
+            adjacentPaper.toGrpcProjectPaperWithData(paper)
+        }
 
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
@@ -277,20 +275,8 @@ class ProjectPaperService(
         }
 
     override suspend fun getNextPaper(request: Base.Id): GrpcProjectPaper =
-        getAdjacentPaper(request.id) { projectId, localPaperId ->
-            repo.getAdjacentPaper(
-                projectId,
-                localPaperId,
-                PaperNavigationDirection.NEXT,
-            )
-        }
+        getAdjacentPaper(request.id, PaperNavigationDirection.NEXT)
 
     override suspend fun getPreviousPaper(request: Base.Id): GrpcProjectPaper =
-        getAdjacentPaper(request.id) { projectId, localPaperId ->
-            repo.getAdjacentPaper(
-                projectId,
-                localPaperId,
-                PaperNavigationDirection.PREVIOUS,
-            )
-        }
+        getAdjacentPaper(request.id, PaperNavigationDirection.PREVIOUS)
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.model.PaperNavigationDirection
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.ProjectPaperNotFoundException
@@ -179,7 +180,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
     }
 
     @Nested
-    inner class GetNextPaperLocalId {
+    inner class GetAdjacentPaperLocalId {
         @Test
         fun `When a project paper with a succeeding local paper ID exists, then the local paper ID of this paper is returned`() =
             runTest {
@@ -193,7 +194,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     localPaperId = 1,
                     createdBy = testUserId,
                 )
-                insertProjectPaperAndGetId(
+                val nextPaperId = insertProjectPaperAndGetId(
                     paperId = paperId2,
                     projectId = projectId,
                     localPaperId = 3,
@@ -201,10 +202,17 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 )
                 val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-                val nextPaperLocalId = repo.getNextPaperLocalId(projectId, projectPaper.localPaperId)
+                val nextPaper = repo.getAdjacentPaper(
+                    projectId,
+                    projectPaper.localPaperId,
+                    PaperNavigationDirection.NEXT,
+                )
 
-                val result = assertResultSuccess(nextPaperLocalId)
-                assertEquals(3, result)
+                val result = assertResultSuccess(nextPaper)
+                assertEquals(nextPaperId, result.id)
+                assertEquals(3, result.localPaperId)
+                assertEquals(paperId2, result.paperId)
+                assertEquals(projectId, result.projectId)
             }
 
         @Test
@@ -221,9 +229,70 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 )
                 val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-                val nextPaperLocalId = repo.getNextPaperLocalId(projectId, projectPaper.localPaperId)
+                val nextPaper = repo.getAdjacentPaper(
+                    projectId,
+                    projectPaper.localPaperId,
+                    PaperNavigationDirection.NEXT,
+                )
 
-                assertResultFailure<FailedPreconditionException>(nextPaperLocalId)
+                assertResultFailure<FailedPreconditionException>(nextPaper)
+            }
+
+        @Test
+        fun `When a project paper with a preceding local paper ID exists, then the local paper ID of this paper is returned`() =
+            runTest {
+                val projectId =
+                    insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val previousPaperId = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    localPaperId = 1,
+                    createdBy = testUserId,
+                )
+                val projectPaperId = insertProjectPaperAndGetId(
+                    paperId = paperId2,
+                    projectId = projectId,
+                    localPaperId = 3,
+                    createdBy = testUserId,
+                )
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+
+                val previousPaper = repo.getAdjacentPaper(
+                    projectId,
+                    projectPaper.localPaperId,
+                    PaperNavigationDirection.PREVIOUS,
+                )
+
+                val result = assertResultSuccess(previousPaper)
+                assertEquals(previousPaperId, result.id)
+                assertEquals(1, result.localPaperId)
+                assertEquals(paperId1, result.paperId)
+                assertEquals(projectId, result.projectId)
+            }
+
+        @Test
+        fun `When no project paper with a preceding local paper ID exists, then a FailedPreconditionException is returned`() =
+            runTest {
+                val projectId =
+                    insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val projectPaperId = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    localPaperId = 1,
+                    createdBy = testUserId,
+                )
+                val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+
+                val previousPaper = repo.getAdjacentPaper(
+                    projectId,
+                    projectPaper.localPaperId,
+                    PaperNavigationDirection.PREVIOUS,
+                )
+
+                assertResultFailure<FailedPreconditionException>(previousPaper)
             }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
-import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -97,7 +97,7 @@ class GetNextPaperTest : MainServiceTest() {
         }
 
     @Test
-    fun `When no next paper exists, then a FailedPreconditionException is thrown`() = runTest {
+    fun `When no next paper exists, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -116,8 +116,8 @@ class GetNextPaperTest : MainServiceTest() {
                 project.id, projectPaper.localPaperId,
                 PaperNavigationDirection.NEXT,
             )
-        } returns Result.failure(FailedPreconditionException("No next paper exists"))
+        } returns Result.failure(TestSpecificException())
 
-        assertThrows<FailedPreconditionException> { mainService.getNextPaper(getExampleRequest()) }
+        assertThrows<TestSpecificException> { mainService.getNextPaper(getExampleRequest()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -14,19 +14,19 @@ import snowballr.Base
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
-class GetNextPaperTest : MainServiceTest() {
+class GetPreviousPaperTest : MainServiceTest() {
     private val projectPaperId = UUID.randomUUID()
 
     private fun getExampleRequest() = Base.Id.newBuilder().setId(projectPaperId.toString()).build()
 
     @Test
-    fun `When a server admin requests the next project paper, then no exception is thrown`() = runTest {
+    fun `When a server admin requests the previous project paper, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper =
             DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id, paperId = paper.id)
-        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
+        val previousProjectPaper = DataBuilder.createExampleProjectPaper()
         val author = DataBuilder.createExampleAuthor()
 
         mockCurrentUser(currentUser)
@@ -38,25 +38,25 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(
                 project.id, projectPaper.localPaperId,
-                PaperNavigationDirection.NEXT,
+                PaperNavigationDirection.PREVIOUS,
             )
-        } returns Result.success(nextProjectPaper)
-        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
+        } returns Result.success(previousProjectPaper)
+        coEvery { paperRepoMock.getPaperById(previousProjectPaper.paperId) } returns Result.success(paper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(previousProjectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getNextPaper(getExampleRequest()) }
+        assertDoesNotThrow { mainService.getPreviousPaper(getExampleRequest()) }
     }
 
     @Test
-    fun `When a project member requests the next project paper, then no exception is thrown`() = runTest {
+    fun `When a project member requests the previous project paper, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper =
             DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id, paperId = paper.id)
-        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
+        val previousProjectPaper = DataBuilder.createExampleProjectPaper()
         val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val author = DataBuilder.createExampleAuthor()
 
@@ -69,19 +69,19 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(
                 project.id, projectPaper.localPaperId,
-                PaperNavigationDirection.NEXT,
+                PaperNavigationDirection.PREVIOUS,
             )
-        } returns Result.success(nextProjectPaper)
-        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
+        } returns Result.success(previousProjectPaper)
+        coEvery { paperRepoMock.getPaperById(previousProjectPaper.paperId) } returns Result.success(paper)
         coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(previousProjectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getNextPaper(getExampleRequest()) }
+        assertDoesNotThrow { mainService.getPreviousPaper(getExampleRequest()) }
     }
 
     @Test
-    fun `When a non project member requests the next project paper, then an UnauthorizedException is thrown`() =
+    fun `When a non project member requests the previous project paper, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
             val project = DataBuilder.createExampleProject()
@@ -93,11 +93,11 @@ class GetNextPaperTest : MainServiceTest() {
             } returns Result.success(projectPaper)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-            assertThrows<UnauthorizedException> { mainService.getNextPaper(getExampleRequest()) }
+            assertThrows<UnauthorizedException> { mainService.getPreviousPaper(getExampleRequest()) }
         }
 
     @Test
-    fun `When no next paper exists, then a FailedPreconditionException is thrown`() = runTest {
+    fun `When no previous paper exists, then a FailedPreconditionException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -114,10 +114,10 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(
                 project.id, projectPaper.localPaperId,
-                PaperNavigationDirection.NEXT,
+                PaperNavigationDirection.PREVIOUS,
             )
-        } returns Result.failure(FailedPreconditionException("No next paper exists"))
+        } returns Result.failure(FailedPreconditionException("No previous paper exists"))
 
-        assertThrows<FailedPreconditionException> { mainService.getNextPaper(getExampleRequest()) }
+        assertThrows<FailedPreconditionException> { mainService.getPreviousPaper(getExampleRequest()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
-import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -97,7 +97,7 @@ class GetPreviousPaperTest : MainServiceTest() {
         }
 
     @Test
-    fun `When no previous paper exists, then a FailedPreconditionException is thrown`() = runTest {
+    fun `When no previous paper exists, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -116,8 +116,7 @@ class GetPreviousPaperTest : MainServiceTest() {
                 project.id, projectPaper.localPaperId,
                 PaperNavigationDirection.PREVIOUS,
             )
-        } returns Result.failure(FailedPreconditionException("No previous paper exists"))
-
-        assertThrows<FailedPreconditionException> { mainService.getPreviousPaper(getExampleRequest()) }
+        } returns Result.failure(TestSpecificException())
+        assertThrows<TestSpecificException> { mainService.getPreviousPaper(getExampleRequest()) }
     }
 }


### PR DESCRIPTION
Closes #102 

## What I have made

I have implemented the repo, service and grpc layer for the `getPreviousPaper` call. Since the functionality is analog to the `getNextPaper` call I just had to make some functions generic and adjust some code.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
