### PR TITLE
Implement `createReview` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -352,7 +352,7 @@ class SnowballRServer(
             mainService.getAllReviewsForProjectPaper(request)
 
         override suspend fun createReview(request: ReviewOuterClass.Review.Create): ReviewOuterClass.Review =
-            super.createReview(request)
+            mainService.createReview(request)
 
         override suspend fun updateReview(request: ReviewOuterClass.Review.Update): ReviewOuterClass.Review =
             super.updateReview(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -84,6 +84,7 @@ private class ExceptionCall<ReqT, RespT>(
                 is SnowballRException.StageNotFoundException -> Status.NOT_FOUND
                 is SnowballRException.NotFoundException -> Status.NOT_FOUND
                 is SnowballRException.DuplicateEntityException -> Status.ALREADY_EXISTS
+                is SnowballRException.DuplicateReviewException -> Status.ALREADY_EXISTS
                 is SnowballRException.UnauthorizedException -> Status.PERMISSION_DENIED
                 is SnowballRException.FailedPreconditionException -> Status.FAILED_PRECONDITION
                 is SnowballRException.EntityNotPersistedException -> Status.INTERNAL

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/SnowballRException.kt
@@ -87,6 +87,17 @@ sealed class SnowballRException(
     )
 
     /**
+     * Represents an exception that occurs when a user attempts to review a project paper that has already been reviewed by this user.
+     *
+     * @param projectPaperId The ID of the project paper that has already been reviewed.
+     * @param userId The ID of the user who has already reviewed the project paper.
+     */
+    class DuplicateReviewException(
+        projectPaperId: String,
+        userId: String,
+    ) : SnowballRException("Project paper with ID '$projectPaperId' was already reviewed by user with ID '$userId'.")
+
+    /**
      * Represents an exception that occurs when an entity creation was triggered, but it couldn't be fetched afterward.
      *
      * @param entityType The type of the entity that was not persisted.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -1,13 +1,17 @@
 package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.insert
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.ReviewTable
+import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import se.uulm.snowballr.backend.table.toReview
 import java.util.UUID
+import snowballr.ReviewOuterClass.Review as GrpcReview
 
 /**
  * Defines an interface for repository operations related to the [Review].
@@ -30,6 +34,16 @@ interface IReviewTableRepo {
      * @return A list of reviews associated with the given project paper.
      */
     suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review>
+
+    /**
+     * Creates a new review in the database with the provided [request] data.
+     *
+     * @param request The review request containing the project paper that was reviewed, the review decision and
+     * the selected project criteria to justify the decision.
+     * @param userId The ID of the user who created the review.
+     * @return The created [Review] object representing the newly created review.
+     */
+    suspend fun createReview(request: GrpcReview.Create, userId: UUID): Review
 }
 
 /**
@@ -52,5 +66,24 @@ class ReviewTableRepo(
 
     override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {
         ReviewTable.getEntities(ResultRow::toReview) { ReviewTable.projectPaperId eq projectPaperId }
+    }
+
+    override suspend fun createReview(request: GrpcReview.Create, userId: UUID): Review = db.query {
+        val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
+
+        val review = ReviewTable.insertAndGet(ResultRow::toReview, EntityType.REVIEW) {
+            it[ReviewTable.projectPaperId] = projectPaperId
+            it[ReviewTable.userId] = userId
+            it[decision] = request.decision
+        }
+
+        request.selectedCriteriaIdsList.forEach { criterionId ->
+            ReviewHasCriterionTable.insert {
+                it[this.reviewId] = review.id
+                it[this.criterionId] = parseUUID(criterionId, EntityType.CRITERION)
+            }
+        }
+
+        review
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
@@ -120,6 +121,14 @@ interface IProjectPaperTableRepo {
      * @return A float between 0.0 and 1.0 representing the project progress.
      */
     suspend fun getProjectProgress(projectId: UUID): Float
+
+    /**
+     * Updates the decision of a project paper.
+     *
+     * @param projectPaperId The unique identifier of the project paper to be updated.
+     * @param decision The new [PaperDecision] to be set.
+     */
+    suspend fun updateProjectPaperDecision(projectPaperId: UUID, decision: PaperDecision): Unit
 }
 
 /**
@@ -132,6 +141,7 @@ interface IProjectPaperTableRepo {
  *
  * @param db The database abstraction used for executing queries within a transaction.
  */
+@Suppress("TooManyFunctions")
 class ProjectPaperTableRepo(
     private val db: IDatabase,
 ) : IProjectPaperTableRepo {
@@ -241,6 +251,12 @@ class ProjectPaperTableRepo(
             }.count()
             val progress = fullyReviewedPapersCount.toFloat() / allPapersCount
             progress
+        }
+    }
+
+    override suspend fun updateProjectPaperDecision(projectPaperId: UUID, decision: PaperDecision): Unit = db.query {
+        ProjectPaperTable.update({ ProjectPaperTable.id eq projectPaperId }) {
+            it[ProjectPaperTable.decision] = decision
         }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -233,7 +233,7 @@ class ProjectPaperTableRepo(
                 it[ProjectPaperTable.projectId] = projectId
                 it[ProjectPaperTable.localPaperId] = localPaperId
                 it[stage] = request.stage
-                it[decision] = PaperDecision.PAPER_DECISION_UNSPECIFIED
+                it[decision] = PaperDecision.PAPER_DECISION_UNREVIEWED
                 it[createdBy] = userId
             }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.toGrpcCriteria
@@ -114,9 +113,7 @@ class CriterionService(
 
                 val project = projectRepo.getProjectById(projectId).getOrThrow()
 
-                isProjectActive()
-                    .orElseThrow(EntityNotActiveException(EntityType.PROJECT, project.id.toString()))
-                    .checkFor(currentUser, project)
+                isProjectActive().checkFor(currentUser, project)
             }
 
             repo.createCriterion(request, currentUser.id).toGrpcCriterion()
@@ -130,9 +127,7 @@ class CriterionService(
             if (criterion is Criterion.ProjectCriterion) {
                 val project = projectRepo.getProjectById(criterion.projectId).getOrThrow()
 
-                isProjectActive()
-                    .orElseThrow(EntityNotActiveException(EntityType.PROJECT, project.id.toString()))
-                    .checkFor(currentUser, project)
+                isProjectActive().checkFor(currentUser, project)
             }
 
             isCreatorOfCriterion()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -6,7 +6,6 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.InvalidIdException
 import se.uulm.snowballr.backend.model.SnowballRException.InvitationTokenNotFoundException
@@ -25,7 +24,6 @@ import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
-import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.User
@@ -110,9 +108,7 @@ class InvitationService(
 
         val project = projectRepo.getProjectById(projectId).getOrThrow()
 
-        isProjectActive()
-            .orElseThrow(EntityNotActiveException(EntityType.PROJECT, projectId.toString()))
-            .checkFor(currentUser, project)
+        isProjectActive().checkFor(currentUser, project)
 
         // Generate and save invitation token
         val invitationToken = NanoId.generate(INVITATION_TOKEN_LENGTH)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -4,7 +4,6 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateEntityException
-import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
 import se.uulm.snowballr.backend.model.SnowballRException.OutOfRangeException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Author
@@ -31,7 +30,6 @@ import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
-import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.Project
@@ -226,9 +224,7 @@ class ProjectPaperService(
             isServerOrProjectAdmin(projectMemberRepo, AccessType.CREATE).checkFor(currentUser, projectId)
 
             val project = projectRepo.getProjectById(projectId).getOrThrow()
-            isProjectActive()
-                .orElseThrow(EntityNotActiveException(EntityType.PROJECT, projectId.toString()))
-                .checkFor(currentUser, project)
+            isProjectActive().checkFor(currentUser, project)
 
             val paper = paperRepo.getPaperById(paperId).getOrThrow()
             if (repo.doesProjectPaperExist(projectId, paperId)) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -20,6 +20,7 @@ import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadReview
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.ReviewOuterClass
 import java.util.UUID
 import snowballr.ReviewOuterClass.Review as GrpcReview
 
@@ -93,6 +94,48 @@ class ReviewService(
             reviews.toGrpcReviews(reviewSelectedCriteriaMap)
         }
 
+    /**
+     * Determines the final paper decision based on the given list of reviews.
+     *
+     * At the moment, this is a simple sum function that adds one for each accepted review, subtracts one for each rejected,
+     * and leaves the sum unchanged for each maybe review. If the entire sum is above 0, the paper is accepted,
+     * if it is below 0, the paper is declined, if it is 0, the paper is in review. If the list is empty, the paper
+     * is considered to be unreviewed. At least two reviews are required to make a final decision.
+     * Exchange this by loading the decision matrix and calculating the final decision based on the matrix (see #345)
+     *
+     * @param projectPaperId ID of the project paper for which the final paper decision is to be determined.
+     * @param reviews List of reviews to be considered for the final paper decision.
+     */
+    @Suppress("MagicNumber")
+    private suspend fun determinePaperDecision(projectPaperId: UUID, reviews: List<Review>) {
+        val requiredReviews = 2
+        if (reviews.isEmpty()) {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_UNREVIEWED)
+            return
+        } else if (reviews.size < requiredReviews) {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+            return
+        }
+
+        val sum = reviews.sumOf { review ->
+            when (review.decision) {
+                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_UNSPECIFIED -> 0
+                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_DECLINED -> -1
+                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE -> 0
+                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED -> 1
+                ReviewOuterClass.ReviewDecision.UNRECOGNIZED -> 0
+            }
+        }
+
+        if (sum > 0) {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+        } else if (sum < 0) {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+        } else {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+        }
+    }
+
     override suspend fun createReview(request: GrpcReview.Create): GrpcReview = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
@@ -119,6 +162,8 @@ class ReviewService(
 
         val review = repo.createReview(request, currentUser.id)
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+
+        determinePaperDecision(projectPaper.id, reviewsForProjectPaper + review)
 
         // TODO: (question for reviewer): Think about directly injecting the selected criteria ids instead of requesting
         // them from the repo.

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -20,6 +20,7 @@ import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadReview
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ReviewOuterClass
 import java.util.UUID
 import snowballr.ReviewOuterClass.Review as GrpcReview
@@ -105,16 +106,19 @@ class ReviewService(
      * TODO: Exchange this by loading the decision matrix and calculating the final decision based on the matrix (see #345)
      *
      * @param projectPaperId ID of the project paper for which the final paper decision is to be determined.
+     * @param decisionMatrix Decision matrix of the project, where the project paper is in, that can be used to define
+     * the final paper decision.
      * @param reviews List of reviews to be considered for the final paper decision.
      */
-    @Suppress("MagicNumber")
-    private suspend fun updatePaperDecision(projectPaperId: UUID, reviews: List<Review>) {
-
-        val requiredReviews = 2
+    private suspend fun updatePaperDecision(
+        projectPaperId: UUID,
+        decisionMatrix: ReviewDecisionMatrix,
+        reviews: List<Review>,
+    ) {
         if (reviews.isEmpty()) {
             projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_UNREVIEWED)
             return
-        } else if (reviews.size < requiredReviews) {
+        } else if (reviews.size < decisionMatrix.numberOfReviewers) {
             projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
             return
         }
@@ -157,7 +161,7 @@ class ReviewService(
             projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
         if (!isPaperNotFinallyDecided) {
             throw FailedPreconditionException(
-                "The project paper must be either unreviewed or still in review." +
+                "The project paper must be either unreviewed or still in review. " +
                     "Finally decided project papers cannot be reviewed anymore.",
             )
         }
@@ -165,10 +169,8 @@ class ReviewService(
         val review = repo.createReview(request, currentUser.id)
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
 
-        updatePaperDecision(projectPaper.id, reviewsForProjectPaper + review)
+        updatePaperDecision(projectPaper.id, project.reviewDecisionMatrix, reviewsForProjectPaper + review)
 
-        // TODO: (question for reviewer): Think about directly injecting the selected criteria ids instead of requesting
-        // them from the repo.
         review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -2,10 +2,14 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException
+import se.uulm.snowballr.backend.model.SnowballRException.DuplicateReviewException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.dto.toGrpcReview
 import se.uulm.snowballr.backend.model.dto.toGrpcReviews
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
@@ -14,7 +18,10 @@ import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTable
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadReview
+import se.uulm.snowballr.backend.service.accessrules.isProjectActive
+import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
+import snowballr.ProjectOuterClass.PaperDecision
 import java.util.UUID
 import snowballr.ReviewOuterClass.Review as GrpcReview
 
@@ -28,6 +35,11 @@ interface IReviewService {
      * Service implementation of [SnowballRService.getAllReviewsForProjectPaper].
      */
     suspend fun getAllReviewsForProjectPaper(request: Base.Id): GrpcReview.List
+
+    /**
+     * Service implementation of [SnowballRService.createReview].
+     */
+    suspend fun createReview(request: GrpcReview.Create): GrpcReview
 }
 
 /**
@@ -43,6 +55,7 @@ interface IReviewService {
  * @param repo Interface for persistence and retrieval operations related to reviews.
  * @param userRepo Interface for persistence and retrieval operations related to users.
  * @param projectPaperRepo Interface for persistence and retrieval operations related to project papers.
+ * @param projectRepo Interface for persistence and retrieval operations related to projects.
  * @param projectMemberRepo Interface for persistence and retrieval operations related to project members.
  * @param reviewHasCriterionRepo Interface for persistence and retrieval operations related to review criteria.
  */
@@ -50,6 +63,7 @@ class ReviewService(
     private val repo: IReviewTableRepo,
     private val userRepo: IUserTableRepo,
     private val projectPaperRepo: IProjectPaperTableRepo,
+    private val projectRepo: IProjectTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val reviewHasCriterionRepo: IReviewHasCriterionTableRepo,
 ) : IReviewService {
@@ -80,4 +94,38 @@ class ReviewService(
 
             reviews.toGrpcReviews(reviewSelectedCriteriaMap)
         }
+
+    override suspend fun createReview(request: GrpcReview.Create): GrpcReview = withUser(userRepo) { currentUser ->
+        val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
+        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
+
+        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+
+        val project = projectRepo.getProjectById(projectPaper.projectId).getOrThrow()
+        isProjectActive()
+            .orElseThrow(SnowballRException.EntityNotActiveException(EntityType.PROJECT, project.id.toString()))
+            .checkFor(currentUser, project)
+
+        val reviewsForProjectPaper = repo.getAllReviewsForProjectPaper(projectPaperId)
+        val hasUserAlreadyReviewed = reviewsForProjectPaper.any { review -> review.userId == currentUser.id }
+        if (hasUserAlreadyReviewed) {
+            throw DuplicateReviewException(projectPaperId.toString(), currentUser.id.toString())
+        }
+
+        val isPaperNotFinallyDecided = projectPaper.decision == PaperDecision.PAPER_DECISION_IN_REVIEW ||
+            projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
+        if (!isPaperNotFinallyDecided) {
+            throw FailedPreconditionException(
+                "The project paper must be either unreviewed or still in review." +
+                    "Finally decided project papers cannot be reviewed anymore.",
+            )
+        }
+
+        val review = repo.createReview(request, currentUser.id)
+        val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+
+        // TODO: (question for reviewer): Think about directly injecting the selected criteria ids instead of requesting
+        // them from the repo.
+        review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.SnowballRException
 import se.uulm.snowballr.backend.model.SnowballRException.DuplicateReviewException
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.dto.Review
@@ -19,7 +18,6 @@ import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadReview
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
-import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
 import java.util.UUID
@@ -102,9 +100,7 @@ class ReviewService(
         isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
 
         val project = projectRepo.getProjectById(projectPaper.projectId).getOrThrow()
-        isProjectActive()
-            .orElseThrow(SnowballRException.EntityNotActiveException(EntityType.PROJECT, project.id.toString()))
-            .checkFor(currentUser, project)
+        isProjectActive().checkFor(currentUser, project)
 
         val reviewsForProjectPaper = repo.getAllReviewsForProjectPaper(projectPaperId)
         val hasUserAlreadyReviewed = reviewsForProjectPaper.any { review -> review.userId == currentUser.id }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -95,19 +95,21 @@ class ReviewService(
         }
 
     /**
-     * Determines the final paper decision based on the given list of reviews.
+     * Determines the final paper decision based on the given list of reviews and updates the project paper decision
+     * accordingly.
      *
      * At the moment, this is a simple sum function that adds one for each accepted review, subtracts one for each rejected,
      * and leaves the sum unchanged for each maybe review. If the entire sum is above 0, the paper is accepted,
      * if it is below 0, the paper is declined, if it is 0, the paper is in review. If the list is empty, the paper
      * is considered to be unreviewed. At least two reviews are required to make a final decision.
-     * Exchange this by loading the decision matrix and calculating the final decision based on the matrix (see #345)
+     * TODO: Exchange this by loading the decision matrix and calculating the final decision based on the matrix (see #345)
      *
      * @param projectPaperId ID of the project paper for which the final paper decision is to be determined.
      * @param reviews List of reviews to be considered for the final paper decision.
      */
     @Suppress("MagicNumber")
-    private suspend fun determinePaperDecision(projectPaperId: UUID, reviews: List<Review>) {
+    private suspend fun updatePaperDecision(projectPaperId: UUID, reviews: List<Review>) {
+
         val requiredReviews = 2
         if (reviews.isEmpty()) {
             projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_UNREVIEWED)
@@ -163,7 +165,7 @@ class ReviewService(
         val review = repo.createReview(request, currentUser.id)
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
 
-        determinePaperDecision(projectPaper.id, reviewsForProjectPaper + review)
+        updatePaperDecision(projectPaper.id, reviewsForProjectPaper + review)
 
         // TODO: (question for reviewer): Think about directly injecting the selected criteria ids instead of requesting
         // them from the repo.

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -4,6 +4,7 @@ package se.uulm.snowballr.backend.service.accessrules
 
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Project
@@ -28,12 +29,15 @@ fun isProjectExistent(projectRepo: IProjectTableRepo): AccessRule<UUID> {
 }
 
 /**
- * Check whether the project is active (or active, but settings are locked).
+ * Check whether the project is active (or active, but settings are locked);
+ * otherwise, throws an [EntityNotActiveException].
  */
 @CheckReturnValue
-fun isProjectActive() = AccessRule<Project> { _, project ->
-    project.status == ProjectStatus.PROJECT_STATUS_ACTIVE ||
-        project.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+fun isProjectActive(): AccessRule<Project> {
+    return AccessRule<Project> { _, project ->
+        project.status == ProjectStatus.PROJECT_STATUS_ACTIVE ||
+            project.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+    }.orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id.toString()) }
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -14,11 +14,16 @@ import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
 import java.util.UUID
 
+private const val REQUIRED_REVIEWERS = 2
+
 private const val ARE_HOTKEYS_SHOWN_DEFAULT = true
 private const val IS_REVIEW_MODE_ENABLED_DEFAULT = false
 private val CRITERIA_IDS_DEFAULT = emptyList<UUID>()
 private const val SIMILARITY_THRESHOLD_DEFAULT = 0F
-private val DECISION_MATRIX_DEFAULT: ByteArray = ReviewDecisionMatrix.getDefaultInstance().toByteArray()
+private val DECISION_MATRIX_DEFAULT: ByteArray = ReviewDecisionMatrix.newBuilder()
+    .setNumberOfReviewers(REQUIRED_REVIEWERS)
+    .build()
+    .toByteArray()
 private val FETCHERS_DEFAULT = emptyMap<String, Map<String, String>>()
 private val SNOWBALLING_TYPE_DEFAULT = SnowballingType.SNOWBALLING_TYPE_BOTH
 private const val REVIEW_MAYBE_ALLOWED_DEFAULT = true

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ReviewValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ReviewValidator.kt
@@ -1,0 +1,19 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.ReviewOuterClass.Review
+import snowballr.ReviewOuterClass.Review.Create
+
+/**
+ * A validator for [Review] related requests.
+ */
+@Suppress("StringLiteralDuplication")
+object ReviewValidator {
+    fun validateCreateRequest(request: Create): EitherNel<ValidationIssue, Unit> = either {
+        ensureIdValidity("project_paper_id", request.projectPaperId)
+        ensureEnumNotUnspecified("decision", request.decision)
+        ensureIdListValidity("selected_criteria_ids", request.selectedCriteriaIdsList)
+    }.toEitherNel()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ValidationHelper.kt
@@ -96,6 +96,16 @@ fun Raise<ValidationIssue>.ensureIdValidity(name: String, id: String) =
     ensure(runCatching { UUID.fromString(id) }.isSuccess) { InvalidId(name, id) }
 
 /**
+ * Ensures that the provided list of [ids] has a valid format.
+ *
+ * @param name The name of the id list being validated.
+ * @param ids The list of IDs to check for validity.
+ */
+fun Raise<ValidationIssue>.ensureIdListValidity(name: String, ids: List<String>) {
+    ids.forEach { ensureIdValidity(name, it) }
+}
+
+/**
  * Ensures that the provided email has a valid format.
  * If the email does not match the [EMAIL_REGEX], an [InvalidEmail] validation issue is raised.
  *

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -11,6 +11,7 @@ import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.PaperOuterClass.Paper
 import snowballr.ProjectOuterClass
+import snowballr.ReviewOuterClass
 import snowballr.UserOuterClass
 
 /**
@@ -55,6 +56,8 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     // Criterion
     is CriterionOuterClass.Criterion.Create -> CriterionValidator.validateCreateRequest(request)
     is CriterionOuterClass.Criterion.Update -> CriterionValidator.validateUpdateRequest(request)
+    // Review
+    is ReviewOuterClass.Review.Create -> ReviewValidator.validateCreateRequest(request)
     // Base
     is Base.Id -> BaseValidator.validateId(request)
     is Base.Email -> BaseValidator.validateEmail(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -5,26 +5,35 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertUserAndGetId
+import se.uulm.snowballr.backend.repository.association.ReviewHasCriterionTableRepo
+import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
+import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ReviewOuterClass.Review
 import snowballr.ReviewOuterClass.ReviewDecision
 import java.sql.SQLException
 import java.util.UUID
+import kotlin.test.assertContains
 
-class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable), true) {
+class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable,
+    ReviewHasCriterionTable, CriterionTable
+), true) {
     private val repo = ReviewTableRepo(db)
+    private val reviewHasCriterionRepo = ReviewHasCriterionTableRepo(db)
 
     @Nested
     inner class GetReviewById {
@@ -120,7 +129,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
         private fun createReviewRequest(projectPaperId: UUID) = Review.Create.newBuilder()
             .setProjectPaperId(projectPaperId.toString())
             .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
-            .build()
+
 
         @Test
         fun `When a review is created, then the correct review is returned`() = runTest {
@@ -130,7 +139,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
                 insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
             val userId = insertUserAndGetId(email = "existing.reviewer@example.com")
 
-            val review = repo.createReview(createReviewRequest(projectPaperId), userId)
+            val review = assertDoesNotThrow { repo.createReview(createReviewRequest(projectPaperId).build(), userId) }
 
             assertEquals(projectPaperId, review.projectPaperId)
             assertEquals(ReviewDecision.REVIEW_DECISION_ACCEPTED, review.decision)
@@ -145,7 +154,7 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
                 val projectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
 
-                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId), UUID.randomUUID()) }
+                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId).build(), UUID.randomUUID()) }
             }
 
         @Test
@@ -158,9 +167,23 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
                 val userId = insertUserAndGetId(email = "double.reviewing.user@example.com")
                 insertReviewAndGetId(projectPaperId, userId)
 
-                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId), userId) }
+                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId).build(), userId) }
             }
 
-        // TODO: (question for reviewer): Check whether the selected criteria are correctly stored for the review
+        @Test
+        fun `When a review is created with criteria, then the correct review is created and the criteria are stored correctly`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val userId = insertUserAndGetId(email = "reviewing.user.with.criteria@example.com")
+            val selectedCriterion = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+
+            val review = assertDoesNotThrow { repo.createReview(createReviewRequest(projectPaperId).addSelectedCriteriaIds(selectedCriterion.toString()).build(), userId) }
+
+            val selectedCriteria = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+            assertThat(selectedCriteria).hasSize(1)
+            assertContains(selectedCriteria, selectedCriterion)
+        }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -29,9 +29,17 @@ import java.sql.SQLException
 import java.util.UUID
 import kotlin.test.assertContains
 
-class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable,
-    ReviewHasCriterionTable, CriterionTable
-), true) {
+class ReviewTableRepoTest : RepositoryTest(
+    arrayOf(
+        ReviewTable,
+        ProjectTable,
+        ProjectPaperTable,
+        PaperTable,
+        ReviewHasCriterionTable,
+        CriterionTable,
+    ),
+    true,
+) {
     private val repo = ReviewTableRepo(db)
     private val reviewHasCriterionRepo = ReviewHasCriterionTableRepo(db)
 
@@ -130,7 +138,6 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
             .setProjectPaperId(projectPaperId.toString())
             .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
 
-
         @Test
         fun `When a review is created, then the correct review is returned`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
@@ -154,7 +161,9 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
                 val projectPaperId =
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
 
-                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId).build(), UUID.randomUUID()) }
+                assertThrows<SQLException> {
+                    repo.createReview(createReviewRequest(projectPaperId).build(), UUID.randomUUID())
+                }
             }
 
         @Test
@@ -171,19 +180,24 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
             }
 
         @Test
-        fun `When a review is created with criteria, then the correct review is created and the criteria are stored correctly`() = runTest {
-            val projectId = insertProjectAndGetId(createdBy = testUserId)
-            val paperId = insertPaperAndGetId()
-            val projectPaperId =
-                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
-            val userId = insertUserAndGetId(email = "reviewing.user.with.criteria@example.com")
-            val selectedCriterion = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+        fun `When a review is created with criteria, then the correct review is created and the criteria are stored correctly`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+                val userId = insertUserAndGetId(email = "reviewing.user.with.criteria@example.com")
+                val selectedCriterion = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
 
-            val review = assertDoesNotThrow { repo.createReview(createReviewRequest(projectPaperId).addSelectedCriteriaIds(selectedCriterion.toString()).build(), userId) }
+                val createReviewWithCriteriaRequest = createReviewRequest(projectPaperId)
+                    .addSelectedCriteriaIds(selectedCriterion.toString())
+                    .build()
 
-            val selectedCriteria = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
-            assertThat(selectedCriteria).hasSize(1)
-            assertContains(selectedCriteria, selectedCriterion)
-        }
+                val review = assertDoesNotThrow { repo.createReview(createReviewWithCriteriaRequest, userId) }
+
+                val selectedCriteria = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+                assertThat(selectedCriteria).hasSize(1)
+                assertContains(selectedCriteria, selectedCriterion)
+            }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -5,18 +5,22 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertReviewAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertUserAndGetId
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
+import snowballr.ReviewOuterClass.Review
 import snowballr.ReviewOuterClass.ReviewDecision
+import java.sql.SQLException
 import java.util.UUID
 
 class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, ProjectPaperTable, PaperTable), true) {
@@ -109,5 +113,54 @@ class ReviewTableRepoTest : RepositoryTest(arrayOf(ReviewTable, ProjectTable, Pr
                 assertThat(reviews).anyMatch { it.id == reviewId1 }
                 assertThat(reviews).noneMatch { it.id == reviewId2 }
             }
+    }
+
+    @Nested
+    inner class CreateReview {
+        private fun createReviewRequest(projectPaperId: UUID) = Review.Create.newBuilder()
+            .setProjectPaperId(projectPaperId.toString())
+            .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+            .build()
+
+        @Test
+        fun `When a review is created, then the correct review is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId =
+                insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+            val userId = insertUserAndGetId(email = "existing.reviewer@example.com")
+
+            val review = repo.createReview(createReviewRequest(projectPaperId), userId)
+
+            assertEquals(projectPaperId, review.projectPaperId)
+            assertEquals(ReviewDecision.REVIEW_DECISION_ACCEPTED, review.decision)
+            assertEquals(userId, review.userId)
+        }
+
+        @Test
+        fun `When a review is created, but the assigned user does not exist, then a SQLException is thrown`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+
+                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId), UUID.randomUUID()) }
+            }
+
+        @Test
+        fun `When a review is created, but the user already reviewed this project paper, then a SQLException is thrown`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+                val userId = insertUserAndGetId(email = "double.reviewing.user@example.com")
+                insertReviewAndGetId(projectPaperId, userId)
+
+                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId), userId) }
+            }
+
+        // TODO: (question for reviewer): Check whether the selected criteria are correctly stored for the review
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -338,6 +338,10 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         @Test
         fun `When a user is found, then a successful result with the user settings is returned`() = runTest {
             val userId = insertUserAndGetId()
+            val decisionMatrix = ReviewDecisionMatrix.newBuilder()
+                .setNumberOfReviewers(2)
+                .build()
+
             val result = repo.getUserSettings(userId)
 
             val userSettings = assertResultSuccess(result)
@@ -345,7 +349,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
             assertFalse(userSettings.isReviewModeEnabled)
             assertThat(userSettings.criteriaIds).isEmpty()
             assertEquals(0F, userSettings.similarityThreshold)
-            assertEquals(ReviewDecisionMatrix.getDefaultInstance(), userSettings.decisionMatrix)
+            assertEquals(decisionMatrix, userSettings.decisionMatrix)
             assertThat(userSettings.fetchers).isEmpty()
             assertEquals(SnowballingType.SNOWBALLING_TYPE_BOTH, userSettings.snowballingType)
             assertTrue(userSettings.reviewMaybeAllowed)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -421,4 +421,24 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             Arguments.of(PaperDecision.PAPER_DECISION_DECLINED, 1.0f),
         )
     }
+
+    @Nested
+    inner class UpdateProjectPaperDecisionTest {
+        @Test
+        fun `When a project paper decision is updated, then the project paper is updated`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId = insertPaperAndGetId()
+            val projectPaperId = insertProjectPaperAndGetId(
+                paperId,
+                projectId,
+                decision = PaperDecision.PAPER_DECISION_IN_REVIEW,
+                createdBy = testUserId,
+            )
+
+            repo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+
+            val projectPaper = assertResultSuccess(repo.getProjectPaperById(projectPaperId))
+            assertEquals(PaperDecision.PAPER_DECISION_ACCEPTED, projectPaper.decision)
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -299,7 +299,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 assertEquals(projectId, projectPaper.projectId)
                 assertEquals(0, projectPaper.localPaperId)
                 assertEquals(0, projectPaper.stage)
-                assertEquals(PaperDecision.PAPER_DECISION_UNSPECIFIED, projectPaper.decision)
+                assertEquals(PaperDecision.PAPER_DECISION_UNREVIEWED, projectPaper.decision)
                 assertEquals(testUserId, projectPaper.createdBy)
             }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -95,6 +95,9 @@ class CreateReviewTest : MainServiceTest() {
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
+        coEvery {
+            projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+        } returns Unit
     }
 
     @ParameterizedTest
@@ -131,6 +134,29 @@ class CreateReviewTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.createReview(validCreateReviewRequest.build()) }
+        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "PROJECT_STATUS_ARCHIVED",
+            "PROJECT_STATUS_DELETED",
+        ],
+    )
+    fun `When the project paper to review is in an inactive project, then a FailedPreconditionException is thrown`(
+        statusName: String,
+    ) = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+        assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
@@ -192,32 +218,12 @@ class CreateReviewTest : MainServiceTest() {
             coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(reviewByAnotherUser)
             coEvery { reviewRepoMock.createReview(validCreateReviewRequest.build(), currentUser.id) } returns review
             coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) } returns emptyList()
+            coEvery {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+            } returns Unit
 
             assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
         }
-
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            "PROJECT_STATUS_ARCHIVED",
-            "PROJECT_STATUS_DELETED",
-        ],
-    )
-    fun `When the project paper to review is in an inactive project, then a FailedPreconditionException is thrown`(
-        statusName: String,
-    ) = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-
-        assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
-        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
-    }
 
     @Test
     fun `When the project paper is already finally decided, then a FailedPreconditionException is thrown`() = runTest {
@@ -238,4 +244,107 @@ class CreateReviewTest : MainServiceTest() {
         assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `When the project paper is not finally decided, then the paper decision is updated accordingly to the review`() =
+        runTest {
+            val firstReviewer = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val secondReviewer = DataBuilder.createExampleUser(
+                email = "second.reviewer@example.com",
+                role = UserRole.USER_ROLE_ADMIN,
+            )
+            val thirdReviewer = DataBuilder.createExampleUser(
+                email = "third.reviewer@example.com",
+                role = UserRole.USER_ROLE_ADMIN,
+            )
+            val project = DataBuilder.createExampleProject()
+            val projectPaper = DataBuilder.createExampleProjectPaper(
+                id = projectPaperId,
+                projectId = project.id,
+                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+            )
+
+            mockCurrentUser(firstReviewer)
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns emptyList()
+            val firstReview = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                userId = firstReviewer.id,
+                decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
+            )
+            val createFirstReviewRequest = validCreateReviewRequest.setDecision(
+                ReviewDecision.REVIEW_DECISION_ACCEPTED,
+            ).build()
+            coEvery {
+                reviewRepoMock.createReview(createFirstReviewRequest, firstReviewer.id)
+            } returns firstReview
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(firstReview.id)
+            } returns selectedCriteriaIds
+            coEvery {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+            } returns Unit
+
+            assertDoesNotThrow { mainService.createReview(createFirstReviewRequest) }
+
+            mockCurrentUser(secondReviewer)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(firstReview)
+            val secondReview = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                userId = secondReviewer.id,
+                decision = ReviewDecision.REVIEW_DECISION_DECLINED,
+            )
+            val createSecondReviewRequest = validCreateReviewRequest.setDecision(
+                ReviewDecision.REVIEW_DECISION_DECLINED,
+            ).build()
+            coEvery {
+                reviewRepoMock.createReview(createSecondReviewRequest, secondReviewer.id)
+            } returns secondReview
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(secondReview.id)
+            } returns selectedCriteriaIds
+            coEvery {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+            } returns Unit
+
+            assertDoesNotThrow { mainService.createReview(createSecondReviewRequest) }
+
+            mockCurrentUser(thirdReviewer)
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId)
+            } returns listOf(firstReview, secondReview)
+            val thirdReview = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                userId = thirdReviewer.id,
+                decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
+            )
+            val createThirdReviewRequest = validCreateReviewRequest.setDecision(
+                ReviewDecision.REVIEW_DECISION_ACCEPTED,
+            ).build()
+            coEvery {
+                reviewRepoMock.createReview(createThirdReviewRequest, thirdReviewer.id)
+            } returns thirdReview
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(thirdReview.id)
+            } returns selectedCriteriaIds
+            coEvery {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+            } returns Unit
+
+            assertDoesNotThrow { mainService.createReview(createThirdReviewRequest) }
+
+            coVerify(exactly = 2) {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+            }
+            coVerify(exactly = 1) {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+            }
+            coVerify(exactly = 0) {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+            }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -1,0 +1,241 @@
+package se.uulm.snowballr.backend.service.review
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.SnowballRException.DuplicateReviewException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+import java.util.stream.Stream
+import kotlin.reflect.KFunction
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CreateReviewTest : MainServiceTest() {
+    private val projectPaperId = UUID.randomUUID()
+    private val decision = ReviewDecision.REVIEW_DECISION_ACCEPTED
+    private val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+
+    private val validCreateReviewRequest: ReviewOuterClass.Review.Create.Builder =
+        ReviewOuterClass.Review.Create.newBuilder()
+            .setProjectPaperId(projectPaperId.toString())
+            .setDecision(decision)
+            .addAllSelectedCriteriaIds(selectedCriteriaIds.map(UUID::toString))
+
+    fun failingFunctions(): Stream<Arguments?> = Stream.of(
+        Arguments.of(projectPaperRepoMock::getProjectPaperById),
+        Arguments.of(projectRepoMock::getProjectById),
+    )
+
+    @Suppress("ReturnCount")
+    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (isUserAdmin) {
+                UserRole.USER_ROLE_ADMIN
+            } else {
+                UserRole.USER_ROLE_DEFAULT
+            },
+        )
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = projectPaperId,
+            projectId = project.id,
+            decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val review = DataBuilder.createExampleReview(
+            projectPaperId = projectPaperId,
+            decision = decision,
+            userId = currentUser.id,
+        )
+
+        mockCurrentUser(currentUser)
+
+        if (failAt == projectPaperRepoMock::getProjectPaperById) {
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaperId)
+            } returns Result.failure(TestSpecificException())
+            return
+        }
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
+            if (isUserAdmin) {
+                emptyList()
+            } else {
+                listOf(projectMember)
+            }
+
+        if (failAt == projectRepoMock::getProjectById) {
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+            return
+        }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns emptyList()
+        coEvery {
+            reviewRepoMock.createReview(validCreateReviewRequest.build(), currentUser.id)
+        } returns review
+        coEvery {
+            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+        } returns selectedCriteriaIds
+    }
+
+    @ParameterizedTest
+    @MethodSource("failingFunctions")
+    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
+        mockHappyPathUntil(failAt, true)
+
+        assertThrows<TestSpecificException> { mainService.createReview(validCreateReviewRequest.build()) }
+        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
+    }
+
+    @Test
+    fun `When a server admin creates a review, then no exception is thrown`() = runTest {
+        mockHappyPathUntil(null, true)
+
+        assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
+    }
+
+    @Test
+    fun `When a project member creates a review, then no exception is thrown`() = runTest {
+        mockHappyPathUntil(null, false)
+
+        assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
+    }
+
+    @Test
+    fun `When a non project member creates a review, then an UnauthorizedException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+
+        assertThrows<UnauthorizedException> { mainService.createReview(validCreateReviewRequest.build()) }
+        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
+    }
+
+    @Test
+    fun `When the user already reviewed the project paper, then a DuplicateReviewException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+        val review = DataBuilder.createExampleReview(
+            projectPaperId = projectPaperId,
+            decision = decision,
+            userId = currentUser.id,
+        )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(review)
+
+        assertThrows<DuplicateReviewException> { mainService.createReview(validCreateReviewRequest.build()) }
+        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
+    }
+
+    @Test
+    fun `When another user already reviewed the project paper but not finally decided it, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val anotherUser = DataBuilder.createExampleUser(
+                email = "another.user@example.com",
+                role = UserRole.USER_ROLE_DEFAULT,
+            )
+            val project = DataBuilder.createExampleProject()
+            val projectPaper = DataBuilder.createExampleProjectPaper(
+                id = projectPaperId,
+                projectId = project.id,
+                decision = PaperDecision.PAPER_DECISION_IN_REVIEW,
+            )
+            val reviewByAnotherUser = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                decision = decision,
+                userId = anotherUser.id,
+            )
+            val review = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                decision = decision,
+                userId = currentUser.id,
+            )
+            val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = anotherUser.id)
+
+            mockCurrentUser(currentUser)
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+            coEvery {
+                projectMemberRepoMock.getProjectMembers(project.id)
+            } returns listOf(projectMember1, projectMember2)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(reviewByAnotherUser)
+            coEvery { reviewRepoMock.createReview(validCreateReviewRequest.build(), currentUser.id) } returns review
+            coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) } returns emptyList()
+
+            assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
+        }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "PROJECT_STATUS_ARCHIVED",
+            "PROJECT_STATUS_DELETED",
+        ],
+    )
+    fun `When the project paper to review is in an inactive project, then a FailedPreconditionException is thrown`(
+        statusName: String,
+    ) = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
+        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
+
+        mockCurrentUser(currentUser)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+        assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
+        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
+    }
+
+    @Test
+    fun `When the project paper is already finally decided, then a FailedPreconditionException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
+        val projectPaper = DataBuilder.createExampleProjectPaper(
+            id = projectPaperId,
+            projectId = project.id,
+            decision = PaperDecision.PAPER_DECISION_ACCEPTED,
+        )
+
+        mockCurrentUser(currentUser)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns emptyList()
+
+        assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
+        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -17,6 +17,7 @@ import se.uulm.snowballr.backend.model.SnowballRException.DuplicateReviewExcepti
 import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ReviewOuterClass
@@ -28,6 +29,9 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CreateReviewTest : MainServiceTest() {
+    private val project = DataBuilder.createExampleProject(
+        reviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.newBuilder().setNumberOfReviewers(2).build(),
+    )
     private val projectPaperId = UUID.randomUUID()
     private val decision = ReviewDecision.REVIEW_DECISION_ACCEPTED
     private val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
@@ -52,7 +56,6 @@ class CreateReviewTest : MainServiceTest() {
                 UserRole.USER_ROLE_DEFAULT
             },
         )
-        val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(
             id = projectPaperId,
             projectId = project.id,
@@ -126,7 +129,6 @@ class CreateReviewTest : MainServiceTest() {
     @Test
     fun `When a non project member creates a review, then an UnauthorizedException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
 
         mockCurrentUser(currentUser)
@@ -148,7 +150,10 @@ class CreateReviewTest : MainServiceTest() {
         statusName: String,
     ) = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
+        val project = DataBuilder.createExampleProject(
+            status = ProjectStatus.valueOf(statusName),
+            reviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.newBuilder().setNumberOfReviewers(2).build(),
+        )
         val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
 
         mockCurrentUser(currentUser)
@@ -163,7 +168,6 @@ class CreateReviewTest : MainServiceTest() {
     @Test
     fun `When the user already reviewed the project paper, then a DuplicateReviewException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
         val review = DataBuilder.createExampleReview(
             projectPaperId = projectPaperId,
@@ -190,7 +194,6 @@ class CreateReviewTest : MainServiceTest() {
                 email = "another.user@example.com",
                 role = UserRole.USER_ROLE_DEFAULT,
             )
-            val project = DataBuilder.createExampleProject()
             val projectPaper = DataBuilder.createExampleProjectPaper(
                 id = projectPaperId,
                 projectId = project.id,
@@ -228,7 +231,6 @@ class CreateReviewTest : MainServiceTest() {
     @Test
     fun `When the project paper is already finally decided, then a FailedPreconditionException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
         val projectPaper = DataBuilder.createExampleProjectPaper(
             id = projectPaperId,
             projectId = project.id,
@@ -258,7 +260,6 @@ class CreateReviewTest : MainServiceTest() {
                 email = "third.reviewer@example.com",
                 role = UserRole.USER_ROLE_ADMIN,
             )
-            val project = DataBuilder.createExampleProject()
             val projectPaper = DataBuilder.createExampleProjectPaper(
                 id = projectPaperId,
                 projectId = project.id,
@@ -276,9 +277,9 @@ class CreateReviewTest : MainServiceTest() {
                 userId = firstReviewer.id,
                 decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
             )
-            val createFirstReviewRequest = validCreateReviewRequest.setDecision(
-                ReviewDecision.REVIEW_DECISION_ACCEPTED,
-            ).build()
+            val createFirstReviewRequest = validCreateReviewRequest
+                .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+                .build()
             coEvery {
                 reviewRepoMock.createReview(createFirstReviewRequest, firstReviewer.id)
             } returns firstReview
@@ -298,9 +299,9 @@ class CreateReviewTest : MainServiceTest() {
                 userId = secondReviewer.id,
                 decision = ReviewDecision.REVIEW_DECISION_DECLINED,
             )
-            val createSecondReviewRequest = validCreateReviewRequest.setDecision(
-                ReviewDecision.REVIEW_DECISION_DECLINED,
-            ).build()
+            val createSecondReviewRequest = validCreateReviewRequest
+                .setDecision(ReviewDecision.REVIEW_DECISION_DECLINED)
+                .build()
             coEvery {
                 reviewRepoMock.createReview(createSecondReviewRequest, secondReviewer.id)
             } returns secondReview
@@ -322,9 +323,9 @@ class CreateReviewTest : MainServiceTest() {
                 userId = thirdReviewer.id,
                 decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
             )
-            val createThirdReviewRequest = validCreateReviewRequest.setDecision(
-                ReviewDecision.REVIEW_DECISION_ACCEPTED,
-            ).build()
+            val createThirdReviewRequest = validCreateReviewRequest
+                .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+                .build()
             coEvery {
                 reviewRepoMock.createReview(createThirdReviewRequest, thirdReviewer.id)
             } returns thirdReview

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ReviewValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ReviewValidatorTest.kt
@@ -1,0 +1,74 @@
+package se.uulm.snowballr.backend.validation
+
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.EnumUnspecified
+import se.uulm.snowballr.backend.model.InvalidId
+import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.Review.Create
+import java.util.UUID
+
+class ReviewValidatorTest {
+    @Nested
+    inner class CreateRequest {
+        private val validCreateRequestBuilder: Create.Builder =
+            Create
+                .newBuilder()
+                .setProjectPaperId(UUID.randomUUID().toString())
+                .setDecision(ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED)
+                .addAllSelectedCriteriaIds(listOf(UUID.randomUUID().toString()))
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validCreateRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When an invalid project paper ID is validated, then the 'InvalidID' issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .setProjectPaperId("invalid-id")
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When an invalid decision is validated, then the 'EnumUnspecified' issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .setDecision(ReviewOuterClass.ReviewDecision.REVIEW_DECISION_UNSPECIFIED)
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<EnumUnspecified>(result)
+        }
+
+        @Test
+        fun `When the list of criteria IDs contains an invalid ID and is validated, then the 'InvalidID' issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .addAllSelectedCriteriaIds(listOf(UUID.randomUUID().toString(), "invalid-id"))
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<InvalidId>(result)
+        }
+
+        @Test
+        fun `When the list of criteria IDs is empty and is validated, then no issue is returned`() {
+            val request =
+                validCreateRequestBuilder
+                    .clearSelectedCriteriaIds()
+                    .build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+    }
+}


### PR DESCRIPTION
Closes #178 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I added the repo layer function for creating reviews with criteria
- I added a validator for review related requests and implemented a validation function that checks the `createReview` call
- I added the service layer function that authorizes and creates reviews
  - it checks whether the project paper exists, can still be reviewed and was not reviewed by the requesting user before
  - if it can be reviewed, the review from the requesting user is saved and
  - it is checked, what the final decision of the paper is based on the new review

The system for checking whether the paper is now finally decided is not finished and only a temporary solution. It will finished and properly tested in #345.
Furthermore, if the paper is finally decided no new papers based on the decision are fetched, as the fetching procedure is not finished yet. To include this behavior, the issue #205 exists.

One thing, I am not sure about, is the question whether we should finally decide / decline a paper, if the user selects a hard exclusion criterion. Because therefore you need to check whether the decision matches the criterion and whether other criteria has been selected, that might be conflicting. I propose to first discuss the desired behavior before implementing it. Let me now what you think.

P.S: I did not manually test this feature. If you want that it is fully tested, I need some more time, but if it doesn't matter or you want to completely test it on your own, then this PR is ready for a first review.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
