### PR TITLE
Exclude already invited users as well from invite candidates

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -75,10 +75,10 @@ interface IUserTableRepo {
      * their similarity to the search query.
      *
      * @param searchQuery The query against which the firstnames, lastnames, and emails of the users are checked.
-     * @param excludedUsers A list of user ids to be excluded from the results.
+     * @param excludedUsers A list of user emails to be excluded from the results.
      * @return A list of up to 10 matching users.
      */
-    suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<UUID>): List<User>
+    suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<String>): List<User>
 
     /**
      * Creates a new user in the database with the provided registration request and password hash.
@@ -191,17 +191,16 @@ class UserTableRepo(
     }
 
     @Suppress("MagicNumber")
-    override suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<UUID>): List<User> =
+    override suspend fun getUsersMatchingSearchQuery(searchQuery: String, excludedUsers: Set<String>): List<User> =
         db.query {
             val userTable = "\"${UserTable.tableName}\""
-            val idCol = "$userTable.${UserTable.id.name}"
             val firstNameCol = "$userTable.${UserTable.firstName.name}"
             val lastNameCol = "$userTable.${UserTable.lastName.name}"
             val emailCol = "$userTable.${UserTable.email.name}"
             val statusCol = "$userTable.${UserTable.status.name}"
 
             val excludeUsersClause = if (excludedUsers.isNotEmpty()) {
-                "AND $idCol NOT IN (${excludedUsers.joinToString(",") { "'$it'" }})"
+                "AND $emailCol NOT IN (${excludedUsers.joinToString(",") { "'$it'" }})"
             } else {
                 ""
             }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -84,11 +84,14 @@ class InvitationService(
                 return@withUser GrpcUser.List.getDefaultInstance()
             }
 
-            val excludedUsersFromSearch = mutableSetOf(currentUser.id)
+            val excludedUsersFromSearch = mutableSetOf(currentUser.email)
             try {
                 val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-                val projectMembers = projectMemberRepo.getProjectMembers(projectId)
-                excludedUsersFromSearch += projectMembers.map { it.userId }
+                val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
+                excludedUsersFromSearch += projectMembers.map { it.user.email }
+
+                val invitedMembers = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
+                excludedUsersFromSearch += invitedMembers.map { it.email }
             } catch (_: InvalidIdException.UUID) {
                 Logger.warn { "Invalid project ID in invite candidates request: ${request.projectId}" }
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -412,9 +412,10 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable)) {
         @Test
         fun `When a user is matching the search query but should be excluded, then this user is not returned`() =
             runTest {
-                val userId = insertUserAndGetId(firstName = "johnathan")
+                val userEmail = "johnathan@example.com"
+                insertUserAndGetId(email = userEmail, firstName = "johnathan")
 
-                val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf(userId))
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf(userEmail))
 
                 assertThat(matchingUsers).hasSize(0)
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetInviteCandidatesTest.kt
@@ -19,7 +19,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     private val requestingUserEmail = "test.user@example.com"
     private val searchQuery = "john"
     private val projectId = UUID.randomUUID()
-    private val validGetInviteCandidatesRequest = InviteCandidatesRequest.newBuilder()
+    private val validGetInviteCandidatesRequestBuilder = InviteCandidatesRequest.newBuilder()
         .setQuery(searchQuery)
         .setProjectId(projectId.toString())
 
@@ -55,7 +55,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When the search query is too short, then an empty list is returned`() = runTest {
         mockGetInviteCandidates(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
 
-        val shortGetInviteCandidatesRequest = validGetInviteCandidatesRequest.setQuery("jo")
+        val shortGetInviteCandidatesRequest = validGetInviteCandidatesRequestBuilder.setQuery("jo")
 
         val candidates = assertDoesNotThrow { mainService.getInviteCandidates(shortGetInviteCandidatesRequest.build()) }
         assertThat(candidates.usersList).isEmpty()
@@ -68,7 +68,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             userRepoMock.getUsersMatchingSearchQuery(searchQuery, any())
         } returns emptyList()
 
-        val requestWithInvalidProjectId = validGetInviteCandidatesRequest.setProjectId("invalid-uuid")
+        val requestWithInvalidProjectId = validGetInviteCandidatesRequestBuilder.setProjectId("invalid-uuid")
 
         assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId.build()) }
         coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembersWithUsers(any()) }
@@ -79,7 +79,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
     fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
         mockGetInviteCandidates()
 
-        assertDoesNotThrow { mainService.getInviteCandidates(validGetInviteCandidatesRequest.build()) }
+        assertDoesNotThrow { mainService.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build()) }
         coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(requestingUserEmail)) }
     }
 
@@ -88,7 +88,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
         runTest {
             mockGetInviteCandidates()
 
-            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequest.build())
+            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
             assertThat(inviteCandidates.usersList).hasSize(1)
             assertNull(inviteCandidates.usersList.find { it.email == requestingUserEmail })
         }
@@ -99,7 +99,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
             mockGetInviteCandidates(projectMembers = listOf(projectMember))
 
-            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequest.build())
+            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
             assertNull(inviteCandidates.usersList.find { it.email == projectMember.email })
         }
 
@@ -109,7 +109,7 @@ class GetInviteCandidatesTest : MainServiceTest() {
             val invitee = DataBuilder.createExampleUser(email = "invited.user@example.com")
             mockGetInviteCandidates(invitees = listOf(invitee))
 
-            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequest.build())
+            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
             assertNull(inviteCandidates.usersList.find { it.email == invitee.email })
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetInviteCandidatesTest.kt
@@ -1,108 +1,115 @@
 package se.uulm.snowballr.backend.service.invitations
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertNull
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
+import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
 import java.util.UUID
+import kotlin.reflect.KFunction
 
 class GetInviteCandidatesTest : MainServiceTest() {
+    private val requestingUserEmail = "test.user@example.com"
     private val searchQuery = "john"
     private val projectId = UUID.randomUUID()
-    private val validInviteCandidatesRequest = InviteCandidatesRequest.newBuilder()
+    private val validGetInviteCandidatesRequest = InviteCandidatesRequest.newBuilder()
         .setQuery(searchQuery)
         .setProjectId(projectId.toString())
-        .build()
+
+    private fun mockGetInviteCandidates(
+        projectMembers: List<User> = emptyList(),
+        invitees: List<User> = emptyList(),
+        stopBefore: KFunction<*>? = null,
+    ) {
+        val currentUser = DataBuilder.createExampleUser(email = requestingUserEmail)
+        val anotherUser = DataBuilder.createExampleUser(email = "another.user@example.com")
+        val users = listOf(currentUser, anotherUser) + projectMembers + invitees
+        val projectMembersWithUsers = projectMembers.map {
+            ProjectMemberWithUser(DataBuilder.createExampleProjectMember(projectId, it.id), it)
+        }
+        val inviteeToken = invitees.map {
+            DataBuilder.createExampleInvitationToken(email = it.email, projectId = projectId)
+        }
+
+        val excludedUsers = setOf(currentUser.email) + projectMembers.map { it.email } + invitees.map { it.email }
+
+        mockCurrentUser(currentUser)
+        if (stopBefore == projectMemberRepoMock::getProjectMembersWithUsers) {
+            return
+        }
+        coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns projectMembersWithUsers
+        coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns inviteeToken
+        coEvery {
+            userRepoMock.getUsersMatchingSearchQuery(searchQuery, excludedUsers)
+        } returns users.filterNot { it.email in excludedUsers }
+    }
 
     @Test
     fun `When the search query is too short, then an empty list is returned`() = runTest {
-        val shortSearchQuery = InviteCandidatesRequest.newBuilder().setQuery("j").build()
+        mockGetInviteCandidates(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
 
-        mockCurrentUser(DataBuilder.createExampleUser())
+        val shortGetInviteCandidatesRequest = validGetInviteCandidatesRequest.setQuery("jo")
 
-        val candidates = assertDoesNotThrow { mainService.getInviteCandidates(shortSearchQuery) }
+        val candidates = assertDoesNotThrow { mainService.getInviteCandidates(shortGetInviteCandidatesRequest.build()) }
         assertThat(candidates.usersList).isEmpty()
     }
 
     @Test
     fun `When parsing the project id fails, then only a warning is logged`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val requestWithInvalidProjectId = InviteCandidatesRequest
-            .newBuilder()
-            .setQuery(searchQuery)
-            .setProjectId("invalid-uuid")
-            .build()
+        mockGetInviteCandidates(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
+        coEvery {
+            userRepoMock.getUsersMatchingSearchQuery(searchQuery, any())
+        } returns emptyList()
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id)) } returns emptyList()
+        val requestWithInvalidProjectId = validGetInviteCandidatesRequest.setProjectId("invalid-uuid")
 
-        assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId) }
+        assertDoesNotThrow { mainService.getInviteCandidates(requestWithInvalidProjectId.build()) }
+        coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembersWithUsers(any()) }
+        coVerify(exactly = 0) { invitationTokenRepoMock.getActiveInvitationTokensForProject(any()) }
     }
 
     @Test
     fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
+        mockGetInviteCandidates()
 
-        mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id)) } returns emptyList()
-
-        assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
-    }
-
-    @Test
-    fun `When retrieving the users matching the search query fails, then an empty list is returned`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-
-        mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
-        coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id)) } returns emptyList()
-
-        val candidates = assertDoesNotThrow { mainService.getInviteCandidates(validInviteCandidatesRequest) }
-        assertThat(candidates.usersList).isEmpty()
+        assertDoesNotThrow { mainService.getInviteCandidates(validGetInviteCandidatesRequest.build()) }
+        coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(requestingUserEmail)) }
     }
 
     @Test
     fun `When retrieving the invite candidates is successful, then these are returned except for the current user`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
-            val anotherUser = DataBuilder.createExampleUser(email = "another.user@example.com")
-            val users = listOf(currentUser, anotherUser)
-            val excludedUsers = setOf(currentUser.id)
+            mockGetInviteCandidates()
 
-            mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
-            coEvery {
-                userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id))
-            } returns users.filterNot { it.id in excludedUsers }
-
-            val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
+            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequest.build())
             assertThat(inviteCandidates.usersList).hasSize(1)
-            assertNull(inviteCandidates.usersList.find { it.id == currentUser.id.toString() })
+            assertNull(inviteCandidates.usersList.find { it.email == requestingUserEmail })
         }
 
     @Test
     fun `When retrieving the project members is successful, then these members are not returned as invite candidates`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(email = "current.user@example.com")
             val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
-            val users = listOf(currentUser, projectMember)
-            val excludedUsers = setOf(currentUser.id, projectMember.id)
+            mockGetInviteCandidates(projectMembers = listOf(projectMember))
 
-            mockCurrentUser(currentUser)
-            coEvery {
-                projectMemberRepoMock.getProjectMembers(projectId)
-            } returns listOf(DataBuilder.createExampleProjectMember(userId = projectMember.id))
-            coEvery {
-                userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(currentUser.id, projectMember.id))
-            } returns users.filterNot { it.id in excludedUsers }
+            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequest.build())
+            assertNull(inviteCandidates.usersList.find { it.email == projectMember.email })
+        }
 
-            val inviteCandidates = mainService.getInviteCandidates(validInviteCandidatesRequest)
-            assertThat(inviteCandidates.usersList).isEmpty()
+    @Test
+    fun `When retrieving the invitees is successful, then these invitees are not returned as invite candidates`() =
+        runTest {
+            val invitee = DataBuilder.createExampleUser(email = "invited.user@example.com")
+            mockGetInviteCandidates(invitees = listOf(invitee))
+
+            val inviteCandidates = mainService.getInviteCandidates(validGetInviteCandidatesRequest.build())
+            assertNull(inviteCandidates.usersList.find { it.email == invitee.email })
         }
 }


### PR DESCRIPTION
Closes #357 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a service, which does x -->

- I refactored the `getUsersMatchingSearchQuery` repo layer function that determines users that are matching a search query to not use user ids but email address as invitees have an email address but no user ID
- I added the already invited "project members" to the excluded user set in the `GetInviteCandidates` call
- I refactored the service tests for the `GetInviteCandidates` call to use one common setup method

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] (for reviewer) I have checked the implementation against the requirements
