### PR TITLE
Prevent invited users from accepting an invitation to a deleted project

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepo.kt
@@ -65,6 +65,11 @@ interface IInvitationTokenTableRepo {
      * Deletes all invitation tokens that have expired.
      */
     suspend fun deleteExpiredInvitationTokens()
+
+    /**
+     * Deletes all invitation tokens associated with a given project.
+     */
+    suspend fun deleteInvitationTokensForProject(projectId: UUID)
 }
 
 class InvitationTokenTableRepo(
@@ -118,5 +123,11 @@ class InvitationTokenTableRepo(
         }
 
         logger.info { "Deleted $deletedTokens expired invitation tokens." }
+    }
+
+    override suspend fun deleteInvitationTokensForProject(projectId: UUID) {
+        db.query {
+            InvitationTokenTable.deleteWhere { InvitationTokenTable.projectId eq projectId }
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -15,6 +15,7 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAl
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
+import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
@@ -103,6 +104,7 @@ interface IProjectService {
  * @param projectMemberRepo The repository responsible for managing persistence operations for project members.
  * @param projectPaperRepo The repository responsible for managing persistence operations for project papers.
  * @param criterionRepo The repository responsible for managing persistence operations for criteria.
+ * @param invitationTokenRepo The repository responsible for managing persistence operations for invitation tokens.
  */
 class ProjectService(
     private val repo: IProjectTableRepo,
@@ -110,6 +112,7 @@ class ProjectService(
     private val projectMemberRepo: IProjectMemberTableRepo,
     private val projectPaperRepo: IProjectPaperTableRepo,
     private val criterionRepo: ICriterionTableRepo,
+    private val invitationTokenRepo: IInvitationTokenTableRepo,
 ) : IProjectService {
     override suspend fun getProjectById(request: Base.Id): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
@@ -251,6 +254,7 @@ class ProjectService(
         }
 
         repo.softDeleteProject(projectId)
+        invitationTokenRepo.deleteInvitationTokensForProject(projectId)
 
         Base.Nothing.getDefaultInstance()
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -153,23 +153,6 @@ class ProjectService(
         repo.getAllProjects().toGrpcProjects()
     }
 
-    private suspend fun getAllProjectsForUserAndStatus(
-        request: Base.Id,
-        statuses: Set<ProjectStatus>,
-    ): GrpcProject.List = withUser(userRepo) { currentUser ->
-        val requestedUserId = parseUUID(request.id, EntityType.USER)
-        val requestedUser = userRepo.getUserById(requestedUserId).getOrThrow()
-
-        isServerAdminOrSameUser()
-            .forProperty(User::id)
-            .orElseThrow { requestingUser, _ ->
-                UnauthorizedReadException(requestingUser.id, requestedUserId, EntityType.USER)
-            }
-            .checkFor(currentUser, requestedUser)
-
-        repo.getUserProjects(requestedUserId, statuses).toGrpcProjects()
-    }
-
     override suspend fun getAllProjectsForUser(request: Base.Id): GrpcProject.List = getAllProjectsForUserAndStatus(
         request,
         setOf(ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED),
@@ -202,6 +185,91 @@ class ProjectService(
         }
 
         repo.updateProject(finalRequest).toGrpcProject()
+    }
+
+    override suspend fun getProjectInformation(request: GrpcProject.Information.Get): GrpcProject.Information =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+
+            isAllowedToReadProject(projectMemberRepo)
+                .andAlso(isProjectExistent(repo))
+                .checkFor(currentUser, projectId)
+
+            val project = repo.getProjectById(projectId).getOrThrow()
+            val progress = projectPaperRepo.getProjectProgress(projectId)
+            val builder = GrpcProject.Information.newBuilder()
+            val has = if (request.hasMask() && request.mask.pathsList.isNotEmpty()) {
+                val fieldMaskPaths = FieldMaskUtil.normalize(request.mask).pathsList.toSet();
+                { path: String -> path in fieldMaskPaths }
+            } else {
+                { _ -> true }
+            }
+
+            if (has("project_progress")) {
+                builder.setProjectProgress(progress)
+            }
+
+            if (has("creation_date")) {
+                builder.setCreationDate(timestamp { seconds = project.createdAt.toEpochSecond() })
+            }
+
+            if (has("last_stage_started")) {
+                builder.setLastStageStarted(timestamp { seconds = project.currentStageStartedAt.toEpochSecond() })
+            }
+
+            builder.build()
+        }
+
+    override suspend fun getDecisionStatisticsForStage(
+        request: GrpcProjectDecisionStatistics.Get,
+    ): GrpcProjectDecisionStatistics = withUser(userRepo) { currentUser ->
+        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+
+        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
+
+        val project = repo.getProjectById(projectId).getOrThrow()
+        val maxStage = project.maxStage
+
+        if (request.stage > maxStage) {
+            throw StageNotFoundException(request.stage)
+        }
+
+        val statistics = createStatistics(projectId, request.stage)
+        GrpcProjectDecisionStatistics
+            .newBuilder()
+            .addAllStatistics(statistics)
+            .build()
+    }
+
+    override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
+        val projectId = parseUUID(request.id, EntityType.PROJECT)
+
+        isServerOrProjectAdmin(projectMemberRepo, AccessType.DELETE).checkFor(currentUser, projectId)
+
+        if (!repo.doesProjectExistById(projectId)) {
+            throw ProjectNotFoundException(projectId)
+        }
+
+        repo.softDeleteProject(projectId)
+
+        Base.Nothing.getDefaultInstance()
+    }
+
+    private suspend fun getAllProjectsForUserAndStatus(
+        request: Base.Id,
+        statuses: Set<ProjectStatus>,
+    ): GrpcProject.List = withUser(userRepo) { currentUser ->
+        val requestedUserId = parseUUID(request.id, EntityType.USER)
+        val requestedUser = userRepo.getUserById(requestedUserId).getOrThrow()
+
+        isServerAdminOrSameUser()
+            .forProperty(User::id)
+            .orElseThrow { requestingUser, _ ->
+                UnauthorizedReadException(requestingUser.id, requestedUserId, EntityType.USER)
+            }
+            .checkFor(currentUser, requestedUser)
+
+        repo.getUserProjects(requestedUserId, statuses).toGrpcProjects()
     }
 
     /**
@@ -301,60 +369,6 @@ class ProjectService(
         }
     }
 
-    override suspend fun getProjectInformation(request: GrpcProject.Information.Get): GrpcProject.Information =
-        withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
-            isAllowedToReadProject(projectMemberRepo)
-                .andAlso(isProjectExistent(repo))
-                .checkFor(currentUser, projectId)
-
-            val project = repo.getProjectById(projectId).getOrThrow()
-            val progress = projectPaperRepo.getProjectProgress(projectId)
-            val builder = GrpcProject.Information.newBuilder()
-            val has = if (request.hasMask() && request.mask.pathsList.isNotEmpty()) {
-                val fieldMaskPaths = FieldMaskUtil.normalize(request.mask).pathsList.toSet();
-                { path: String -> path in fieldMaskPaths }
-            } else {
-                { _ -> true }
-            }
-
-            if (has("project_progress")) {
-                builder.setProjectProgress(progress)
-            }
-
-            if (has("creation_date")) {
-                builder.setCreationDate(timestamp { seconds = project.createdAt.toEpochSecond() })
-            }
-
-            if (has("last_stage_started")) {
-                builder.setLastStageStarted(timestamp { seconds = project.currentStageStartedAt.toEpochSecond() })
-            }
-
-            builder.build()
-        }
-
-    override suspend fun getDecisionStatisticsForStage(
-        request: GrpcProjectDecisionStatistics.Get,
-    ): GrpcProjectDecisionStatistics = withUser(userRepo) { currentUser ->
-        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
-
-        val project = repo.getProjectById(projectId).getOrThrow()
-        val maxStage = project.maxStage
-
-        if (request.stage > maxStage) {
-            throw StageNotFoundException(request.stage)
-        }
-
-        val statistics = createStatistics(projectId, request.stage)
-        GrpcProjectDecisionStatistics
-            .newBuilder()
-            .addAllStatistics(statistics)
-            .build()
-    }
-
     /**
      * Creates a list of [GrpcProjectDecisionStatistics.Statistic] objects for the given [stage]
      * in the project with the ID [projectId].
@@ -383,19 +397,5 @@ class ProjectService(
             PaperDecision.PAPER_DECISION_UNREVIEWED,
             PaperDecision.PAPER_DECISION_IN_REVIEW,
         ).map(::createStatistic)
-    }
-
-    override suspend fun softDeleteProject(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
-        val projectId = parseUUID(request.id, EntityType.PROJECT)
-
-        isServerOrProjectAdmin(projectMemberRepo, AccessType.DELETE).checkFor(currentUser, projectId)
-
-        if (!repo.doesProjectExistById(projectId)) {
-            throw ProjectNotFoundException(projectId)
-        }
-
-        repo.softDeleteProject(projectId)
-
-        Base.Nothing.getDefaultInstance()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.table
 
 import arrow.core.mapValuesNotNull
+import org.jetbrains.exposed.sql.BasicBinaryColumnType
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Table
@@ -54,6 +55,11 @@ fun Table.expiresAt() = timestampWithTimeZone("expires_at").clientDefault { Offs
  */
 fun Table.obfuscatedText(name: String, collate: String? = null, eagerLoading: Boolean = false) =
     registerColumn(name, ObfuscatedTextColumnType(collate, eagerLoading))
+
+/**
+ * Same as [Table.binary], but with the [RedactedBinaryColumnType] instead of the [BasicBinaryColumnType].
+ */
+fun Table.redactedBinary(name: String) = registerColumn(name, RedactedBinaryColumnType())
 
 /**
  * Stores a Map<String, String> inside an [HStoreColumnType]. Unallowed characters are automatically escaped.

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
@@ -50,7 +50,7 @@ object ProjectTable : UUIDTable("project") {
     val similarityThreshold = float("similarity_threshold")
     val snowballingType = enumeration<SnowballingType>("snowballing_type")
     val reviewMaybeAllowed = bool("review_maybe_allowed")
-    val reviewDecisionMatrixBinary = binary("review_decision_matrix")
+    val reviewDecisionMatrixBinary = redactedBinary("review_decision_matrix")
     val fetchers = json<Map<String, Map<String, String>>>("fetchers", Json)
     val currentStageStartedAt = timestampWithTimeZone("current_stage_started_at").clientDefault { OffsetDateTime.now() }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/RedactedBinaryColumnType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/RedactedBinaryColumnType.kt
@@ -1,0 +1,10 @@
+package se.uulm.snowballr.backend.table
+
+import org.jetbrains.exposed.sql.BasicBinaryColumnType
+
+/**
+ * [BasicBinaryColumnType], but the value is redacted for logging.
+ */
+class RedactedBinaryColumnType : BasicBinaryColumnType() {
+    override fun valueToString(value: ByteArray?) = "[REDACTED BINARY]"
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -118,7 +118,7 @@ object UserTable : UUIDTable("user") {
 
     // Project settings defaults
     val similarityThreshold = float("similarity_threshold").clientDefault { SIMILARITY_THRESHOLD_DEFAULT }
-    val decisionMatrix = binary("review_decision_matrix").clientDefault { DECISION_MATRIX_DEFAULT }
+    val decisionMatrix = redactedBinary("review_decision_matrix").clientDefault { DECISION_MATRIX_DEFAULT }
     val fetchers = json<Map<String, Map<String, String>>>("fetchers", Json).clientDefault { FETCHERS_DEFAULT }
     val snowballingType =
         enumeration<SnowballingType>("snowballing_type").clientDefault { SNOWBALLING_TYPE_DEFAULT }

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -205,6 +205,7 @@ private class NamingConventions {
             .orShould(haveSimpleNameEndingWith("ColumnHelperKt")) // exception
             .orShould(haveSimpleName("TableHelperKt")) // exception
             .orShould(haveSimpleNameEndingWith("ObfuscatedTextColumnType")) // exception
+            .orShould(haveSimpleNameEndingWith("RedactedBinaryColumnType")) // exception
             .orShould(haveSimpleName("HStoreColumnType")) // exception
             .orShould(haveNameMatching(".*inlined\\\$json\\\$.*")) // exception
             .because("All tables should have the 'Table' suffix")

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
@@ -231,4 +231,45 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             )
         }
     }
+
+    @Nested
+    inner class DeleteInvitationTokensForProject {
+        @Test
+        fun `When tokens exist for a project, then they are deleted`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+
+            insertTestInvitationToken(testEmail, projectId, "token-to-be-deleted")
+
+            assertDoesNotThrow { repo.deleteInvitationTokensForProject(projectId) }
+
+            assertResultFailure<InvitationTokenNotFoundException>(
+                repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId),
+            )
+        }
+
+        @Test
+        fun `When no tokens exist for a project, then no exception is thrown`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId)
+
+            assertDoesNotThrow { repo.deleteInvitationTokensForProject(projectId) }
+        }
+
+        @Test
+        fun `When deleting token for one project, tokens for other projects are not affected`() = runTest {
+            val projectId1 = insertProjectAndGetId(createdBy = testUserId)
+            val projectId2 = insertProjectAndGetId(createdBy = testUserId)
+
+            insertTestInvitationToken(testEmail, projectId1, "token-in-project-1")
+            insertTestInvitationToken(testEmail, projectId2, "token-in-project-2")
+
+            assertDoesNotThrow { repo.deleteInvitationTokensForProject(projectId1) }
+
+            assertResultFailure<InvitationTokenNotFoundException>(
+                repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId1),
+            )
+
+            // Token for project 2 should still exist
+            assertResultSuccess(repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId2))
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -48,6 +48,7 @@ class SoftDeleteProjectTest : MainServiceTest() {
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
 
         coEvery { projectRepoMock.softDeleteProject(projectId) } returns Unit
+        coEvery { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) } returns Unit
     }
 
     @Test


### PR DESCRIPTION
Closes #391 

## What I have made

- Binary data in SQL statements is redacted in logging
- When a project is soft-deleted, all related invitation tokens are deleted
- The current testing abilities can't test this correctly, which is why I started #424 where I will add a regression test for this
- In the frontend, the user will be noticed that the invitation token is either expired or the project has been deleted

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the implementation against the requirements
