### PR TITLE
Added release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
     push:
         branches: ["develop"]
-        tags: ["v*"]
+        tags: ["v*.*.*"]
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,3 +112,44 @@ jobs:
                   subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
                   subject-digest: ${{ steps.push.outputs.digest }}
                   push-to-registry: true
+
+    release:
+        name: Create a new release
+        runs-on: ubuntu-latest
+        needs: build-jar
+        if: ${{ github.ref_type == 'tag' }}
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Download jar file
+              uses: actions/download-artifact@v4
+              with:
+                  name: snowballr-backend-jar
+
+            - name: Create Release
+              uses: docker://antonyurchenko/git-release:v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  args: snowballr-backend-*.jar
+
+    update-main:
+        name: Update main branch
+        runs-on: ubuntu-latest
+        needs:
+            - release
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Merge develop -> main
+              uses: devmasx/merge-branch@master
+              with:
+                  type: now
+                  target_branch: main
+                  github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -1,0 +1,30 @@
+name: Linting Changelog
+
+on:
+    pull_request:
+        paths:
+            - CHANGELOG.md
+
+jobs:
+    changelog-linting:
+        name: Linting the changelog
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v5
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "22"
+
+            - name: Install hallmark
+              run: npm install -g hallmark
+
+            - name: Lint CHANGELOG.md
+              run: hallmark CHANGELOG.md
+
+            - name: Check for broken references in CHANGELOG.md
+              uses: becheran/mlc@v0.21.0
+              with:
+                  args: --ignore-links "https://github.com/SE-UUlm/snowballr-backend/releases/tag/*" CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2025-10-31
+
+_:seedling: Initial release._
+
+This version uses API version [v0.9.0](https://github.com/SE-UUlm/snowballr-api/releases/tag/v0.9.0).
+
+[0.1.0]: https://github.com/SE-UUlm/snowballr-backend/releases/tag/v0.1.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ version = "0.0.0"
 
 gitVersioning.apply {
     refs {
-        tag("v(?<version>.*)") {
+        tag("v(?<version>\\d+\\.\\d+\\.\\d+)") {
             version = "\${ref.version}"
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,11 +9,25 @@ plugins {
     alias(libs.plugins.protobuf)
     alias(libs.plugins.shadow.jar)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.git.versioning)
     application
 }
 
 group = "se.uulm.snowballr.backend"
-version = "0.1.0"
+version = "0.0.0"
+
+gitVersioning.apply {
+    refs {
+        tag("v(?<version>.*)") {
+            version = "\${ref.version}"
+        }
+    }
+
+    // optional fallback configuration in case of no matching ref configuration
+    rev {
+        version = "\${commit}"
+    }
+}
 
 application {
     mainClass.set("se.uulm.snowballr.backend.MainKt")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ handlebars = "4.5.0"
 testcontainers = "1.21.3"
 kotlinx-serialization-json = "1.9.0"
 nanoid = "1.0.1"
+git-versioning = "6.4.4"
 
 [libraries]
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
@@ -95,3 +96,4 @@ kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kov
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }
 shadow-jar = { id = "com.gradleup.shadow", version.ref = "shadow-jar" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+git-versioning = { id = "me.qoomon.git-versioning", version.ref = "git-versioning" }

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -13,11 +13,13 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
     * [Table](#table)
     * [Repository](#repository)
     * [Service](#service)
+      * [Access Rules and Authorization Checks](#access-rules-and-authorization-checks)
     * [Input Validation](#input-validation)
   * [Testing](#testing)
   * [Miscellaneous Commands](#miscellaneous-commands)
     * [Formatting](#formatting)
     * [Linting](#linting)
+  * [Release procedure](#release-procedure)
 <!-- TOC -->
 <!-- @formatter:on -->
 <!-- markdownlint-enable MD007 -->
@@ -323,3 +325,41 @@ For information about our testing setup, see [Testing](https://github.com/SE-UUl
 ```bash
 ./gradlew lint
 ```
+
+## Release procedure
+
+We create a new release whenever a set of features, bug fixes, or changes is ready to be deployed and used by the
+frontend.
+To release a new version of the backend, follow these steps:
+
+1. Create a release branch for the release:
+
+   ```bash
+   git checkout -b releases/vX.Y.Z
+   ```
+
+   Replace `X`, `Y`, `Z` with the correct version numbers according to semantic versioning.
+
+2. Add an entry to the *CHANGELOG.md*. Prefer using [hallmark](https://github.com/vweevers/hallmark) to add the entry:
+
+   ```bash
+   hallmark cc add major|minor|patch
+   ```
+
+   Follow the guidelines of [Common Changelog](https://common-changelog.org/), i.e. especially use imperative mood.
+
+   > **Note**: To use hallmark locally install it globally with `npm install -g hallmark`
+
+3. Commit and push changes to the *CHANGELOG.md*.
+
+4. Create a pull request and request a review, so the *CHANGELOG.md* syntax and content is validated.
+
+5. After the pull request is merged, create a tag with the same version - so "vX.Y.Z" - at the merge commit.
+
+   ```bash
+   git pull main
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   Then the CI automatically creates the release.


### PR DESCRIPTION
Closes #374

## What I have made

This adds a release workflow for upcoming releases.

1. We added a Git versioning Gradle plugin that automatically names the jar according to the release version.
2. We added the release workflow that creates a GitHub release with the jar and then merges the develop branch into main.
3. We added a release procedure to the wiki and added a changelog linting job.

It's hard for you to review these changes. I manually tested the workflow, and [this](https://github.com/SE-UUlm/snowballr-backend/actions/runs/18972441714) is the test run.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only CI changes)
- [x] (for reviewer) I have checked the implementation against the requirements
