### PR TITLE
Do not delete users although they are last project admin

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
@@ -21,7 +22,9 @@ import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.toProjectMember
 import se.uulm.snowballr.backend.table.association.toProjectMemberWithUser
+import se.uulm.snowballr.backend.table.toUser
 import snowballr.ProjectOuterClass.MemberRole
+import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 /**
@@ -30,6 +33,9 @@ import java.util.UUID
  * This interface provides abstraction for handling persistence and retrieval
  * operations for project members. By using this interface, the functionality for creating
  * project members can remain decoupled from the specifics of the database layer.
+ *
+ * **Note**: A user that was soft-deleted is still in the project member relation in case the user is restored but
+ * is not considered an active member of a project anymore and thus not returned when project members / admin are queried.
  */
 interface IProjectMemberTableRepo {
     /**
@@ -103,6 +109,15 @@ class ProjectMemberTableRepo(
     private val db: IDatabase,
 ) : IProjectMemberTableRepo {
     /**
+     * Retrieves a list of UUID from these users that are marked as deleted.
+     *
+     * @return A list of UUIDs representing users that are soft-deleted.
+     */
+    private fun getSoftDeletedUsers(): List<UUID> = UserTable
+        .getEntities(ResultRow::toUser) { UserTable.status eq UserStatus.USER_STATUS_DELETED }
+        .map { it.id }
+
+    /**
      * Requesting a project member from the database.
      *
      * @param projectId The ID of the requested project.
@@ -111,7 +126,9 @@ class ProjectMemberTableRepo(
      */
     private fun getProjectMemberByComposedIdOrNull(projectId: UUID, userId: UUID): ProjectMember? = ProjectMemberTable
         .getEntityOrNull(ResultRow::toProjectMember) {
-            (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId eq userId)
+            (ProjectMemberTable.projectId eq projectId) and
+                (ProjectMemberTable.userId eq userId) and
+                (ProjectMemberTable.userId notInList getSoftDeletedUsers())
         }
 
     override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember> = db.query {
@@ -134,7 +151,9 @@ class ProjectMemberTableRepo(
     }
 
     override suspend fun getProjectMembers(projectId: UUID): List<ProjectMember> = db.query {
-        ProjectMemberTable.getEntities(ResultRow::toProjectMember) { ProjectMemberTable.projectId eq projectId }
+        ProjectMemberTable.getEntities(ResultRow::toProjectMember) {
+            (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId notInList getSoftDeletedUsers())
+        }
     }
 
     override suspend fun getMembersInSameProjectsAsUser(userId: UUID): List<ProjectMember> = db.query {
@@ -151,15 +170,17 @@ class ProjectMemberTableRepo(
                 // Condition to find projects where the specific user is a member
                 userMembership[ProjectMemberTable.userId] eq userId
             }.selectAll()
-            // Filter out the calling user
+            // Filter out the calling user and soft-deleted users
             .where { ProjectMemberTable.userId neq userId }
+            .andWhere { ProjectMemberTable.userId notInList getSoftDeletedUsers() }
             .map { it.toProjectMember() }
     }
 
     override suspend fun getAllProjectAdmins(projectId: UUID): List<ProjectMember> = db.query {
         ProjectMemberTable.getEntities(ResultRow::toProjectMember) {
             (ProjectMemberTable.projectId eq projectId) and
-                (ProjectMemberTable.role eq MemberRole.MEMBER_ROLE_ADMIN)
+                (ProjectMemberTable.role eq MemberRole.MEMBER_ROLE_ADMIN) and
+                (ProjectMemberTable.userId notInList getSoftDeletedUsers())
         }
     }
 
@@ -182,6 +203,7 @@ class ProjectMemberTableRepo(
             .join(UserTable, JoinType.INNER, onColumn = ProjectMemberTable.userId, otherColumn = UserTable.id)
             .selectAll()
             .where { ProjectMemberTable.projectId eq projectId }
+            .andWhere { UserTable.status neq UserStatus.USER_STATUS_DELETED }
             .map { it.toProjectMemberWithUser() }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -109,7 +109,8 @@ class ProjectMemberTableRepo(
     private val db: IDatabase,
 ) : IProjectMemberTableRepo {
     /**
-     * Retrieves a list of UUID from these users that are marked as deleted.
+     * Retrieves a list of UUIDs from these users that are marked as deleted.
+     * As users are automatically hard-deleted after some time, this list should not be that long.
      *
      * @return A list of UUIDs representing users that are soft-deleted.
      */
@@ -121,7 +122,7 @@ class ProjectMemberTableRepo(
      * Requesting a project member from the database.
      *
      * @param projectId The ID of the requested project.
-     * @param userId The id of the requested user.
+     * @param userId The ID of the requested user.
      * @return The [ProjectMember] object or null, if no project with the given [projectId] and [userId] was found.
      */
     private fun getProjectMemberByComposedIdOrNull(projectId: UUID, userId: UUID): ProjectMember? = ProjectMemberTable
@@ -170,7 +171,6 @@ class ProjectMemberTableRepo(
                 // Condition to find projects where the specific user is a member
                 userMembership[ProjectMemberTable.userId] eq userId
             }.selectAll()
-            // Filter out the calling user and soft-deleted users
             .where { ProjectMemberTable.userId neq userId }
             .andWhere { ProjectMemberTable.userId notInList getSoftDeletedUsers() }
             .map { it.toProjectMember() }
@@ -199,8 +199,7 @@ class ProjectMemberTableRepo(
         }
 
     override suspend fun getProjectMembersWithUsers(projectId: UUID): List<ProjectMemberWithUser> = db.query {
-        ProjectMemberTable
-            .join(UserTable, JoinType.INNER, onColumn = ProjectMemberTable.userId, otherColumn = UserTable.id)
+        (ProjectMemberTable innerJoin UserTable)
             .selectAll()
             .where { ProjectMemberTable.projectId eq projectId }
             .andWhere { UserTable.status neq UserStatus.USER_STATUS_DELETED }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepo.kt
@@ -114,7 +114,7 @@ class ProjectMemberTableRepo(
      *
      * @return A list of UUIDs representing users that are soft-deleted.
      */
-    private fun getSoftDeletedUsers(): List<UUID> = UserTable
+    private fun getSoftDeletedUserIds(): List<UUID> = UserTable
         .getEntities(ResultRow::toUser) { UserTable.status eq UserStatus.USER_STATUS_DELETED }
         .map { it.id }
 
@@ -129,7 +129,7 @@ class ProjectMemberTableRepo(
         .getEntityOrNull(ResultRow::toProjectMember) {
             (ProjectMemberTable.projectId eq projectId) and
                 (ProjectMemberTable.userId eq userId) and
-                (ProjectMemberTable.userId notInList getSoftDeletedUsers())
+                (ProjectMemberTable.userId notInList getSoftDeletedUserIds())
         }
 
     override suspend fun getProjectMemberByComposedId(projectId: UUID, userId: UUID): Result<ProjectMember> = db.query {
@@ -153,7 +153,8 @@ class ProjectMemberTableRepo(
 
     override suspend fun getProjectMembers(projectId: UUID): List<ProjectMember> = db.query {
         ProjectMemberTable.getEntities(ResultRow::toProjectMember) {
-            (ProjectMemberTable.projectId eq projectId) and (ProjectMemberTable.userId notInList getSoftDeletedUsers())
+            (ProjectMemberTable.projectId eq projectId) and
+                (ProjectMemberTable.userId notInList getSoftDeletedUserIds())
         }
     }
 
@@ -172,7 +173,7 @@ class ProjectMemberTableRepo(
                 userMembership[ProjectMemberTable.userId] eq userId
             }.selectAll()
             .where { ProjectMemberTable.userId neq userId }
-            .andWhere { ProjectMemberTable.userId notInList getSoftDeletedUsers() }
+            .andWhere { ProjectMemberTable.userId notInList getSoftDeletedUserIds() }
             .map { it.toProjectMember() }
     }
 
@@ -180,7 +181,7 @@ class ProjectMemberTableRepo(
         ProjectMemberTable.getEntities(ResultRow::toProjectMember) {
             (ProjectMemberTable.projectId eq projectId) and
                 (ProjectMemberTable.role eq MemberRole.MEMBER_ROLE_ADMIN) and
-                (ProjectMemberTable.userId notInList getSoftDeletedUsers())
+                (ProjectMemberTable.userId notInList getSoftDeletedUserIds())
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -17,6 +17,7 @@ import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forProperty
 import se.uulm.snowballr.backend.service.accessrules.forTarget
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
+import se.uulm.snowballr.backend.service.accessrules.isNotLastProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.isProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isProjectMember
@@ -82,7 +83,7 @@ class ProjectMemberService(
             isServerOrProjectAdmin(repo, AccessType.UPDATE).checkFor(currentUser, projectId)
 
             projectRepo.getProjectById(projectId).getOrThrow()
-            userRepo.getUserById(userId).getOrThrow()
+            val user = userRepo.getUserById(userId).getOrThrow()
 
             val currentMember = try {
                 repo.getProjectMemberByComposedId(projectId, userId).getOrThrow()
@@ -93,10 +94,8 @@ class ProjectMemberService(
             }
 
             if (currentMember.role == MemberRole.MEMBER_ROLE_ADMIN && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
-                val projectAdmins = repo.getAllProjectAdmins(projectId)
-                if (projectAdmins.size <= 1) {
-                    throw FailedPreconditionException("Cannot demote the last admin of a project.")
-                }
+                isNotLastProjectAdmin(repo, "Cannot demote the user")
+                    .checkFor(user, projectId)
             }
 
             repo.updateProjectMemberRole(projectId, userId, request.newRole)
@@ -139,14 +138,13 @@ class ProjectMemberService(
             }
 
             val projectMembers = repo.getProjectMembers(projectId)
-            val projectAdmins = repo.getAllProjectAdmins(projectId)
-            if (projectMembers.size == 1 && projectMembers.any { it.userId == requestedUserId }) {
+            val isLastMember = projectMembers.size == 1 && projectMembers.first().userId == requestedUserId
+            if (isLastMember) {
                 projectRepo.softDeleteProject(projectId)
-            } else if (projectAdmins.size == 1 && projectAdmins.any { it.userId == requestedUserId }) {
-                throw FailedPreconditionException(
-                    "The user can not be removed from the project, because this user is the last " +
-                        "project admin.",
-                )
+            } else {
+                val user = userRepo.getUserById(requestedUserId).getOrThrow()
+                isNotLastProjectAdmin(repo, "The user cannot be removed from the project")
+                    .checkFor(user, projectId)
             }
 
             repo.removeProjectMember(projectId, requestedUserId)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -29,6 +29,7 @@ import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forProperty
 import se.uulm.snowballr.backend.service.accessrules.forTarget
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadUser
+import se.uulm.snowballr.backend.service.accessrules.isNotLastProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.isSameUserById
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isServerAdminOrSameUser
@@ -260,14 +261,9 @@ class UserService(
                 ProjectStatus.PROJECT_STATUS_ARCHIVED,
             ),
         )
-        val isLastProjectAdminInAnyProject = projectsOfTargetUser.any { project ->
-            projectMemberRepo.getAllProjectAdmins(project.id).all { it.userId == targetUser.id }
-        }
-        if (isLastProjectAdminInAnyProject) {
-            throw FailedPreconditionException(
-                "The user with the ID '${targetUser.id}' is the last project admin in one or more projects. " +
-                    "Please assign a new project admin in the affected projects before deleting this user.",
-            )
+        projectsOfTargetUser.forEach { project ->
+            isNotLastProjectAdmin(projectMemberRepo, "The user cannot be (soft-)deleted")
+                .checkFor(targetUser, project.id)
         }
 
         userRepo.softDeleteUser(targetUser.id)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -20,6 +20,7 @@ import se.uulm.snowballr.backend.model.dto.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
@@ -37,6 +38,7 @@ import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import se.uulm.snowballr.backend.service.accessrules.targetUserIsNotAdmin
 import snowballr.Authentication
 import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.nothing
 import java.util.UUID
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
@@ -98,6 +100,7 @@ private const val VERIFICATION_TOKEN_LENGTH = 48
  * @constructor Initializes the [UserService] with a user repository.
  * @param userRepo The repository responsible for managing persistence operations for users.
  * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
+ * @param projectRepo The repository responsible for managing persistence operations for projects.
  * @param criterionRepo The repository responsible for managing persistence operations for criteria.
  * @param verificationTokenRepo The repository responsible for managing persistence operations for verification tokens.
  * @param emailManager The manager responsible for sending emails.
@@ -105,6 +108,7 @@ private const val VERIFICATION_TOKEN_LENGTH = 48
 class UserService(
     private val userRepo: IUserTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
+    private val projectRepo: IProjectTableRepo,
     private val criterionRepo: ICriterionTableRepo,
     private val verificationTokenRepo: IVerificationTokenTableRepo,
     private val emailManager: IEmailManager,
@@ -246,6 +250,25 @@ class UserService(
                     ),
             )
             .checkFor(currentUser, targetUser)
+
+        // Verify that the user to be deleted is no project admin in any active or archived project anymore.
+        val projectsOfTargetUser = projectRepo.getUserProjects(
+            targetUser.id,
+            setOf(
+                ProjectStatus.PROJECT_STATUS_ACTIVE,
+                ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED,
+                ProjectStatus.PROJECT_STATUS_ARCHIVED,
+            ),
+        )
+        val isLastProjectAdminInAnyProject = projectsOfTargetUser.any { project ->
+            projectMemberRepo.getAllProjectAdmins(project.id).all { it.userId == targetUser.id }
+        }
+        if (isLastProjectAdminInAnyProject) {
+            throw FailedPreconditionException(
+                "The user with the ID '${targetUser.id}' is the last project admin in one or more projects. " +
+                    "Please assign a new project admin in the affected projects before deleting this user.",
+            )
+        }
 
         userRepo.softDeleteUser(targetUser.id)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -5,6 +5,7 @@ package se.uulm.snowballr.backend.service.accessrules
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.SnowballRException.EntityNotActiveException
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.Project
@@ -60,6 +61,25 @@ fun isProjectMember(projectMemberRepo: IProjectMemberTableRepo) = AccessRule<UUI
 fun isProjectAdmin(projectMemberRepo: IProjectMemberTableRepo) = AccessRule<UUID> { requester, targetId ->
     val projectAdmins = projectMemberRepo.getAllProjectAdmins(targetId)
     projectAdmins.any { it.userId == requester.id }
+}
+
+/**
+ * Check whether the user is not the last project admin of a specific project; otherwise, throws a [FailedPreconditionException].
+ *
+ * @param projectMemberRepo The project member repository used to retrieve a project admins list.
+ * @param action The action that is being performed and wherefore the user must not be the last project admin.
+ */
+@CheckReturnValue
+fun isNotLastProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, action: String): AccessRule<UUID> {
+    return AccessRule<UUID> { user, targetId ->
+        val projectAdmins = projectMemberRepo.getAllProjectAdmins(targetId)
+        !(projectAdmins.size == 1 && projectAdmins.first().userId == user.id)
+    }.orElseThrow { user, projectId ->
+        FailedPreconditionException(
+            "$action, because the user with the ID '${user.id}' " +
+                "is the last admin of the project with the ID '$projectId'.",
+        )
+    }
 }
 
 /**

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -8,11 +8,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
 import se.uulm.snowballr.backend.model.dto.ProjectMember
-import se.uulm.snowballr.backend.repository.RepositoryHelper
+import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
+import se.uulm.snowballr.backend.repository.RepositoryHelper.assignUserToProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.createAndAssignUserToProject
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
+import se.uulm.snowballr.backend.repository.RepositoryHelper.insertUserAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.repository.UserTableRepo
 import se.uulm.snowballr.backend.table.ProjectTable
@@ -20,6 +24,7 @@ import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass.MemberRole
+import snowballr.UserOuterClass.UserStatus
 import java.sql.SQLException
 import java.util.UUID
 
@@ -28,21 +33,43 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
     private val userRepo = UserTableRepo(db)
 
     private suspend fun setupProject(
-        numberOfTestMembers: Int = 0,
+        numberOfAdditionalMembers: Int = 0,
         addTestUser: Boolean = true,
+        addDeletedUser: Boolean = false,
     ): Pair<UUID, List<ProjectMember>> {
         val projectId = insertProjectAndGetId(createdBy = testUserId)
         val members = mutableListOf<ProjectMember>()
 
         if (addTestUser) {
-            repo.addUserToProject(testUserId, projectId).also { members.add(it) }
+            members += assignUserToProject(testUserId, projectId)
         }
 
-        for (i in 1..numberOfTestMembers) {
-            createAndAssignUserToProject("test.user$i@example.com", projectId).also { members.add(it) }
+        if (addDeletedUser) {
+            val deletedUser = insertUserAndGetId(
+                email = "deleted.user@example.com",
+                status = UserStatus.USER_STATUS_DELETED,
+            )
+            members += assignUserToProject(deletedUser, projectId)
+        }
+
+        for (i in 1..numberOfAdditionalMembers) {
+            val userEmail = "test.user$i.in.${projectId.toString().substring(0,3)}@example.com"
+            members += createAndAssignUserToProject(userEmail, projectId)
         }
 
         return projectId to members
+    }
+
+    /**
+     * Checks that the given [expected] and [actual] project members are equal, i.e., that they have the same
+     *   - project ID
+     *   - user ID
+     *   - role
+     */
+    private fun assertSameMember(expected: ProjectMember, actual: ProjectMember) {
+        assertThat(actual.projectId).isEqualTo(expected.projectId)
+        assertThat(actual.userId).isEqualTo(expected.userId)
+        assertThat(actual.role).isEqualTo(expected.role)
     }
 
     @Nested
@@ -51,12 +78,10 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When a project member is found, then a successful result with the correct project member is returned`() =
             runTest {
                 val (projectId, members) = setupProject()
-                val result = repo.getProjectMemberByComposedId(projectId, members[0].userId)
+                val result = repo.getProjectMemberByComposedId(projectId, members.first().userId)
 
-                val projectMember = assertResultSuccess(result)
-                assertEquals(projectId, projectMember.projectId)
-                assertEquals(testUserId, projectMember.userId)
-                assertEquals(members[0].role, projectMember.role)
+                val member = assertResultSuccess(result)
+                assertSameMember(members.first(), member)
             }
 
         @Test
@@ -66,31 +91,42 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
 
                 assertResultFailure<NotFoundException>(result)
             }
+
+        @Test
+        fun `When a project member is found, but the user is marked as deleted, then a failed result with a NotFoundException is returned`() =
+            runTest {
+                val (projectId, members) = setupProject(addTestUser = false, addDeletedUser = true)
+
+                val result = repo.getProjectMemberByComposedId(projectId, members.first().userId)
+
+                assertResultFailure<NotFoundException>(result)
+            }
     }
 
     @Nested
     inner class AddUserToProject {
         @Test
         fun `When a user is added to a project, then they can be retrieved as project member`() = runTest {
-            val (projectId, members) = setupProject()
-            val member = members.first()
+            val (projectId, _) = setupProject()
 
-            assertEquals(testUserId, member.userId)
-            assertEquals(projectId, member.projectId)
-            assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, member.role)
+            val members = repo.getProjectMembers(projectId)
+            assertThat(members).hasSize(1)
 
-            val actualMembers = repo.getProjectMembers(projectId)
-            assertThat(actualMembers).hasSize(1)
-            assertThat(actualMembers).containsExactly(member)
+            val newUser = insertUserAndGetId("new.user@example.com")
+            val newMember = repo.addUserToProject(newUser, projectId)
+
+            val newMembers = repo.getProjectMembers(projectId)
+            assertThat(newMembers).hasSize(2)
+            assertThat(newMembers).containsExactlyInAnyOrder(members.first(), newMember)
         }
 
         @Test
         fun `When a user is added to a project twice, then only one member is created`() = runTest {
             val (projectId, members) = setupProject()
             val member = members.first()
-            val member1 = repo.addUserToProject(testUserId, projectId)
+            val sameMember = repo.addUserToProject(member.userId, member.projectId)
 
-            assertEquals(member, member1)
+            assertSameMember(member, sameMember)
 
             val actualMembers = repo.getProjectMembers(projectId)
             assertThat(actualMembers).hasSize(1)
@@ -99,18 +135,14 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
 
         @Test
         fun `When a user is added to a nonexistent project, then an SQLException is thrown`() = runTest {
-            assertThrows<SQLException> {
-                repo.addUserToProject(testUserId, UUID.randomUUID())
-            }
+            assertThrows<SQLException> { repo.addUserToProject(testUserId, UUID.randomUUID()) }
         }
 
         @Test
         fun `When a nonexistent user is added to a project, then an SQLException is thrown`() = runTest {
             val projectId = insertProjectAndGetId(createdBy = testUserId)
 
-            assertThrows<SQLException> {
-                repo.addUserToProject(UUID.randomUUID(), projectId)
-            }
+            assertThrows<SQLException> { repo.addUserToProject(UUID.randomUUID(), projectId) }
         }
     }
 
@@ -127,28 +159,29 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
 
         @Test
         fun `When one member is in a project, then they are part of the list`() = runTest {
-            val (projectId, _) = setupProject()
+            val (projectId, members) = setupProject()
 
             val actualMembers = repo.getProjectMembers(projectId)
 
             assertThat(actualMembers).hasSize(1)
-            val member = actualMembers.first()
-            assertEquals(testUserId, member.userId)
+            assertSameMember(members.first(), actualMembers.first())
         }
 
         @Test
-        fun `When several members are in a project, then they are part of the list`() = runTest {
-            val (projectId, members) = setupProject(3)
+        fun `When several members are in a project, then they are part of the list, except the user is soft-deleted`() =
+            runTest {
+                val (projectId, members) = setupProject(
+                    numberOfAdditionalMembers = 3,
+                    addTestUser = true,
+                    addDeletedUser = true,
+                )
 
-            val actualMembers = repo.getProjectMembers(projectId)
+                val actualMembers = repo.getProjectMembers(projectId)
 
-            assertThat(actualMembers).hasSize(4)
-            assertEquals(testUserId, actualMembers[0].userId)
-            assertEquals(members[0], actualMembers[0])
-            assertEquals(members[1], actualMembers[1])
-            assertEquals(members[2], actualMembers[2])
-            assertEquals(members[3], actualMembers[3])
-        }
+                assertThat(actualMembers).hasSize(4)
+                // The deleted user is the second member if the test user and deleted user are assigned to the project
+                assertThat(actualMembers).doesNotContain(members[1])
+            }
     }
 
     @Nested
@@ -161,44 +194,54 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         }
 
         @Test
-        fun `When the user is in a project, then they are not part of the list of members`() = runTest {
-            setupProject()
+        fun `When the user is in a project without other users, then they are not part of the list of members`() =
+            runTest {
+                val (_, members) = setupProject()
+                assertThat(members).hasSize(1)
+
+                val result = repo.getMembersInSameProjectsAsUser(testUserId)
+
+                assertThat(result).isEmpty()
+            }
+
+        @Test
+        fun `When the user is in projects with other users, then they are part of the list of members`() = runTest {
+            val (_, members1) = setupProject(numberOfAdditionalMembers = 1)
+            val (_, members2) = setupProject(numberOfAdditionalMembers = 1)
 
             val result = repo.getMembersInSameProjectsAsUser(testUserId)
 
-            assertThat(result).isEmpty()
+            assertThat(result).hasSize(2)
+            assertThat(result).containsExactlyInAnyOrder(members1[1], members2[1])
         }
 
         @Test
-        fun `When the user is in projects with other users, then all members are part of the list`() = runTest {
-            val project1Id = setupProject().first
-            val project2Id = setupProject().first
-            val project3Id = setupProject().first
+        fun `When the user is in a project with another user who is soft-deleted, then they are not part of the list of members`() =
+            runTest {
+                val (_, members1) = setupProject(addDeletedUser = true)
+                val (_, members2) = setupProject(numberOfAdditionalMembers = 1)
 
-            val member1 = createAndAssignUserToProject("test.user1@example.com", project1Id)
-            val member2 = createAndAssignUserToProject("test.user2@example.com", project2Id)
-            val member3 = createAndAssignUserToProject("test.user3@example.com", project3Id)
+                val result = repo.getMembersInSameProjectsAsUser(testUserId)
 
-            val result = repo.getMembersInSameProjectsAsUser(testUserId)
-
-            assertThat(result).hasSize(3)
-            assertThat(result).containsExactlyInAnyOrder(member1, member2, member3)
-        }
+                assertThat(result).hasSize(1)
+                assertThat(result).containsExactlyInAnyOrder(members2[1])
+                assertThat(result).doesNotContain(members1[1])
+            }
     }
 
     @Nested
     inner class GetAllProjectAdmins {
         @Test
-        fun `When all project members are project admins, then the correct list of project admins is returned`() =
+        fun `When all project members are project admins, then they are all part of the list of project admins`() =
             runTest {
                 val (projectId, members) = setupProject(1)
-                val firstMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
-                val secondMember = repo.getProjectMemberByComposedId(projectId, members[1].userId).getOrThrow()
-                assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, firstMember.role)
-                assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, secondMember.role)
 
-                repo.updateProjectMemberRole(projectId, firstMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
-                repo.updateProjectMemberRole(projectId, secondMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
+                members.forEach { member ->
+                    val actualMember = repo.getProjectMemberByComposedId(projectId, member.userId).getOrThrow()
+                    assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, actualMember.role)
+
+                    repo.updateProjectMemberRole(projectId, actualMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
+                }
 
                 val projectAdmins = repo.getAllProjectAdmins(projectId)
 
@@ -210,67 +253,74 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
             }
 
         @Test
-        fun `When not all project members are project admins, then the correct list of project admins is returned`() =
+        fun `When a project member is not project admin, then they are not part of the list of project admins`() =
             runTest {
                 val (projectId, members) = setupProject(1)
-                val firstMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
-                val secondMember = repo.getProjectMemberByComposedId(projectId, members[1].userId).getOrThrow()
-                assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, firstMember.role)
-                assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, secondMember.role)
+                members.forEach { member ->
+                    val actualMember = repo.getProjectMemberByComposedId(projectId, member.userId).getOrThrow()
+                    assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, actualMember.role)
+                }
 
-                repo.updateProjectMemberRole(projectId, firstMember.userId, MemberRole.MEMBER_ROLE_ADMIN)
+                val projectAdmin = repo.updateProjectMemberRole(
+                    projectId,
+                    members.first().userId,
+                    MemberRole.MEMBER_ROLE_ADMIN,
+                )
 
                 val projectAdmins = repo.getAllProjectAdmins(projectId)
 
                 assertThat(projectAdmins).hasSize(1)
-                assertThat(projectAdmins).anyMatch { it.userId == firstMember.userId }
-                assertThat(projectAdmins).noneMatch { it.userId == secondMember.userId }
+                assertThat(projectAdmins).containsExactlyInAnyOrder(projectAdmin)
+                assertThat(projectAdmins).doesNotContain(members.last())
             }
-    }
 
-    @Nested
-    inner class PromoteProjectMemberToAdmin {
         @Test
-        fun `When a project member is promoted to admin, then the role of the project member is correctly updated`() =
+        fun `When a user is project admin but soft-deleted, then they are not part of the list of project admins`() =
             runTest {
-                val (projectId, _) = setupProject()
-                val normalMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
-                assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, normalMember.role)
+                val (projectId, members) = setupProject(addTestUser = true, addDeletedUser = true)
 
-                val promotedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
+                val projectAdmin = repo.updateProjectMemberRole(
+                    projectId,
+                    members[0].userId,
+                    MemberRole.MEMBER_ROLE_ADMIN,
+                )
+                val deletedAdmin = repo.updateProjectMemberRole(
+                    projectId,
+                    members[1].userId,
+                    MemberRole.MEMBER_ROLE_ADMIN,
+                )
 
-                assertEquals(projectId, promotedMember.projectId)
-                assertEquals(testUserId, promotedMember.userId)
-                assertEquals(MemberRole.MEMBER_ROLE_ADMIN, promotedMember.role)
+                val projectAdmins = repo.getAllProjectAdmins(projectId)
+
+                assertThat(projectAdmins).hasSize(1)
+                assertThat(projectAdmins).containsExactlyInAnyOrder(projectAdmin)
+                assertThat(projectAdmins).doesNotContain(deletedAdmin)
             }
-
-        @Test
-        fun `When a project admin is promoted, then the role of the project admin does not change`() = runTest {
-            val (projectId, _) = setupProject()
-            var promotedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
-            assertEquals(MemberRole.MEMBER_ROLE_ADMIN, promotedMember.role)
-
-            promotedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
-
-            assertEquals(projectId, promotedMember.projectId)
-            assertEquals(testUserId, promotedMember.userId)
-            assertEquals(MemberRole.MEMBER_ROLE_ADMIN, promotedMember.role)
-        }
     }
 
     @Nested
     inner class UpdateProjectMemberRole {
-        @Test
-        fun `When a project member is updated, then the role of the project member is correctly updated`() = runTest {
-            val (projectId, _) = setupProject()
-            val normalMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
-            assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, normalMember.role)
+        @ParameterizedTest(name = "When role changes from {0} to {1}, then the final role should be {2}")
+        @CsvSource(
+            "MEMBER_ROLE_DEFAULT, MEMBER_ROLE_DEFAULT, MEMBER_ROLE_DEFAULT",
+            "MEMBER_ROLE_DEFAULT, MEMBER_ROLE_ADMIN, MEMBER_ROLE_ADMIN",
+            "MEMBER_ROLE_ADMIN, MEMBER_ROLE_DEFAULT, MEMBER_ROLE_DEFAULT",
+            "MEMBER_ROLE_ADMIN, MEMBER_ROLE_ADMIN, MEMBER_ROLE_ADMIN",
+        )
+        fun `When a project member is updated, then the role of the project member is correctly updated`(
+            initialRole: MemberRole,
+            updatedRole: MemberRole,
+            expectedRole: MemberRole,
+        ) = runTest {
+            val (projectId, members) = setupProject()
+            val member = repo.updateProjectMemberRole(projectId, members.first().userId, initialRole)
+            assertEquals(initialRole, member.role)
 
-            val updatedMember = repo.updateProjectMemberRole(projectId, testUserId, MemberRole.MEMBER_ROLE_ADMIN)
+            val updatedMember = repo.updateProjectMemberRole(projectId, member.userId, updatedRole)
 
             assertEquals(projectId, updatedMember.projectId)
-            assertEquals(testUserId, updatedMember.userId)
-            assertEquals(MemberRole.MEMBER_ROLE_ADMIN, updatedMember.role)
+            assertEquals(member.userId, updatedMember.userId)
+            assertEquals(expectedRole, updatedMember.role)
         }
     }
 
@@ -285,24 +335,39 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
                 val projectMembersWithUsers = repo.getProjectMembersWithUsers(projectId)
 
                 assertThat(projectMembersWithUsers).hasSize(1)
-                assertThat(projectMembersWithUsers).anyMatch { it.projectMember == normalMember }
-                assertThat(projectMembersWithUsers).anyMatch { it.user == user }
+                assertThat(projectMembersWithUsers).containsExactlyInAnyOrder(ProjectMemberWithUser(normalMember, user))
             }
 
         @Test
         fun `When not all users are project members, then only the correct project members with users are returned`() =
             runTest {
-                val (projectId, _) = setupProject()
-                val user = userRepo.getUserById(testUserId).getOrThrow()
-                val nonProjectMemberUserId = RepositoryHelper.insertUserAndGetId("test-user@example.com")
-                val nonProjectMemberUser = userRepo.getUserById(nonProjectMemberUserId).getOrThrow()
-                val normalMember = repo.getProjectMemberByComposedId(projectId, testUserId).getOrThrow()
+                val (projectId, members) = setupProject()
+                val nonProjectMemberUserId = insertUserAndGetId("test-user@example.com")
+                val user = userRepo.getUserById(members.first().userId).getOrThrow()
+
                 val projectMembersWithUsers = repo.getProjectMembersWithUsers(projectId)
 
                 assertThat(projectMembersWithUsers).hasSize(1)
-                assertThat(projectMembersWithUsers).anyMatch { it.projectMember == normalMember }
+                assertThat(projectMembersWithUsers).anyMatch { it.projectMember == members.first() }
                 assertThat(projectMembersWithUsers).anyMatch { it.user == user }
-                assertThat(projectMembersWithUsers).noneMatch { it.projectMember.userId == nonProjectMemberUser.id }
+                assertThat(projectMembersWithUsers).noneMatch { it.projectMember.userId == nonProjectMemberUserId }
+            }
+
+        @Test
+        fun `When a project member exists but the corresponding user is soft-deleted, then they are not returned`() =
+            runTest {
+                val (projectId, members) = setupProject(addTestUser = true, addDeletedUser = true)
+                assertThat(members).hasSize(2)
+                val activeUser = userRepo.getUserById(members[0].userId).getOrThrow()
+                val deletedUser = userRepo.getUserById(members[1].userId).getOrThrow()
+
+                val projectMembersWithUsers = repo.getProjectMembersWithUsers(projectId)
+
+                assertThat(projectMembersWithUsers).hasSize(1)
+                assertThat(projectMembersWithUsers).anyMatch { it.projectMember == members[0] }
+                assertThat(projectMembersWithUsers).anyMatch { it.user == activeUser }
+                assertThat(projectMembersWithUsers).noneMatch { it.projectMember == members[1] }
+                assertThat(projectMembersWithUsers).noneMatch { it.user == deletedUser }
             }
     }
 
@@ -311,6 +376,7 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         @Test
         fun `When a project member is found, then the correct project member is removed`() = runTest {
             val (projectId, members) = setupProject()
+
             repo.removeProjectMember(projectId, members[0].userId)
 
             assertTrue(repo.getProjectMemberByComposedId(projectId, members[0].userId).isFailure)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -24,6 +24,10 @@ class RemoveProjectMemberTest : MainServiceTest() {
     @Test
     fun `When a server admin removes a project member, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
+        val userToRemove = DataBuilder.createExampleUser(
+            id = userId,
+            status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE,
+        )
         val project = DataBuilder.createExampleProject(id = projectId)
         val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
         val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = UUID.randomUUID())
@@ -35,6 +39,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
         coEvery {
             projectMemberRepoMock.getProjectMembers(project.id)
         } returns listOf(projectMember1, projectMember2)
+        coEvery { userRepoMock.getUserById(userId) } returns Result.success(userToRemove)
         coEvery { projectMemberRepoMock.removeProjectMember(project.id, userId) } returns Unit
 
         assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
@@ -43,10 +48,13 @@ class RemoveProjectMemberTest : MainServiceTest() {
     @Test
     fun `When a project admin removes another project member, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
+        val userToRemove = DataBuilder.createExampleUser(
+            id = userId,
+            status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE,
+        )
         val project = DataBuilder.createExampleProject(id = projectId)
         val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
-        val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = UUID.randomUUID())
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userId)
 
         mockCurrentUser(currentUser)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
@@ -54,7 +62,8 @@ class RemoveProjectMemberTest : MainServiceTest() {
         coEvery { userRepoMock.doesUserExistById(userId) } returns true
         coEvery {
             projectMemberRepoMock.getProjectMembers(project.id)
-        } returns listOf(projectMember1, projectMember2)
+        } returns listOf(projectMember, projectAdmin)
+        coEvery { userRepoMock.getUserById(userId) } returns Result.success(userToRemove)
         coEvery { projectMemberRepoMock.removeProjectMember(project.id, userId) } returns Unit
 
         assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
@@ -187,7 +196,6 @@ class RemoveProjectMemberTest : MainServiceTest() {
 
             mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(lastProjectMember)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(lastProjectMember)
             coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { userRepoMock.doesUserExistById(currentUser.id) } returns true
             coEvery { projectRepoMock.softDeleteProject(project.id) } returns Unit

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -57,6 +57,7 @@ class SoftDeleteUserTest : MainServiceTest() {
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
+        coEvery { projectRepoMock.getUserProjects(requestedUserId, any()) } returns emptyList()
         coEvery { userRepoMock.softDeleteUser(requestedUserId) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
@@ -67,6 +68,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.getUserProjects(requestedUserId, any()) } returns emptyList()
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
@@ -77,8 +79,51 @@ class SoftDeleteUserTest : MainServiceTest() {
         val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.getUserProjects(requestedUserId, any()) } returns emptyList()
         coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
 
         assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
     }
+
+    @Test
+    fun `When trying to delete a user that still is the last project admin in any project, then a FailedPrecondition is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
+            val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
+            val project = DataBuilder.createExampleProject()
+            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = requestedUserId)
+
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
+            coEvery { projectRepoMock.getUserProjects(requestedUserId, any()) } returns listOf(project)
+            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
+
+            assertThrows<FailedPreconditionException> { mainService.softDeleteUser(getExampleRequest()) }
+        }
+
+    @Test
+    fun `When trying to delete a user that is not the last project admin in a project, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_ADMIN)
+            val userToDelete = DataBuilder.createExampleUser(id = requestedUserId)
+            val project = DataBuilder.createExampleProject()
+            val projectAdmin = DataBuilder.createExampleProjectMember(
+                projectId = project.id,
+                userId = UUID.randomUUID(),
+            )
+            val secondProjectAdmin = DataBuilder.createExampleProjectMember(
+                projectId = project.id,
+                userId = currentUser.id,
+            )
+
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(userToDelete)
+            coEvery { projectRepoMock.getUserProjects(requestedUserId, any()) } returns listOf(project)
+            coEvery {
+                projectMemberRepoMock.getAllProjectAdmins(project.id)
+            } returns listOf(projectAdmin, secondProjectAdmin)
+            coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
+
+            assertDoesNotThrow { mainService.softDeleteUser(getExampleRequest()) }
+        }
 }


### PR DESCRIPTION
Closes #114 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I extended the project member repo with filters, that no users that are soft deleted and still in a project are listed when requesting the project members or admins and adapted the tests (+ further refactoring and adding of missing tests)
- I added a check, that ensures that the user to be soft-deleted is not the last project admin in any project
- I created a new project access rule `isNotLastProjectAdmin`. Actually this is not the best location, as this is actually not for an access, but I was not sure where else to place this helper function I introduced, because we often check, whether a user is not the last project admin and if so, throw a FailedPreconditionException. I am open for suggestions where we could place this helper instead.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
