### PR TITLE
Fix missing fetcher functionality

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.auth
 
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import java.util.UUID
@@ -28,7 +29,7 @@ object DummyUser {
     var criteriaIds: List<UUID> = emptyList()
     var similarityThreshold: Float = 0F
     var decisionMatrix: ByteArray = ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
-    var fetchers: Map<String, Map<String, String>> = emptyMap()
+    var fetchers: FetcherMap = emptyMap()
     var snowballingType: ProjectOuterClass.SnowballingType = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
     var reviewMaybeAllowed: Boolean = true
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherManager.kt
@@ -54,9 +54,8 @@ class FetcherManager {
      * @param fetcher The name of the fetcher whose options should be retrieved.
      * @return A set of names for options the fetcher has specified it would accept.
      */
-    suspend fun getAvailableOptions(fetcher: String): Map<String, String> = getFetcherOrThrow(
-        fetcher,
-    ).getAvailableOptions()
+    suspend fun getAvailableOptions(fetcher: String): Map<String, String> =
+        getFetcherOrThrow(fetcher).getAvailableOptions()
 
     /**
      * Search for papers using a search query.
@@ -67,16 +66,16 @@ class FetcherManager {
      * @return A set of papers best matching the provided searchQuery.
      */
     suspend fun searchPapers(fetcher: String, searchQuery: String, options: Map<String, String>): Set<Paper> =
-        getFetcherOrThrow(
-            fetcher,
-        ).searchPapers(searchQuery, options)
+        getFetcherOrThrow(fetcher).searchPapers(searchQuery, options)
 
     /**
      * Get the papers that are forward references of the specified paper.
-     * Paper A is a forward reference of Paper B if it is referred to in B:
+     * Paper C is a forward reference of Paper B if it cites B.
      *
-     *    Paper A <-referring-- Paper B <-referring-- Paper C
-     *  forward ref.                                backward ref.
+     * ```
+     *     Paper A <-citing-- Paper B <-citing-- Paper C
+     *  backward ref.                          forward ref.
+     * ```
      *
      * @param fetcher The name of the fetcher to be used for this request.
      * @param paper The paper from which the forward references should be fetched.
@@ -88,10 +87,12 @@ class FetcherManager {
 
     /**
      * Get the papers that are backward references of the specified paper.
-     * Paper C is a backward reference of Paper B if it is referring to B:
+     * Paper A is a backward reference of Paper B if it is cited by B:
      *
-     *    Paper A <-referring-- Paper B <-referring-- Paper C
-     *  forward ref.                                backward ref.
+     * ```
+     *     Paper A <-citing-- Paper B <-citing-- Paper C
+     *  backward ref.                          forward ref.
+     * ```
      *
      * @param fetcher The name of the fetcher to be used for this request.
      * @param paper The paper from which the backward references should be fetched.

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherMap.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherMap.kt
@@ -1,0 +1,7 @@
+package se.uulm.snowballr.backend.fetcher
+
+/**
+ * Map of a fetcher name to its option map.
+ * The option map maps the key to its value.
+ */
+typealias FetcherMap = Map<String, Map<String, String>>

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.table.ProjectTable
 import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass
@@ -19,7 +20,7 @@ data class Project(
     val snowballingType: ProjectOuterClass.SnowballingType,
     val reviewMaybeAllowed: Boolean,
     val reviewDecisionMatrix: ProjectOuterClass.ReviewDecisionMatrix,
-    val fetchers: Map<String, Map<String, String>>,
+    val fetchers: FetcherMap,
     val currentStageStartedAt: OffsetDateTime,
     val createdAt: OffsetDateTime,
     val createdBy: UUID,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import snowballr.CriterionOuterClass
 import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass
@@ -12,7 +13,7 @@ data class UserSettings(
     val criteriaIds: List<UUID>,
     val similarityThreshold: Float,
     val decisionMatrix: ProjectOuterClass.ReviewDecisionMatrix,
-    val fetchers: Map<String, Map<String, String>>,
+    val fetchers: FetcherMap,
     val snowballingType: ProjectOuterClass.SnowballingType,
     val reviewMaybeAllowed: Boolean,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -330,5 +330,9 @@ class ProjectTableRepo(
         if ("project.settings.review_maybe_allowed" in paths) {
             this[ProjectTable.reviewMaybeAllowed] = settings.reviewMaybeAllowed
         }
+        if ("project.settings.fetchers" in paths) {
+            val fetcherMap = settings.fetchersMap.mapValues { (_, value) -> value.optionsMap }
+            this[ProjectTable.fetchers] = fetcherMap
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
@@ -30,7 +30,7 @@ import java.time.OffsetDateTime
  * as a [Boolean].
  * - [reviewDecisionMatrixBinary]: Represents the decision matrix on how the [PaperDecision] for a paper should be
  * determined as a [ByteArray].
- * - [fetchers]: Represents the fetchers used by the project as a json object mapping the fetcher names to their
+ * - [fetchers]: Represents the fetchers used by the project as a JSON object mapping the fetcher names to their
  * options.
  * - [currentStageStartedAt]: Represents the timestamp of when the current stage of the project was started as a
  * [OffsetDateTime].

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.json.json
 import org.jetbrains.exposed.sql.kotlin.datetime.timestampWithTimeZone
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.Project
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
@@ -51,7 +52,7 @@ object ProjectTable : UUIDTable("project") {
     val snowballingType = enumeration<SnowballingType>("snowballing_type")
     val reviewMaybeAllowed = bool("review_maybe_allowed")
     val reviewDecisionMatrixBinary = redactedBinary("review_decision_matrix")
-    val fetchers = json<Map<String, Map<String, String>>>("fetchers", Json)
+    val fetchers = json<FetcherMap>("fetchers", Json)
     val currentStageStartedAt = timestampWithTimeZone("current_stage_started_at").clientDefault { OffsetDateTime.now() }
 
     // Metadata

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.json.json
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import snowballr.ProjectOuterClass.PaperDecision
@@ -75,7 +76,7 @@ private val DECISION_MATRIX_DEFAULT: ByteArray = ReviewDecisionMatrix.newBuilder
     .addPatterns(MAYBE_MAYBE_PATTERN)
     .build()
     .toByteArray()
-private val FETCHERS_DEFAULT = emptyMap<String, Map<String, String>>()
+private val FETCHERS_DEFAULT: FetcherMap = emptyMap()
 private val SNOWBALLING_TYPE_DEFAULT = SnowballingType.SNOWBALLING_TYPE_BOTH
 private const val REVIEW_MAYBE_ALLOWED_DEFAULT = true
 
@@ -119,7 +120,7 @@ object UserTable : UUIDTable("user") {
     // Project settings defaults
     val similarityThreshold = float("similarity_threshold").clientDefault { SIMILARITY_THRESHOLD_DEFAULT }
     val decisionMatrix = redactedBinary("review_decision_matrix").clientDefault { DECISION_MATRIX_DEFAULT }
-    val fetchers = json<Map<String, Map<String, String>>>("fetchers", Json).clientDefault { FETCHERS_DEFAULT }
+    val fetchers = json<FetcherMap>("fetchers", Json).clientDefault { FETCHERS_DEFAULT }
     val snowballingType =
         enumeration<SnowballingType>("snowballing_type").clientDefault { SNOWBALLING_TYPE_DEFAULT }
     val reviewMaybeAllowed = bool("review_maybe_allowed").clientDefault { REVIEW_MAYBE_ALLOWED_DEFAULT }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/FetcherValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/FetcherValidator.kt
@@ -1,0 +1,16 @@
+package se.uulm.snowballr.backend.validation
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import se.uulm.snowballr.backend.model.ValidationIssue
+import snowballr.Fetcher
+
+object FetcherValidator {
+    const val NAME_MAX_LENGTH = 100
+
+    fun validateGetAvailableFetcherOptionsRequest(
+        request: Fetcher.GetAvailableFetcherOptionsRequest,
+    ): EitherNel<ValidationIssue, Unit> = either {
+        ensureTextFieldValidity("fetcher_name", request.fetcherName, NAME_MAX_LENGTH)
+    }.toEitherNel()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/Validator.kt
@@ -13,6 +13,7 @@ import snowballr.Authentication
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.Export
+import snowballr.Fetcher
 import snowballr.PaperOuterClass.Paper
 import snowballr.ProjectOuterClass
 import snowballr.ReviewOuterClass
@@ -71,6 +72,8 @@ fun <T> validateRequest(request: T): EitherNel<ValidationIssue, Unit> = when (re
     is Paper -> PaperValidator.validateCreateRequest(request)
     // Export
     is Export.ExportRequest -> ExportValidator.validateExportRequest(request)
+    // Fetcher
+    is Fetcher.GetAvailableFetcherOptionsRequest -> FetcherValidator.validateGetAvailableFetcherOptionsRequest(request)
     // Fallback for unknown request types
     else -> Either.Left(nonEmptyListOf(UnknownRequest))
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend
 
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.InvitationToken
@@ -44,7 +45,7 @@ object DataBuilder {
         snowballingType: SnowballingType = SnowballingType.SNOWBALLING_TYPE_BOTH,
         reviewMaybeAllowed: Boolean = true,
         reviewDecisionMatrix: ReviewDecisionMatrix = ReviewDecisionMatrix.getDefaultInstance(),
-        fetchers: Map<String, Map<String, String>> = emptyMap(),
+        fetchers: FetcherMap = emptyMap(),
         currentStageStartedAt: OffsetDateTime = OffsetDateTime.now(),
         createdAt: OffsetDateTime = OffsetDateTime.now(),
         createdBy: UUID = UUID.randomUUID(),
@@ -156,7 +157,7 @@ object DataBuilder {
         criteriaIds: List<UUID> = emptyList(),
         similarityThreshold: Float = 0.5f,
         decisionMatrix: ReviewDecisionMatrix = ReviewDecisionMatrix.getDefaultInstance(),
-        fetchers: Map<String, Map<String, String>> = emptyMap(),
+        fetchers: FetcherMap = emptyMap(),
         snowballingType: SnowballingType = SnowballingType.SNOWBALLING_TYPE_BOTH,
         reviewMaybeAllowed: Boolean = false,
     ) = UserSettings(

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -34,6 +34,7 @@ import se.uulm.snowballr.backend.table.association.ProjectMemberTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
+import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
@@ -67,6 +68,7 @@ class ProjectTableRepoTest :
             Arguments.of(listOf("project.settings.similarity_threshold")),
             Arguments.of(listOf("project.settings.snowballing_type")),
             Arguments.of(listOf("project.settings.review_maybe_allowed")),
+            Arguments.of(listOf("project.settings.fetchers")),
         )
     }
 
@@ -202,6 +204,7 @@ class ProjectTableRepoTest :
     inner class UpdateProject {
         @ParameterizedTest(name = "Update the fields {0}")
         @MethodSource("se.uulm.snowballr.backend.repository.ProjectTableRepoTest#validFieldMasks")
+        @Suppress("LongMethod")
         fun `When a project is updated, then only the fields specified in the field mask are updated and the updated project is returned`(
             fieldMask: List<String>,
         ) = runTest {
@@ -218,6 +221,12 @@ class ProjectTableRepoTest :
                         .setSimilarityThreshold(1F)
                         .setSnowballingType(SnowballingType.SNOWBALLING_TYPE_FORWARD)
                         .setReviewMaybeAllowed(false)
+                        .putFetchers(
+                            "test fetcher",
+                            FetcherOptions.newBuilder()
+                                .putOptions("Opt1", "Val1")
+                                .build(),
+                        )
                         .build(),
                 )
                 .build()
@@ -253,6 +262,19 @@ class ProjectTableRepoTest :
                 assertFalse(updatedProject.reviewMaybeAllowed)
             } else {
                 assertTrue(updatedProject.reviewMaybeAllowed)
+            }
+            val fetchers = updatedProject.fetchers
+            val fetcher = fetchers["test fetcher"]
+            if ("project.settings.fetchers" in fieldMask) {
+                assertEquals(1, fetchers.size)
+                assertNotNull(fetcher)
+                val fetcherOption1 = fetcher["Opt1"]
+                assertEquals("Val1", fetcherOption1)
+                val fetcherOption2 = fetcher["Opt2"]
+                assertNull(fetcherOption2)
+            } else {
+                assertEquals(0, fetchers.size)
+                assertNull(fetcher)
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
 import se.uulm.snowballr.backend.db.IDatabase
+import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.InvitationTokenTable
@@ -131,7 +132,7 @@ object RepositoryHelper {
         snowballingType: SnowballingType = SnowballingType.SNOWBALLING_TYPE_BOTH,
         reviewMaybeAllowed: Boolean = true,
         reviewDecisionMatrix: ReviewDecisionMatrix = ReviewDecisionMatrix.getDefaultInstance(),
-        fetcherApis: Map<String, Map<String, String>> = emptyMap(),
+        fetcherApis: FetcherMap = emptyMap(),
         createdBy: UUID,
         deletedAt: OffsetDateTime? = null,
     ): UUID = db.query {

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/FetcherValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/FetcherValidatorTest.kt
@@ -1,0 +1,49 @@
+package se.uulm.snowballr.backend.validation
+
+import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.BlankField
+import se.uulm.snowballr.backend.model.TooLongField
+import se.uulm.snowballr.backend.validation.FetcherValidator.NAME_MAX_LENGTH
+import snowballr.Fetcher
+
+class FetcherValidatorTest {
+    @Nested
+    inner class GetAvailableFetcherOptions {
+        private val validGetAvailableFetcherOptionsRequestBuilder: Fetcher.GetAvailableFetcherOptionsRequest.Builder =
+            Fetcher.GetAvailableFetcherOptionsRequest
+                .newBuilder()
+                .setFetcherName("Valid Fetcher Name")
+
+        @Test
+        fun `When a valid request is validated, then no issue is returned`() {
+            val request = validGetAvailableFetcherOptionsRequestBuilder.build()
+            val result = validateRequest(request)
+
+            EitherAssert.assertThat(result).isRight()
+        }
+
+        @Test
+        fun `When a blank name is validated, then the 'BlankField' issue is returned`() {
+            val request =
+                validGetAvailableFetcherOptionsRequestBuilder
+                    .setFetcherName("")
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<BlankField>(result)
+        }
+
+        @Test
+        fun `When a too long name is validated, then the 'TooLongField' issue is returned`() {
+            val request =
+                validGetAvailableFetcherOptionsRequestBuilder
+                    .setFetcherName("a".repeat(NAME_MAX_LENGTH + 1))
+                    .build()
+            val result = validateRequest(request)
+
+            assertInvalidResult<TooLongField>(result)
+        }
+    }
+}


### PR DESCRIPTION
Closes #421 

## What I have made

I fixed the missing functionalities.

To test the behavior, add the following code at the end of the `createProject` method in `ProjectService`:
```kotlin
        fetcherManager.registerFetcher(
            "foo-${project.name}",
            object : IFetcher {
                override suspend fun getAvailableOptions(): Map<String, String> =
                    mapOf(Pair("Opt1", "Val1"), Pair("Opt2", "Val2"))

                override suspend fun searchPapers(searchQuery: String, options: Map<String, String>): Set<Paper> =
                    emptySet()

                override suspend fun fetchForwardReferences(paper: Paper, options: Map<String, String>): Set<Paper> =
                    emptySet()

                override suspend fun fetchBackwardReferences(paper: Paper, options: Map<String, String>): Set<Paper> =
                    emptySet()
            },
        )

        project.toGrpcProject()
```
This adds a fetcher when a project is added. Enough to test the fixes. Don't forget to add the `FetcherManager` as a dependency (`private val fetcherManager: FetcherManager`).

I also used the `feat/20-use-case-delete-project` branch in the frontend, since I added some minor fixes there.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the implementation against the requirements
