### PR TITLE
Implement `getNextPaperToReview` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -217,7 +217,7 @@ class SnowballRServer(
             mainService.getNextPaper(request)
 
         override suspend fun getNextPaperToReview(request: Base.Id): ProjectOuterClass.Project.Paper =
-            super.getNextPaperToReview(request)
+            mainService.getNextPaperToReview(request)
 
         override suspend fun getPreviousPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
             mainService.getPreviousPaper(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithReviewsCount.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithReviewsCount.kt
@@ -1,0 +1,26 @@
+package se.uulm.snowballr.backend.model.dto
+
+/**
+ * Composite class that contains a [ProjectPaper] and the number of [Review]s that have been given to it.
+ */
+data class ProjectPaperWithReviewsCount(
+    val projectPaper: ProjectPaper,
+    val reviewsCount: Int,
+) : Comparable<ProjectPaperWithReviewsCount> {
+    /**
+     * Compares this [ProjectPaperWithReviewsCount] to another [ProjectPaperWithReviewsCount].
+     *
+     * The comparison is done in the following order:
+     * 1. By [ProjectPaper.stage] in ascending order
+     * 2. By [reviewsCount] in ascending order
+     */
+    override fun compareTo(other: ProjectPaperWithReviewsCount): Int {
+        val compareByStage = projectPaper.stage.compareTo(other.projectPaper.stage)
+
+        if (compareByStage != 0) {
+            return compareByStage
+        }
+
+        return reviewsCount.compareTo(other.reviewsCount)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -3,6 +3,8 @@ package se.uulm.snowballr.backend.repository.association
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
@@ -141,7 +143,7 @@ interface IProjectPaperTableRepo {
      * @param stage The stage of the papers that should be considered when retrieving later project papers.
      * @return A list of subsequent [ProjectPaper] instances meeting the specified criteria.
      */
-    suspend fun getLaterProjectPapers(projectId: UUID, localPaperId: Long, stage: Long): List<ProjectPaper>
+    suspend fun getSubsequentProjectPapers(projectId: UUID, localPaperId: Long, stage: Long): List<ProjectPaper>
 
     /**
      * Updates the decision of a project paper.
@@ -300,18 +302,19 @@ class ProjectPaperTableRepo(
         }
     }
 
-    override suspend fun getLaterProjectPapers(projectId: UUID, localPaperId: Long, stage: Long): List<ProjectPaper> =
-        db.query {
-            ProjectPaperTable
-                .selectAll()
-                .where {
-                    (ProjectPaperTable.projectId eq projectId) and
-                        (
-                            (ProjectPaperTable.stage eq stage and (ProjectPaperTable.localPaperId greater localPaperId))
-                                or (ProjectPaperTable.stage greater stage)
-                            )
-                }
-                .orderBy(ProjectPaperTable.stage to SortOrder.ASC, ProjectPaperTable.localPaperId to SortOrder.ASC)
-                .map { it.toProjectPaper() }
-        }
+    override suspend fun getSubsequentProjectPapers(
+        projectId: UUID,
+        localPaperId: Long,
+        stage: Long,
+    ): List<ProjectPaper> = db.query {
+        val sameStageButGreaterLocalIdOp =
+            (ProjectPaperTable.stage eq stage) and (ProjectPaperTable.localPaperId greater localPaperId)
+        val greaterStageOp = ProjectPaperTable.stage greater stage
+        ProjectPaperTable
+            .selectAll()
+            .where {
+                (ProjectPaperTable.projectId eq projectId) and (sameStageButGreaterLocalIdOp or greaterStageOp)
+            }
+            .map { it.toProjectPaper() }
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -133,10 +133,12 @@ interface IProjectPaperTableRepo {
     suspend fun getProjectProgress(projectId: UUID): Float
 
     /**
-     * Retrieves a list of later project papers from a given starting point defined by `localPaperId` and `stage`.
+     * Retrieves a list of subsequent project papers from a given starting point defined by `localPaperId` and `stage`.
      *
-     * This method fetches all project papers within the same project that come after the specified
-     * paper (`localPaperId`) and are part of the given `stage` or a later `stage`.
+     * Subsequent project papers are defined as project papers
+     *  - within the same project
+     *  - with a greater `localPaperId` than the given project paper and
+     *  - are part of the given `stage` or a subsequent `stage`.
      *
      * @param projectId The unique identifier of the project to which the papers belong.
      * @param localPaperId The local ID of the starting paper in the project from which the later papers are retrieved.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -37,6 +37,7 @@ import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
  * operations for project papers. By using this interface, the functionality for creating
  * project papers can remain decoupled from the specifics of the database layer.
  */
+@Suppress("ComplexInterface")
 interface IProjectPaperTableRepo {
     /**
      * Returns a [Result] containing the project paper by its ID or a [NotFoundException] if the project paper with the
@@ -128,6 +129,19 @@ interface IProjectPaperTableRepo {
      * @return A float between 0.0 and 1.0 representing the project progress.
      */
     suspend fun getProjectProgress(projectId: UUID): Float
+
+    /**
+     * Retrieves a list of later project papers from a given starting point defined by `localPaperId` and `stage`.
+     *
+     * This method fetches all project papers within the same project that come after the specified
+     * paper (`localPaperId`) and are part of the given `stage` or a later `stage`.
+     *
+     * @param projectId The unique identifier of the project to which the papers belong.
+     * @param localPaperId The local ID of the starting paper in the project from which the later papers are retrieved.
+     * @param stage The stage of the papers that should be considered when retrieving later project papers.
+     * @return A list of subsequent [ProjectPaper] instances meeting the specified criteria.
+     */
+    suspend fun getLaterProjectPapers(projectId: UUID, localPaperId: Long, stage: Long): List<ProjectPaper>
 
     /**
      * Updates the decision of a project paper.
@@ -285,4 +299,19 @@ class ProjectPaperTableRepo(
             it[ProjectPaperTable.decision] = decision
         }
     }
+
+    override suspend fun getLaterProjectPapers(projectId: UUID, localPaperId: Long, stage: Long): List<ProjectPaper> =
+        db.query {
+            ProjectPaperTable
+                .selectAll()
+                .where {
+                    (ProjectPaperTable.projectId eq projectId) and
+                        (
+                            (ProjectPaperTable.stage eq stage and (ProjectPaperTable.localPaperId greater localPaperId))
+                                or (ProjectPaperTable.stage greater stage)
+                            )
+                }
+                .orderBy(ProjectPaperTable.stage to SortOrder.ASC, ProjectPaperTable.localPaperId to SortOrder.ASC)
+                .map { it.toProjectPaper() }
+        }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -135,10 +135,9 @@ interface IProjectPaperTableRepo {
     /**
      * Retrieves a list of subsequent project papers from a given starting point defined by `localPaperId` and `stage`.
      *
-     * Subsequent project papers are defined as project papers
-     *  - within the same project
-     *  - with a greater `localPaperId` than the given project paper and
-     *  - are part of the given `stage` or a subsequent `stage`.
+     * Subsequent project papers are defined as project papers within the same project that are either:
+     * - in the same `stage` but have a greater `localPaperId`, or
+     * - in a subsequent `stage` regardless of their `localPaperId`.
      *
      * @param projectId The unique identifier of the project to which the papers belong.
      * @param localPaperId The local ID of the starting paper in the project from which the later papers are retrieved.

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -13,8 +13,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
-import se.uulm.snowballr.backend.model.dto.Review
-import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithReviewsCount
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPapers
 import se.uulm.snowballr.backend.model.dto.toGrpcReview
@@ -206,35 +205,27 @@ class ProjectPaperService(
         }
 
     /**
-     * Filters a list of [ProjectPaper]s paired with their associated reviews to retrieve those
-     * that the current user has not reviewed.
+     * Sorts a list of project papers paired with their corresponding review counts.
      *
-     * @param papersWithReviews A list of pairs, where each pair contains a [ProjectPaper] and a list of its [Review]s.
-     * @param currentUser The [User] object representing the current user whose reviews are to be excluded.
-     * @return A list of pairs, where each pair consists of a [ProjectPaper] and the count of its associated reviews.
+     * The result only contains the sorted project papers, excluding the review counts.
+     *
+     * @param projectPapersWithReviewsCount A list of [ProjectPaperWithReviewsCount] objects to be sorted.
+     * @return A list of [ProjectPaper] objects sorted by stage (ascending) and reviews count (ascending).
      */
-    private fun getProjectPapersWithoutOwnReview(
-        papersWithReviews: List<Pair<ProjectPaper, List<Review>>>,
-        currentUser: User,
-    ) = papersWithReviews
-        .filter { (_, reviews) ->
-            reviews.none { review -> review.userId == currentUser.id }
-        }
-        .map { (paper, reviews) -> paper to reviews.size }
+    private fun sortPapersByStageAndReviewsCount(projectPapersWithReviewsCount: List<ProjectPaperWithReviewsCount>) =
+        projectPapersWithReviewsCount.sorted().map { it.projectPaper }
 
     /**
-     * Sorts a list of project papers paired with their corresponding review counts. The sorting is done primarily by
-     * the stage of the project paper in ascending order, and secondarily by the review count in ascending order. The
-     * result includes only the sorted project papers, excluding the review counts from the output.
+     * Determines whether the given project paper lacks a final decision.
+     * A project paper is considered to have no final decision if its decision state
+     * is either `PAPER_DECISION_UNSPECIFIED` or `PAPER_DECISION_UNREVIEWED`.
      *
-     * @param projectPapersWithReviewCount A list of pairs, where each pair contains a [ProjectPaper] and its
-     * corresponding review count, represented as an integer.
-     * @return A list of [ProjectPaper] objects sorted by stage and review count.
+     * @param projectPaper The [ProjectPaper] object whose decision state is to be evaluated.
+     * @return `true` if the project paper has no final decision; otherwise, `false`.
      */
-    private fun sortPapersByStageAndReviewCount(projectPapersWithReviewCount: List<Pair<ProjectPaper, Int>>) =
-        projectPapersWithReviewCount
-            .sortedWith(compareBy<Pair<ProjectPaper, Int>> { it.first.stage }.thenBy { it.second })
-            .map { it.first }
+    private fun hasNoFinalDecision(projectPaper: ProjectPaper): Boolean =
+        projectPaper.decision == PaperDecision.PAPER_DECISION_UNSPECIFIED ||
+            projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
 
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
@@ -314,32 +305,32 @@ class ProjectPaperService(
 
         isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
 
-        val projectPapers = repo.getLaterProjectPapers(
-            projectId,
-            projectPaper.localPaperId,
-            projectPaper.stage,
-        )
-        val projectPapersWithReviews: List<Pair<ProjectPaper, List<Review>>> = projectPapers
-            .map { paper ->
-                val reviews = reviewTableRepo.getAllReviewsForProjectPaper(paper.id)
-                paper to reviews
-            }
+        val projectPapers = repo.getSubsequentProjectPapers(projectId, projectPaper.localPaperId, projectPaper.stage)
+        val projectPapersWithReviewsCount = getProjectPapersWithReviewsCount(projectPapers, currentUser.id)
 
-        val projectPapersWithoutOwnReview = getProjectPapersWithoutOwnReview(projectPapersWithReviews, currentUser)
-
-        if (projectPapersWithoutOwnReview.isEmpty()) {
+        if (projectPapersWithReviewsCount.isEmpty()) {
             throw FailedPreconditionException(
                 "There is no next project paper available to review in the project with ID $projectId",
             )
         }
 
-        val sortedPapers = sortPapersByStageAndReviewCount(projectPapersWithoutOwnReview)
-
-        val papersWithoutFinalDecision = sortedPapers.filter {
-            it.decision == PaperDecision.PAPER_DECISION_UNSPECIFIED ||
-                it.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
-        }
+        val sortedPapers = sortPapersByStageAndReviewsCount(projectPapersWithReviewsCount)
+        val papersWithoutFinalDecision = sortedPapers.filter(::hasNoFinalDecision)
 
         (papersWithoutFinalDecision.firstOrNull() ?: sortedPapers.first()).toGrpcProjectPaperWithData()
     }
+
+    private suspend fun getProjectPapersWithReviewsCount(projectPapers: List<ProjectPaper>, currentUserId: UUID) =
+        projectPapers
+            .map { projectPaper ->
+                val reviews = reviewTableRepo.getAllReviewsForProjectPaper(projectPaper.id)
+
+                val hasOwnReview = reviews.any { it.userId == currentUserId }
+                if (hasOwnReview) {
+                    ProjectPaperWithReviewsCount(projectPaper, -1)
+                } else {
+                    ProjectPaperWithReviewsCount(projectPaper, reviews.size)
+                }
+            }
+            .filter { it.reviewsCount >= 0 }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
@@ -12,6 +13,8 @@ import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPapers
 import se.uulm.snowballr.backend.model.dto.toGrpcReview
@@ -72,6 +75,11 @@ interface IProjectPaperService {
      * Service implementation of [SnowballRService.getPreviousPaper].
      */
     suspend fun getPreviousPaper(request: Base.Id): GrpcProjectPaper
+
+    /**
+     * Service implementation of [SnowballRService.getNextPaperToReview].
+     */
+    suspend fun getNextPaperToReview(request: Base.Id): GrpcProjectPaper
 }
 
 /**
@@ -91,7 +99,7 @@ interface IProjectPaperService {
  * @param reviewTableRepo The repository responsible for managing persistence operations for the reviews
  * @param reviewHasCriterionTableRepo The repository responsible for managing persistence operations for the review has
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class ProjectPaperService(
     private val repo: IProjectPaperTableRepo,
     private val userRepo: IUserTableRepo,
@@ -197,6 +205,37 @@ class ProjectPaperService(
             adjacentPaper.toGrpcProjectPaperWithData(paper)
         }
 
+    /**
+     * Filters a list of [ProjectPaper]s paired with their associated reviews to retrieve those
+     * that the current user has not reviewed.
+     *
+     * @param papersWithReviews A list of pairs, where each pair contains a [ProjectPaper] and a list of its [Review]s.
+     * @param currentUser The [User] object representing the current user whose reviews are to be excluded.
+     * @return A list of pairs, where each pair consists of a [ProjectPaper] and the count of its associated reviews.
+     */
+    private fun getProjectPapersWithoutOwnReview(
+        papersWithReviews: List<Pair<ProjectPaper, List<Review>>>,
+        currentUser: User,
+    ) = papersWithReviews
+        .filter { (_, reviews) ->
+            reviews.none { review -> review.userId == currentUser.id }
+        }
+        .map { (paper, reviews) -> paper to reviews.size }
+
+    /**
+     * Sorts a list of project papers paired with their corresponding review counts. The sorting is done primarily by
+     * the stage of the project paper in ascending order, and secondarily by the review count in ascending order. The
+     * result includes only the sorted project papers, excluding the review counts from the output.
+     *
+     * @param projectPapersWithReviewCount A list of pairs, where each pair contains a [ProjectPaper] and its
+     * corresponding review count, represented as an integer.
+     * @return A list of [ProjectPaper] objects sorted by stage and review count.
+     */
+    private fun sortPapersByStageAndReviewCount(projectPapersWithReviewCount: List<Pair<ProjectPaper, Int>>) =
+        projectPapersWithReviewCount
+            .sortedWith(compareBy<Pair<ProjectPaper, Int>> { it.first.stage }.thenBy { it.second })
+            .map { it.first }
+
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
@@ -267,4 +306,40 @@ class ProjectPaperService(
 
     override suspend fun getPreviousPaper(request: Base.Id): GrpcProjectPaper =
         getAdjacentPaper(request.id, PaperNavigationDirection.PREVIOUS)
+
+    override suspend fun getNextPaperToReview(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
+        val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
+        val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+        val projectId = projectPaper.projectId
+
+        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
+
+        val projectPapers = repo.getLaterProjectPapers(
+            projectId,
+            projectPaper.localPaperId,
+            projectPaper.stage,
+        )
+        val projectPapersWithReviews: List<Pair<ProjectPaper, List<Review>>> = projectPapers
+            .map { paper ->
+                val reviews = reviewTableRepo.getAllReviewsForProjectPaper(paper.id)
+                paper to reviews
+            }
+
+        val projectPapersWithoutOwnReview = getProjectPapersWithoutOwnReview(projectPapersWithReviews, currentUser)
+
+        if (projectPapersWithoutOwnReview.isEmpty()) {
+            throw FailedPreconditionException(
+                "There is no next project paper available to review in the project with ID $projectId",
+            )
+        }
+
+        val sortedPapers = sortPapersByStageAndReviewCount(projectPapersWithoutOwnReview)
+
+        val papersWithoutFinalDecision = sortedPapers.filter {
+            it.decision == PaperDecision.PAPER_DECISION_UNSPECIFIED ||
+                it.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
+        }
+
+        (papersWithoutFinalDecision.firstOrNull() ?: sortedPapers.first()).toGrpcProjectPaperWithData()
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -512,61 +512,62 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
     }
 
     @Nested
-    inner class GetLaterProjectPapers {
+    inner class GetSubsequentProjectPapersTest {
         @Test
-        fun `When later projectPapers are found, then a list of only the later project paper is returned`() = runTest {
-            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
-            val paperId1 = insertPaperAndGetId()
-            val paperId2 = insertPaperAndGetId()
-            val paperId3 = insertPaperAndGetId()
-            val paperId4 = insertPaperAndGetId()
-            val paperId5 = insertPaperAndGetId()
+        fun `When subsequent projectPapers are found, then a list of only the subsequent project papers is returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val paperId3 = insertPaperAndGetId()
+                val paperId4 = insertPaperAndGetId()
+                val paperId5 = insertPaperAndGetId()
 
-            val currentId = insertProjectPaperAndGetId(
-                paperId = paperId1,
-                projectId = projectId,
-                localPaperId = 2,
-                stage = 1,
-                createdBy = testUserId,
-            )
-            val nextInSameStageId = insertProjectPaperAndGetId(
-                paperId = paperId2,
-                projectId = projectId,
-                localPaperId = 3,
-                stage = 1,
-                createdBy = testUserId,
-            )
-            val nextInHigherStageId = insertProjectPaperAndGetId(
-                paperId = paperId3,
-                projectId = projectId,
-                localPaperId = 1,
-                stage = 2,
-                createdBy = testUserId,
-            )
-            val lowerStageId = insertProjectPaperAndGetId(
-                paperId = paperId4,
-                projectId = projectId,
-                localPaperId = 4,
-                stage = 0,
-                createdBy = testUserId,
-            )
-            val sameStageLowerId = insertProjectPaperAndGetId(
-                paperId = paperId5,
-                projectId = projectId,
-                localPaperId = 0,
-                stage = 1,
-                createdBy = testUserId,
-            )
+                val currentId = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    localPaperId = 2,
+                    stage = 1,
+                    createdBy = testUserId,
+                )
+                val nextInSameStageId = insertProjectPaperAndGetId(
+                    paperId = paperId2,
+                    projectId = projectId,
+                    localPaperId = 3,
+                    stage = 1,
+                    createdBy = testUserId,
+                )
+                val nextInHigherStageId = insertProjectPaperAndGetId(
+                    paperId = paperId3,
+                    projectId = projectId,
+                    localPaperId = 1,
+                    stage = 2,
+                    createdBy = testUserId,
+                )
+                val lowerStageId = insertProjectPaperAndGetId(
+                    paperId = paperId4,
+                    projectId = projectId,
+                    localPaperId = 4,
+                    stage = 0,
+                    createdBy = testUserId,
+                )
+                val sameStageLowerId = insertProjectPaperAndGetId(
+                    paperId = paperId5,
+                    projectId = projectId,
+                    localPaperId = 0,
+                    stage = 1,
+                    createdBy = testUserId,
+                )
 
-            val projectPaperIds = repo.getLaterProjectPapers(projectId, 2, 1).map { it.id }
+                val projectPaperIds = repo.getSubsequentProjectPapers(projectId, 2, 1).map { it.id }
 
-            assertThat(projectPaperIds).hasSize(2)
-            assertThat(projectPaperIds).containsExactly(nextInSameStageId, nextInHigherStageId)
-            assertThat(projectPaperIds).doesNotContain(currentId, lowerStageId, sameStageLowerId)
-        }
+                assertThat(projectPaperIds).hasSize(2)
+                assertThat(projectPaperIds).containsExactly(nextInSameStageId, nextInHigherStageId)
+                assertThat(projectPaperIds).doesNotContain(currentId, lowerStageId, sameStageLowerId)
+            }
 
         @Test
-        fun `When no later projectPapers are found, then an empty list is returned`() = runTest {
+        fun `When no subsequent projectPapers are found, then an empty list is returned`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
             val paperId1 = insertPaperAndGetId()
             insertProjectPaperAndGetId(
@@ -577,69 +578,13 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 createdBy = testUserId,
             )
 
-            val projectPaperIds = repo.getLaterProjectPapers(projectId, 0, 1).map { it.id }
+            val projectPaperIds = repo.getSubsequentProjectPapers(projectId, 0, 1).map { it.id }
 
             assertThat(projectPaperIds).isEmpty()
         }
 
         @Test
-        fun `When later projectPapers are found, then a list with the correct order is returned`() = runTest {
-            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
-            val paperId1 = insertPaperAndGetId()
-            val paperId2 = insertPaperAndGetId()
-            val paperId3 = insertPaperAndGetId()
-            val paperId4 = insertPaperAndGetId()
-            val paperId5 = insertPaperAndGetId()
-            val currentId = insertProjectPaperAndGetId(
-                paperId = paperId1,
-                projectId = projectId,
-                localPaperId = 0,
-                stage = 1,
-                createdBy = testUserId,
-            )
-            val nextInHigherStageId2 = insertProjectPaperAndGetId(
-                paperId = paperId5,
-                projectId = projectId,
-                localPaperId = 5,
-                stage = 2,
-                createdBy = testUserId,
-            )
-            val nextInSameStageId2 = insertProjectPaperAndGetId(
-                paperId = paperId3,
-                projectId = projectId,
-                localPaperId = 4,
-                stage = 1,
-                createdBy = testUserId,
-            )
-            val nextInHigherStageId1 = insertProjectPaperAndGetId(
-                paperId = paperId4,
-                projectId = projectId,
-                localPaperId = 3,
-                stage = 2,
-                createdBy = testUserId,
-            )
-            val nextInSameStageId1 = insertProjectPaperAndGetId(
-                paperId = paperId2,
-                projectId = projectId,
-                localPaperId = 2,
-                stage = 1,
-                createdBy = testUserId,
-            )
-
-            val projectPaperIds = repo.getLaterProjectPapers(projectId, 0, 1).map { it.id }
-
-            assertThat(projectPaperIds).hasSize(4)
-            assertThat(projectPaperIds).containsExactly(
-                nextInSameStageId1,
-                nextInSameStageId2,
-                nextInHigherStageId1,
-                nextInHigherStageId2,
-            )
-            assertThat(projectPaperIds).doesNotContain(currentId)
-        }
-
-        @Test
-        fun `When later projectPapers are found,only the project papers in the correct project are returned`() =
+        fun `When later projectPapers are found, then only the project papers in the correct project are returned`() =
             runTest {
                 val projectId1 = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
                 val projectId2 = insertProjectAndGetId(createdBy = testUserId)
@@ -668,7 +613,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     createdBy = testUserId,
                 )
 
-                val projectPaperIds = repo.getLaterProjectPapers(projectId1, 0, 1).map { it.id }
+                val projectPaperIds = repo.getSubsequentProjectPapers(projectId1, 0, 1).map { it.id }
 
                 assertThat(projectPaperIds).hasSize(1)
                 assertThat(projectPaperIds).containsExactly(nextProjectPaperId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -584,7 +584,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
         }
 
         @Test
-        fun `When later projectPapers are found, then only the project papers in the correct project are returned`() =
+        fun `When subsequent projectPapers are found, then only the project papers in the correct project are returned`() =
             runTest {
                 val projectId1 = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
                 val projectId2 = insertProjectAndGetId(createdBy = testUserId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -510,4 +510,169 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             assertEquals(PaperDecision.PAPER_DECISION_ACCEPTED, projectPaper.decision)
         }
     }
+
+    @Nested
+    inner class GetLaterProjectPapers {
+        @Test
+        fun `When later projectPapers are found, then a list of only the later project paper is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
+            val paperId1 = insertPaperAndGetId()
+            val paperId2 = insertPaperAndGetId()
+            val paperId3 = insertPaperAndGetId()
+            val paperId4 = insertPaperAndGetId()
+            val paperId5 = insertPaperAndGetId()
+
+            val currentId = insertProjectPaperAndGetId(
+                paperId = paperId1,
+                projectId = projectId,
+                localPaperId = 2,
+                stage = 1,
+                createdBy = testUserId,
+            )
+            val nextInSameStageId = insertProjectPaperAndGetId(
+                paperId = paperId2,
+                projectId = projectId,
+                localPaperId = 3,
+                stage = 1,
+                createdBy = testUserId,
+            )
+            val nextInHigherStageId = insertProjectPaperAndGetId(
+                paperId = paperId3,
+                projectId = projectId,
+                localPaperId = 1,
+                stage = 2,
+                createdBy = testUserId,
+            )
+            val lowerStageId = insertProjectPaperAndGetId(
+                paperId = paperId4,
+                projectId = projectId,
+                localPaperId = 4,
+                stage = 0,
+                createdBy = testUserId,
+            )
+            val sameStageLowerId = insertProjectPaperAndGetId(
+                paperId = paperId5,
+                projectId = projectId,
+                localPaperId = 0,
+                stage = 1,
+                createdBy = testUserId,
+            )
+
+            val projectPaperIds = repo.getLaterProjectPapers(projectId, 2, 1).map { it.id }
+
+            assertThat(projectPaperIds).hasSize(2)
+            assertThat(projectPaperIds).containsExactly(nextInSameStageId, nextInHigherStageId)
+            assertThat(projectPaperIds).doesNotContain(currentId, lowerStageId, sameStageLowerId)
+        }
+
+        @Test
+        fun `When no later projectPapers are found, then an empty list is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
+            val paperId1 = insertPaperAndGetId()
+            insertProjectPaperAndGetId(
+                paperId = paperId1,
+                projectId = projectId,
+                localPaperId = 1,
+                stage = 0,
+                createdBy = testUserId,
+            )
+
+            val projectPaperIds = repo.getLaterProjectPapers(projectId, 0, 1).map { it.id }
+
+            assertThat(projectPaperIds).isEmpty()
+        }
+
+        @Test
+        fun `When later projectPapers are found, then a list with the correct order is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
+            val paperId1 = insertPaperAndGetId()
+            val paperId2 = insertPaperAndGetId()
+            val paperId3 = insertPaperAndGetId()
+            val paperId4 = insertPaperAndGetId()
+            val paperId5 = insertPaperAndGetId()
+            val currentId = insertProjectPaperAndGetId(
+                paperId = paperId1,
+                projectId = projectId,
+                localPaperId = 0,
+                stage = 1,
+                createdBy = testUserId,
+            )
+            val nextInHigherStageId2 = insertProjectPaperAndGetId(
+                paperId = paperId5,
+                projectId = projectId,
+                localPaperId = 5,
+                stage = 2,
+                createdBy = testUserId,
+            )
+            val nextInSameStageId2 = insertProjectPaperAndGetId(
+                paperId = paperId3,
+                projectId = projectId,
+                localPaperId = 4,
+                stage = 1,
+                createdBy = testUserId,
+            )
+            val nextInHigherStageId1 = insertProjectPaperAndGetId(
+                paperId = paperId4,
+                projectId = projectId,
+                localPaperId = 3,
+                stage = 2,
+                createdBy = testUserId,
+            )
+            val nextInSameStageId1 = insertProjectPaperAndGetId(
+                paperId = paperId2,
+                projectId = projectId,
+                localPaperId = 2,
+                stage = 1,
+                createdBy = testUserId,
+            )
+
+            val projectPaperIds = repo.getLaterProjectPapers(projectId, 0, 1).map { it.id }
+
+            assertThat(projectPaperIds).hasSize(4)
+            assertThat(projectPaperIds).containsExactly(
+                nextInSameStageId1,
+                nextInSameStageId2,
+                nextInHigherStageId1,
+                nextInHigherStageId2,
+            )
+            assertThat(projectPaperIds).doesNotContain(currentId)
+        }
+
+        @Test
+        fun `When later projectPapers are found,only the project papers in the correct project are returned`() =
+            runTest {
+                val projectId1 = insertProjectAndGetId(createdBy = testUserId, maxStage = 2)
+                val projectId2 = insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val paperId3 = insertPaperAndGetId()
+                val currentId = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId1,
+                    localPaperId = 0,
+                    stage = 1,
+                    createdBy = testUserId,
+                )
+                val nextProjectPaperId = insertProjectPaperAndGetId(
+                    paperId = paperId2,
+                    projectId = projectId1,
+                    localPaperId = 1,
+                    stage = 2,
+                    createdBy = testUserId,
+                )
+                val projectPaperIndifferentProjectId = insertProjectPaperAndGetId(
+                    paperId = paperId3,
+                    projectId = projectId2,
+                    localPaperId = 0,
+                    stage = 1,
+                    createdBy = testUserId,
+                )
+
+                val projectPaperIds = repo.getLaterProjectPapers(projectId1, 0, 1).map { it.id }
+
+                assertThat(projectPaperIds).hasSize(1)
+                assertThat(projectPaperIds).containsExactly(nextProjectPaperId)
+                assertThat(projectPaperIds).doesNotContain(currentId, projectPaperIndifferentProjectId)
+            }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -33,7 +33,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             localPaperId = 0,
         )
         val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
-        val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
 
         mockCurrentUser(currentUser)
@@ -42,7 +41,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery {
-            projectPaperRepoMock.getLaterProjectPapers(
+            projectPaperRepoMock.getSubsequentProjectPapers(
                 project.id, projectPaper.localPaperId, projectPaper.stage,
             )
         } returns listOf(nextProjectPaper)
@@ -50,7 +49,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
         } returns listOf(review)
         coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
 
@@ -71,7 +69,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             localPaperId = 0,
         )
         val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
-        val author = DataBuilder.createExampleAuthor()
         val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
 
         mockCurrentUser(currentUser)
@@ -80,7 +77,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery {
-            projectPaperRepoMock.getLaterProjectPapers(
+            projectPaperRepoMock.getSubsequentProjectPapers(
                 project.id, projectPaper.localPaperId, projectPaper.stage,
             )
         } returns listOf(nextProjectPaper)
@@ -88,7 +85,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
         } returns listOf(review)
         coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
 
@@ -133,7 +129,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery {
-            projectPaperRepoMock.getLaterProjectPapers(
+            projectPaperRepoMock.getSubsequentProjectPapers(
                 project.id, projectPaper.localPaperId, projectPaper.stage,
             )
         } returns listOf(nextProjectPaper)
@@ -174,7 +170,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
                 localPaperId = 2,
                 decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
             )
-            val author = DataBuilder.createExampleAuthor()
             val review = DataBuilder.createExampleReview(projectPaperId = projectPaper1.id, userId = currentUser.id)
 
             mockCurrentUser(currentUser)
@@ -183,7 +178,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             } returns Result.success(currentProjectPaper)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
-                projectPaperRepoMock.getLaterProjectPapers(
+                projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
                 )
             } returns listOf(projectPaper1, projectPaper2)
@@ -191,7 +186,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
 
             coEvery { paperRepoMock.getPaperById(paper2.id) } returns Result.success(paper2)
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns emptyList()
 
             assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
@@ -237,7 +231,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
                 localPaperId = 3,
                 decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
             )
-            val author = DataBuilder.createExampleAuthor()
             val review = DataBuilder.createExampleReview(projectPaperId = projectPaper1.id, userId = UUID.randomUUID())
 
             mockCurrentUser(currentUser)
@@ -246,7 +239,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             } returns Result.success(currentProjectPaper)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
-                projectPaperRepoMock.getLaterProjectPapers(
+                projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
                 )
             } returns listOf(projectPaper1, projectPaper2, projectPaper3)
@@ -255,7 +248,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) } returns emptyList()
 
             coEvery { paperRepoMock.getPaperById(paper3.id) } returns Result.success(paper3)
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper3.id) } returns listOf(author)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper3.id) } returns emptyList()
 
             assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
@@ -294,7 +286,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
                 localPaperId = 2,
                 decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
             )
-            val author = DataBuilder.createExampleAuthor()
 
             mockCurrentUser(currentUser)
             coEvery {
@@ -302,7 +293,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             } returns Result.success(currentProjectPaper)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
-                projectPaperRepoMock.getLaterProjectPapers(
+                projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
                 )
             } returns listOf(projectPaper1, projectPaper2)
@@ -310,7 +301,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
 
             coEvery { paperRepoMock.getPaperById(paper2.id) } returns Result.success(paper2)
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns emptyList()
 
             assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
@@ -348,7 +338,6 @@ class GetNextPaperToReviewTest : MainServiceTest() {
                 localPaperId = 2,
                 decision = PaperDecision.PAPER_DECISION_ACCEPTED,
             )
-            val author = DataBuilder.createExampleAuthor()
 
             mockCurrentUser(currentUser)
             coEvery {
@@ -356,7 +345,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             } returns Result.success(currentProjectPaper)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
-                projectPaperRepoMock.getLaterProjectPapers(
+                projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
                 )
             } returns listOf(projectPaper1, projectPaper2)
@@ -364,7 +353,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
 
             coEvery { paperRepoMock.getPaperById(paper1.id) } returns Result.success(paper1)
-            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper1.id) } returns listOf(author)
+
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper1.id) } returns emptyList()
 
             assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -1,0 +1,374 @@
+package se.uulm.snowballr.backend.service.projectpaper
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+
+class GetNextPaperToReviewTest : MainServiceTest() {
+    private val projectPaperId = UUID.randomUUID()
+
+    private fun getExampleRequest() = Base.Id.newBuilder().setId(projectPaperId.toString()).build()
+
+    @Test
+    fun `When a server admin requests the next project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = projectPaperId,
+            projectId = project.id,
+            paperId = paper.id,
+            stage = 0,
+            localPaperId = 0,
+        )
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery {
+            projectPaperRepoMock.getLaterProjectPapers(
+                project.id, projectPaper.localPaperId, projectPaper.stage,
+            )
+        } returns listOf(nextProjectPaper)
+        coEvery {
+            reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
+        } returns listOf(review)
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member requests the next project paper, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = projectPaperId,
+            projectId = project.id,
+            paperId = paper.id,
+            stage = 0,
+            localPaperId = 0,
+        )
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
+        val author = DataBuilder.createExampleAuthor()
+        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery {
+            projectPaperRepoMock.getLaterProjectPapers(
+                project.id, projectPaper.localPaperId, projectPaper.stage,
+            )
+        } returns listOf(nextProjectPaper)
+        coEvery {
+            reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
+        } returns listOf(review)
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
+        coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper.id) } returns listOf(author)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+
+        assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a non project member requests the next project paper, then an UnauthorizedException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.success(projectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+            assertThrows<UnauthorizedException> { mainService.getNextPaperToReview(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When no next paper to review exists, then a FailedPreconditionException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = projectPaperId,
+            projectId = project.id,
+            paperId = paper.id,
+            stage = 0,
+            localPaperId = 0,
+        )
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
+        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id, userId = currentUser.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery {
+            projectPaperRepoMock.getLaterProjectPapers(
+                project.id, projectPaper.localPaperId, projectPaper.stage,
+            )
+        } returns listOf(nextProjectPaper)
+        coEvery {
+            reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
+        } returns listOf(review)
+
+        assertThrows<FailedPreconditionException> { mainService.getNextPaperToReview(getExampleRequest()) }
+    }
+
+    @Test
+    fun `When a project member requests the next project paper, then the project papers without own review are filtered out correctly`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val currentPaper = DataBuilder.createExamplePaper()
+            val paper1 = DataBuilder.createExamplePaper()
+            val paper2 = DataBuilder.createExamplePaper()
+            val currentProjectPaper = DataBuilder.createExampleProjectPaper(
+                id = projectPaperId,
+                projectId = project.id,
+                paperId = currentPaper.id,
+                stage = 0,
+                localPaperId = 0,
+            )
+            val projectPaper1 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper1.id,
+                stage = 0,
+                localPaperId = 1,
+                decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
+            )
+            val projectPaper2 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper2.id,
+                stage = 0,
+                localPaperId = 2,
+                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+            )
+            val author = DataBuilder.createExampleAuthor()
+            val review = DataBuilder.createExampleReview(projectPaperId = projectPaper1.id, userId = currentUser.id)
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
+            } returns Result.success(currentProjectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery {
+                projectPaperRepoMock.getLaterProjectPapers(
+                    project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
+                )
+            } returns listOf(projectPaper1, projectPaper2)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) } returns listOf(review)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
+
+            coEvery { paperRepoMock.getPaperById(paper2.id) } returns Result.success(paper2)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns emptyList()
+
+            assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
+            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
+            coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
+        }
+
+    @Test
+    fun `When a project member requests the next project paper, then the project papers are sorted correctly`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val currentPaper = DataBuilder.createExamplePaper()
+            val paper1 = DataBuilder.createExamplePaper()
+            val paper2 = DataBuilder.createExamplePaper()
+            val paper3 = DataBuilder.createExamplePaper()
+            val currentProjectPaper = DataBuilder.createExampleProjectPaper(
+                id = projectPaperId,
+                projectId = project.id,
+                paperId = currentPaper.id,
+                stage = 0,
+                localPaperId = 0,
+            )
+            val projectPaper1 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper1.id,
+                stage = 0,
+                localPaperId = 1,
+                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+            )
+            val projectPaper2 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper2.id,
+                stage = 1,
+                localPaperId = 2,
+                decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
+            )
+            val projectPaper3 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper3.id,
+                stage = 0,
+                localPaperId = 3,
+                decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
+            )
+            val author = DataBuilder.createExampleAuthor()
+            val review = DataBuilder.createExampleReview(projectPaperId = projectPaper1.id, userId = UUID.randomUUID())
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
+            } returns Result.success(currentProjectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery {
+                projectPaperRepoMock.getLaterProjectPapers(
+                    project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
+                )
+            } returns listOf(projectPaper1, projectPaper2, projectPaper3)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) } returns listOf(review)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) } returns emptyList()
+
+            coEvery { paperRepoMock.getPaperById(paper3.id) } returns Result.success(paper3)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper3.id) } returns listOf(author)
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper3.id) } returns emptyList()
+
+            assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
+            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
+            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
+            coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) }
+        }
+
+    @Test
+    fun `When a project member requests the next project paper, then the already decided paper are correctly filtered`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val currentPaper = DataBuilder.createExamplePaper()
+            val paper1 = DataBuilder.createExamplePaper()
+            val paper2 = DataBuilder.createExamplePaper()
+            val currentProjectPaper = DataBuilder.createExampleProjectPaper(
+                id = projectPaperId,
+                projectId = project.id,
+                paperId = currentPaper.id,
+                stage = 0,
+                localPaperId = 0,
+            )
+            val projectPaper1 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper1.id,
+                stage = 0,
+                localPaperId = 1,
+                decision = PaperDecision.PAPER_DECISION_ACCEPTED,
+            )
+            val projectPaper2 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper2.id,
+                stage = 1,
+                localPaperId = 2,
+                decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
+            )
+            val author = DataBuilder.createExampleAuthor()
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
+            } returns Result.success(currentProjectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery {
+                projectPaperRepoMock.getLaterProjectPapers(
+                    project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
+                )
+            } returns listOf(projectPaper1, projectPaper2)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) } returns emptyList()
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
+
+            coEvery { paperRepoMock.getPaperById(paper2.id) } returns Result.success(paper2)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper2.id) } returns listOf(author)
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns emptyList()
+
+            assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
+            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
+            coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
+        }
+
+    @Test
+    fun `When a project member requests the next project paper and only already decided papers are left, then an already decided paper is returned`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
+            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val currentPaper = DataBuilder.createExamplePaper()
+            val paper1 = DataBuilder.createExamplePaper()
+            val paper2 = DataBuilder.createExamplePaper()
+            val currentProjectPaper = DataBuilder.createExampleProjectPaper(
+                id = projectPaperId,
+                projectId = project.id,
+                paperId = currentPaper.id,
+                stage = 0,
+                localPaperId = 0,
+            )
+            val projectPaper1 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper1.id,
+                stage = 0,
+                localPaperId = 1,
+                decision = PaperDecision.PAPER_DECISION_ACCEPTED,
+            )
+            val projectPaper2 = DataBuilder.createExampleProjectPaper(
+                projectId = project.id,
+                paperId = paper2.id,
+                stage = 1,
+                localPaperId = 2,
+                decision = PaperDecision.PAPER_DECISION_ACCEPTED,
+            )
+            val author = DataBuilder.createExampleAuthor()
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
+            } returns Result.success(currentProjectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery {
+                projectPaperRepoMock.getLaterProjectPapers(
+                    project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
+                )
+            } returns listOf(projectPaper1, projectPaper2)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) } returns emptyList()
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
+
+            coEvery { paperRepoMock.getPaperById(paper1.id) } returns Result.success(paper1)
+            coEvery { authorOfPaperRepoMock.getAuthorsOfPaperById(paper1.id) } returns listOf(author)
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper1.id) } returns emptyList()
+
+            assertDoesNotThrow { mainService.getNextPaperToReview(getExampleRequest()) }
+            coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
+            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
+        }
+}


### PR DESCRIPTION
Closes #101 

## What I have made

I implemented the repo, service and grpc layer of the `getNextPaperToReview` call.

The startegy that is implemented is the following:
1. The next paper to review is the next paper that is still undecided and not already reviewed by the user, in the same stage as the current project paper with the least reviews (ordered by the `localPaperId`). If there is no such paper the next proper project paper from the next stage is taken.
2. If there is no undecided paper left, the next paper is the next paper in the same stage with the least reviews (ordered by the `localPaperId`). If there is no such paper the next proper project paper from the next stage is taken.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
