### PR TITLE
Implement `softDeleteProject` call

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -292,7 +292,7 @@ class SnowballRServer(
 
         override suspend fun exportProject(request: Export.ExportRequest): Base.Blob = super.exportProject(request)
 
-        override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = super.softDeleteProject(request)
+        override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = mainService.softDeleteProject(request)
 
         override suspend fun softUndeleteProject(request: Base.Id): Base.Nothing = super.softUndeleteProject(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -115,8 +115,8 @@ interface IProjectTableRepo {
     suspend fun isProjectLocked(projectId: UUID): Boolean
 
     /**
-     * Performs a soft delete of the project with the given [projectId], i.e., do not remove the
-     * project from the database but mark it as deleted by setting the status to [ProjectStatus.PROJECT_STATUS_DELETED].
+     * Performs a soft delete of the project with the given [projectId], i.e., does not remove the
+     * project from the database but marks it as deleted by setting the status to [ProjectStatus.PROJECT_STATUS_DELETED].
      */
     suspend fun softDeleteProject(projectId: UUID)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.statements.UpdateStatement
+import org.jetbrains.exposed.sql.update
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
@@ -112,6 +113,12 @@ interface IProjectTableRepo {
      * @return `true` if the project is locked, `false` otherwise.
      */
     suspend fun isProjectLocked(projectId: UUID): Boolean
+
+    /**
+     * Performs a soft delete of the project with the given [projectId], i.e., do not remove the
+     * project from the database but mark it as deleted by setting the status to [ProjectStatus.PROJECT_STATUS_DELETED].
+     */
+    suspend fun softDeleteProject(projectId: UUID)
 }
 
 /**
@@ -197,6 +204,15 @@ class ProjectTableRepo(
             .where { ProjectPaperTable.projectId eq projectId }
             .limit(1)
             .any()
+    }
+
+    override suspend fun softDeleteProject(projectId: UUID) {
+        db.query {
+            ProjectTable.update({ ProjectTable.id eq projectId }) {
+                it[status] = ProjectStatus.PROJECT_STATUS_DELETED
+                it[deletedAt] = OffsetDateTime.now()
+            }
+        }
     }
 
     private fun UpdateStatement.applyProjectNameUpdate(project: GrpcProject, paths: Set<String>) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -106,6 +106,11 @@ interface IProjectService {
      * Service implementation of [SnowballRService.removeProjectMember]
      */
     suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing
+
+    /**
+     * Service implementation of [SnowballRService.softDeleteProject]
+     */
+    suspend fun softDeleteProject(request: Base.Id): Base.Nothing
 }
 
 /**
@@ -496,6 +501,20 @@ class ProjectService(
             }
 
             projectMemberRepo.removeProjectMember(projectId, requestedUserId)
-            Base.Nothing.newBuilder().build()
+            Base.Nothing.getDefaultInstance()
         }
+
+    override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+        isServerOrProjectAdmin(projectMemberRepo, AccessType.DELETE).checkFor(currentUser, projectId)
+
+        if (!repo.doesProjectExistById(projectId)) {
+            throw NotFoundException(EntityType.PROJECT, projectId.toString())
+        }
+
+        repo.softDeleteProject(projectId)
+
+        Base.Nothing.getDefaultInstance()
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -492,7 +492,7 @@ class ProjectService(
             val projectMembers = projectMemberRepo.getProjectMembers(projectId)
             val projectAdmins = projectMemberRepo.getAllProjectAdmins(projectId)
             if (projectMembers.size == 1 && projectMembers.any { it.userId == requestedUserId }) {
-                // TODO soft delete the project asa the call is implemented in #87.
+                repo.softDeleteProject(projectId)
             } else if (projectAdmins.size == 1 && projectAdmins.any { it.userId == requestedUserId }) {
                 throw FailedPreconditionException(
                     "The user can not be removed from the project, because this user is the last " +

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.assertThrows
@@ -16,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.isBetweenWithDelta
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
@@ -36,6 +38,7 @@ import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.SnowballingType
 import java.sql.SQLException
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ProjectTableRepoTest :
@@ -418,6 +421,31 @@ class ProjectTableRepoTest :
             insertReviewAndGetId(projectPaperId, userId = testUserId)
 
             assertTrue(repo.isProjectLocked(projectId))
+        }
+    }
+
+    @Nested
+    inner class SoftDeleteProject {
+        @Test
+        fun `When a project is soft deleted, then it is marked as deleted`() = runTest {
+            val projectId =
+                insertProjectAndGetId(status = ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
+
+            val before = OffsetDateTime.now()
+            repo.softDeleteProject(projectId)
+            val after = OffsetDateTime.now()
+
+            val deletedProject = repo.getProjectById(projectId).getOrThrow()
+
+            assertTrue(deletedProject.status == ProjectStatus.PROJECT_STATUS_DELETED)
+            assertThat(deletedProject.deletedAt).isBetweenWithDelta(before, after)
+        }
+
+        @Test
+        fun `When the project to be soft deleted is not found, then nothing happens`() = runTest {
+            val projectId = UUID.randomUUID()
+
+            assertDoesNotThrow { repo.softDeleteProject(projectId) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/RemoveProjectMemberTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -172,5 +173,29 @@ class RemoveProjectMemberTest : MainServiceTest() {
             assertThrows<SnowballRException.FailedPreconditionException> {
                 mainService.removeProjectMember(getExampleRequest())
             }
+        }
+
+    @Test
+    fun `When a project member to be deleted is the last member, then no exception is thrown and the project marked as deleted`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(id = userId)
+            val project = DataBuilder.createExampleProject(id = projectId)
+            val lastProjectMember = DataBuilder.createExampleProjectMember(
+                projectId = project.id,
+                userId = currentUser.id,
+            )
+
+            mockCurrentUser(currentUser)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(lastProjectMember)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(lastProjectMember)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { userRepoMock.doesUserExistById(currentUser.id) } returns true
+            coEvery { projectRepoMock.softDeleteProject(project.id) } returns Unit
+            coEvery {
+                projectMemberRepoMock.removeProjectMember(project.id, currentUser.id)
+            } returns Unit
+
+            assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+            coVerify(exactly = 1) { projectRepoMock.softDeleteProject(project.id) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/RemoveProjectMemberTest.kt
@@ -176,7 +176,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a project member to be deleted is the last member, then no exception is thrown and the project marked as deleted`() =
+    fun `When a project member to be deleted is the last member, then no exception is thrown and the project is marked as deleted`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(id = userId)
             val project = DataBuilder.createExampleProject(id = projectId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -65,7 +65,7 @@ class SoftDeleteProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a normal project member deletes a project, then a UnauthorizedException is thrown`() = runTest {
+    fun `When a normal project member deletes a project, then an UnauthorizedException is thrown`() = runTest {
         mockSoftDeleteProject(false, projectId, projectMemberRepoMock::getAllProjectAdmins)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -66,7 +66,7 @@ class SoftDeleteProjectTest : MainServiceTest() {
 
     @Test
     fun `When a normal project member deletes a project, then an UnauthorizedException is thrown`() = runTest {
-        mockSoftDeleteProject(false, projectId, projectMemberRepoMock::getAllProjectAdmins)
+        mockSoftDeleteProject(false, projectId, stopBefore = projectMemberRepoMock::getAllProjectAdmins)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.softDeleteProject(validSoftDeleteProjectRequest.build()) }
@@ -77,7 +77,7 @@ class SoftDeleteProjectTest : MainServiceTest() {
     fun `When the project to delete does not exist, then a NotFoundException is thrown`() = runTest {
         val nonExistentProjectId = UUID.randomUUID()
 
-        mockSoftDeleteProject(false, nonExistentProjectId, projectRepoMock::doesProjectExistById)
+        mockSoftDeleteProject(false, nonExistentProjectId, stopBefore = projectRepoMock::doesProjectExistById)
         coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
 
         val invalidSoftDeleteProjectRequest = validSoftDeleteProjectRequest

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -1,0 +1,89 @@
+package se.uulm.snowballr.backend.service.project
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.Base
+import snowballr.ProjectOuterClass
+import snowballr.UserOuterClass.UserRole
+import java.util.UUID
+import kotlin.reflect.KFunction
+
+class SoftDeleteProjectTest : MainServiceTest() {
+    private val projectId = UUID.randomUUID()
+    private val validSoftDeleteProjectRequest = Base.Id.newBuilder()
+        .setId(projectId.toString())
+
+    private fun mockSoftDeleteProject(useAdminUser: Boolean, projectId: UUID, stopBefore: KFunction<*>? = null) {
+        val currentUser = DataBuilder.createExampleUser(
+            role = if (useAdminUser) {
+                UserRole.USER_ROLE_ADMIN
+            } else {
+                UserRole.USER_ROLE_DEFAULT
+            },
+        )
+        val projectAdmin = DataBuilder.createExampleProjectMember(
+            projectId = projectId,
+            userId = currentUser.id,
+            role = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN,
+        )
+
+        mockCurrentUser(currentUser)
+
+        if (stopBefore == projectMemberRepoMock::getAllProjectAdmins) {
+            return
+        }
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns listOf(projectAdmin)
+
+        if (stopBefore == projectRepoMock::doesProjectExistById) {
+            return
+        }
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+
+        coEvery { projectRepoMock.softDeleteProject(projectId) } returns Unit
+    }
+
+    @Test
+    fun `When a server admin deletes a project, then no exception is thrown`() = runTest {
+        mockSoftDeleteProject(true, projectId)
+
+        assertDoesNotThrow { mainService.softDeleteProject(validSoftDeleteProjectRequest.build()) }
+    }
+
+    @Test
+    fun `When a project admin deletes a project, then no exception is thrown`() = runTest {
+        mockSoftDeleteProject(false, projectId)
+
+        assertDoesNotThrow { mainService.softDeleteProject(validSoftDeleteProjectRequest.build()) }
+    }
+
+    @Test
+    fun `When a normal project member deletes a project, then a UnauthorizedException is thrown`() = runTest {
+        mockSoftDeleteProject(false, projectId, projectMemberRepoMock::getAllProjectAdmins)
+        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
+
+        assertThrows<UnauthorizedException> { mainService.softDeleteProject(validSoftDeleteProjectRequest.build()) }
+        coVerify(exactly = 0) { projectRepoMock.softDeleteProject(any()) }
+    }
+
+    @Test
+    fun `When the project to delete does not exist, then a NotFoundException is thrown`() = runTest {
+        val nonExistentProjectId = UUID.randomUUID()
+
+        mockSoftDeleteProject(false, nonExistentProjectId, projectRepoMock::doesProjectExistById)
+        coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
+
+        val invalidSoftDeleteProjectRequest = validSoftDeleteProjectRequest
+            .setId(nonExistentProjectId.toString())
+
+        assertThrows<NotFoundException> { mainService.softDeleteProject(invalidSoftDeleteProjectRequest.build()) }
+        coVerify(exactly = 0) { projectRepoMock.softDeleteProject(any()) }
+    }
+}


### PR DESCRIPTION
Closes #87 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I implemented the `softDeleteProject` call
- I added the logic, that projects are deleted when the last project member is removed

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
