### PR TITLE
Implement export functionality

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -55,9 +55,11 @@ import se.uulm.snowballr.backend.scheduler.TokenMaintenanceService
 import se.uulm.snowballr.backend.scheduler.UserMaintenanceService
 import se.uulm.snowballr.backend.service.AuthenticationService
 import se.uulm.snowballr.backend.service.CriterionService
+import se.uulm.snowballr.backend.service.ExportService
 import se.uulm.snowballr.backend.service.FetcherService
 import se.uulm.snowballr.backend.service.IAuthenticationService
 import se.uulm.snowballr.backend.service.ICriterionService
+import se.uulm.snowballr.backend.service.IExportService
 import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IInvitationService
 import se.uulm.snowballr.backend.service.IMainService
@@ -211,6 +213,7 @@ fun Module.serviceLayerDeps() {
     singleOf(::AuthenticationService) { bind<IAuthenticationService>() }
     singleOf(::InvitationService) { bind<IInvitationService>() }
     singleOf(::ProjectMemberService) { bind<IProjectMemberService>() }
+    singleOf(::ExportService) { bind<IExportService>() }
     // The main service comes last
     singleOf(::MainService) { bind<IMainService>() }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/IExporter.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/IExporter.kt
@@ -1,0 +1,13 @@
+package se.uulm.snowballr.backend.export
+
+import se.uulm.snowballr.backend.model.export.ProjectExport
+
+fun interface IExporter {
+    /**
+     * Exports the given [ProjectExport] to a byte array in the implementor's format.
+     *
+     * @param export The project export data to be exported.
+     * @return A byte array representing the exported project data.
+     */
+    fun export(export: ProjectExport): ByteArray
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/IExporter.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/IExporter.kt
@@ -2,7 +2,7 @@ package se.uulm.snowballr.backend.export
 
 import se.uulm.snowballr.backend.model.export.ProjectExport
 
-fun interface IExporter {
+interface IExporter {
     /**
      * Exports the given [ProjectExport] to a byte array in the implementor's format.
      *
@@ -10,4 +10,9 @@ fun interface IExporter {
      * @return A byte array representing the exported project data.
      */
     fun export(export: ProjectExport): ByteArray
+
+    /**
+     * @return The file extension that is used for this exporter (without the dot).
+     */
+    fun getExtension(): String
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/JsonExporter.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/JsonExporter.kt
@@ -13,4 +13,6 @@ class JsonExporter : IExporter {
         val jsonString = json.encodeToString<ProjectExport>(export)
         return jsonString.toByteArray()
     }
+
+    override fun getExtension() = "json"
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/JsonExporter.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/JsonExporter.kt
@@ -11,7 +11,7 @@ class JsonExporter : IExporter {
 
     override fun export(export: ProjectExport): ByteArray {
         val jsonString = json.encodeToString<ProjectExport>(export)
-        return jsonString.toByteArray()
+        return jsonString.toByteArray(Charsets.UTF_8)
     }
 
     override fun getExtension() = "json"

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/JsonExporter.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/JsonExporter.kt
@@ -1,0 +1,16 @@
+package se.uulm.snowballr.backend.export
+
+import kotlinx.serialization.json.Json
+import se.uulm.snowballr.backend.model.export.ProjectExport
+
+/**
+ * Exports a [ProjectExport] to the JSON format.
+ */
+class JsonExporter : IExporter {
+    private val json = Json
+
+    override fun export(export: ProjectExport): ByteArray {
+        val jsonString = json.encodeToString<ProjectExport>(export)
+        return jsonString.toByteArray()
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportBuilder.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportBuilder.kt
@@ -1,0 +1,96 @@
+package se.uulm.snowballr.backend.export
+
+import se.uulm.snowballr.backend.model.dto.Criterion
+import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
+import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
+import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
+import se.uulm.snowballr.backend.model.export.CriterionExport
+import se.uulm.snowballr.backend.model.export.PaperExport
+import se.uulm.snowballr.backend.model.export.PaperReviewExport
+import se.uulm.snowballr.backend.model.export.ProjectExport
+import se.uulm.snowballr.backend.model.export.ProjectMemberExport
+import se.uulm.snowballr.backend.model.export.ProjectStageExport
+import snowballr.ProjectOuterClass.PaperDecision
+
+/**
+ * Builder class responsible for constructing a [ProjectExport] from project data.
+ *
+ * @param project The project to be exported.
+ * @param projectMembers The members of the project along with their user details.
+ * @param projectPapers The papers associated with the project, including reviews and decisions.
+ * @param projectCriteria The criteria defined for the project.
+ */
+class ProjectExportBuilder(
+    private val project: Project,
+    private val projectMembers: List<ProjectMemberWithUser>,
+    private val projectPapers: List<ProjectPaperFull>,
+    private val projectCriteria: List<Criterion>,
+) {
+    fun buildExport(): ProjectExport {
+        val projectMembersExport = projectMembers.mapIndexed { id, member -> member.toProjectMemberExport(id) }
+        val stageToPapersExport = projectPapers.toPapersExportByStage()
+        val stages = stageToPapersExport.toProjectStagesExport()
+        val criteria = projectCriteria.toCriteriaExport()
+
+        return ProjectExport(project.name, projectMembersExport, stages, criteria)
+    }
+
+    private fun ProjectMemberWithUser.toProjectMemberExport(id: Int): ProjectMemberExport = ProjectMemberExport(
+        id = "$id",
+        firstName = user.firstName,
+        lastName = user.lastName,
+        email = user.email,
+        role = projectMember.role,
+    )
+
+    private fun Paper.toPaperExport(reviews: List<PaperReviewExport>, finalDecision: PaperDecision): PaperExport =
+        PaperExport(
+            title = title,
+            externalId = externalId.orEmpty(),
+            abstract = abstract,
+            year = year,
+            publisher = publisher,
+            publicationType = publicationType,
+            publicationName = publicationName,
+            authors = authors.map { "${it.firstName} ${it.lastName}" },
+            reviews = reviews,
+            finalDecision = finalDecision,
+        )
+
+    private fun List<ProjectPaperFull>.toPapersExportByStage(): Map<Long, List<PaperExport>> =
+        this.groupBy { it.projectPaper.stage }.mapValues { entry ->
+            entry.value.map { it.toPaperExport() }
+        }
+
+    private fun ProjectPaperFull.toPaperExport(): PaperExport = paper.toPaperExport(
+        reviews = reviewsWithSelectedCriteria.map { it.toPaperReviewExport() },
+        finalDecision = projectPaper.decision,
+    )
+
+    private fun ReviewWithSelectedCriteriaIds.toPaperReviewExport(): PaperReviewExport {
+        val projectMemberId = projectMembers.indexOfFirst { it.user.id == review.userId }
+        val reviewerId = if (projectMemberId == -1) "unknown" else projectMemberId.toString()
+        val selectedCriteriaIdsAsStrings = selectedCriteriaIds.map { criterionId ->
+            val criterionIndex = projectCriteria.indexOfFirst { it.id == criterionId }
+            if (criterionIndex == -1) "unknown" else "$criterionIndex"
+        }
+        return PaperReviewExport(reviewerId, review.decision, selectedCriteriaIdsAsStrings)
+    }
+
+    private fun Map<Long, List<PaperExport>>.toProjectStagesExport(): List<ProjectStageExport> =
+        this.map { (stage, papers) ->
+            ProjectStageExport(id = "$stage", papers = papers)
+        }
+
+    private fun List<Criterion>.toCriteriaExport(): List<CriterionExport> = this.mapIndexed { index, criterion ->
+        CriterionExport(
+            id = "$index",
+            tag = criterion.tag,
+            name = criterion.name,
+            description = criterion.description,
+            category = criterion.category,
+        )
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportBuilder.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportBuilder.kt
@@ -34,7 +34,7 @@ class ProjectExportBuilder(
         val stages = stageToPapersExport.toProjectStagesExport()
         val criteria = projectCriteria.toCriteriaExport()
 
-        return ProjectExport(project.name, projectMembersExport, stages, criteria)
+        return ProjectExport(project.name, projectMembersExport, stages, criteria, project.createdAt.toString())
     }
 
     private fun ProjectMemberWithUser.toProjectMemberExport(id: Int): ProjectMemberExport = ProjectMemberExport(
@@ -57,6 +57,8 @@ class ProjectExportBuilder(
             authors = authors.map { "${it.firstName} ${it.lastName}" },
             reviews = reviews,
             finalDecision = finalDecision,
+            createdAt = createdAt.toString(),
+            modifiedAt = modifiedAt?.toString().orEmpty(),
         )
 
     private fun List<ProjectPaperFull>.toPapersExportByStage(): Map<Long, List<PaperExport>> =

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -6,12 +6,14 @@ import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.model.export.PaperExport
 import se.uulm.snowballr.backend.model.export.PaperReviewExport
 import se.uulm.snowballr.backend.model.export.ProjectExport
 import se.uulm.snowballr.backend.model.export.ProjectMemberExport
 import se.uulm.snowballr.backend.model.export.ProjectStageExport
 import snowballr.ProjectOuterClass.PaperDecision
+import java.time.Instant
 
 /**
  * Manager responsible for exporting projects in various formats.
@@ -28,7 +30,7 @@ object ProjectExportManager {
         project: Project,
         projectMembers: List<ProjectMemberWithUser>,
         projectPapers: List<ProjectPaperFull>,
-    ): ByteArray {
+    ): FileExport {
         val exporter = exporters[format] ?: throw IllegalArgumentException("Unsupported export format: $format")
 
         val projectMembersExport = projectMembers.mapIndexed { id, member -> member.toProjectMemberExport(id) }
@@ -36,8 +38,10 @@ object ProjectExportManager {
         val stages = stageToPapersExport.toProjectStagesExport()
 
         val projectExport = ProjectExport(name = project.name, members = projectMembersExport, stages = stages)
-
-        return exporter.export(projectExport)
+        val data = exporter.export(projectExport)
+        val timestamp = Instant.now().toString()
+        val filename = "${project.name}-${timestamp}.${exporter.getExtension()}"
+        return FileExport(data, sanitizeFilename(filename))
     }
 
     private fun ProjectMemberWithUser.toProjectMemberExport(id: Int): ProjectMemberExport = ProjectMemberExport(
@@ -84,4 +88,19 @@ object ProjectExportManager {
         this.map { (stage, papers) ->
             ProjectStageExport(id = "$stage", papers = papers)
         }
+
+    private fun sanitizeFilename(input: String): String {
+        // Define characters not allowed in filenames (Windows + UNIX safe set)
+        val illegalChars = """[\\/:*?"<>|\p{Cntrl}]""".toRegex()
+
+        var sanitized = input.replace(illegalChars, "_")
+
+        // Trim spaces and dots (Windows doesn't like names ending with . or space)
+        sanitized = sanitized.trim().trimEnd('.')
+
+        // Fallback for empty filenames
+        if (sanitized.isEmpty()) sanitized = "unnamed"
+
+        return sanitized
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -1,0 +1,89 @@
+package se.uulm.snowballr.backend.export
+
+import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
+import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
+import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.model.export.PaperExport
+import se.uulm.snowballr.backend.model.export.PaperReviewExport
+import se.uulm.snowballr.backend.model.export.ProjectExport
+import se.uulm.snowballr.backend.model.export.ProjectMemberExport
+import se.uulm.snowballr.backend.model.export.ProjectStageExport
+import snowballr.ProjectOuterClass.PaperDecision
+
+/**
+ * Manager responsible for exporting projects in various formats.
+ */
+object ProjectExportManager {
+    private val exporters = mapOf<ExportFormat, IExporter>(
+        ExportFormat.JSON to JsonExporter(),
+    )
+
+    fun getSupportedFormats(): Set<ExportFormat> = exporters.keys
+
+    fun exportProject(
+        format: ExportFormat,
+        project: Project,
+        projectMembers: List<ProjectMemberWithUser>,
+        projectPapers: List<ProjectPaperFull>,
+    ): ByteArray {
+        val projectMembersExport = projectMembers.mapIndexed { id, member -> member.toProjectMemberExport(id) }
+        val stageToPapersExport = projectPapers.toPapersExportByStage(projectMembers)
+        val stages = stageToPapersExport.toProjectStagesExport()
+
+        val projectExport = ProjectExport(
+            name = project.name,
+            members = projectMembersExport,
+            stages = stages,
+        )
+
+        val exporter = exporters[format] ?: throw IllegalArgumentException("Unsupported export format: $format")
+        return exporter.export(projectExport)
+    }
+
+    private fun ProjectMemberWithUser.toProjectMemberExport(id: Int): ProjectMemberExport = ProjectMemberExport(
+        id = "$id",
+        firstName = user.firstName,
+        lastName = user.lastName,
+        email = user.email,
+        role = projectMember.role,
+    )
+
+    private fun Paper.toPaperExport(reviews: List<PaperReviewExport>, finalDecision: PaperDecision): PaperExport =
+        PaperExport(
+            title = title,
+            externalId = externalId.orEmpty(),
+            abstract = abstract,
+            year = year,
+            publisher = publisher,
+            publicationType = publicationType,
+            publicationName = publicationName,
+            authors = authors.map { "${it.firstName} ${it.lastName}" },
+            reviews = reviews,
+            finalDecision = finalDecision,
+        )
+
+    private fun List<ProjectPaperFull>.toPapersExportByStage(
+        projectMembers: List<ProjectMemberWithUser>,
+    ): Map<Long, List<PaperExport>> = this.groupBy { it.projectPaper.stage }.mapValues { entry ->
+        entry.value.map { it.toPaperExport(projectMembers) }
+    }
+
+    private fun ProjectPaperFull.toPaperExport(projectMembers: List<ProjectMemberWithUser>): PaperExport =
+        paper.toPaperExport(
+            reviews = reviews.map { it.toPaperReviewExport(projectMembers) },
+            finalDecision = projectPaper.decision,
+        )
+
+    private fun Review.toPaperReviewExport(projectMembers: List<ProjectMemberWithUser>): PaperReviewExport {
+        val reviewerId = projectMembers.firstOrNull { it.user.id == userId }?.toString() ?: "unknown"
+        return PaperReviewExport(reviewerId, decision)
+    }
+
+    private fun Map<Long, List<PaperExport>>.toProjectStagesExport(): List<ProjectStageExport> =
+        this.map { (stage, papers) ->
+            ProjectStageExport(id = "$stage", papers = papers)
+        }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -29,17 +29,14 @@ object ProjectExportManager {
         projectMembers: List<ProjectMemberWithUser>,
         projectPapers: List<ProjectPaperFull>,
     ): ByteArray {
+        val exporter = exporters[format] ?: throw IllegalArgumentException("Unsupported export format: $format")
+
         val projectMembersExport = projectMembers.mapIndexed { id, member -> member.toProjectMemberExport(id) }
         val stageToPapersExport = projectPapers.toPapersExportByStage(projectMembers)
         val stages = stageToPapersExport.toProjectStagesExport()
 
-        val projectExport = ProjectExport(
-            name = project.name,
-            members = projectMembersExport,
-            stages = stages,
-        )
+        val projectExport = ProjectExport(name = project.name, members = projectMembersExport, stages = stages)
 
-        val exporter = exporters[format] ?: throw IllegalArgumentException("Unsupported export format: $format")
         return exporter.export(projectExport)
     }
 
@@ -78,7 +75,8 @@ object ProjectExportManager {
         )
 
     private fun Review.toPaperReviewExport(projectMembers: List<ProjectMemberWithUser>): PaperReviewExport {
-        val reviewerId = projectMembers.firstOrNull { it.user.id == userId }?.toString() ?: "unknown"
+        val projectMemberId = projectMembers.indexOfFirst { it.user.id == userId }
+        val reviewerId = if (projectMemberId == -1) "unknown" else projectMemberId.toString()
         return PaperReviewExport(reviewerId, decision)
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -1,10 +1,12 @@
 package se.uulm.snowballr.backend.export
 
+import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
-import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
+import se.uulm.snowballr.backend.model.export.CriterionExport
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.model.export.PaperExport
@@ -13,11 +15,13 @@ import se.uulm.snowballr.backend.model.export.ProjectExport
 import se.uulm.snowballr.backend.model.export.ProjectMemberExport
 import se.uulm.snowballr.backend.model.export.ProjectStageExport
 import snowballr.ProjectOuterClass.PaperDecision
-import java.time.Instant
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 /**
  * Manager responsible for exporting projects in various formats.
  */
+@Suppress("TooManyFunctions")
 object ProjectExportManager {
     private val exporters = mapOf<ExportFormat, IExporter>(
         ExportFormat.JSON to JsonExporter(),
@@ -30,18 +34,19 @@ object ProjectExportManager {
         project: Project,
         projectMembers: List<ProjectMemberWithUser>,
         projectPapers: List<ProjectPaperFull>,
+        projectCriteria: List<Criterion>,
     ): FileExport {
         val exporter = exporters[format] ?: throw IllegalArgumentException("Unsupported export format: $format")
 
         val projectMembersExport = projectMembers.mapIndexed { id, member -> member.toProjectMemberExport(id) }
         val stageToPapersExport = projectPapers.toPapersExportByStage(projectMembers)
         val stages = stageToPapersExport.toProjectStagesExport()
+        val criteria = projectCriteria.toCriteriaExport()
 
-        val projectExport = ProjectExport(name = project.name, members = projectMembersExport, stages = stages)
+        val projectExport = ProjectExport(project.name, projectMembersExport, stages, criteria)
         val data = exporter.export(projectExport)
-        val timestamp = Instant.now().toString()
-        val filename = "${project.name}-${timestamp}.${exporter.getExtension()}"
-        return FileExport(data, sanitizeFilename(filename))
+        val filename = createFilename(project.name, exporter.getExtension())
+        return FileExport(data, filename)
     }
 
     private fun ProjectMemberWithUser.toProjectMemberExport(id: Int): ProjectMemberExport = ProjectMemberExport(
@@ -74,20 +79,37 @@ object ProjectExportManager {
 
     private fun ProjectPaperFull.toPaperExport(projectMembers: List<ProjectMemberWithUser>): PaperExport =
         paper.toPaperExport(
-            reviews = reviews.map { it.toPaperReviewExport(projectMembers) },
+            reviews = reviewsWithSelectedCriteria.map { it.toPaperReviewExport(projectMembers) },
             finalDecision = projectPaper.decision,
         )
 
-    private fun Review.toPaperReviewExport(projectMembers: List<ProjectMemberWithUser>): PaperReviewExport {
-        val projectMemberId = projectMembers.indexOfFirst { it.user.id == userId }
+    private fun ReviewWithSelectedCriteriaIds.toPaperReviewExport(
+        projectMembers: List<ProjectMemberWithUser>,
+    ): PaperReviewExport {
+        val projectMemberId = projectMembers.indexOfFirst { it.user.id == review.userId }
         val reviewerId = if (projectMemberId == -1) "unknown" else projectMemberId.toString()
-        return PaperReviewExport(reviewerId, decision)
+        return PaperReviewExport(reviewerId, review.decision, selectedCriteriaIds.map { "$it" })
     }
 
     private fun Map<Long, List<PaperExport>>.toProjectStagesExport(): List<ProjectStageExport> =
         this.map { (stage, papers) ->
             ProjectStageExport(id = "$stage", papers = papers)
         }
+
+    private fun List<Criterion>.toCriteriaExport(): List<CriterionExport> = this.mapIndexed { index, criterion ->
+        CriterionExport(
+            id = "$index",
+            tag = criterion.tag,
+            name = criterion.name,
+            description = criterion.description,
+            category = criterion.category,
+        )
+    }
+
+    private fun createFilename(projectName: String, fileExtension: String): String {
+        val timestamp = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString()
+        return sanitizeFilename("$projectName-$timestamp.$fileExtension")
+    }
 
     private fun sanitizeFilename(input: String): String {
         // Define characters not allowed in filenames (Windows + UNIX safe set)

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -17,8 +17,23 @@ object ProjectExportManager {
         ExportFormat.JSON to JsonExporter(),
     )
 
+    /**
+     * Returns the set of supported export formats.
+     */
     fun getSupportedFormats(): Set<ExportFormat> = exporters.keys
 
+    /**
+     * Exports the given project and its associated data in the specified format.
+     *
+     * @param format The desired export format.
+     * @param project The project to export.
+     * @param projectMembers The members associated with the project.
+     * @param projectPapers The papers associated with the project.
+     * @param projectCriteria The criteria associated with the project.
+     * @return A [FileExport] containing the exported data and filename.
+     * @throws IllegalArgumentException if the specified format is not supported. Check with [getSupportedFormats]
+     * first.
+     */
     fun exportProject(
         format: ExportFormat,
         project: Project,

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -1,27 +1,17 @@
 package se.uulm.snowballr.backend.export
 
 import se.uulm.snowballr.backend.model.dto.Criterion
-import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
-import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
-import se.uulm.snowballr.backend.model.export.CriterionExport
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
-import se.uulm.snowballr.backend.model.export.PaperExport
-import se.uulm.snowballr.backend.model.export.PaperReviewExport
-import se.uulm.snowballr.backend.model.export.ProjectExport
-import se.uulm.snowballr.backend.model.export.ProjectMemberExport
-import se.uulm.snowballr.backend.model.export.ProjectStageExport
-import snowballr.ProjectOuterClass.PaperDecision
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 /**
  * Manager responsible for exporting projects in various formats.
  */
-@Suppress("TooManyFunctions")
 object ProjectExportManager {
     private val exporters = mapOf<ExportFormat, IExporter>(
         ExportFormat.JSON to JsonExporter(),
@@ -38,72 +28,12 @@ object ProjectExportManager {
     ): FileExport {
         val exporter = exporters[format] ?: throw IllegalArgumentException("Unsupported export format: $format")
 
-        val projectMembersExport = projectMembers.mapIndexed { id, member -> member.toProjectMemberExport(id) }
-        val stageToPapersExport = projectPapers.toPapersExportByStage(projectMembers)
-        val stages = stageToPapersExport.toProjectStagesExport()
-        val criteria = projectCriteria.toCriteriaExport()
+        val builder = ProjectExportBuilder(project, projectMembers, projectPapers, projectCriteria)
+        val projectExport = builder.buildExport()
 
-        val projectExport = ProjectExport(project.name, projectMembersExport, stages, criteria)
         val data = exporter.export(projectExport)
         val filename = createFilename(project.name, exporter.getExtension())
         return FileExport(data, filename)
-    }
-
-    private fun ProjectMemberWithUser.toProjectMemberExport(id: Int): ProjectMemberExport = ProjectMemberExport(
-        id = "$id",
-        firstName = user.firstName,
-        lastName = user.lastName,
-        email = user.email,
-        role = projectMember.role,
-    )
-
-    private fun Paper.toPaperExport(reviews: List<PaperReviewExport>, finalDecision: PaperDecision): PaperExport =
-        PaperExport(
-            title = title,
-            externalId = externalId.orEmpty(),
-            abstract = abstract,
-            year = year,
-            publisher = publisher,
-            publicationType = publicationType,
-            publicationName = publicationName,
-            authors = authors.map { "${it.firstName} ${it.lastName}" },
-            reviews = reviews,
-            finalDecision = finalDecision,
-        )
-
-    private fun List<ProjectPaperFull>.toPapersExportByStage(
-        projectMembers: List<ProjectMemberWithUser>,
-    ): Map<Long, List<PaperExport>> = this.groupBy { it.projectPaper.stage }.mapValues { entry ->
-        entry.value.map { it.toPaperExport(projectMembers) }
-    }
-
-    private fun ProjectPaperFull.toPaperExport(projectMembers: List<ProjectMemberWithUser>): PaperExport =
-        paper.toPaperExport(
-            reviews = reviewsWithSelectedCriteria.map { it.toPaperReviewExport(projectMembers) },
-            finalDecision = projectPaper.decision,
-        )
-
-    private fun ReviewWithSelectedCriteriaIds.toPaperReviewExport(
-        projectMembers: List<ProjectMemberWithUser>,
-    ): PaperReviewExport {
-        val projectMemberId = projectMembers.indexOfFirst { it.user.id == review.userId }
-        val reviewerId = if (projectMemberId == -1) "unknown" else projectMemberId.toString()
-        return PaperReviewExport(reviewerId, review.decision, selectedCriteriaIds.map { "$it" })
-    }
-
-    private fun Map<Long, List<PaperExport>>.toProjectStagesExport(): List<ProjectStageExport> =
-        this.map { (stage, papers) ->
-            ProjectStageExport(id = "$stage", papers = papers)
-        }
-
-    private fun List<Criterion>.toCriteriaExport(): List<CriterionExport> = this.mapIndexed { index, criterion ->
-        CriterionExport(
-            id = "$index",
-            tag = criterion.tag,
-            name = criterion.name,
-            description = criterion.description,
-            category = criterion.category,
-        )
     }
 
     private fun createFilename(projectName: String, fileExtension: String): String {

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -112,8 +112,8 @@ object ProjectExportManager {
     }
 
     private fun sanitizeFilename(input: String): String {
-        // Define characters not allowed in filenames (Windows + UNIX safe set)
-        val illegalChars = """[\\/:*?"<>|\p{Cntrl}]""".toRegex()
+        // Define characters not allowed in filenames (Windows + UNIX safe set) + white-space
+        val illegalChars = """[\\/:*?"<>|\p{Cntrl}\s]""".toRegex()
 
         var sanitized = input.replace(illegalChars, "_")
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/export/ProjectExportManager.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.export
 
+import se.uulm.snowballr.backend.export.ProjectExportManager.getSupportedFormats
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
@@ -51,11 +52,30 @@ object ProjectExportManager {
         return FileExport(data, filename)
     }
 
+    /**
+     * Creates a sanitized filename using the project name and current timestamp.
+     *
+     * @param projectName The name of the project.
+     * @param fileExtension The file extension for the export format.
+     * @return A sanitized filename in the format "{projectName}-{timestamp}.{fileExtension}".
+     */
     private fun createFilename(projectName: String, fileExtension: String): String {
         val timestamp = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString()
         return sanitizeFilename("$projectName-$timestamp.$fileExtension")
     }
 
+    /**
+     * Sanitizes a filename by removing or replacing illegal characters.
+     *
+     * This includes:
+     * - Replacing characters not allowed in filenames (such as \ / : * ? " < > | and control characters) with
+     * underscores.
+     * - Trimming leading and trailing whitespace and dots.
+     * - Providing a fallback name ("unnamed") if the resulting filename is empty.
+     *
+     * @param input The original filename.
+     * @return A sanitized filename safe for use in file systems.
+     */
     private fun sanitizeFilename(input: String): String {
         // Define characters not allowed in filenames (Windows + UNIX safe set) + white-space
         val illegalChars = """[\\/:*?"<>|\p{Cntrl}\s]""".toRegex()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -254,9 +254,6 @@ class SnowballRServer(
         override suspend fun removePaperFromReadingList(request: Base.Id): Base.Nothing =
             mainService.removePaperFromReadingList(request)
 
-        override suspend fun getPendingInvitationsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            super.getPendingInvitationsForUser(request)
-
         override suspend fun getInviteCandidates(
             request: ProjectOuterClass.Project.InviteCandidatesRequest,
         ): UserOuterClass.User.List = mainService.getInviteCandidates(request)
@@ -303,7 +300,7 @@ class SnowballRServer(
         override suspend fun updateProject(request: ProjectOuterClass.Project.Update): ProjectOuterClass.Project =
             mainService.updateProject(request)
 
-        override suspend fun getAvailableExportFormats(request: Base.Nothing): Export.AvailableExportFormatsReply =
+        override suspend fun getAvailableExportFormats(request: Base.Nothing): Export.AvailableExportFormatsResponse =
             mainService.getAvailableExportFormats()
 
         override suspend fun exportProject(request: Export.ExportRequest): Export.ExportResponse =

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -304,10 +304,10 @@ class SnowballRServer(
             mainService.updateProject(request)
 
         override suspend fun getAvailableExportFormats(request: Base.Nothing): Export.AvailableExportFormatsReply =
-            super.getAvailableExportFormats(request)
+            mainService.getAvailableExportFormats()
 
-        override suspend fun exportProject(request: Export.ExportRequest): Export.ExportResponse =
-            super.exportProject(request)
+        override suspend fun exportProject(request: Export.ExportRequest): Base.Blob =
+            mainService.exportProject(request)
 
         override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = mainService.softDeleteProject(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -306,7 +306,7 @@ class SnowballRServer(
         override suspend fun getAvailableExportFormats(request: Base.Nothing): Export.AvailableExportFormatsReply =
             mainService.getAvailableExportFormats()
 
-        override suspend fun exportProject(request: Export.ExportRequest): Base.Blob =
+        override suspend fun exportProject(request: Export.ExportRequest): Export.ExportResponse =
             mainService.exportProject(request)
 
         override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = mainService.softDeleteProject(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -175,3 +175,12 @@ data class TooLongList(val name: String, val maxLength: Int) : ValidationIssue {
 data class CompositeIssue(val baseMessage: String, val issues: List<ValidationIssue>) : ValidationIssue {
     override fun toString(): String = "$baseMessage: ${issues.joinToString("; ")}"
 }
+
+/**
+ * Represents a validation issue where an unsupported export format is requested.
+ *
+ * @property format The unsupported export format.
+ */
+data class UnsupportedExportFormat(val format: String) : ValidationIssue {
+    override fun toString(): String = "The export format '$format' is not supported."
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperFull.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperFull.kt
@@ -1,0 +1,7 @@
+package se.uulm.snowballr.backend.model.dto
+
+data class ProjectPaperFull(
+    val projectPaper: ProjectPaper,
+    val paper: Paper,
+    val reviews: List<Review>,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperFull.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperFull.kt
@@ -1,7 +1,14 @@
 package se.uulm.snowballr.backend.model.dto
 
+/**
+ * DTO representing a project paper along with its associated paper and reviews with selected criteria.
+ *
+ * @property projectPaper The project paper information.
+ * @property paper The associated paper information.
+ * @property reviewsWithSelectedCriteria A list of reviews along with their selected criteria.
+ */
 data class ProjectPaperFull(
     val projectPaper: ProjectPaper,
     val paper: Paper,
-    val reviews: List<Review>,
+    val reviewsWithSelectedCriteria: List<ReviewWithSelectedCriteriaIds>,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -58,3 +58,18 @@ fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
         },
     )
     .build()
+
+/**
+ * Converts a [ProjectPaperWithPaper] instance into a [ProjectPaperFull] object.
+ *
+ * @param reviewsWithSelectedCriteriaIds A list of [ReviewWithSelectedCriteriaIds] associated with the project paper.
+ * @return A [ProjectPaperFull] object containing the project paper, paper, and associated reviews with selected
+ * criteria.
+ */
+fun ProjectPaperWithPaper.toProjectPaperFull(
+    reviewsWithSelectedCriteriaIds: List<ReviewWithSelectedCriteriaIds>,
+): ProjectPaperFull = ProjectPaperFull(
+    projectPaper = this.projectPaper,
+    paper = this.paper,
+    reviewsWithSelectedCriteria = reviewsWithSelectedCriteriaIds,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ReviewWithSelectedCriteriaIds.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ReviewWithSelectedCriteriaIds.kt
@@ -1,0 +1,14 @@
+package se.uulm.snowballr.backend.model.dto
+
+import java.util.UUID
+
+/**
+ * DTO representing a review along with its selected criteria IDs.
+ *
+ * @property review The review information.
+ * @property selectedCriteriaIds A list of selected criteria IDs associated with the review.
+ */
+data class ReviewWithSelectedCriteriaIds(
+    val review: Review,
+    val selectedCriteriaIds: List<UUID>,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/CriterionExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/CriterionExport.kt
@@ -1,0 +1,19 @@
+package se.uulm.snowballr.backend.model.export
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import snowballr.CriterionOuterClass.CriterionCategory
+
+@Serializable
+data class CriterionExport(
+    @SerialName("id")
+    val id: String,
+    @SerialName("tag")
+    val tag: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("category")
+    val category: CriterionCategory,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
@@ -1,0 +1,5 @@
+package se.uulm.snowballr.backend.model.export
+
+enum class ExportFormat {
+    JSON,
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
@@ -1,5 +1,8 @@
 package se.uulm.snowballr.backend.model.export
 
+/**
+ * Formats used for exporting data.
+ */
 enum class ExportFormat {
     JSON,
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/FileExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/FileExport.kt
@@ -1,0 +1,25 @@
+package se.uulm.snowballr.backend.model.export
+
+/**
+ * Data class that represents a file that has been exported.
+ */
+data class FileExport(
+    val data: ByteArray,
+    val filename: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FileExport) return false
+
+        if (!data.contentEquals(other.data)) return false
+        if (filename != other.filename) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = data.contentHashCode()
+        result = 31 * result + filename.hashCode()
+        return result
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperExport.kt
@@ -1,0 +1,29 @@
+package se.uulm.snowballr.backend.model.export
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import snowballr.ProjectOuterClass
+
+@Serializable
+data class PaperExport(
+    @SerialName("title")
+    val title: String,
+    @SerialName("external_id")
+    val externalId: String,
+    @SerialName("abstract")
+    val abstract: String,
+    @SerialName("year")
+    val year: Int,
+    @SerialName("publisher")
+    val publisher: String,
+    @SerialName("publication_type")
+    val publicationType: String,
+    @SerialName("publication_name")
+    val publicationName: String,
+    @SerialName("authors")
+    val authors: List<String>,
+    @SerialName("reviews")
+    val reviews: List<PaperReviewExport>,
+    @SerialName("final_decision")
+    val finalDecision: ProjectOuterClass.PaperDecision,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperExport.kt
@@ -26,4 +26,8 @@ data class PaperExport(
     val reviews: List<PaperReviewExport>,
     @SerialName("final_decision")
     val finalDecision: ProjectOuterClass.PaperDecision,
+    @SerialName("created_at")
+    val createdAt: String,
+    @SerialName("modified_at")
+    val modifiedAt: String,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperReviewExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperReviewExport.kt
@@ -1,0 +1,13 @@
+package se.uulm.snowballr.backend.model.export
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import snowballr.ReviewOuterClass
+
+@Serializable
+data class PaperReviewExport(
+    @SerialName("reviewer_id")
+    val reviewerId: String,
+    @SerialName("decision")
+    val decision: ReviewOuterClass.ReviewDecision,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperReviewExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/PaperReviewExport.kt
@@ -10,4 +10,6 @@ data class PaperReviewExport(
     val reviewerId: String,
     @SerialName("decision")
     val decision: ReviewOuterClass.ReviewDecision,
+    @SerialName("selected_criteria_ids")
+    val selectedCriteriaIds: List<String>,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectExport.kt
@@ -11,4 +11,6 @@ data class ProjectExport(
     val members: List<ProjectMemberExport>,
     @SerialName("stages")
     val stages: List<ProjectStageExport>,
+    @SerialName("criteria")
+    val criteria: List<CriterionExport>,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectExport.kt
@@ -1,0 +1,14 @@
+package se.uulm.snowballr.backend.model.export
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProjectExport(
+    @SerialName("name")
+    val name: String,
+    @SerialName("members")
+    val members: List<ProjectMemberExport>,
+    @SerialName("stages")
+    val stages: List<ProjectStageExport>,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectExport.kt
@@ -13,4 +13,6 @@ data class ProjectExport(
     val stages: List<ProjectStageExport>,
     @SerialName("criteria")
     val criteria: List<CriterionExport>,
+    @SerialName("created_at")
+    val createdAt: String,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectMemberExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectMemberExport.kt
@@ -1,0 +1,19 @@
+package se.uulm.snowballr.backend.model.export
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import snowballr.ProjectOuterClass
+
+@Serializable
+data class ProjectMemberExport(
+    @SerialName("id")
+    val id: String,
+    @SerialName("first_name")
+    val firstName: String,
+    @SerialName("last_name")
+    val lastName: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("role")
+    val role: ProjectOuterClass.MemberRole,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectStageExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ProjectStageExport.kt
@@ -1,0 +1,12 @@
+package se.uulm.snowballr.backend.model.export
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ProjectStageExport(
+    @SerialName("id")
+    val id: String,
+    @SerialName("papers")
+    val papers: List<PaperExport>,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -1,10 +1,13 @@
 package se.uulm.snowballr.backend.repository
 
+import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.ReviewTable
@@ -34,6 +37,17 @@ interface IReviewTableRepo {
      * @return A list of reviews associated with the given project paper.
      */
     suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review>
+
+    /**
+     * Retrieves all reviews along with their selected criteria for the specified project paper.
+     *
+     * @param projectPaperId The unique identifier of the project paper whose reviews with selected criteria are to be
+     * fetched.
+     * @return A list of [ReviewWithSelectedCriteriaIds] associated with the given project paper.
+     */
+    suspend fun getAllReviewsWithSelectedCriteriaIdsForProjectPaper(
+        projectPaperId: UUID,
+    ): List<ReviewWithSelectedCriteriaIds>
 
     /**
      * Creates a new review in the database with the provided [request] data.
@@ -66,6 +80,26 @@ class ReviewTableRepo(
 
     override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<Review> = db.query {
         ReviewTable.getEntities(ResultRow::toReview) { ReviewTable.projectPaperId eq projectPaperId }
+    }
+
+    override suspend fun getAllReviewsWithSelectedCriteriaIdsForProjectPaper(
+        projectPaperId: UUID,
+    ): List<ReviewWithSelectedCriteriaIds> = db.query {
+        ReviewTable.join(
+            ReviewHasCriterionTable,
+            onColumn = ReviewTable.id,
+            otherColumn = ReviewHasCriterionTable.reviewId,
+            joinType = JoinType.LEFT,
+        ).selectAll()
+            .where { ReviewTable.projectPaperId eq projectPaperId }
+            .groupBy { it[ReviewTable.id].value }
+            .map { (_, rows) ->
+                val review = rows.first().toReview()
+                val selectedCriteriaIds = rows.mapNotNull { row ->
+                    row.getOrNull(ReviewHasCriterionTable.criterionId)?.value
+                }
+                ReviewWithSelectedCriteriaIds(review, selectedCriteriaIds)
+            }
     }
 
     override suspend fun createReview(request: GrpcReview.Create, userId: UUID): Review = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -10,8 +10,13 @@ import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
+import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+import se.uulm.snowballr.backend.service.accessrules.andAlso
+import se.uulm.snowballr.backend.service.accessrules.checkFor
+import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
+import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import snowballr.Export.AvailableExportFormatsReply
 import snowballr.Export.ExportRequest
 import snowballr.Export.ExportResponse
@@ -41,6 +46,7 @@ interface IExportService {
  * @param projectPaperRepo Repository interface to manage operations related to project papers.
  * @param reviewRepo Repository interface to manage operations related to reviews of project papers.
  * @param criterionRepo Repository interface to manage operations related to project criteria.
+ * @param userRepo Repository interface to manage operations related to user data.
  */
 class ExportService(
     private val projectRepo: IProjectTableRepo,
@@ -48,15 +54,20 @@ class ExportService(
     private val projectPaperRepo: IProjectPaperTableRepo,
     private val reviewRepo: IReviewTableRepo,
     private val criterionRepo: ICriterionTableRepo,
+    private val userRepo: IUserTableRepo,
 ) : IExportService {
     override suspend fun getAvailableExportFormats(): AvailableExportFormatsReply =
         AvailableExportFormatsReply.newBuilder()
             .addAllFormats(ProjectExportManager.getSupportedFormats().map { it.toString() })
             .build()
 
-    override suspend fun exportProject(request: ExportRequest): ExportResponse {
+    override suspend fun exportProject(request: ExportRequest): ExportResponse = withUser(userRepo) { currentUser ->
         val format = ProjectExportManager.getSupportedFormats().first { it.toString() == request.format }
         val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+        isAllowedToReadProject(projectMemberRepo)
+            .andAlso(isProjectExistent(projectRepo))
+            .checkFor(currentUser, projectId)
 
         val project = projectRepo.getProjectById(projectId).getOrThrow()
         val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
@@ -66,7 +77,7 @@ class ExportService(
 
         val fileExport =
             ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
-        return exportResponse {
+        exportResponse {
             data = fileExport.data.toByteString()
             fileName = fileExport.filename
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -1,0 +1,77 @@
+package se.uulm.snowballr.backend.service
+
+import com.google.protobuf.kotlin.toByteString
+import se.uulm.snowballr.backend.export.ProjectExportManager
+import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.IReviewTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+import snowballr.Base
+import snowballr.Export.AvailableExportFormatsReply
+import snowballr.Export.ExportRequest
+import snowballr.blob
+
+interface IExportService {
+    /**
+     * Service implementation of [SnowballRService.getAvailableExportFormats].
+     */
+    suspend fun getAvailableExportFormats(): AvailableExportFormatsReply
+
+    /**
+     * Service implementation of [SnowballRService.exportProject].
+     */
+    suspend fun exportProject(request: ExportRequest): Base.Blob
+}
+
+/**
+ * Service responsible for exporting project data in various formats.
+ *
+ * This class provides functionalities to retrieve available export formats and handle the
+ * process of exporting a project along with its members, papers, and reviews. The exported data
+ * can be formatted in supported output types, e.g., JSON.
+ *
+ * @param projectRepo Repository interface to manage operations related to project data.
+ * @param projectMemberRepo Repository interface to manage operations related to project members.
+ * @param projectPaperRepo Repository interface to manage operations related to project papers.
+ * @param reviewRepo Repository interface to manage operations related to reviews of project papers.
+ */
+class ExportService(
+    private val projectRepo: IProjectTableRepo,
+    private val projectMemberRepo: IProjectMemberTableRepo,
+    private val projectPaperRepo: IProjectPaperTableRepo,
+    private val reviewRepo: IReviewTableRepo,
+) : IExportService {
+    override suspend fun getAvailableExportFormats(): AvailableExportFormatsReply =
+        AvailableExportFormatsReply.newBuilder()
+            .addAllFormats(ProjectExportManager.getSupportedFormats().map { it.toString() })
+            .build()
+
+    override suspend fun exportProject(request: ExportRequest): Base.Blob {
+        val format = ProjectExportManager.getSupportedFormats().first { it.toString() == request.format }
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+        val project = projectRepo.getProjectById(projectId).getOrThrow()
+        val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
+        val projectPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
+            .map { it.toProjectPaperFull() }
+
+        val bytes = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+        return blob {
+            data = bytes.toByteString()
+        }
+    }
+
+    private suspend fun ProjectPaperWithPaper.toProjectPaperFull(): ProjectPaperFull {
+        val reviews = reviewRepo.getAllReviewsForProjectPaper(this.projectPaper.id)
+        return ProjectPaperFull(
+            projectPaper = this.projectPaper,
+            paper = this.paper,
+            reviews = reviews,
+        )
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -4,8 +4,7 @@ import com.google.protobuf.kotlin.toByteString
 import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
-import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.model.dto.toProjectPaperFull
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -72,7 +71,11 @@ class ExportService(
         val project = projectRepo.getProjectById(projectId).getOrThrow()
         val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
         val projectPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
-            .map { it.toProjectPaperFull() }
+            .map {
+                val reviewsWithSelectedCriteriaIds =
+                    reviewRepo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(it.projectPaper.id)
+                it.toProjectPaperFull(reviewsWithSelectedCriteriaIds)
+            }
         val projectCriteria = criterionRepo.getAllProjectCriteria(projectId)
 
         val fileExport =
@@ -81,16 +84,5 @@ class ExportService(
             data = fileExport.data.toByteString()
             fileName = fileExport.filename
         }
-    }
-
-    private suspend fun ProjectPaperWithPaper.toProjectPaperFull(): ProjectPaperFull {
-        val reviewsWithSelectedCriteriaIds =
-            reviewRepo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(this.projectPaper.id)
-
-        return ProjectPaperFull(
-            projectPaper = this.projectPaper,
-            paper = this.paper,
-            reviewsWithSelectedCriteria = reviewsWithSelectedCriteriaIds,
-        )
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -17,7 +17,7 @@ import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
-import snowballr.Export.AvailableExportFormatsReply
+import snowballr.Export.AvailableExportFormatsResponse
 import snowballr.Export.ExportRequest
 import snowballr.Export.ExportResponse
 import snowballr.exportResponse
@@ -26,7 +26,7 @@ interface IExportService {
     /**
      * Service implementation of [SnowballRService.getAvailableExportFormats].
      */
-    suspend fun getAvailableExportFormats(): AvailableExportFormatsReply
+    suspend fun getAvailableExportFormats(): AvailableExportFormatsResponse
 
     /**
      * Service implementation of [SnowballRService.exportProject].
@@ -56,8 +56,8 @@ class ExportService(
     private val criterionRepo: ICriterionTableRepo,
     private val userRepo: IUserTableRepo,
 ) : IExportService {
-    override suspend fun getAvailableExportFormats(): AvailableExportFormatsReply =
-        AvailableExportFormatsReply.newBuilder()
+    override suspend fun getAvailableExportFormats(): AvailableExportFormatsResponse =
+        AvailableExportFormatsResponse.newBuilder()
             .addAllFormats(ProjectExportManager.getSupportedFormats().map { it.toString() })
             .build()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -11,10 +11,10 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
-import snowballr.Base
 import snowballr.Export.AvailableExportFormatsReply
 import snowballr.Export.ExportRequest
-import snowballr.blob
+import snowballr.Export.ExportResponse
+import snowballr.exportResponse
 
 interface IExportService {
     /**
@@ -25,7 +25,7 @@ interface IExportService {
     /**
      * Service implementation of [SnowballRService.exportProject].
      */
-    suspend fun exportProject(request: ExportRequest): Base.Blob
+    suspend fun exportProject(request: ExportRequest): ExportResponse
 }
 
 /**
@@ -51,7 +51,7 @@ class ExportService(
             .addAllFormats(ProjectExportManager.getSupportedFormats().map { it.toString() })
             .build()
 
-    override suspend fun exportProject(request: ExportRequest): Base.Blob {
+    override suspend fun exportProject(request: ExportRequest): ExportResponse {
         val format = ProjectExportManager.getSupportedFormats().first { it.toString() == request.format }
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
@@ -60,9 +60,10 @@ class ExportService(
         val projectPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
             .map { it.toProjectPaperFull() }
 
-        val bytes = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
-        return blob {
-            data = bytes.toByteString()
+        val fileExport = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+        return exportResponse {
+            data = fileExport.data.toByteString()
+            fileName = fileExport.filename
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
@@ -39,12 +40,14 @@ interface IExportService {
  * @param projectMemberRepo Repository interface to manage operations related to project members.
  * @param projectPaperRepo Repository interface to manage operations related to project papers.
  * @param reviewRepo Repository interface to manage operations related to reviews of project papers.
+ * @param criterionRepo Repository interface to manage operations related to project criteria.
  */
 class ExportService(
     private val projectRepo: IProjectTableRepo,
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val projectPaperRepo: IProjectPaperTableRepo,
     private val reviewRepo: IReviewTableRepo,
+    private val criterionRepo: ICriterionTableRepo,
 ) : IExportService {
     override suspend fun getAvailableExportFormats(): AvailableExportFormatsReply =
         AvailableExportFormatsReply.newBuilder()
@@ -59,8 +62,10 @@ class ExportService(
         val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
         val projectPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
             .map { it.toProjectPaperFull() }
+        val projectCriteria = criterionRepo.getAllProjectCriteria(projectId)
 
-        val fileExport = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+        val fileExport =
+            ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
         return exportResponse {
             data = fileExport.data.toByteString()
             fileName = fileExport.filename
@@ -68,11 +73,13 @@ class ExportService(
     }
 
     private suspend fun ProjectPaperWithPaper.toProjectPaperFull(): ProjectPaperFull {
-        val reviews = reviewRepo.getAllReviewsForProjectPaper(this.projectPaper.id)
+        val reviewsWithSelectedCriteriaIds =
+            reviewRepo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(this.projectPaper.id)
+
         return ProjectPaperFull(
             projectPaper = this.projectPaper,
             paper = this.paper,
-            reviews = reviews,
+            reviewsWithSelectedCriteria = reviewsWithSelectedCriteriaIds,
         )
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/MainService.kt
@@ -20,7 +20,8 @@ interface IMainService :
     IProjectPaperService,
     IAuthenticationService,
     IInvitationService,
-    IProjectMemberService
+    IProjectMemberService,
+    IExportService
 
 /**
  * The [MainService] class serves as the primary service implementation layer that aggregates multiple sub-services.
@@ -39,6 +40,7 @@ interface IMainService :
  * @param authenticationService The service responsible for handling business logic related to user authentication
  * @param invitationService The service responsible for handling business logic related to user invitations
  * @param projectMemberService The service responsible for handling business logic related to project members.
+ * @param exportService The service responsible for handling business logic related to exporting projects
  */
 @Suppress("LongParameterList")
 class MainService(
@@ -53,6 +55,7 @@ class MainService(
     private val authenticationService: IAuthenticationService,
     private val invitationService: IInvitationService,
     private val projectMemberService: IProjectMemberService,
+    private val exportService: IExportService,
 ) : IMainService,
     IProjectService by projectService,
     ICriterionService by criterionService,
@@ -64,4 +67,5 @@ class MainService(
     IProjectPaperService by projectPaperService,
     IAuthenticationService by authenticationService,
     IInvitationService by invitationService,
-    IProjectMemberService by projectMemberService
+    IProjectMemberService by projectMemberService,
+    IExportService by exportService

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExportValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExportValidator.kt
@@ -1,0 +1,18 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import se.uulm.snowballr.backend.export.ProjectExportManager
+import se.uulm.snowballr.backend.model.UnsupportedExportFormat
+import se.uulm.snowballr.backend.model.ValidationIssue
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import snowballr.Export
+
+object ExportValidator {
+    fun validateExportRequest(request: Export.ExportRequest): EitherNel<ValidationIssue, Unit> = either {
+        ensure(
+            ProjectExportManager.getSupportedFormats().map(ExportFormat::toString).contains(request.format),
+        ) { UnsupportedExportFormat(request.format) }
+    }.toEitherNel()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -2,13 +2,17 @@ package se.uulm.snowballr.backend.validation
 
 import arrow.core.Either
 import arrow.core.EitherNel
+import arrow.core.NonEmptyList
 import arrow.core.nonEmptyListOf
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
 import io.grpc.health.v1.HealthCheckRequest
 import se.uulm.snowballr.backend.model.UnknownRequest
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.Authentication
 import snowballr.Base
 import snowballr.CriterionOuterClass
+import snowballr.Export
 import snowballr.PaperOuterClass.Paper
 import snowballr.ProjectOuterClass
 import snowballr.ReviewOuterClass
@@ -65,15 +69,18 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     // Paper
     is Paper.Update -> PaperValidator.validateUpdateRequest(request)
     is Paper -> PaperValidator.validateCreateRequest(request)
+    // Export
+    is Export.ExportRequest -> ExportValidator.validateExportRequest(request)
+    // Fallback for unknown request types
     else -> Either.Left(nonEmptyListOf(UnknownRequest))
 }
 
 /**
- * Creates a [arrow.core.NonEmptyList] from this [Either].
+ * Creates a [NonEmptyList] from this [Either].
  *
- * While some validation methods use [arrow.core.raise.zipOrAccumulate] to process several input validation conditions,
- * others might require only validating one parameter and use a simple [arrow.core.raise.either].
- * For the latter, one can use this method to create a [arrow.core.NonEmptyList] to get the same data type as the other
+ * While some validation methods use [zipOrAccumulate] to process several input validation conditions,
+ * others might require only validating one parameter and use a simple [either].
+ * For the latter, one can use this method to create a [NonEmptyList] to get the same data type as the other
  * methods that accumulate the validation results.
  */
 fun Either<ValidationIssue, Unit>.toEitherNel() = when (this) {

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -6,6 +6,7 @@ import se.uulm.snowballr.backend.model.dto.InvitationToken
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
+import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.dto.User
@@ -268,5 +269,23 @@ object DataBuilder {
         projectId = projectId,
         token = token,
         expiresAt = expiresAt,
+    )
+
+    fun createExampleProjectMemberWithUser(
+        projectMember: ProjectMember = createExampleProjectMember(),
+        user: User = createExampleUser(),
+    ) = ProjectMemberWithUser(
+        projectMember = projectMember,
+        user = user,
+    )
+
+    fun createExampleProjectPaperFull(
+        projectPaper: ProjectPaper = createExampleProjectPaper(),
+        paper: Paper = createExamplePaper(),
+        reviews: List<Review> = emptyList(),
+    ) = se.uulm.snowballr.backend.model.dto.ProjectPaperFull(
+        projectPaper = projectPaper,
+        paper = paper,
+        reviews = reviews,
     )
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -8,6 +8,8 @@ import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
+import se.uulm.snowballr.backend.model.dto.ProjectPaperFull
+import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.dto.User
@@ -283,17 +285,17 @@ object DataBuilder {
     fun createExampleProjectPaperFull(
         projectPaper: ProjectPaper = createExampleProjectPaper(),
         paper: Paper = createExamplePaper(),
-        reviews: List<Review> = emptyList(),
-    ) = se.uulm.snowballr.backend.model.dto.ProjectPaperFull(
+        reviewsWithSelectedCriteria: List<ReviewWithSelectedCriteriaIds> = emptyList(),
+    ) = ProjectPaperFull(
         projectPaper = projectPaper,
         paper = paper,
-        reviews = reviews,
+        reviewsWithSelectedCriteria = reviewsWithSelectedCriteria,
     )
 
     fun createExampleProjectPaperWithPaper(
         projectPaper: ProjectPaper = createExampleProjectPaper(),
         paper: Paper = createExamplePaper(),
-    ) = se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper(
+    ) = ProjectPaperWithPaper(
         projectPaper = projectPaper,
         paper = paper,
     )

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -288,4 +288,12 @@ object DataBuilder {
         paper = paper,
         reviews = reviews,
     )
+
+    fun createExampleProjectPaperWithPaper(
+        projectPaper: ProjectPaper = createExampleProjectPaper(),
+        paper: Paper = createExamplePaper(),
+    ) = se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper(
+        projectPaper = projectPaper,
+        paper = paper,
+    )
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -9,6 +9,7 @@ import se.uulm.snowballr.backend.model.dto.ProjectMember
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
@@ -295,5 +296,13 @@ object DataBuilder {
     ) = se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper(
         projectPaper = projectPaper,
         paper = paper,
+    )
+
+    fun createExampleReviewWithSelectedCriteriaIds(
+        review: Review = createExampleReview(),
+        selectedCriteriaIds: List<UUID> = emptyList(),
+    ) = ReviewWithSelectedCriteriaIds(
+        review = review,
+        selectedCriteriaIds = selectedCriteriaIds,
     )
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/JsonExporterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/JsonExporterTest.kt
@@ -1,0 +1,38 @@
+package se.uulm.snowballr.backend.export
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.export.testdata.emptyProjectExport
+import se.uulm.snowballr.backend.export.testdata.fullProjectExport
+import se.uulm.snowballr.backend.model.export.ProjectExport
+import kotlin.test.assertEquals
+
+class JsonExporterTest {
+    companion object {
+        @JvmStatic
+        fun exportExamples() = listOf(
+            Arguments.of(emptyProjectExport, "export-test-files/json/emptyProjectExport.json"),
+            Arguments.of(fullProjectExport, "export-test-files/json/fullProjectExport.json"),
+        )
+    }
+
+    val json = Json
+
+    @ParameterizedTest(name = "When a project is exported, then a valid JSON file is produced matching {1}")
+    @MethodSource("exportExamples")
+    fun `When a project is exported, then a valid JSON is produced`(
+        projectExport: ProjectExport,
+        expectedFile: String,
+    ) {
+        val url = this::class.java.classLoader.getResource(expectedFile)
+        val expectedStringRaw = url?.readText().orEmpty()
+        // Do round-trip test to check validity of serialization and remove pretty printing
+        val expectedString = json.encodeToString(json.decodeFromString<ProjectExport>(expectedStringRaw))
+
+        val actualString = String(JsonExporter().export(projectExport))
+
+        assertEquals(expectedString, actualString, "JSON export does not match expected JSON")
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.ProjectExport
+import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ReviewOuterClass.ReviewDecision
 import java.util.UUID
@@ -39,8 +40,10 @@ class ProjectExportManagerTest {
             val project = DataBuilder.createExampleProject(name = "Exported Project")
             val projectMembers = listOf(DataBuilder.createExampleProjectMemberWithUser())
             val projectPapers = listOf(DataBuilder.createExampleProjectPaperFull())
+            val projectCriteria = listOf(DataBuilder.createExampleProjectCriterion())
 
-            val fileExport = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+            val fileExport =
+                ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
 
             assertThat(fileExport.data).isNotEmpty()
             val filename = fileExport.filename
@@ -65,39 +68,60 @@ class ProjectExportManagerTest {
                     projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_DEFAULT),
                 ),
             )
+            val projectCriteria = listOf(
+                DataBuilder.createExampleProjectCriterion(
+                    category = CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION,
+                ),
+                DataBuilder.createExampleProjectCriterion(
+                    category = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
+                ),
+                DataBuilder.createExampleProjectCriterion(
+                    category = CriterionCategory.CRITERION_CATEGORY_INCLUSION,
+                ),
+            )
             val projectPapers = listOf(
                 DataBuilder.createExampleProjectPaperFull(
                     projectPaper = DataBuilder.createExampleProjectPaper(stage = 0),
                     paper = DataBuilder.createExamplePaper(externalId = null),
-                    reviews = listOf(
-                        DataBuilder.createExampleReview(
-                            decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
-                            userId = projectMembers[0].user.id,
+                    reviewsWithSelectedCriteria = listOf(
+                        DataBuilder.createExampleReviewWithSelectedCriteriaIds(
+                            review = DataBuilder.createExampleReview(
+                                decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
+                                userId = projectMembers[0].user.id,
+                            ),
+                            selectedCriteriaIds = listOf(projectCriteria[0].id),
                         ),
                     ),
                 ),
                 DataBuilder.createExampleProjectPaperFull(
                     projectPaper = DataBuilder.createExampleProjectPaper(stage = 1),
-                    reviews = listOf(
-                        DataBuilder.createExampleReview(
-                            decision = ReviewDecision.REVIEW_DECISION_MAYBE,
-                            userId = projectMembers[1].user.id,
+                    reviewsWithSelectedCriteria = listOf(
+                        DataBuilder.createExampleReviewWithSelectedCriteriaIds(
+                            review = DataBuilder.createExampleReview(
+                                decision = ReviewDecision.REVIEW_DECISION_MAYBE,
+                                userId = projectMembers[1].user.id,
+                            ),
+                            selectedCriteriaIds = listOf(projectCriteria[1].id),
                         ),
                     ),
                 ),
                 DataBuilder.createExampleProjectPaperFull(
                     projectPaper = DataBuilder.createExampleProjectPaper(stage = 2),
-                    reviews = listOf(
-                        DataBuilder.createExampleReview(
-                            decision = ReviewDecision.REVIEW_DECISION_DECLINED,
-                            userId = UUID.randomUUID(),
+                    reviewsWithSelectedCriteria = listOf(
+                        DataBuilder.createExampleReviewWithSelectedCriteriaIds(
+                            review = DataBuilder.createExampleReview(
+                                decision = ReviewDecision.REVIEW_DECISION_DECLINED,
+                                userId = UUID.randomUUID(),
+                            ),
+                            selectedCriteriaIds = listOf(projectCriteria[2].id),
                         ),
                     ),
                 ),
             )
 
             val format = ExportFormat.JSON
-            val fileExport = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+            val fileExport =
+                ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
 
             val projectExport = Json.decodeFromString<ProjectExport>(String(fileExport.data))
 
@@ -133,10 +157,11 @@ class ProjectExportManagerTest {
                     val authorExport = paperExport.authors[authorIndex]
                     assertEquals("${author.firstName} ${author.lastName}", authorExport)
                 }
-                assertThat(paperExport.reviews).hasSize(paperInStage.reviews.size)
-                paperInStage.reviews.forEachIndexed { reviewIndex, review ->
+                assertThat(paperExport.reviews).hasSize(paperInStage.reviewsWithSelectedCriteria.size)
+                paperInStage.reviewsWithSelectedCriteria.forEachIndexed { reviewIndex, reviewWithSelectedCriteriaIds ->
                     val reviewExport = paperExport.reviews[reviewIndex]
                     val projectMemberIndex = stageIndex.toString()
+                    val review = reviewWithSelectedCriteriaIds.review
                     if (stageIndex != 2) {
                         assertEquals(projectMemberIndex, reviewExport.reviewerId)
                     } else {
@@ -144,8 +169,25 @@ class ProjectExportManagerTest {
                         assertEquals("unknown", reviewExport.reviewerId)
                     }
                     assertEquals(review.decision, reviewExport.decision)
+
+                    val selectedCriteriaIds = reviewWithSelectedCriteriaIds.selectedCriteriaIds
+                    assertThat(reviewExport.selectedCriteriaIds).hasSize(selectedCriteriaIds.size)
+                    selectedCriteriaIds.forEachIndexed { criterionIdIndex, criterionId ->
+                        val criterionIdExport = reviewExport.selectedCriteriaIds[criterionIdIndex]
+                        assertEquals("$criterionId", criterionIdExport)
+                    }
                 }
                 assertEquals(paperInStage.projectPaper.decision, paperExport.finalDecision)
+            }
+
+            val projectCriteriaExport = projectExport.criteria
+            projectCriteria.forEachIndexed { index, criterion ->
+                val criterionExport = projectCriteriaExport[index]
+                assertEquals(index.toString(), criterionExport.id)
+                assertEquals(criterion.tag, criterionExport.tag)
+                assertEquals(criterion.name, criterionExport.name)
+                assertEquals(criterion.description, criterionExport.description)
+                assertEquals(criterion.category, criterionExport.category)
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -174,7 +174,8 @@ class ProjectExportManagerTest {
                     assertThat(reviewExport.selectedCriteriaIds).hasSize(selectedCriteriaIds.size)
                     selectedCriteriaIds.forEachIndexed { criterionIdIndex, criterionId ->
                         val criterionIdExport = reviewExport.selectedCriteriaIds[criterionIdIndex]
-                        assertEquals("$criterionId", criterionIdExport)
+                        val expectedCriterionId = projectCriteria.indexOfFirst { it.id == criterionId }
+                        assertEquals("$expectedCriterionId", criterionIdExport)
                     }
                 }
                 assertEquals(paperInStage.projectPaper.decision, paperExport.finalDecision)

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -13,6 +13,8 @@ import se.uulm.snowballr.backend.model.export.ProjectExport
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ReviewOuterClass.ReviewDecision
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 
@@ -54,8 +56,12 @@ class ProjectExportManagerTest {
         @Test
         @Suppress("LongMethod")
         fun `When exporting a project with members and papers, then exported bytes are returned`() {
+            val exampleDateTime = OffsetDateTime.of(2023, 3, 15, 10, 0, 0, 0, ZoneOffset.UTC)
+            val exampleDateTimeString = "2023-03-15T10:00Z"
+
             val project = DataBuilder.createExampleProject(
                 maxStage = 2,
+                createdAt = exampleDateTime,
             )
             val projectMembers = listOf(
                 DataBuilder.createExampleProjectMemberWithUser(
@@ -82,7 +88,11 @@ class ProjectExportManagerTest {
             val projectPapers = listOf(
                 DataBuilder.createExampleProjectPaperFull(
                     projectPaper = DataBuilder.createExampleProjectPaper(stage = 0),
-                    paper = DataBuilder.createExamplePaper(externalId = null),
+                    paper = DataBuilder.createExamplePaper(
+                        externalId = null,
+                        createdAt = exampleDateTime,
+                        modifiedAt = null,
+                    ),
                     reviewsWithSelectedCriteria = listOf(
                         DataBuilder.createExampleReviewWithSelectedCriteriaIds(
                             review = DataBuilder.createExampleReview(
@@ -95,6 +105,7 @@ class ProjectExportManagerTest {
                 ),
                 DataBuilder.createExampleProjectPaperFull(
                     projectPaper = DataBuilder.createExampleProjectPaper(stage = 1),
+                    paper = DataBuilder.createExamplePaper(createdAt = exampleDateTime, modifiedAt = null),
                     reviewsWithSelectedCriteria = listOf(
                         DataBuilder.createExampleReviewWithSelectedCriteriaIds(
                             review = DataBuilder.createExampleReview(
@@ -107,6 +118,7 @@ class ProjectExportManagerTest {
                 ),
                 DataBuilder.createExampleProjectPaperFull(
                     projectPaper = DataBuilder.createExampleProjectPaper(stage = 2),
+                    paper = DataBuilder.createExamplePaper(createdAt = exampleDateTime, modifiedAt = exampleDateTime),
                     reviewsWithSelectedCriteria = listOf(
                         DataBuilder.createExampleReviewWithSelectedCriteriaIds(
                             review = DataBuilder.createExampleReview(
@@ -128,6 +140,8 @@ class ProjectExportManagerTest {
             assertThat(projectExport.name).isEqualTo(project.name)
             assertThat(projectExport.members).hasSize(projectMembers.size)
             assertThat(projectExport.stages).hasSize(3)
+            assertThat(projectExport.criteria).hasSize(projectCriteria.size)
+            assertEquals(exampleDateTimeString, projectExport.createdAt)
 
             val projectMembersExport = projectExport.members
             projectMembers.forEachIndexed { index, member ->
@@ -179,6 +193,12 @@ class ProjectExportManagerTest {
                     }
                 }
                 assertEquals(paperInStage.projectPaper.decision, paperExport.finalDecision)
+                assertEquals(exampleDateTimeString, paperExport.createdAt)
+                if (stageIndex == 2) {
+                    assertEquals(exampleDateTimeString, paperExport.modifiedAt)
+                } else {
+                    assertEquals("", paperExport.modifiedAt)
+                }
             }
 
             val projectCriteriaExport = projectExport.criteria

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -1,0 +1,149 @@
+package se.uulm.snowballr.backend.export
+
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.model.export.ProjectExport
+import snowballr.ProjectOuterClass.MemberRole
+import snowballr.ReviewOuterClass.ReviewDecision
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class ProjectExportManagerTest {
+    companion object {
+        @JvmStatic
+        fun supportedFormats() = ProjectExportManager.getSupportedFormats().map { Arguments.of(it.name) }
+    }
+
+    @Nested
+    inner class GetSupportedFormats {
+        @Test
+        fun `When the supported formats are requested, then the set of formats is not empty`() {
+            val formats = ProjectExportManager.getSupportedFormats()
+
+            assertThat(formats).isNotEmpty()
+        }
+    }
+
+    @Nested
+    inner class ExportProject {
+        @ParameterizedTest(name = "When exporting a project in the {0} format, then no exception is thrown")
+        @MethodSource("se.uulm.snowballr.backend.export.ProjectExportManagerTest#supportedFormats")
+        fun `When exporting a project in a format, then no exception is thrown`(format: ExportFormat) {
+            val project = DataBuilder.createExampleProject()
+            val projectMembers = listOf(DataBuilder.createExampleProjectMemberWithUser())
+            val projectPapers = listOf(DataBuilder.createExampleProjectPaperFull())
+
+            val exportedBytes = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+
+            assertThat(exportedBytes).isNotEmpty()
+        }
+
+        @Test
+        @Suppress("LongMethod")
+        fun `When exporting a project with members and papers, then exported bytes are returned`() {
+            val project = DataBuilder.createExampleProject(
+                maxStage = 2,
+            )
+            val projectMembers = listOf(
+                DataBuilder.createExampleProjectMemberWithUser(
+                    projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_DEFAULT),
+                ),
+                DataBuilder.createExampleProjectMemberWithUser(
+                    projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_ADMIN),
+                ),
+                DataBuilder.createExampleProjectMemberWithUser(
+                    projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_DEFAULT),
+                ),
+            )
+            val projectPapers = listOf(
+                DataBuilder.createExampleProjectPaperFull(
+                    projectPaper = DataBuilder.createExampleProjectPaper(stage = 0),
+                    paper = DataBuilder.createExamplePaper(externalId = null),
+                    reviews = listOf(
+                        DataBuilder.createExampleReview(
+                            decision = ReviewDecision.REVIEW_DECISION_ACCEPTED,
+                            userId = projectMembers[0].user.id,
+                        ),
+                    ),
+                ),
+                DataBuilder.createExampleProjectPaperFull(
+                    projectPaper = DataBuilder.createExampleProjectPaper(stage = 1),
+                    reviews = listOf(
+                        DataBuilder.createExampleReview(
+                            decision = ReviewDecision.REVIEW_DECISION_MAYBE,
+                            userId = projectMembers[1].user.id,
+                        ),
+                    ),
+                ),
+                DataBuilder.createExampleProjectPaperFull(
+                    projectPaper = DataBuilder.createExampleProjectPaper(stage = 2),
+                    reviews = listOf(
+                        DataBuilder.createExampleReview(
+                            decision = ReviewDecision.REVIEW_DECISION_DECLINED,
+                            userId = UUID.randomUUID(),
+                        ),
+                    ),
+                ),
+            )
+
+            val format = ExportFormat.JSON
+            val exportedBytes = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+
+            val projectExport = Json.decodeFromString<ProjectExport>(String(exportedBytes))
+
+            assertThat(projectExport.name).isEqualTo(project.name)
+            assertThat(projectExport.members).hasSize(projectMembers.size)
+            assertThat(projectExport.stages).hasSize(3)
+
+            val projectMembersExport = projectExport.members
+            projectMembers.forEachIndexed { index, member ->
+                val memberExport = projectMembersExport[index]
+                assertEquals(index.toString(), memberExport.id)
+                assertEquals(member.user.firstName, memberExport.firstName)
+                assertEquals(member.user.lastName, memberExport.lastName)
+                assertEquals(member.user.email, memberExport.email)
+                assertEquals(member.projectMember.role, memberExport.role)
+            }
+
+            val projectStagesExport = projectExport.stages
+            projectStagesExport.forEachIndexed { stageIndex, stageExport ->
+                assertEquals(stageIndex.toString(), stageExport.id)
+                assertThat(stageExport.papers).hasSize(1)
+                val paperInStage = projectPapers[stageIndex]
+                val paperExport = stageExport.papers[0]
+                assertEquals(paperInStage.paper.title, paperExport.title)
+                assertEquals(paperInStage.paper.externalId.orEmpty(), paperExport.externalId)
+                assertEquals(paperInStage.paper.abstract, paperExport.abstract)
+                assertEquals(paperInStage.paper.year, paperExport.year)
+                assertEquals(paperInStage.paper.publisher, paperExport.publisher)
+                assertEquals(paperInStage.paper.publicationType, paperExport.publicationType)
+                assertEquals(paperInStage.paper.publicationName, paperExport.publicationName)
+                assertThat(paperExport.authors).hasSize(paperInStage.paper.authors.size)
+                paperInStage.paper.authors.forEachIndexed { authorIndex, author ->
+                    val authorExport = paperExport.authors[authorIndex]
+                    assertEquals("${author.firstName} ${author.lastName}", authorExport)
+                }
+                assertThat(paperExport.reviews).hasSize(paperInStage.reviews.size)
+                paperInStage.reviews.forEachIndexed { reviewIndex, review ->
+                    val reviewExport = paperExport.reviews[reviewIndex]
+                    val projectMemberIndex = stageIndex.toString()
+                    if (stageIndex != 2) {
+                        assertEquals(projectMemberIndex, reviewExport.reviewerId)
+                    } else {
+                        // Reviews by unknown reviewers get "unknown" as reviewer ID
+                        assertEquals("unknown", reviewExport.reviewerId)
+                    }
+                    assertEquals(review.decision, reviewExport.decision)
+                }
+                assertEquals(paperInStage.projectPaper.decision, paperExport.finalDecision)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -36,13 +36,16 @@ class ProjectExportManagerTest {
         @ParameterizedTest(name = "When exporting a project in the {0} format, then no exception is thrown")
         @MethodSource("se.uulm.snowballr.backend.export.ProjectExportManagerTest#supportedFormats")
         fun `When exporting a project in a format, then no exception is thrown`(format: ExportFormat) {
-            val project = DataBuilder.createExampleProject()
+            val project = DataBuilder.createExampleProject(name = "Exported Project")
             val projectMembers = listOf(DataBuilder.createExampleProjectMemberWithUser())
             val projectPapers = listOf(DataBuilder.createExampleProjectPaperFull())
 
-            val exportedBytes = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+            val fileExport = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
 
-            assertThat(exportedBytes).isNotEmpty()
+            assertThat(fileExport.data).isNotEmpty()
+            val filename = fileExport.filename
+            assertThat(filename).startsWith("Exported_Project-")
+            assertThat(filename.split('.').last()).isNotEmpty
         }
 
         @Test
@@ -94,9 +97,9 @@ class ProjectExportManagerTest {
             )
 
             val format = ExportFormat.JSON
-            val exportedBytes = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
+            val fileExport = ProjectExportManager.exportProject(format, project, projectMembers, projectPapers)
 
-            val projectExport = Json.decodeFromString<ProjectExport>(String(exportedBytes))
+            val projectExport = Json.decodeFromString<ProjectExport>(String(fileExport.data))
 
             assertThat(projectExport.name).isEqualTo(project.name)
             assertThat(projectExport.members).hasSize(projectMembers.size)

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/testdata/TestProjectExports.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/testdata/TestProjectExports.kt
@@ -1,0 +1,136 @@
+package se.uulm.snowballr.backend.export.testdata
+
+import se.uulm.snowballr.backend.model.export.PaperExport
+import se.uulm.snowballr.backend.model.export.PaperReviewExport
+import se.uulm.snowballr.backend.model.export.ProjectExport
+import se.uulm.snowballr.backend.model.export.ProjectMemberExport
+import se.uulm.snowballr.backend.model.export.ProjectStageExport
+import snowballr.ProjectOuterClass.MemberRole
+import snowballr.ProjectOuterClass.PaperDecision
+import snowballr.ReviewOuterClass.ReviewDecision
+
+val emptyProjectExport = ProjectExport(
+    name = "Empty Project",
+    members = emptyList(),
+    stages = emptyList(),
+)
+
+@Suppress("NamedArguments")
+val fullProjectExport = ProjectExport(
+    name = "Full Project",
+    members = listOf(
+        ProjectMemberExport("1", "Alice", "Smith", "alice.smith@example.com", MemberRole.MEMBER_ROLE_DEFAULT),
+        ProjectMemberExport("2", "John", "Doe", "john.doe@example.com", MemberRole.MEMBER_ROLE_DEFAULT),
+        ProjectMemberExport("3", "Jane", "Doe", "jane.doe@example.com", MemberRole.MEMBER_ROLE_UNSPECIFIED),
+    ),
+    stages = listOf(
+        ProjectStageExport(
+            "1",
+            papers = listOf(
+                PaperExport(
+                    "Paper Title 1",
+                    "doi/1234",
+                    "Example Abstract",
+                    2001,
+                    "Publisher 1",
+                    "Publication Type 1",
+                    "Publication Name 1",
+                    authors = listOf("Author 1", "Author 2"),
+                    reviews = listOf(
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                    ),
+                    finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                ),
+                PaperExport(
+                    "Paper Title 2",
+                    "doi/5678",
+                    "Example Abstract 2",
+                    2002,
+                    "Publisher 2",
+                    "Publication Type 2",
+                    "Publication Name 2",
+                    authors = listOf("Author 3", "Author 4"),
+                    reviews = listOf(
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                    ),
+                    finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                ),
+            ),
+        ),
+        ProjectStageExport(
+            "2",
+            papers = listOf(
+                PaperExport(
+                    "Paper Title 3",
+                    "doi/9876",
+                    "Example Abstract 3",
+                    2003,
+                    "Publisher 3",
+                    "Publication Type 3",
+                    "Publication Name 3",
+                    authors = listOf("Author 5", "Author 6"),
+                    reviews = listOf(
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                    ),
+                    finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                ),
+                PaperExport(
+                    "Paper Title 4",
+                    "doi/0123",
+                    "Example Abstract 4",
+                    2004,
+                    "Publisher 4",
+                    "Publication Type 4",
+                    "Publication Name 4",
+                    authors = listOf("Author 7", "Author 8"),
+                    reviews = listOf(
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_DECLINED),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_DECLINED),
+                    ),
+                    finalDecision = PaperDecision.PAPER_DECISION_DECLINED,
+                ),
+            ),
+        ),
+        ProjectStageExport(
+            "3",
+            papers = listOf(
+                PaperExport(
+                    "Paper Title 5",
+                    "doi/4321",
+                    "Example Abstract 5",
+                    2005,
+                    "Publisher 5",
+                    "Publication Type 5",
+                    "Publication Name 5",
+                    authors = listOf("Author 9", "Author 10"),
+                    reviews = listOf(
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                    ),
+                    finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                ),
+                PaperExport(
+                    "Paper Title 6",
+                    "doi/6543",
+                    "Example Abstract 6",
+                    2006,
+                    "Publisher 6",
+                    "Publication Type 6",
+                    "Publication Name 6",
+                    authors = listOf("Author 11", "Author 12"),
+                    reviews = listOf(
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_MAYBE),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED),
+                    ),
+                    finalDecision = PaperDecision.PAPER_DECISION_DECLINED,
+                ),
+            ),
+        ),
+    ),
+)

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/testdata/TestProjectExports.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/testdata/TestProjectExports.kt
@@ -1,10 +1,12 @@
 package se.uulm.snowballr.backend.export.testdata
 
+import se.uulm.snowballr.backend.model.export.CriterionExport
 import se.uulm.snowballr.backend.model.export.PaperExport
 import se.uulm.snowballr.backend.model.export.PaperReviewExport
 import se.uulm.snowballr.backend.model.export.ProjectExport
 import se.uulm.snowballr.backend.model.export.ProjectMemberExport
 import se.uulm.snowballr.backend.model.export.ProjectStageExport
+import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ReviewOuterClass.ReviewDecision
@@ -13,6 +15,7 @@ val emptyProjectExport = ProjectExport(
     name = "Empty Project",
     members = emptyList(),
     stages = emptyList(),
+    criteria = emptyList(),
 )
 
 @Suppress("NamedArguments")
@@ -37,9 +40,9 @@ val fullProjectExport = ProjectExport(
                     "Publication Name 1",
                     authors = listOf("Author 1", "Author 2"),
                     reviews = listOf(
-                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
-                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED),
-                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("0")),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("1")),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
                 ),
@@ -53,9 +56,9 @@ val fullProjectExport = ProjectExport(
                     "Publication Name 2",
                     authors = listOf("Author 3", "Author 4"),
                     reviews = listOf(
-                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
-                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_ACCEPTED),
-                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("0")),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("1")),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
                 ),
@@ -74,9 +77,9 @@ val fullProjectExport = ProjectExport(
                     "Publication Name 3",
                     authors = listOf("Author 5", "Author 6"),
                     reviews = listOf(
-                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
-                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_ACCEPTED),
-                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("0")),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("1")),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
                 ),
@@ -90,9 +93,9 @@ val fullProjectExport = ProjectExport(
                     "Publication Name 4",
                     authors = listOf("Author 7", "Author 8"),
                     reviews = listOf(
-                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_DECLINED),
-                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED),
-                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_DECLINED),
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("0")),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("1")),
+                        PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_DECLINED,
                 ),
@@ -111,7 +114,7 @@ val fullProjectExport = ProjectExport(
                     "Publication Name 5",
                     authors = listOf("Author 9", "Author 10"),
                     reviews = listOf(
-                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED),
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("0")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
                 ),
@@ -125,12 +128,35 @@ val fullProjectExport = ProjectExport(
                     "Publication Name 6",
                     authors = listOf("Author 11", "Author 12"),
                     reviews = listOf(
-                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_MAYBE),
-                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED),
+                        PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_MAYBE, listOf("0")),
+                        PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("1")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_DECLINED,
                 ),
             ),
+        ),
+    ),
+    criteria = listOf(
+        CriterionExport(
+            id = "0",
+            tag = "C1",
+            name = "Criterion 1",
+            description = "Description for Criterion 1",
+            category = CriterionCategory.CRITERION_CATEGORY_INCLUSION,
+        ),
+        CriterionExport(
+            id = "1",
+            tag = "C2",
+            name = "Criterion 2",
+            description = "Description for Criterion 2",
+            category = CriterionCategory.CRITERION_CATEGORY_EXCLUSION,
+        ),
+        CriterionExport(
+            id = "2",
+            tag = "C3",
+            name = "Criterion 3",
+            description = "Description for Criterion 3",
+            category = CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION,
         ),
     ),
 )

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/testdata/TestProjectExports.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/testdata/TestProjectExports.kt
@@ -16,6 +16,7 @@ val emptyProjectExport = ProjectExport(
     members = emptyList(),
     stages = emptyList(),
     criteria = emptyList(),
+    createdAt = "2023-03-15T10:00:00Z",
 )
 
 @Suppress("NamedArguments")
@@ -45,6 +46,8 @@ val fullProjectExport = ProjectExport(
                         PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                    createdAt = "2023-03-15T10:00:00Z",
+                    modifiedAt = "",
                 ),
                 PaperExport(
                     "Paper Title 2",
@@ -61,6 +64,8 @@ val fullProjectExport = ProjectExport(
                         PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                    createdAt = "2023-03-15T10:00:00Z",
+                    modifiedAt = "",
                 ),
             ),
         ),
@@ -82,6 +87,8 @@ val fullProjectExport = ProjectExport(
                         PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                    createdAt = "2023-03-15T10:00:00Z",
+                    modifiedAt = "",
                 ),
                 PaperExport(
                     "Paper Title 4",
@@ -98,6 +105,8 @@ val fullProjectExport = ProjectExport(
                         PaperReviewExport("3", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("2")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_DECLINED,
+                    createdAt = "2023-03-15T10:00:00Z",
+                    modifiedAt = "2025-03-15T10:00:00Z",
                 ),
             ),
         ),
@@ -117,6 +126,8 @@ val fullProjectExport = ProjectExport(
                         PaperReviewExport("1", ReviewDecision.REVIEW_DECISION_ACCEPTED, listOf("0")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
+                    createdAt = "2023-03-15T10:00:00Z",
+                    modifiedAt = "",
                 ),
                 PaperExport(
                     "Paper Title 6",
@@ -132,6 +143,8 @@ val fullProjectExport = ProjectExport(
                         PaperReviewExport("2", ReviewDecision.REVIEW_DECISION_DECLINED, listOf("1")),
                     ),
                     finalDecision = PaperDecision.PAPER_DECISION_DECLINED,
+                    createdAt = "2023-03-15T10:00:00Z",
+                    modifiedAt = "2024-03-15T10:00:00Z",
                 ),
             ),
         ),
@@ -159,4 +172,5 @@ val fullProjectExport = ProjectExport(
             category = CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION,
         ),
     ),
+    createdAt = "2021-03-15T10:00:00Z",
 )

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LongParameterList")
+
 package se.uulm.snowballr.backend.repository
 
 import org.jetbrains.exposed.sql.ResultRow
@@ -39,7 +41,6 @@ object RepositoryHelper {
      *
      * @return The UUID of the created user.
      */
-    @Suppress("LongParameterList")
     suspend fun insertUserAndGetId(
         email: String = "test.user@example.com",
         firstName: String = "Test",
@@ -92,7 +93,6 @@ object RepositoryHelper {
      *
      * @return The UUID of the created paper.
      */
-    @Suppress("LongParameterList")
     suspend fun insertPaperAndGetId(
         title: String = "Title",
         externalId: String = UUID.randomUUID().toString(),
@@ -122,7 +122,6 @@ object RepositoryHelper {
      *
      * @return The UUID of the created project.
      */
-    @Suppress("LongParameterList")
     suspend fun insertProjectAndGetId(
         name: String = "Test Project",
         status: ProjectStatus = ProjectStatus.PROJECT_STATUS_ACTIVE,
@@ -157,7 +156,6 @@ object RepositoryHelper {
      *
      * @return The UUID of the created project paper.
      */
-    @Suppress("LongParameterList")
     suspend fun insertProjectPaperAndGetId(
         paperId: UUID,
         projectId: UUID,
@@ -181,7 +179,6 @@ object RepositoryHelper {
      *
      * @return The UUID of the created review.
      */
-    @Suppress("LongParameterList")
     suspend fun insertReviewAndGetId(
         projectPaperId: UUID,
         userId: UUID,
@@ -199,7 +196,6 @@ object RepositoryHelper {
      *
      * @return The UUID of the created criterion.
      */
-    @Suppress("LongParameterList")
     suspend fun insertCriterionAndGetId(
         tag: String = "Test Tag",
         name: String = "Test Criterion",

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.repository.RepositoryHelper.assignCriterionToReview
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
@@ -129,6 +130,86 @@ class ReviewTableRepoTest : RepositoryTest(
                 assertThat(reviews).hasSize(1)
                 assertThat(reviews).anyMatch { it.id == reviewId1 }
                 assertThat(reviews).noneMatch { it.id == reviewId2 }
+            }
+    }
+
+    @Nested
+    inner class GetAllReviewsWithSelectedCriteriaIdsForProjectPaper {
+        @Test
+        fun `When the project paper has reviews with selected criteria, then the reviews are correctly returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId = insertPaperAndGetId()
+                val projectPaperId =
+                    insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
+                val reviewId = insertReviewAndGetId(projectPaperId, userId = testUserId)
+                val criterionId1 = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+                assignCriterionToReview(reviewId, criterionId1)
+                val criterionId2 = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+                assignCriterionToReview(reviewId, criterionId2)
+                val reviews = repo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(projectPaperId)
+
+                assertThat(reviews).hasSize(1)
+                assertThat(reviews).anyMatch { it.review.id == reviewId }
+                val reviewWithCriteria = reviews[0]
+                assertThat(reviewWithCriteria.selectedCriteriaIds).hasSize(2)
+                assertThat(reviewWithCriteria.selectedCriteriaIds).contains(criterionId1, criterionId2)
+            }
+
+        @Test
+        fun `When the project paper has no reviews, then an empty list is returned`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+            val paperId1 = insertPaperAndGetId()
+            val paperId2 = insertPaperAndGetId()
+            val noReviewProjectPaperId = insertProjectPaperAndGetId(
+                paperId = paperId1,
+                projectId = projectId,
+                createdBy = testUserId,
+            )
+            val reviewProjectPaperId = insertProjectPaperAndGetId(
+                paperId = paperId2,
+                projectId = projectId,
+                createdBy = testUserId,
+            )
+            val reviewId = insertReviewAndGetId(reviewProjectPaperId, userId = testUserId)
+            val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+            assignCriterionToReview(reviewId, criterionId)
+            val reviews = repo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(noReviewProjectPaperId)
+
+            assertThat(reviews).hasSize(0)
+            assertThat(reviews).noneMatch { it.review.id == reviewId }
+        }
+
+        @Test
+        fun `When the project paper has reviews and other reviews exist too, then only the project paper reviews are returned`() =
+            runTest {
+                val projectId = insertProjectAndGetId(createdBy = testUserId)
+                val paperId1 = insertPaperAndGetId()
+                val paperId2 = insertPaperAndGetId()
+                val projectPaperId1 = insertProjectPaperAndGetId(
+                    paperId = paperId1,
+                    projectId = projectId,
+                    createdBy = testUserId,
+                )
+                val projectPaperId2 = insertProjectPaperAndGetId(
+                    paperId = paperId2,
+                    projectId = projectId,
+                    createdBy = testUserId,
+                )
+                val reviewId1 = insertReviewAndGetId(projectPaperId1, userId = testUserId)
+                val criterionId1 = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+                assignCriterionToReview(reviewId1, criterionId1)
+                val reviewId2 = insertReviewAndGetId(projectPaperId2, userId = testUserId)
+                val criterionId2 = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
+                assignCriterionToReview(reviewId2, criterionId2)
+                val reviews = repo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(projectPaperId1)
+
+                assertThat(reviews).hasSize(1)
+                assertThat(reviews).anyMatch { it.review.id == reviewId1 }
+                assertThat(reviews).noneMatch { it.review.id == reviewId2 }
+                val review = reviews[0]
+                assertThat(review.selectedCriteriaIds).hasSize(1)
+                assertThat(review.selectedCriteriaIds).contains(criterionId1)
             }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -46,9 +46,10 @@ class ExportProjectTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getAllProjectPapersWithPapers(projectId)
         } returns listOf(DataBuilder.createExampleProjectPaperWithPaper())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(any()) } returns emptyList()
+        coEvery { criterionRepoMock.getAllProjectCriteria(any()) } returns emptyList()
         every {
-            ProjectExportManager.exportProject(any(), any(), any(), any())
+            ProjectExportManager.exportProject(any(), any(), any(), any(), any())
         } returns FileExport(ByteArray(0), "test.json")
 
         mainService.exportProject(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.export.ProjectExportManager
+import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.UserOuterClass.UserRole
 import snowballr.copy
 import snowballr.exportRequest
 import java.util.UUID
@@ -23,24 +25,17 @@ class ExportProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the exported project doesn't exist, then a TestSpecificException is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-        val request = getExampleRequest().copy { id = projectId.toString() }
-
-        mockkObject(ProjectExportManager)
-        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectRepoMock.getProjectById(projectId) } throws TestSpecificException()
-
-        assertThrows<TestSpecificException> { mainService.exportProject(request) }
-    }
-
-    @Test
     fun `When exporting a project is successful, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val projectId = UUID.randomUUID()
         val request = getExampleRequest().copy { id = projectId.toString() }
+        val projectMember = DataBuilder.createExampleProjectMember(projectId = projectId, userId = user.id)
 
+        mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
         coEvery { projectRepoMock.getProjectById(projectId) } returns Result.success(DataBuilder.createExampleProject())
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns emptyList()
         coEvery {
@@ -53,5 +48,63 @@ class ExportProjectTest : MainServiceTest() {
         } returns FileExport(ByteArray(0), "test.json")
 
         mainService.exportProject(request)
+    }
+
+    @Test
+    fun `When the non-project-member exports a project, then an UnauthorizedReadException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val projectId = UUID.randomUUID()
+        val request = getExampleRequest().copy { id = projectId.toString() }
+
+        mockCurrentUser(user)
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+
+        assertThrows<UnauthorizedReadException> {
+            mainService.exportProject(request)
+        }
+    }
+
+    @Test
+    fun `When a server admin export a project, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val projectId = UUID.randomUUID()
+        val request = getExampleRequest().copy { id = projectId.toString() }
+
+        mockCurrentUser(user)
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+        coEvery {
+            projectRepoMock.getProjectById(projectId)
+        } returns Result.success(DataBuilder.createExampleProject(id = projectId))
+        coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns emptyList()
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(projectId)
+        } returns listOf(DataBuilder.createExampleProjectPaperWithPaper())
+        coEvery { reviewRepoMock.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(any()) } returns emptyList()
+        coEvery { criterionRepoMock.getAllProjectCriteria(any()) } returns emptyList()
+        every {
+            ProjectExportManager.exportProject(any(), any(), any(), any(), any())
+        } returns FileExport(ByteArray(0), "test.json")
+
+        mainService.exportProject(request)
+    }
+
+    @Test
+    fun `When the exported project doesn't exist, then a NotFoundException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val projectId = UUID.randomUUID()
+        val request = getExampleRequest().copy { id = projectId.toString() }
+
+        mockCurrentUser(user)
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+
+        assertThrows<NotFoundException> { mainService.exportProject(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -10,6 +10,7 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.copy
 import snowballr.exportRequest
@@ -46,7 +47,9 @@ class ExportProjectTest : MainServiceTest() {
             projectPaperRepoMock.getAllProjectPapersWithPapers(projectId)
         } returns listOf(DataBuilder.createExampleProjectPaperWithPaper())
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } returns emptyList()
-        every { ProjectExportManager.exportProject(any(), any(), any(), any()) } returns ByteArray(0)
+        every {
+            ProjectExportManager.exportProject(any(), any(), any(), any())
+        } returns FileExport(ByteArray(0), "test.json")
 
         mainService.exportProject(request)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -1,0 +1,53 @@
+package se.uulm.snowballr.backend.service.export
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkObject
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.export.ProjectExportManager
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.service.MainServiceTest
+import snowballr.copy
+import snowballr.exportRequest
+import java.util.UUID
+
+class ExportProjectTest : MainServiceTest() {
+    fun getExampleRequest() = exportRequest {
+        id = UUID.randomUUID().toString()
+        format = ExportFormat.JSON.toString()
+    }
+
+    @Test
+    fun `When the exported project doesn't exist, then a TestSpecificException is thrown`() = runTest {
+        val projectId = UUID.randomUUID()
+        val request = getExampleRequest().copy { id = projectId.toString() }
+
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectRepoMock.getProjectById(projectId) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.exportProject(request) }
+    }
+
+    @Test
+    fun `When exporting a project is successful, then no exception is thrown`() = runTest {
+        val projectId = UUID.randomUUID()
+        val request = getExampleRequest().copy { id = projectId.toString() }
+
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.success(DataBuilder.createExampleProject())
+        coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns emptyList()
+        coEvery {
+            projectPaperRepoMock.getAllProjectPapersWithPapers(projectId)
+        } returns listOf(DataBuilder.createExampleProjectPaperWithPaper())
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(any()) } returns emptyList()
+        every { ProjectExportManager.exportProject(any(), any(), any(), any()) } returns ByteArray(0)
+
+        mainService.exportProject(request)
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
@@ -1,0 +1,20 @@
+package se.uulm.snowballr.backend.service.export
+
+import io.mockk.every
+import io.mockk.mockkObject
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import se.uulm.snowballr.backend.export.ProjectExportManager
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.service.MainServiceTest
+
+class GetAvailableExportFormatsTest : MainServiceTest() {
+    @Test
+    fun `When available export formats are requested, then no exception is thrown`() = runTest {
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns ExportFormat.entries.toSet()
+
+        assertDoesNotThrow { mainService.getAvailableExportFormats() }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExportValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExportValidatorTest.kt
@@ -1,0 +1,42 @@
+package se.uulm.snowballr.backend.validation
+
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import io.mockk.every
+import io.mockk.mockkObject
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.export.ProjectExportManager
+import se.uulm.snowballr.backend.model.UnsupportedExportFormat
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import snowballr.Export.ExportRequest
+
+class ExportValidatorTest {
+    @Test
+    fun `When validating an export request with a supported format, then no issue is returned`() {
+        val supportedFormat = ExportFormat.JSON
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(supportedFormat)
+
+        val request = ExportRequest.newBuilder()
+            .setFormat(supportedFormat.toString())
+            .build()
+
+        val result = validateRequest(request)
+
+        EitherAssert.assertThat(result).isRight()
+    }
+
+    @Test
+    fun `When validating an export request with an unsupported format, then an 'UnsupportedExportFormat' issue is returned`() {
+        val supportedFormat = ExportFormat.JSON
+        mockkObject(ProjectExportManager)
+        every { ProjectExportManager.getSupportedFormats() } returns setOf(supportedFormat)
+
+        val request = ExportRequest.newBuilder()
+            .setFormat("UNSUPPORTED_FORMAT")
+            .build()
+
+        val result = validateRequest(request)
+
+        assertInvalidResult<UnsupportedExportFormat>(result)
+    }
+}

--- a/src/test/resources/export-test-files/json/emptyProjectExport.json
+++ b/src/test/resources/export-test-files/json/emptyProjectExport.json
@@ -2,5 +2,6 @@
     "name": "Empty Project",
     "members": [],
     "stages": [],
-    "criteria": []
+    "criteria": [],
+    "created_at": "2023-03-15T10:00:00Z"
 }

--- a/src/test/resources/export-test-files/json/emptyProjectExport.json
+++ b/src/test/resources/export-test-files/json/emptyProjectExport.json
@@ -1,0 +1,5 @@
+{
+    "name": "Empty Project",
+    "members": [],
+    "stages": []
+}

--- a/src/test/resources/export-test-files/json/emptyProjectExport.json
+++ b/src/test/resources/export-test-files/json/emptyProjectExport.json
@@ -1,5 +1,6 @@
 {
     "name": "Empty Project",
     "members": [],
-    "stages": []
+    "stages": [],
+    "criteria": []
 }

--- a/src/test/resources/export-test-files/json/fullProjectExport.json
+++ b/src/test/resources/export-test-files/json/fullProjectExport.json
@@ -62,7 +62,9 @@
                             ]
                         }
                     ],
-                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                    "final_decision": "PAPER_DECISION_ACCEPTED",
+                    "created_at": "2023-03-15T10:00:00Z",
+                    "modified_at": ""
                 },
                 {
                     "title": "Paper Title 2",
@@ -99,7 +101,9 @@
                             ]
                         }
                     ],
-                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                    "final_decision": "PAPER_DECISION_ACCEPTED",
+                    "created_at": "2023-03-15T10:00:00Z",
+                    "modified_at": ""
                 }
             ]
         },
@@ -141,7 +145,9 @@
                             ]
                         }
                     ],
-                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                    "final_decision": "PAPER_DECISION_ACCEPTED",
+                    "created_at": "2023-03-15T10:00:00Z",
+                    "modified_at": ""
                 },
                 {
                     "title": "Paper Title 4",
@@ -178,7 +184,9 @@
                             ]
                         }
                     ],
-                    "final_decision": "PAPER_DECISION_DECLINED"
+                    "final_decision": "PAPER_DECISION_DECLINED",
+                    "created_at": "2023-03-15T10:00:00Z",
+                    "modified_at": "2025-03-15T10:00:00Z"
                 }
             ]
         },
@@ -206,7 +214,9 @@
                             ]
                         }
                     ],
-                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                    "final_decision": "PAPER_DECISION_ACCEPTED",
+                    "created_at": "2023-03-15T10:00:00Z",
+                    "modified_at": ""
                 },
                 {
                     "title": "Paper Title 6",
@@ -236,7 +246,9 @@
                             ]
                         }
                     ],
-                    "final_decision": "PAPER_DECISION_DECLINED"
+                    "final_decision": "PAPER_DECISION_DECLINED",
+                    "created_at": "2023-03-15T10:00:00Z",
+                    "modified_at": "2024-03-15T10:00:00Z"
                 }
             ]
         }
@@ -263,5 +275,6 @@
             "description": "Description for Criterion 3",
             "category": "CRITERION_CATEGORY_HARD_EXCLUSION"
         }
-    ]
+    ],
+    "created_at": "2021-03-15T10:00:00Z"
 }

--- a/src/test/resources/export-test-files/json/fullProjectExport.json
+++ b/src/test/resources/export-test-files/json/fullProjectExport.json
@@ -1,0 +1,199 @@
+{
+    "name": "Full Project",
+    "members": [
+        {
+            "id": "1",
+            "first_name": "Alice",
+            "last_name": "Smith",
+            "email": "alice.smith@example.com",
+            "role": "MEMBER_ROLE_DEFAULT"
+        },
+        {
+            "id": "2",
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john.doe@example.com",
+            "role": "MEMBER_ROLE_DEFAULT"
+        },
+        {
+            "id": "3",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "email": "jane.doe@example.com",
+            "role": "MEMBER_ROLE_UNSPECIFIED"
+        }
+    ],
+    "stages": [
+        {
+            "id": "1",
+            "papers": [
+                {
+                    "title": "Paper Title 1",
+                    "external_id": "doi/1234",
+                    "abstract": "Example Abstract",
+                    "year": 2001,
+                    "publisher": "Publisher 1",
+                    "publication_type": "Publication Type 1",
+                    "publication_name": "Publication Name 1",
+                    "authors": [
+                        "Author 1",
+                        "Author 2"
+                    ],
+                    "reviews": [
+                        {
+                            "reviewer_id": "1",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        },
+                        {
+                            "reviewer_id": "2",
+                            "decision": "REVIEW_DECISION_DECLINED"
+                        },
+                        {
+                            "reviewer_id": "3",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        }
+                    ],
+                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                },
+                {
+                    "title": "Paper Title 2",
+                    "external_id": "doi/5678",
+                    "abstract": "Example Abstract 2",
+                    "year": 2002,
+                    "publisher": "Publisher 2",
+                    "publication_type": "Publication Type 2",
+                    "publication_name": "Publication Name 2",
+                    "authors": [
+                        "Author 3",
+                        "Author 4"
+                    ],
+                    "reviews": [
+                        {
+                            "reviewer_id": "1",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        },
+                        {
+                            "reviewer_id": "2",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        },
+                        {
+                            "reviewer_id": "3",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        }
+                    ],
+                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                }
+            ]
+        },
+        {
+            "id": "2",
+            "papers": [
+                {
+                    "title": "Paper Title 3",
+                    "external_id": "doi/9876",
+                    "abstract": "Example Abstract 3",
+                    "year": 2003,
+                    "publisher": "Publisher 3",
+                    "publication_type": "Publication Type 3",
+                    "publication_name": "Publication Name 3",
+                    "authors": [
+                        "Author 5",
+                        "Author 6"
+                    ],
+                    "reviews": [
+                        {
+                            "reviewer_id": "1",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        },
+                        {
+                            "reviewer_id": "2",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        },
+                        {
+                            "reviewer_id": "3",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        }
+                    ],
+                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                },
+                {
+                    "title": "Paper Title 4",
+                    "external_id": "doi/0123",
+                    "abstract": "Example Abstract 4",
+                    "year": 2004,
+                    "publisher": "Publisher 4",
+                    "publication_type": "Publication Type 4",
+                    "publication_name": "Publication Name 4",
+                    "authors": [
+                        "Author 7",
+                        "Author 8"
+                    ],
+                    "reviews": [
+                        {
+                            "reviewer_id": "1",
+                            "decision": "REVIEW_DECISION_DECLINED"
+                        },
+                        {
+                            "reviewer_id": "2",
+                            "decision": "REVIEW_DECISION_DECLINED"
+                        },
+                        {
+                            "reviewer_id": "3",
+                            "decision": "REVIEW_DECISION_DECLINED"
+                        }
+                    ],
+                    "final_decision": "PAPER_DECISION_DECLINED"
+                }
+            ]
+        },
+        {
+            "id": "3",
+            "papers": [
+                {
+                    "title": "Paper Title 5",
+                    "external_id": "doi/4321",
+                    "abstract": "Example Abstract 5",
+                    "year": 2005,
+                    "publisher": "Publisher 5",
+                    "publication_type": "Publication Type 5",
+                    "publication_name": "Publication Name 5",
+                    "authors": [
+                        "Author 9",
+                        "Author 10"
+                    ],
+                    "reviews": [
+                        {
+                            "reviewer_id": "1",
+                            "decision": "REVIEW_DECISION_ACCEPTED"
+                        }
+                    ],
+                    "final_decision": "PAPER_DECISION_ACCEPTED"
+                },
+                {
+                    "title": "Paper Title 6",
+                    "external_id": "doi/6543",
+                    "abstract": "Example Abstract 6",
+                    "year": 2006,
+                    "publisher": "Publisher 6",
+                    "publication_type": "Publication Type 6",
+                    "publication_name": "Publication Name 6",
+                    "authors": [
+                        "Author 11",
+                        "Author 12"
+                    ],
+                    "reviews": [
+                        {
+                            "reviewer_id": "1",
+                            "decision": "REVIEW_DECISION_MAYBE"
+                        },
+                        {
+                            "reviewer_id": "2",
+                            "decision": "REVIEW_DECISION_DECLINED"
+                        }
+                    ],
+                    "final_decision": "PAPER_DECISION_DECLINED"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/export-test-files/json/fullProjectExport.json
+++ b/src/test/resources/export-test-files/json/fullProjectExport.json
@@ -42,15 +42,24 @@
                     "reviews": [
                         {
                             "reviewer_id": "1",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "0"
+                            ]
                         },
                         {
                             "reviewer_id": "2",
-                            "decision": "REVIEW_DECISION_DECLINED"
+                            "decision": "REVIEW_DECISION_DECLINED",
+                            "selected_criteria_ids": [
+                                "1"
+                            ]
                         },
                         {
                             "reviewer_id": "3",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "2"
+                            ]
                         }
                     ],
                     "final_decision": "PAPER_DECISION_ACCEPTED"
@@ -70,15 +79,24 @@
                     "reviews": [
                         {
                             "reviewer_id": "1",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "0"
+                            ]
                         },
                         {
                             "reviewer_id": "2",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "1"
+                            ]
                         },
                         {
                             "reviewer_id": "3",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "2"
+                            ]
                         }
                     ],
                     "final_decision": "PAPER_DECISION_ACCEPTED"
@@ -103,15 +121,24 @@
                     "reviews": [
                         {
                             "reviewer_id": "1",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "0"
+                            ]
                         },
                         {
                             "reviewer_id": "2",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "1"
+                            ]
                         },
                         {
                             "reviewer_id": "3",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "2"
+                            ]
                         }
                     ],
                     "final_decision": "PAPER_DECISION_ACCEPTED"
@@ -131,15 +158,24 @@
                     "reviews": [
                         {
                             "reviewer_id": "1",
-                            "decision": "REVIEW_DECISION_DECLINED"
+                            "decision": "REVIEW_DECISION_DECLINED",
+                            "selected_criteria_ids": [
+                                "0"
+                            ]
                         },
                         {
                             "reviewer_id": "2",
-                            "decision": "REVIEW_DECISION_DECLINED"
+                            "decision": "REVIEW_DECISION_DECLINED",
+                            "selected_criteria_ids": [
+                                "1"
+                            ]
                         },
                         {
                             "reviewer_id": "3",
-                            "decision": "REVIEW_DECISION_DECLINED"
+                            "decision": "REVIEW_DECISION_DECLINED",
+                            "selected_criteria_ids": [
+                                "2"
+                            ]
                         }
                     ],
                     "final_decision": "PAPER_DECISION_DECLINED"
@@ -164,7 +200,10 @@
                     "reviews": [
                         {
                             "reviewer_id": "1",
-                            "decision": "REVIEW_DECISION_ACCEPTED"
+                            "decision": "REVIEW_DECISION_ACCEPTED",
+                            "selected_criteria_ids": [
+                                "0"
+                            ]
                         }
                     ],
                     "final_decision": "PAPER_DECISION_ACCEPTED"
@@ -184,16 +223,45 @@
                     "reviews": [
                         {
                             "reviewer_id": "1",
-                            "decision": "REVIEW_DECISION_MAYBE"
+                            "decision": "REVIEW_DECISION_MAYBE",
+                            "selected_criteria_ids": [
+                                "0"
+                            ]
                         },
                         {
                             "reviewer_id": "2",
-                            "decision": "REVIEW_DECISION_DECLINED"
+                            "decision": "REVIEW_DECISION_DECLINED",
+                            "selected_criteria_ids": [
+                                "1"
+                            ]
                         }
                     ],
                     "final_decision": "PAPER_DECISION_DECLINED"
                 }
             ]
+        }
+    ],
+    "criteria": [
+        {
+            "id": "0",
+            "tag": "C1",
+            "name": "Criterion 1",
+            "description": "Description for Criterion 1",
+            "category": "CRITERION_CATEGORY_INCLUSION"
+        },
+        {
+            "id": "1",
+            "tag": "C2",
+            "name": "Criterion 2",
+            "description": "Description for Criterion 2",
+            "category": "CRITERION_CATEGORY_EXCLUSION"
+        },
+        {
+            "id": "2",
+            "tag": "C3",
+            "name": "Criterion 3",
+            "description": "Description for Criterion 3",
+            "category": "CRITERION_CATEGORY_HARD_EXCLUSION"
         }
     ]
 }


### PR DESCRIPTION
Closes #363 
Closes #187 (didn't see this one already exists)

## What I have made

This is the starting point for exports in the backend. I designed the export classes to be independent from the DTOs so that changes in one place don't affect the other. The IDs are numerical and set according to their indices to make them independent from the internal UUIDs. This makes them easier to read in the exported file and provides a bit of information hiding. When importing and exporting back again, we would create new entities either way.

For now, we only have JSON as a supported format, but we can add more in the future.

It's best to test this with the corresponding implementation in the frontend.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (for reviewer) I have checked the implementation against the requirements
