### PR TITLE
Replace api submodule with reference in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
-              with:
-                  submodules: "recursive"
 
             - name: Setup
               uses: ./.github/workflows/setup/

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -19,8 +19,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
-              with:
-                  submodules: "recursive"
 
             - name: Setup
               uses: ./.github/workflows/setup/
@@ -40,8 +38,6 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
-              with:
-                  submodules: "recursive"
 
             - name: Setup
               uses: ./.github/workflows/setup/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "api"]
-	path = api
-	url = git@github.com:SE-UUlm/snowballr-api.git

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,1 @@
 .github
-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ COPY settings.gradle.kts .
 
 # Copy the project's source code and proto files
 COPY src/main src/main
-COPY api/proto api/proto
 
 # Grant execution rights to the Gradle wrapper script and build the jar file
 RUN chmod +x gradlew \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -270,7 +270,7 @@ tasks.register<Download>("downloadApiFiles") {
     val isTag = apiVersion.matches(Regex("""\d+.\d+.\d+"""))
     val isCommit = apiVersion.matches(Regex("""[a-f0-9]{40}"""))
     val isBranch = !isTag && !isCommit
-    println("Using API version: $apiVersion (isTag: $isTag, isCommit: $isCommit)")
+    println("Using API version: $apiVersion (isTag: $isTag, isCommit: $isCommit, isBranch: $isBranch)")
 
     val zipUrl =
         if (isTag) "https://github.com/SE-UUlm/snowballr-api/archive/refs/tags/v${apiVersion}.zip"
@@ -283,6 +283,7 @@ tasks.register<Download>("downloadApiFiles") {
     // Declare inputs & outputs for caching
     inputs.property("apiVersion", apiVersion)
     outputs.dir(protoDir)
+    outputs.cacheIf { !isBranch } // don't cache if apiVersion is a branch
 
     src(zipUrl)
     dest(zipFile)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,11 @@
+import de.undercouch.gradle.tasks.download.Download
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import kotlinx.kover.gradle.plugin.dsl.AggregationType
 import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
 import kotlinx.kover.gradle.plugin.dsl.GroupingEntityType
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -10,11 +15,16 @@ plugins {
     alias(libs.plugins.shadow.jar)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.git.versioning)
+    alias(libs.plugins.undercouch.download)
     application
 }
 
 group = "se.uulm.snowballr.backend"
 version = "0.0.0"
+
+// Snowballr API version to use for the proto files
+val apiVersion = "0.13.0" // can be a tag (e.g., "1.2.3"), commit hash, or branch name like "main"
+val protoDir = layout.buildDirectory.dir("snowballr-api/${apiVersion}")
 
 gitVersioning.apply {
     refs {
@@ -206,14 +216,14 @@ protobuf {
 sourceSets {
     main {
         proto {
-            srcDir("api/proto")
+            srcDir(protoDir)
             include("*.proto")
         }
     }
 }
 
 // Alias for regular detekt lint check
-tasks.register<io.gitlab.arturbosch.detekt.Detekt>("lint") {
+tasks.register<Detekt>("lint") {
     group = "verification"
     description = "Runs Detekt linter"
 
@@ -222,7 +232,7 @@ tasks.register<io.gitlab.arturbosch.detekt.Detekt>("lint") {
 }
 
 // Custom format task as alias for "detekt --auto-correct"
-tasks.register<io.gitlab.arturbosch.detekt.Detekt>("format") {
+tasks.register<Detekt>("format") {
     group = "verification"
     description = "Runs Detekt with the auto-correct flag to format the code."
 
@@ -230,7 +240,7 @@ tasks.register<io.gitlab.arturbosch.detekt.Detekt>("format") {
     autoCorrect = true
 }
 
-tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+tasks.withType<Detekt>().configureEach {
     setSource(files("src"))
     include("**/*.kt", "**/*.kts")
     exclude {
@@ -242,7 +252,7 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     parallel = true
 }
 
-tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
+tasks.withType<DetektCreateBaselineTask>().configureEach {
     setSource(files("src"))
     include("**/*.kt", "**/*.kts")
     exclude {
@@ -251,4 +261,72 @@ tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configure
     jvmTarget = "1.8"
     classpath = sourceSets["main"].runtimeClasspath
     parallel = true
+}
+
+tasks.register<Download>("downloadApiFiles") {
+    group = "other"
+    description = "Downloads the API definition files from the snowballr-api repository."
+
+    val isTag = apiVersion.matches(Regex("""\d+.\d+.\d+"""))
+    val isCommit = apiVersion.matches(Regex("""[a-f0-9]{40}"""))
+    val isBranch = !isTag && !isCommit
+    println("Using API version: $apiVersion (isTag: $isTag, isCommit: $isCommit)")
+
+    val zipUrl =
+        if (isTag) "https://github.com/SE-UUlm/snowballr-api/archive/refs/tags/v${apiVersion}.zip"
+        else if (isCommit) "https://github.com/SE-UUlm/snowballr-api/archive/${apiVersion}.zip"
+        else "https://github.com/SE-UUlm/snowballr-api/archive/refs/heads/${apiVersion}.zip"
+
+    val zipFile = layout.buildDirectory.file("snowballr-api-${apiVersion}.zip").get().asFile
+    val protoDirAsFile = protoDir.get().asFile
+
+    // Declare inputs & outputs for caching
+    inputs.property("apiVersion", apiVersion)
+    outputs.dir(protoDir)
+
+    src(zipUrl)
+    dest(zipFile)
+    overwrite(isBranch) // don't re-download unless file missing or apiVersion is a branch
+
+    doLast {
+        // Only unzip if the directory is empty
+        if (protoDirAsFile.list()?.isNotEmpty() == true && !isBranch) {
+            println("API proto files already extracted - skipping unzip")
+            return@doLast
+        }
+
+        println("Extracting $zipFile to $protoDirAsFile")
+
+        fun unzipFile(zip: ZipFile, entry: ZipEntry) {
+            // We only want the proto files
+            if (!entry.name.startsWith("snowballr-api-${apiVersion}/proto/")) return
+            val entryName = entry.name.removePrefix("snowballr-api-${apiVersion}/proto/")
+
+            val outputFile = protoDirAsFile.resolve(entryName)
+            if (entry.isDirectory) {
+                outputFile.mkdirs()
+            } else {
+                outputFile.parentFile?.mkdirs()
+                zip.getInputStream(entry).use { input ->
+                    outputFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+        }
+
+        ZipFile(zipFile).use { zip ->
+            zip.entries().asSequence().forEach { entry ->
+                unzipFile(zip, entry)
+            }
+        }
+    }
+}
+
+tasks.named("extractProto") {
+    dependsOn("downloadApiFiles")
+}
+
+tasks.named("processResources") {
+    dependsOn("downloadApiFiles")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ testcontainers = "1.21.3"
 kotlinx-serialization-json = "1.9.0"
 nanoid = "1.0.1"
 git-versioning = "6.4.4"
+undercouch-download = "5.6.0"
 
 [libraries]
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
@@ -100,3 +101,4 @@ protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }
 shadow-jar = { id = "com.gradleup.shadow", version.ref = "shadow-jar" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 git-versioning = { id = "me.qoomon.git-versioning", version.ref = "git-versioning" }
+undercouch-download = { id = "de.undercouch.download", version.ref = "undercouch-download" }

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -20,6 +20,7 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
     * [Formatting](#formatting)
     * [Linting](#linting)
   * [Release procedure](#release-procedure)
+  * [Use another API Version](#use-another-api-version)
 <!-- TOC -->
 <!-- @formatter:on -->
 <!-- markdownlint-enable MD007 -->
@@ -334,3 +335,10 @@ For information about our testing setup, see [Testing](https://github.com/SE-UUl
 We create a new release whenever a set of features, bug fixes, or changes is ready to be deployed and used by the
 frontend. To release a new version of the backend, follow the steps in the
 [SnowballR Wiki](https://github.com/SE-UUlm/snowballr/wiki/Contributing#release-procedure).
+
+## Use another API Version
+
+To use another API version than the currently used one, go to the `build.gradle.kts` file and change the
+`apiVersion` variable to the desired version. Make sure that the version exists in the
+[API repository](https://github.com/SE-UUlm/snowballr-api). After changing the version, recompile the code using
+`./gradlew compileKotlin`.

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -31,7 +31,6 @@ To set up the development environment, follow the steps in
 
 ```plaintext
 .
-├── api/                     (snowballr-api submodule)
 ├── src/
 │   ├── main/
 │   │   ├── kotlin/

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -9,12 +9,11 @@ page.
 
 The fastest way to get started is to use the provided Docker setup.
 
-1. Clone the repository and its submodule:
+1. Clone the repository:
 
     ```bash
     git clone git@github.com:SE-UUlm/snowballr-backend.git
     cd snowballr-backend
-    git submodule update --init --recursive
     docker compose up
     ```
 
@@ -49,12 +48,11 @@ the backend with the desired profile.
 
 To build the project from source, run the following commands:
 
-1. Clone the repository and its submodule:
+1. Clone the repository:
 
     ```bash
     git clone git@github.com:SE-UUlm/snowballr-backend.git
     cd snowballr-backend
-    git submodule update --init --recursive
     ./gradlew shadowJar
     ```
 
@@ -65,11 +63,6 @@ To build the project from source, run the following commands:
     ```
 
    The built JAR file can be found in the `build/libs` directory, named `snowballr-backend-<version>.jar`.
-
-   > [!NOTE] API Code Generation
-   >
-   > In comparison to the frontend repository, we don't have to manually generate the API code, as it is done
-   > automatically. You can find the generated API code in the `build/generated` directory.*
 
 3. Run the application:
 


### PR DESCRIPTION
Closes #400

## What I have made

This adds a Gradle task that automatically downloads the proto files of our API.
As a version, we can select a tag, a commit hash, or a branch (for development purposes).

This also employs caching, i.e., if the zip of the version is already downloaded, we don't download it again. If the zip is already unzipped, we don't overwrite the results. We don't employ caching if the version is a branch, since there can be changes.

Run `./gradlew clean` before testing.

All in all, this should make working with the API a lot easier, also when rebasing.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only changes in build pipeline)

### Reviewer

- [x] I have checked the implementation against the requirements
