### PR TITLE
Extract project member-related service calls into a dedicated `ProjectMemberService`

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -56,6 +56,7 @@ import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IInvitationService
 import se.uulm.snowballr.backend.service.IMainService
 import se.uulm.snowballr.backend.service.IPaperService
+import se.uulm.snowballr.backend.service.IProjectMemberService
 import se.uulm.snowballr.backend.service.IProjectPaperService
 import se.uulm.snowballr.backend.service.IProjectService
 import se.uulm.snowballr.backend.service.IReadingListService
@@ -64,6 +65,7 @@ import se.uulm.snowballr.backend.service.IUserService
 import se.uulm.snowballr.backend.service.InvitationService
 import se.uulm.snowballr.backend.service.MainService
 import se.uulm.snowballr.backend.service.PaperService
+import se.uulm.snowballr.backend.service.ProjectMemberService
 import se.uulm.snowballr.backend.service.ProjectPaperService
 import se.uulm.snowballr.backend.service.ProjectService
 import se.uulm.snowballr.backend.service.ReadingListService
@@ -199,6 +201,7 @@ fun Module.serviceLayerDeps() {
     singleOf(::ProjectPaperService) { bind<IProjectPaperService>() }
     singleOf(::AuthenticationService) { bind<IAuthenticationService>() }
     singleOf(::InvitationService) { bind<IInvitationService>() }
+    singleOf(::ProjectMemberService) { bind<IProjectMemberService>() }
     // The main service comes last
     singleOf(::MainService) { bind<IMainService>() }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -19,7 +19,8 @@ interface IMainService :
     IPaperService,
     IProjectPaperService,
     IAuthenticationService,
-    IInvitationService
+    IInvitationService,
+    IProjectMemberService
 
 /**
  * The [MainService] class serves as the primary service implementation layer that aggregates multiple sub-services.
@@ -37,6 +38,7 @@ interface IMainService :
  * @param projectPaperService The service responsible for handling business logic related to project papers.
  * @param authenticationService The service responsible for handling business logic related to user authentication
  * @param invitationService The service responsible for handling business logic related to user invitations
+ * @param projectMemberService The service responsible for handling business logic related to project members.
  */
 @Suppress("LongParameterList")
 class MainService(
@@ -50,6 +52,7 @@ class MainService(
     private val projectPaperService: IProjectPaperService,
     private val authenticationService: IAuthenticationService,
     private val invitationService: IInvitationService,
+    private val projectMemberService: IProjectMemberService,
 ) : IMainService,
     IProjectService by projectService,
     ICriterionService by criterionService,
@@ -60,4 +63,5 @@ class MainService(
     IPaperService by paperService,
     IProjectPaperService by projectPaperService,
     IAuthenticationService by authenticationService,
-    IInvitationService by invitationService
+    IInvitationService by invitationService,
+    IProjectMemberService by projectMemberService

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -1,0 +1,155 @@
+package se.uulm.snowballr.backend.service
+
+import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.SnowballRException.FailedPreconditionException
+import se.uulm.snowballr.backend.model.SnowballRException.NotFoundException
+import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
+import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IUserTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.service.accessrules.AccessRuleCompoundObject
+import se.uulm.snowballr.backend.service.accessrules.andAlso
+import se.uulm.snowballr.backend.service.accessrules.checkFor
+import se.uulm.snowballr.backend.service.accessrules.forProperty
+import se.uulm.snowballr.backend.service.accessrules.forTarget
+import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
+import se.uulm.snowballr.backend.service.accessrules.isProjectAdmin
+import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
+import se.uulm.snowballr.backend.service.accessrules.isProjectMember
+import se.uulm.snowballr.backend.service.accessrules.isSameUserById
+import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
+import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
+import se.uulm.snowballr.backend.service.accessrules.orElse
+import se.uulm.snowballr.backend.service.accessrules.orElseThrow
+import snowballr.Base
+import snowballr.ProjectOuterClass.MemberRole
+import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
+
+interface IProjectMemberService {
+    /**
+     * Service implementation of [SnowballRService.getProjectMembers].
+     */
+    suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List
+
+    /**
+     * Service implementation of [SnowballRService.updateProjectMemberRole].
+     */
+    suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update): Base.Nothing
+
+    /**
+     * Service implementation of [SnowballRService.removeProjectMember].
+     */
+    suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing
+}
+
+/**
+ * The [ProjectMemberService] class handles operations related to project members by implementing the [IProjectMemberService] interface.
+ *
+ * This class serves as a layer that abstracts the responsibility of project members CRUD operations,
+ * delegating the actual persistence operations to the [IProjectMemberTableRepo] repository.
+ *
+ * @constructor Initializes the [ProjectMemberService] with a project member repository.
+ * @param repo The repository responsible for managing persistence operations for project members.
+ * @param projectRepo The repository responsible for managing persistence operations for projects.
+ * @param userRepo The repository responsible for managing persistence operations for users.
+ */
+class ProjectMemberService(
+    private val repo: IProjectMemberTableRepo,
+    private val projectRepo: IProjectTableRepo,
+    private val userRepo: IUserTableRepo,
+) : IProjectMemberService {
+    override suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+            isAllowedToReadProject(repo)
+                .andAlso(isProjectExistent(projectRepo))
+                .checkFor(currentUser, projectId)
+
+            val projectMembersWithUsers = repo.getProjectMembersWithUsers(projectId)
+            projectMembersWithUsers.toGrpcProjectMembers()
+        }
+
+    override suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update): Base.Nothing {
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+            val userId = parseUUID(request.userId, EntityType.USER)
+
+            isServerOrProjectAdmin(repo, AccessType.UPDATE).checkFor(currentUser, projectId)
+
+            projectRepo.getProjectById(projectId).getOrThrow()
+            userRepo.getUserById(userId).getOrThrow()
+
+            val currentMember = try {
+                repo.getProjectMemberByComposedId(projectId, userId).getOrThrow()
+            } catch (_: NotFoundException) {
+                throw FailedPreconditionException(
+                    "User with ID '$userId' is not a member of project with ID '$projectId'.",
+                )
+            }
+
+            if (currentMember.role == MemberRole.MEMBER_ROLE_ADMIN && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
+                val projectAdmins = repo.getAllProjectAdmins(projectId)
+                if (projectAdmins.size <= 1) {
+                    throw FailedPreconditionException("Cannot demote the last admin of a project.")
+                }
+            }
+
+            repo.updateProjectMemberRole(projectId, userId, request.newRole)
+        }
+
+        return Base.Nothing.getDefaultInstance()
+    }
+
+    override suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+            val requestedUserId = parseUUID(request.userId, EntityType.USER)
+
+            val userProjectCompound = AccessRuleCompoundObject(requestedUserId, projectId)
+
+            isSameUserById()
+                .forProperty(AccessRuleCompoundObject::firstTargetId)
+                .andAlso(isProjectMember(repo).forProperty(AccessRuleCompoundObject::secondTargetId))
+                .orElse(
+                    isProjectAdmin(repo)
+                        .orElse(isServerAdmin().forTarget())
+                        .orElseThrow { user, targetId ->
+                            UnauthorizedException.Action(
+                                EntityType.PROJECT,
+                                targetId.toString(),
+                                AccessType.DELETE,
+                                user.id.toString(),
+                            )
+                        }
+                        .forProperty(AccessRuleCompoundObject::secondTargetId),
+                )
+                .checkFor(currentUser, userProjectCompound)
+
+            when {
+                !projectRepo.doesProjectExistById(projectId)
+                -> throw NotFoundException(EntityType.PROJECT, projectId.toString())
+
+                !userRepo.doesUserExistById(requestedUserId)
+                -> throw NotFoundException(EntityType.USER, projectId.toString())
+            }
+
+            val projectMembers = repo.getProjectMembers(projectId)
+            val projectAdmins = repo.getAllProjectAdmins(projectId)
+            if (projectMembers.size == 1 && projectMembers.any { it.userId == requestedUserId }) {
+                projectRepo.softDeleteProject(projectId)
+            } else if (projectAdmins.size == 1 && projectAdmins.any { it.userId == requestedUserId }) {
+                throw FailedPreconditionException(
+                    "The user can not be removed from the project, because this user is the last " +
+                        "project admin.",
+                )
+            }
+
+            repo.removeProjectMember(projectId, requestedUserId)
+            Base.Nothing.getDefaultInstance()
+        }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -11,7 +11,6 @@ import se.uulm.snowballr.backend.model.SnowballRException.StageNotFoundException
 import se.uulm.snowballr.backend.model.SnowballRException.UnauthorizedException
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
-import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.dto.toGrpcProjects
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
@@ -19,20 +18,14 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
-import se.uulm.snowballr.backend.service.accessrules.AccessRuleCompoundObject
 import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forProperty
-import se.uulm.snowballr.backend.service.accessrules.forTarget
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
-import se.uulm.snowballr.backend.service.accessrules.isProjectAdmin
 import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
-import se.uulm.snowballr.backend.service.accessrules.isProjectMember
-import se.uulm.snowballr.backend.service.accessrules.isSameUserById
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isServerAdminOrSameUser
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
-import se.uulm.snowballr.backend.service.accessrules.orElse
 import se.uulm.snowballr.backend.service.accessrules.orElseThrow
 import snowballr.Base
 import snowballr.ProjectOuterClass.MemberRole
@@ -43,9 +36,8 @@ import java.util.UUID
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.ProjectOuterClass.Project.Information.DecisionStatistics as GrpcProjectDecisionStatistics
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
-@Suppress("ComplexInterface", "TooManyFunctions")
+@Suppress("ComplexInterface")
 interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectById].
@@ -83,29 +75,14 @@ interface IProjectService {
     suspend fun updateProject(request: GrpcProject.Update): GrpcProject
 
     /**
-     * Service implementation of [SnowballRService.getProjectMembers].
-     */
-    suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List
-
-    /**
      * Service implementation of [SnowballRService.getProjectInformation].
      */
     suspend fun getProjectInformation(request: GrpcProject.Information.Get): GrpcProject.Information
 
     /**
-     * Service implementation of [SnowballRService.updateProjectMemberRole].
-     */
-    suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update): Base.Nothing
-
-    /**
      * Service implementation of [SnowballRService.getDecisionStatisticsForStage].
      */
     suspend fun getDecisionStatisticsForStage(request: GrpcProjectDecisionStatistics.Get): GrpcProjectDecisionStatistics
-
-    /**
-     * Service implementation of [SnowballRService.removeProjectMember]
-     */
-    suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing
 
     /**
      * Service implementation of [SnowballRService.softDeleteProject]
@@ -329,18 +306,6 @@ class ProjectService(
         }
     }
 
-    override suspend fun getProjectMembers(request: Base.Id): GrpcProjectMember.List =
-        withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.id, EntityType.PROJECT)
-
-            isAllowedToReadProject(projectMemberRepo)
-                .andAlso(isProjectExistent(repo))
-                .checkFor(currentUser, projectId)
-
-            val projectMembersWithUsers = projectMemberRepo.getProjectMembersWithUsers(projectId)
-            projectMembersWithUsers.toGrpcProjectMembers()
-        }
-
     override suspend fun getProjectInformation(request: GrpcProject.Information.Get): GrpcProject.Information =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
@@ -373,37 +338,6 @@ class ProjectService(
 
             builder.build()
         }
-
-    override suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update): Base.Nothing {
-        withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-            val userId = parseUUID(request.userId, EntityType.USER)
-
-            isServerOrProjectAdmin(projectMemberRepo, AccessType.UPDATE).checkFor(currentUser, projectId)
-
-            repo.getProjectById(projectId).getOrThrow()
-            userRepo.getUserById(userId).getOrThrow()
-
-            val currentMember = try {
-                projectMemberRepo.getProjectMemberByComposedId(projectId, userId).getOrThrow()
-            } catch (_: NotFoundException) {
-                throw FailedPreconditionException(
-                    "User with ID '$userId' is not a member of project with ID '$projectId'.",
-                )
-            }
-
-            if (currentMember.role == MemberRole.MEMBER_ROLE_ADMIN && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
-                val projectAdmins = projectMemberRepo.getAllProjectAdmins(projectId)
-                if (projectAdmins.size <= 1) {
-                    throw FailedPreconditionException("Cannot demote the last admin of a project.")
-                }
-            }
-
-            projectMemberRepo.updateProjectMemberRole(projectId, userId, request.newRole)
-        }
-
-        return Base.Nothing.getDefaultInstance()
-    }
 
     override suspend fun getDecisionStatisticsForStage(
         request: GrpcProjectDecisionStatistics.Get,
@@ -455,54 +389,6 @@ class ProjectService(
             PaperDecision.PAPER_DECISION_IN_REVIEW,
         ).map(::createStatistic)
     }
-
-    override suspend fun removeProjectMember(request: GrpcProjectMember.Remove): Base.Nothing =
-        withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-            val requestedUserId = parseUUID(request.userId, EntityType.USER)
-
-            val userProjectCompound = AccessRuleCompoundObject(requestedUserId, projectId)
-
-            isSameUserById()
-                .forProperty(AccessRuleCompoundObject::firstTargetId)
-                .andAlso(isProjectMember(projectMemberRepo).forProperty(AccessRuleCompoundObject::secondTargetId))
-                .orElse(
-                    isProjectAdmin(projectMemberRepo)
-                        .orElse(isServerAdmin().forTarget())
-                        .orElseThrow { user, targetId ->
-                            UnauthorizedException.Action(
-                                EntityType.PROJECT,
-                                targetId.toString(),
-                                AccessType.DELETE,
-                                user.id.toString(),
-                            )
-                        }
-                        .forProperty(AccessRuleCompoundObject::secondTargetId),
-                )
-                .checkFor(currentUser, userProjectCompound)
-
-            when {
-                !repo.doesProjectExistById(projectId)
-                -> throw NotFoundException(EntityType.PROJECT, projectId.toString())
-
-                !userRepo.doesUserExistById(requestedUserId)
-                -> throw NotFoundException(EntityType.USER, projectId.toString())
-            }
-
-            val projectMembers = projectMemberRepo.getProjectMembers(projectId)
-            val projectAdmins = projectMemberRepo.getAllProjectAdmins(projectId)
-            if (projectMembers.size == 1 && projectMembers.any { it.userId == requestedUserId }) {
-                repo.softDeleteProject(projectId)
-            } else if (projectAdmins.size == 1 && projectAdmins.any { it.userId == requestedUserId }) {
-                throw FailedPreconditionException(
-                    "The user can not be removed from the project, because this user is the last " +
-                        "project admin.",
-                )
-            }
-
-            projectMemberRepo.removeProjectMember(projectId, requestedUserId)
-            Base.Nothing.getDefaultInstance()
-        }
 
     override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.service.project
+package se.uulm.snowballr.backend.service.projectmember
 
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.service.project
+package se.uulm.snowballr.backend.service.projectmember
 
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.service.project
+package se.uulm.snowballr.backend.service.projectmember
 
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest


### PR DESCRIPTION
Closes #367

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I moved all project member-related service calls (`getProjectMembers`, `updateProjectMemberRole` and `removeProjectMember`) into a separate `ProjectMemberService` to make the `ProjectService` a bit smaller

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
