### PR TITLE
Determine final paper decision based on (default) decision matrix

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -856,9 +856,8 @@ style:
                 value: 'FIXME:'
             -   reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
                 value: 'STOPSHIP:'
-# TODO: uncomment when backend is in a more stable state
-#            -   reason: 'Forbidden TODO todo marker in comment, please do the changes.'
-#                value: 'TODO:'
+            -   reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+                value: 'TODO:'
         allowedPatterns: ''
     ForbiddenImport:
         active: false

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -21,7 +21,7 @@ import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
-import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
 import java.util.UUID
 import snowballr.ReviewOuterClass.Review as GrpcReview
 
@@ -96,49 +96,54 @@ class ReviewService(
         }
 
     /**
-     * Determines the final paper decision based on the given list of reviews and updates the project paper decision
-     * accordingly.
+     * Determines the final paper decision based on the given list of reviews.
      *
-     * At the moment, this is a simple sum function that adds one for each accepted review, subtracts one for each rejected,
-     * and leaves the sum unchanged for each maybe review. If the entire sum is above 0, the paper is accepted,
-     * if it is below 0, the paper is declined, if it is 0, the paper is in review. If the list is empty, the paper
-     * is considered to be unreviewed. At least two reviews are required to make a final decision.
-     * TODO: Exchange this by loading the decision matrix and calculating the final decision based on the matrix (see #345)
+     * This function follows the following decision process:
+     * - If there are no reviews, the paper is marked as [PaperDecision.PAPER_DECISION_UNREVIEWED].
+     * - If the number of reviews is below the required threshold (as defined in the decision matrix),
+     *   the paper remains with [PaperDecision.PAPER_DECISION_IN_REVIEW].
+     * - Once the expected number of reviews is reached, the function attempts to match the current review distribution
+     *   against the configured decision matrix patterns. If a matching pattern is found (order-sensitive),
+     *   its associated final decision is returned.
+     * - If no matrix pattern matches, the default decision is [PaperDecision.PAPER_DECISION_IN_REVIEW]
+     * - If the required number of reviews were not enough to determine a final decision
+     *   [PaperDecision.PAPER_DECISION_ACCEPTED] or [PaperDecision.PAPER_DECISION_DECLINED]), the latest review
+     *   (assumed to be the deciding one) determines final decision. The paper is then only set to
+     *   [PaperDecision.PAPER_DECISION_ACCEPTED] in case the latest review was [ReviewDecision.REVIEW_DECISION_ACCEPTED];
+     *   otherwise, it is set to [PaperDecision.PAPER_DECISION_DECLINED].
      *
-     * @param projectPaperId ID of the project paper for which the final paper decision is to be determined.
+     * @param reviews List of reviews to be considered for the final paper decision. The latest review is assumed to be the last one in the list.
      * @param decisionMatrix Decision matrix of the project, where the project paper is in, that can be used to define
      * the final paper decision.
-     * @param reviews List of reviews to be considered for the final paper decision.
+     * @return The computed [PaperDecision] based on the given reviews.
      */
-    private suspend fun updatePaperDecision(
-        projectPaperId: UUID,
-        decisionMatrix: ReviewDecisionMatrix,
-        reviews: List<Review>,
-    ) {
+    private fun determinePaperDecision(reviews: List<Review>, decisionMatrix: ReviewDecisionMatrix): PaperDecision {
         if (reviews.isEmpty()) {
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_UNREVIEWED)
-            return
-        } else if (reviews.size < decisionMatrix.numberOfReviewers) {
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
-            return
+            return PaperDecision.PAPER_DECISION_UNREVIEWED
         }
+        if (reviews.size < decisionMatrix.numberOfReviewers) {
+            return PaperDecision.PAPER_DECISION_IN_REVIEW
+        }
+        if (reviews.size == decisionMatrix.numberOfReviewers) {
+            val counts = reviews.groupingBy { it.decision }.eachCount()
 
-        val sum = reviews.sumOf { review ->
-            when (review.decision) {
-                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_UNSPECIFIED -> 0
-                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_DECLINED -> -1
-                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE -> 0
-                ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED -> 1
-                ReviewOuterClass.ReviewDecision.UNRECOGNIZED -> 0
+            for (pattern in decisionMatrix.patternsList) {
+                val doesFoundMatch = pattern.entriesList.all { entry ->
+                    (counts[entry.reviewDecision] ?: 0) >= entry.count.toInt()
+                }
+                if (doesFoundMatch) {
+                    return pattern.decision
+                }
             }
+
+            return PaperDecision.PAPER_DECISION_IN_REVIEW
         }
 
-        if (sum > 0) {
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
-        } else if (sum < 0) {
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+        val decidingReview = reviews.last()
+        return if (decidingReview.decision == ReviewDecision.REVIEW_DECISION_ACCEPTED) {
+            PaperDecision.PAPER_DECISION_ACCEPTED
         } else {
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+            PaperDecision.PAPER_DECISION_DECLINED
         }
     }
 
@@ -169,7 +174,8 @@ class ReviewService(
         val review = repo.createReview(request, currentUser.id)
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
 
-        updatePaperDecision(projectPaper.id, project.reviewDecisionMatrix, reviewsForProjectPaper + review)
+        val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
+        projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)
 
         review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -123,9 +123,6 @@ class ReviewService(
      * @return The computed [PaperDecision] based on the given reviews.
      */
     private fun determinePaperDecision(reviews: List<Review>, decisionMatrix: ReviewDecisionMatrix): PaperDecision {
-        if (reviews.isEmpty()) {
-            return PaperDecision.PAPER_DECISION_UNREVIEWED
-        }
         if (reviews.size < decisionMatrix.numberOfReviewers) {
             return PaperDecision.PAPER_DECISION_IN_REVIEW
         }
@@ -185,10 +182,10 @@ class ReviewService(
         val isAnySelectedCriteriaHardExclusion = selectedCriteriaIds.any { id -> hardExclusionCriteria.contains(id) }
         if (isAnySelectedCriteriaHardExclusion && review.decision == ReviewDecision.REVIEW_DECISION_DECLINED) {
             projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+        } else {
+            val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)
         }
-
-        val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
-        projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)
 
         review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -8,6 +8,7 @@ import se.uulm.snowballr.backend.model.dto.toGrpcReviews
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -19,6 +20,7 @@ import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadReview
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import snowballr.Base
+import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ReviewOuterClass.ReviewDecision
@@ -57,14 +59,17 @@ interface IReviewService {
  * @param projectPaperRepo Interface for persistence and retrieval operations related to project papers.
  * @param projectRepo Interface for persistence and retrieval operations related to projects.
  * @param projectMemberRepo Interface for persistence and retrieval operations related to project members.
- * @param reviewHasCriterionRepo Interface for persistence and retrieval operations related to review criteria.
+ * @param criteriaRepo Interface for persistence and retrieval operations related to criteria.
+ * @param reviewHasCriterionRepo Interface for persistence and retrieval operations related to review-criteria relation.
  */
+@Suppress("LongParameterList")
 class ReviewService(
     private val repo: IReviewTableRepo,
     private val userRepo: IUserTableRepo,
     private val projectPaperRepo: IProjectPaperTableRepo,
     private val projectRepo: IProjectTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
+    private val criteriaRepo: ICriterionTableRepo,
     private val reviewHasCriterionRepo: IReviewHasCriterionTableRepo,
 ) : IReviewService {
     override suspend fun getReviewById(request: Base.Id): GrpcReview = withUser(userRepo) { currentUser ->
@@ -173,6 +178,14 @@ class ReviewService(
 
         val review = repo.createReview(request, currentUser.id)
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+
+        val hardExclusionCriteria = criteriaRepo.getAllProjectCriteria(project.id)
+            .filter { criterion -> criterion.category == CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION }
+            .map { criterion -> criterion.id }
+        val isAnySelectedCriteriaHardExclusion = selectedCriteriaIds.any { id -> hardExclusionCriteria.contains(id) }
+        if (isAnySelectedCriteriaHardExclusion && review.decision == ReviewDecision.REVIEW_DECISION_DECLINED) {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+        }
 
         val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
         projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -123,6 +123,9 @@ class ReviewService(
      * @return The computed [PaperDecision] based on the given reviews.
      */
     private fun determinePaperDecision(reviews: List<Review>, decisionMatrix: ReviewDecisionMatrix): PaperDecision {
+        if (reviews.isEmpty()) {
+            return PaperDecision.PAPER_DECISION_UNREVIEWED
+        }
         if (reviews.size < decisionMatrix.numberOfReviewers) {
             return PaperDecision.PAPER_DECISION_IN_REVIEW
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -7,21 +7,71 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.json.json
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
+import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern
 import snowballr.ProjectOuterClass.SnowballingType
+import snowballr.ReviewOuterClass.ReviewDecision
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
 import java.util.UUID
 
+fun patternOf(vararg decisions: Pair<ReviewDecision, Long>, result: PaperDecision): Pattern {
+    val builder = Pattern.newBuilder()
+    decisions.forEach { (decision, count) ->
+        builder.addEntries(
+            Pattern.Entry.newBuilder()
+                .setReviewDecision(decision)
+                .setCount(count)
+                .build(),
+        )
+    }
+    builder.setDecision(result)
+
+    return builder.build()
+}
+
 private const val REQUIRED_REVIEWERS = 2
+private val ACCEPT_DECLINE_PATTERN = patternOf(
+    ReviewDecision.REVIEW_DECISION_ACCEPTED to 1L,
+    ReviewDecision.REVIEW_DECISION_DECLINED to 1L,
+    result = PaperDecision.PAPER_DECISION_IN_REVIEW,
+)
+private val ACCEPT_ANY_PATTERN = patternOf(
+    ReviewDecision.REVIEW_DECISION_ACCEPTED to 1L,
+    result = PaperDecision.PAPER_DECISION_ACCEPTED,
+)
+private val DECLINE_ANY_PATTERN = patternOf(
+    ReviewDecision.REVIEW_DECISION_DECLINED to 1L,
+    result = PaperDecision.PAPER_DECISION_DECLINED,
+)
+private val MAYBE_MAYBE_PATTERN = patternOf(
+    ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
+    ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
+    result = PaperDecision.PAPER_DECISION_IN_REVIEW,
+)
 
 private const val ARE_HOTKEYS_SHOWN_DEFAULT = true
 private const val IS_REVIEW_MODE_ENABLED_DEFAULT = false
 private val CRITERIA_IDS_DEFAULT = emptyList<UUID>()
 private const val SIMILARITY_THRESHOLD_DEFAULT = 0F
+
+/**
+ * This default decision matrix assumes two reviewers by default.
+ *
+ * It encodes the basic rules for combining reviewer decisions:
+ *  - Accept + Decline → still in review (need final decision)
+ *  - Accept + Anything not already matched → Accepted
+ *  - Decline + Anything not already matched → Declined
+ *  - Maybe + Maybe → still in review (need final decision)
+ */
 private val DECISION_MATRIX_DEFAULT: ByteArray = ReviewDecisionMatrix.newBuilder()
     .setNumberOfReviewers(REQUIRED_REVIEWERS)
+    .addPatterns(ACCEPT_DECLINE_PATTERN)
+    .addPatterns(ACCEPT_ANY_PATTERN)
+    .addPatterns(DECLINE_ANY_PATTERN)
+    .addPatterns(MAYBE_MAYBE_PATTERN)
     .build()
     .toByteArray()
 private val FETCHERS_DEFAULT = emptyMap<String, Map<String, String>>()

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -47,8 +47,7 @@ private val DECLINE_ANY_PATTERN = patternOf(
     result = PaperDecision.PAPER_DECISION_DECLINED,
 )
 private val MAYBE_MAYBE_PATTERN = patternOf(
-    ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
-    ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
+    ReviewDecision.REVIEW_DECISION_MAYBE to REQUIRED_REVIEWERS.toLong(),
     result = PaperDecision.PAPER_DECISION_IN_REVIEW,
 )
 
@@ -60,7 +59,9 @@ private const val SIMILARITY_THRESHOLD_DEFAULT = 0F
 /**
  * This default decision matrix assumes two reviewers by default.
  *
- * It encodes the basic rules for combining reviewer decisions:
+ * It encodes the basic rules for combining reviewer decisions.
+ * Patterns are checked in order, and the first pattern whose entry count requirements
+ * are satisfied determines the result:
  *  - Accept + Decline → still in review (need final decision)
  *  - Accept + Anything not already matched → Accepted
  *  - Decline + Anything not already matched → Declined

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -15,6 +15,7 @@ import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
+import se.uulm.snowballr.backend.table.patternOf
 import snowballr.Base
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole
@@ -273,6 +274,37 @@ object DataBuilder {
         token = token,
         expiresAt = expiresAt,
     )
+
+    private val ACCEPT_DECLINE_PATTERN = patternOf(
+        ReviewDecision.REVIEW_DECISION_ACCEPTED to 1L,
+        ReviewDecision.REVIEW_DECISION_DECLINED to 1L,
+        result = PaperDecision.PAPER_DECISION_IN_REVIEW,
+    )
+    private val ACCEPT_ANY_PATTERN = patternOf(
+        ReviewDecision.REVIEW_DECISION_ACCEPTED to 1L,
+        result = PaperDecision.PAPER_DECISION_ACCEPTED,
+    )
+    private val DECLINE_ANY_PATTERN = patternOf(
+        ReviewDecision.REVIEW_DECISION_DECLINED to 1L,
+        result = PaperDecision.PAPER_DECISION_DECLINED,
+    )
+    private val MAYBE_MAYBE_PATTERN = patternOf(
+        ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
+        ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
+        result = PaperDecision.PAPER_DECISION_IN_REVIEW,
+    )
+
+    fun createExampleReviewDecisionMatrix(
+        pattern: List<ReviewDecisionMatrix.Pattern> = listOf(
+            ACCEPT_DECLINE_PATTERN,
+            ACCEPT_ANY_PATTERN,
+            DECLINE_ANY_PATTERN,
+            MAYBE_MAYBE_PATTERN,
+        ),
+    ): ReviewDecisionMatrix = ReviewDecisionMatrix.newBuilder()
+        .setNumberOfReviewers(2)
+        .addAllPatterns(pattern)
+        .build()
 
     fun createExampleProjectMemberWithUser(
         projectMember: ProjectMember = createExampleProjectMember(),

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -295,6 +295,7 @@ object DataBuilder {
     )
 
     fun createExampleReviewDecisionMatrix(
+        numberOfReviewers: Int = 2,
         pattern: List<ReviewDecisionMatrix.Pattern> = listOf(
             ACCEPT_DECLINE_PATTERN,
             ACCEPT_ANY_PATTERN,
@@ -302,7 +303,7 @@ object DataBuilder {
             MAYBE_MAYBE_PATTERN,
         ),
     ): ReviewDecisionMatrix = ReviewDecisionMatrix.newBuilder()
-        .setNumberOfReviewers(2)
+        .setNumberOfReviewers(numberOfReviewers)
         .addAllPatterns(pattern)
         .build()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -289,8 +289,7 @@ object DataBuilder {
         result = PaperDecision.PAPER_DECISION_DECLINED,
     )
     private val MAYBE_MAYBE_PATTERN = patternOf(
-        ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
-        ReviewDecision.REVIEW_DECISION_MAYBE to 1L,
+        ReviewDecision.REVIEW_DECISION_MAYBE to 2L,
         result = PaperDecision.PAPER_DECISION_IN_REVIEW,
     )
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -499,9 +499,6 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         @Test
         fun `When a user is found, then a successful result with the user settings is returned`() = runTest {
             val userId = insertUserAndGetId()
-            val decisionMatrix = ReviewDecisionMatrix.newBuilder()
-                .setNumberOfReviewers(2)
-                .build()
 
             val result = assertDoesNotThrow { repo.getUserSettings(userId) }
 
@@ -510,7 +507,11 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             assertFalse(userSettings.isReviewModeEnabled)
             assertThat(userSettings.criteriaIds).isEmpty()
             assertEquals(0F, userSettings.similarityThreshold)
-            assertEquals(decisionMatrix, userSettings.decisionMatrix)
+            assertEquals(2, userSettings.decisionMatrix.numberOfReviewers)
+            assertNotEquals(
+                ReviewDecisionMatrix.getDefaultInstance().toByteArray(),
+                userSettings.decisionMatrix.toByteArray(),
+            )
             assertThat(userSettings.fetchers).isEmpty()
             assertEquals(SnowballingType.SNOWBALLING_TYPE_BOTH, userSettings.snowballingType)
             assertTrue(userSettings.reviewMaybeAllowed)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -14,13 +14,17 @@ import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.createExampleReviewDecisionMatrix
 import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
+import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern
+import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry
 import snowballr.ReviewOuterClass
 import snowballr.ReviewOuterClass.ReviewDecision
 import snowballr.UserOuterClass.UserRole
@@ -30,10 +34,12 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CreateReviewTest : MainServiceTest() {
+    private val userId = UUID.randomUUID()
     private val project = DataBuilder.createExampleProject(reviewDecisionMatrix = createExampleReviewDecisionMatrix())
     private val projectPaperId = UUID.randomUUID()
     private val decision = ReviewDecision.REVIEW_DECISION_ACCEPTED
-    private val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
+    private val defaultCriterion = UUID.randomUUID()
+    private val selectedCriteriaIds = listOf<UUID>(defaultCriterion)
 
     private val validCreateReviewRequest: ReviewOuterClass.Review.Create.Builder =
         ReviewOuterClass.Review.Create.newBuilder()
@@ -46,21 +52,31 @@ class CreateReviewTest : MainServiceTest() {
         Arguments.of(projectRepoMock::getProjectById),
     )
 
-    @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
+    @Suppress("LongParameterList", "ReturnCount", "LongMethod")
+    private fun mockCreateReview(
+        useAdminUser: Boolean = true,
+        project: Project = this.project,
+        initialPaperDecision: PaperDecision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+        updatedPaperDecision: PaperDecision = PaperDecision.PAPER_DECISION_IN_REVIEW,
+        existingReviews: List<Review> = emptyList(),
+        stopBefore: KFunction<*>? = null,
+        failAt: KFunction<*>? = null,
+    ) {
         val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
+            id = userId,
+            role = if (useAdminUser) {
                 UserRole.USER_ROLE_ADMIN
             } else {
                 UserRole.USER_ROLE_DEFAULT
             },
         )
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+
         val projectPaper = DataBuilder.createExampleProjectPaper(
             id = projectPaperId,
             projectId = project.id,
-            decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+            decision = initialPaperDecision,
         )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
         val review = DataBuilder.createExampleReview(
             projectPaperId = projectPaperId,
             decision = decision,
@@ -77,35 +93,47 @@ class CreateReviewTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
 
+        if (stopBefore == projectMemberRepoMock::getProjectMembers) {
+            return
+        }
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
-            if (isUserAdmin) {
+            if (useAdminUser) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
 
-        if (failAt == projectRepoMock::getProjectById) {
+        if (stopBefore == projectRepoMock::getProjectById) {
+            return
+        } else if (failAt == projectRepoMock::getProjectById) {
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
             return
         }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns emptyList()
+        if (stopBefore == reviewRepoMock::getAllReviewsForProjectPaper) {
+            return
+        }
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns existingReviews
+        if (stopBefore == reviewRepoMock::createReview) {
+            return
+        }
         coEvery {
             reviewRepoMock.createReview(validCreateReviewRequest.build(), currentUser.id)
         } returns review
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
+        coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns emptyList()
         coEvery {
-            projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
+            projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, updatedPaperDecision)
         } returns Unit
     }
 
     @ParameterizedTest
     @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt, true)
+    fun `When a repo call fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
+        mockCreateReview(failAt = failAt)
 
         assertThrows<TestSpecificException> { mainService.createReview(validCreateReviewRequest.build()) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
@@ -113,25 +141,21 @@ class CreateReviewTest : MainServiceTest() {
 
     @Test
     fun `When a server admin creates a review, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, true)
+        mockCreateReview(useAdminUser = true)
 
         assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
     }
 
     @Test
     fun `When a project member creates a review, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, false)
+        mockCreateReview(useAdminUser = false)
 
         assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
     }
 
     @Test
     fun `When a non project member creates a review, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
+        mockCreateReview(useAdminUser = false, stopBefore = projectMemberRepoMock::getProjectMembers)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.createReview(validCreateReviewRequest.build()) }
@@ -148,16 +172,8 @@ class CreateReviewTest : MainServiceTest() {
     fun `When the project paper to review is in an inactive project, then a FailedPreconditionException is thrown`(
         statusName: String,
     ) = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectStatus.valueOf(statusName),
-            reviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.newBuilder().setNumberOfReviewers(2).build(),
-        )
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
+        mockCreateReview(project = project, stopBefore = projectRepoMock::getProjectById)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
@@ -166,185 +182,125 @@ class CreateReviewTest : MainServiceTest() {
 
     @Test
     fun `When the user already reviewed the project paper, then a DuplicateReviewException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
-        val review = DataBuilder.createExampleReview(
+        val firstReview = DataBuilder.createExampleReview(
             projectPaperId = projectPaperId,
             decision = decision,
-            userId = currentUser.id,
+            userId = userId,
         )
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(review)
+        mockCreateReview(stopBefore = reviewRepoMock::getAllReviewsForProjectPaper)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(firstReview)
 
         assertThrows<DuplicateReviewException> { mainService.createReview(validCreateReviewRequest.build()) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
     @Test
-    fun `When another user already reviewed the project paper but not finally decided it, then no exception is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val anotherUser = DataBuilder.createExampleUser(
-                email = "another.user@example.com",
-                role = UserRole.USER_ROLE_DEFAULT,
-            )
-            val projectPaper = DataBuilder.createExampleProjectPaper(
-                id = projectPaperId,
-                projectId = project.id,
-                decision = PaperDecision.PAPER_DECISION_IN_REVIEW,
-            )
-            val reviewByAnotherUser = DataBuilder.createExampleReview(
-                projectPaperId = projectPaperId,
-                decision = decision,
-                userId = anotherUser.id,
-            )
-            val review = DataBuilder.createExampleReview(
-                projectPaperId = projectPaperId,
-                decision = decision,
-                userId = currentUser.id,
-            )
-            val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-            val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = anotherUser.id)
-
-            mockCurrentUser(currentUser)
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
-            coEvery {
-                projectMemberRepoMock.getProjectMembers(project.id)
-            } returns listOf(projectMember1, projectMember2)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(reviewByAnotherUser)
-            coEvery { reviewRepoMock.createReview(validCreateReviewRequest.build(), currentUser.id) } returns review
-            coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id) } returns emptyList()
-            coEvery {
-                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
-            } returns Unit
-
-            assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
-        }
-
-    @Test
     fun `When the project paper is already finally decided, then a FailedPreconditionException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = projectPaperId,
-            projectId = project.id,
-            decision = PaperDecision.PAPER_DECISION_ACCEPTED,
+        mockCreateReview(
+            initialPaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+            stopBefore = reviewRepoMock::createReview,
         )
-
-        mockCurrentUser(currentUser)
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns emptyList()
 
         assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
     @Test
-    @Suppress("LongMethod")
-    fun `When the project paper is not finally decided, then the paper decision is updated accordingly to the review`() =
+    fun `When another user reviewed the project paper but not finally decided it, then no exception is thrown and the paper decision is updated accordingly to the review decision matrix`() =
         runTest {
-            val firstReviewer = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val secondReviewer = DataBuilder.createExampleUser(
-                email = "second.reviewer@example.com",
-                role = UserRole.USER_ROLE_ADMIN,
+            val reviewByAnotherUser = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                decision = decision,
+                userId = UUID.randomUUID(),
             )
-            val thirdReviewer = DataBuilder.createExampleUser(
-                email = "third.reviewer@example.com",
-                role = UserRole.USER_ROLE_ADMIN,
-            )
-            val projectPaper = DataBuilder.createExampleProjectPaper(
-                id = projectPaperId,
-                projectId = project.id,
-                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+            mockCreateReview(
+                existingReviews = listOf(reviewByAnotherUser),
+                initialPaperDecision = PaperDecision.PAPER_DECISION_IN_REVIEW,
+                updatedPaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
             )
 
-            mockCurrentUser(firstReviewer)
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
+        }
 
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns emptyList()
+    @Test
+    fun `When the paper is not finally decided after the required number of reviews, then the paper is only accepted if the next review is an acceptance`() =
+        runTest {
             val firstReview = DataBuilder.createExampleReview(
                 projectPaperId = projectPaperId,
-                userId = firstReviewer.id,
-                decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
+                decision = ReviewDecision.REVIEW_DECISION_MAYBE,
+                userId = UUID.randomUUID(),
             )
-            val createFirstReviewRequest = validCreateReviewRequest
-                .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
-                .build()
-            coEvery {
-                reviewRepoMock.createReview(createFirstReviewRequest, firstReviewer.id)
-            } returns firstReview
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(firstReview.id)
-            } returns selectedCriteriaIds
-            coEvery {
-                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
-            } returns Unit
-
-            assertDoesNotThrow { mainService.createReview(createFirstReviewRequest) }
-
-            mockCurrentUser(secondReviewer)
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(firstReview)
             val secondReview = DataBuilder.createExampleReview(
                 projectPaperId = projectPaperId,
-                userId = secondReviewer.id,
-                decision = ReviewDecision.REVIEW_DECISION_DECLINED,
+                decision = ReviewDecision.REVIEW_DECISION_MAYBE,
+                userId = UUID.randomUUID(),
             )
-            val createSecondReviewRequest = validCreateReviewRequest
-                .setDecision(ReviewDecision.REVIEW_DECISION_DECLINED)
-                .build()
-            coEvery {
-                reviewRepoMock.createReview(createSecondReviewRequest, secondReviewer.id)
-            } returns secondReview
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(secondReview.id)
-            } returns selectedCriteriaIds
-            coEvery {
-                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
-            } returns Unit
-
-            assertDoesNotThrow { mainService.createReview(createSecondReviewRequest) }
-
-            mockCurrentUser(thirdReviewer)
-            coEvery {
-                reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId)
-            } returns listOf(firstReview, secondReview)
-            val thirdReview = DataBuilder.createExampleReview(
-                projectPaperId = projectPaperId,
-                userId = thirdReviewer.id,
-                decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
+            mockCreateReview(
+                existingReviews = listOf(firstReview, secondReview),
+                initialPaperDecision = PaperDecision.PAPER_DECISION_IN_REVIEW,
+                updatedPaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
             )
-            val createThirdReviewRequest = validCreateReviewRequest
-                .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+
+            assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
+        }
+
+    @Test
+    fun `When no matching pattern could be found in the decision matrix, then the default paper decision is PAPER_DECISION_IN_REVIEW`() =
+        runTest {
+            val declinePattern = Pattern.newBuilder()
+                .addEntries(Entry.newBuilder().setReviewDecision(ReviewDecision.REVIEW_DECISION_DECLINED).setCount(1))
+                .setDecision(PaperDecision.PAPER_DECISION_DECLINED)
                 .build()
-            coEvery {
-                reviewRepoMock.createReview(createThirdReviewRequest, thirdReviewer.id)
-            } returns thirdReview
-            coEvery {
-                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(thirdReview.id)
-            } returns selectedCriteriaIds
-            coEvery {
-                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
-            } returns Unit
+            val project = DataBuilder.createExampleProject(
+                reviewDecisionMatrix = createExampleReviewDecisionMatrix(
+                    numberOfReviewers = 1,
+                    pattern = listOf(declinePattern),
+                ),
+            )
+            mockCreateReview(project = project)
 
-            assertDoesNotThrow { mainService.createReview(createThirdReviewRequest) }
-
-            coVerify(exactly = 2) {
-                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
-            }
+            assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
             coVerify(exactly = 1) {
-                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+                projectPaperRepoMock.updateProjectPaperDecision(
+                    projectPaperId,
+                    PaperDecision.PAPER_DECISION_IN_REVIEW,
+                )
             }
-            coVerify(exactly = 0) {
+        }
+
+    @Test
+    fun `When a declining review decision is justified with a hard exclusion criterion, then the paper decision is instantly PAPER_DECISION_DECLINED`() =
+        runTest {
+            val exclusionCriterion = DataBuilder.createExampleProjectCriterion(
+                category = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
+            )
+            val hardExclusionCriterion = DataBuilder.createExampleProjectCriterion(
+                category = CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION,
+            )
+            val review = DataBuilder.createExampleReview(
+                projectPaperId = projectPaperId,
+                decision = ReviewDecision.REVIEW_DECISION_DECLINED,
+                userId = userId,
+            )
+            val createReviewRequest = validCreateReviewRequest
+                .setDecision(ReviewDecision.REVIEW_DECISION_DECLINED)
+                .addAllSelectedCriteriaIds(
+                    listOf(exclusionCriterion.id.toString(), hardExclusionCriterion.id.toString()),
+                )
+                .build()
+
+            mockCreateReview(stopBefore = reviewRepoMock::createReview)
+            coEvery { reviewRepoMock.createReview(createReviewRequest, userId) } returns review
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
+            } returns listOf(defaultCriterion, exclusionCriterion.id, hardExclusionCriterion.id)
+            coEvery {
+                criterionRepoMock.getAllProjectCriteria(project.id)
+            } returns listOf(exclusionCriterion, hardExclusionCriterion)
+            coEvery {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
-            }
+            } returns Unit
+
+            assertDoesNotThrow { mainService.createReview(createReviewRequest) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.DataBuilder.createExampleReviewDecisionMatrix
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
@@ -29,9 +30,7 @@ import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CreateReviewTest : MainServiceTest() {
-    private val project = DataBuilder.createExampleProject(
-        reviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.newBuilder().setNumberOfReviewers(2).build(),
-    )
+    private val project = DataBuilder.createExampleProject(reviewDecisionMatrix = createExampleReviewDecisionMatrix())
     private val projectPaperId = UUID.randomUUID()
     private val decision = ReviewDecision.REVIEW_DECISION_ACCEPTED
     private val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())


### PR DESCRIPTION
Closes #345 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I added a meaningful default decision matrix (based on two reviewers) to the user settings that is used when a new project is created
- I extended the `createReview` service function, so that the paper decision is not updated based on a simple summation function anymore, but either
  - set to  `DECLINED` when the decision is declined and justified with at least one hard exclusion criterion
  - check the paper decision by pattern match the current reviews to the review decision matrix of the project
- I extended and refactored the `CreateReviewTest` to be up-to-date with the new paper decision update procedure 

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
