### PR TITLE
Fixed GetProjectById call returns the project even when it is deleted

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ group = "se.uulm.snowballr.backend"
 version = "0.0.0"
 
 // Snowballr API version to use for the proto files
-val apiVersion = "0.13.0" // can be a tag (e.g., "1.2.3"), commit hash, or branch name like "main"
+val apiVersion = "0.13.1" // can be a tag (e.g., "1.2.3"), commit hash, or branch name like "main"
 val protoDir = layout.buildDirectory.dir("snowballr-api/${apiVersion}")
 
 gitVersioning.apply {

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
@@ -4,6 +4,7 @@ import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.table.ProjectTable
 import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.ProjectStatus
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -13,7 +14,7 @@ import java.util.UUID
 data class Project(
     val id: UUID,
     val name: String,
-    val status: ProjectOuterClass.ProjectStatus,
+    val status: ProjectStatus,
     val currentStage: Long,
     val maxStage: Long,
     val similarityThreshold: Float,
@@ -72,3 +73,12 @@ fun List<Project>.toGrpcProjects(): ProjectOuterClass.Project.List {
     this.forEach { builder.addProjects(it.toGrpcProject()) }
     return builder.build()
 }
+
+/**
+ * Checks whether the project is active.
+ *
+ * A project is considered active if its status is either [ProjectStatus.PROJECT_STATUS_ACTIVE] or
+ * [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED].
+ */
+fun Project.isActive(): Boolean = this.status == ProjectStatus.PROJECT_STATUS_ACTIVE ||
+    this.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
@@ -80,5 +80,12 @@ fun List<Project>.toGrpcProjects(): ProjectOuterClass.Project.List {
  * A project is considered active if its status is either [ProjectStatus.PROJECT_STATUS_ACTIVE] or
  * [ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED].
  */
-fun Project.isActive(): Boolean = this.status == ProjectStatus.PROJECT_STATUS_ACTIVE ||
+fun Project.isActive() = this.status == ProjectStatus.PROJECT_STATUS_ACTIVE ||
     this.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+
+/**
+ * Checks whether the project is deleted.
+ *
+ * A project is considered deleted if its status is [ProjectStatus.PROJECT_STATUS_DELETED].
+ */
+fun Project.isDeleted() = this.status == ProjectStatus.PROJECT_STATUS_DELETED

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectMember.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectMember.kt
@@ -1,7 +1,7 @@
 package se.uulm.snowballr.backend.model.dto
 
 import se.uulm.snowballr.backend.table.association.ProjectMemberTable
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.MemberRole
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -11,7 +11,14 @@ import java.util.UUID
 data class ProjectMember(
     val projectId: UUID,
     val userId: UUID,
-    val role: ProjectOuterClass.MemberRole,
+    val role: MemberRole,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
 )
+
+/**
+ * Checks whether the project member is a project admin.
+ *
+ * A project member is considered a project admin if their role is set to [MemberRole.MEMBER_ROLE_ADMIN].
+ */
+fun ProjectMember.isProjectAdmin() = this.role == MemberRole.MEMBER_ROLE_ADMIN

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaper.kt
@@ -1,7 +1,7 @@
 package se.uulm.snowballr.backend.model.dto
 
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
-import snowballr.ProjectOuterClass
+import snowballr.ProjectOuterClass.PaperDecision
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -14,9 +14,27 @@ data class ProjectPaper(
     val projectId: UUID,
     val localPaperId: Long,
     val stage: Long,
-    val decision: ProjectOuterClass.PaperDecision,
+    val decision: PaperDecision,
     val createdAt: OffsetDateTime,
     val createdBy: UUID,
     val modifiedAt: OffsetDateTime?,
     val modifiedBy: UUID?,
 )
+
+/**
+ * Checks whether this [ProjectPaper] has a final decision.
+ *
+ * A [ProjectPaper] is considered to have a final decision if its decision is set to
+ * [PaperDecision.PAPER_DECISION_ACCEPTED] or [PaperDecision.PAPER_DECISION_DECLINED].
+ */
+fun ProjectPaper.hasFinalDecision() = this.decision == PaperDecision.PAPER_DECISION_ACCEPTED ||
+    this.decision == PaperDecision.PAPER_DECISION_DECLINED
+
+/**
+ * Checks whether this [ProjectPaper] has no final decision yet.
+ *
+ * A [ProjectPaper] is considered to have no final decision if its decision is set to
+ * [PaperDecision.PAPER_DECISION_UNSPECIFIED] or [PaperDecision.PAPER_DECISION_UNREVIEWED] or
+ * [PaperDecision.PAPER_DECISION_IN_REVIEW].
+ */
+fun ProjectPaper.hasNoFinalDecision() = !this.hasFinalDecision()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/ProjectPaperWithPaper.kt
@@ -73,3 +73,10 @@ fun ProjectPaperWithPaper.toProjectPaperFull(
     paper = this.paper,
     reviewsWithSelectedCriteria = reviewsWithSelectedCriteriaIds,
 )
+
+/**
+ * Checks if the [ProjectPaper] within this [ProjectPaperWithPaper] has no final decision.
+ *
+ * @see ProjectPaper.hasNoFinalDecision
+ */
+fun ProjectPaperWithPaper.hasNoFinalDecision() = this.projectPaper.hasNoFinalDecision()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Review.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Review.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.model.dto
 
 import se.uulm.snowballr.backend.table.ReviewTable
 import snowballr.ReviewOuterClass
+import snowballr.ReviewOuterClass.ReviewDecision
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlin.collections.orEmpty
@@ -13,7 +14,7 @@ data class Review(
     val id: UUID,
     val projectPaperId: UUID,
     val userId: UUID,
-    val decision: ReviewOuterClass.ReviewDecision,
+    val decision: ReviewDecision,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
 )
@@ -39,3 +40,17 @@ fun List<Review>.toGrpcReviews(reviewSelectedCriteriaMap: Map<Review, List<Strin
             },
         )
         .build()
+
+/**
+ * Checks whether the review accepts the paper.
+ *
+ * A review is considered to accept the paper if its decision is set to [ReviewDecision.REVIEW_DECISION_ACCEPTED].
+ */
+fun Review.doesAcceptPaper() = this.decision == ReviewDecision.REVIEW_DECISION_ACCEPTED
+
+/**
+ * Checks whether the review declines the paper.
+ *
+ * A review is considered to decline the paper if its decision is set to [ReviewDecision.REVIEW_DECISION_DECLINED].
+ */
+fun Review.doesDeclinePaper() = this.decision == ReviewDecision.REVIEW_DECISION_DECLINED

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/User.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/User.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.model.dto
 
 import se.uulm.snowballr.backend.table.UserTable
 import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserRole
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -13,7 +14,7 @@ data class User(
     val email: String,
     val firstName: String,
     val lastName: String,
-    val role: UserOuterClass.UserRole,
+    val role: UserRole,
     val status: UserOuterClass.UserStatus,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
@@ -41,3 +42,10 @@ fun List<User>.toGrpcUsers(): UserOuterClass.User.List {
     this.forEach { builder.addUsers(it.toGrpcUser()) }
     return builder.build()
 }
+
+/**
+ * Checks whether the user is a server admin.
+ *
+ * A user is considered a server admin if their role is set to [UserRole.USER_ROLE_ADMIN].
+ */
+fun User.isServerAdmin(): Boolean = this.role == UserRole.USER_ROLE_ADMIN

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/User.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/User.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.model.dto
 import se.uulm.snowballr.backend.table.UserTable
 import snowballr.UserOuterClass
 import snowballr.UserOuterClass.UserRole
+import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -15,7 +16,7 @@ data class User(
     val firstName: String,
     val lastName: String,
     val role: UserRole,
-    val status: UserOuterClass.UserStatus,
+    val status: UserStatus,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
     val deletedAt: OffsetDateTime?,
@@ -48,4 +49,20 @@ fun List<User>.toGrpcUsers(): UserOuterClass.User.List {
  *
  * A user is considered a server admin if their role is set to [UserRole.USER_ROLE_ADMIN].
  */
-fun User.isServerAdmin(): Boolean = this.role == UserRole.USER_ROLE_ADMIN
+fun User.isServerAdmin() = this.role == UserRole.USER_ROLE_ADMIN
+
+/**
+ * Checks whether the user is active and confirmed.
+ *
+ * A user is considered active and confirmed if their status is set to [UserStatus.USER_STATUS_ACTIVE].
+ * The status [UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED] does count as active, but not as confirmed.
+ */
+fun User.isActiveAndConfirmed() = this.status == UserStatus.USER_STATUS_ACTIVE
+
+/**
+ * Checks whether the user is active.
+ *
+ * A user is considered active if their status is either [UserStatus.USER_STATUS_ACTIVE] or
+ * [UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED].
+ */
+fun User.isActive() = this.isActiveAndConfirmed() || this.status == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toAuthor
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.toPaper
@@ -35,9 +36,11 @@ interface IPaperTableRepo {
     suspend fun getPaperByExternalId(externalId: String): Result<Paper>
 
     /**
-     * Checks whether the paper with the passed [id] exists.
+     * Ensures that the paper exists with the passed [id].
+     *
+     * Throws a [PaperNotFoundException] if the paper is missing; otherwise does nothing.
      */
-    suspend fun doesPaperExistById(id: UUID): Boolean
+    suspend fun ensurePaperExists(id: UUID)
 
     /**
      * Checks whether a paper with the passed [externalId] exists.
@@ -89,8 +92,10 @@ class PaperTableRepo(
         getEntityByKeyAsResult(::getPaperByExternalIdOrNull, EntityType.PAPER, externalId)
     }
 
-    override suspend fun doesPaperExistById(id: UUID): Boolean = db.query {
-        PaperTable.doesEntityExistById(id)
+    override suspend fun ensurePaperExists(id: UUID) = db.query {
+        if (!PaperTable.doesEntityExistById(id)) {
+            throw PaperNotFoundException(id)
+        }
     }
 
     override suspend fun doesPaperExistByExternalId(externalId: String): Boolean = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.IJwtManager
 import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
+import se.uulm.snowballr.backend.model.dto.isActiveAndConfirmed
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
@@ -92,8 +93,7 @@ class AuthenticationService(
                 throw UnauthenticatedException()
             }
 
-        // Check whether the user is active (verified email)
-        if (user.status != UserStatus.USER_STATUS_ACTIVE) {
+        if (!user.isActiveAndConfirmed()) {
             throw UnauthenticatedException()
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/CriterionService.kt
@@ -13,14 +13,12 @@ import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forTarget
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isCreatorOfCriterion
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import se.uulm.snowballr.backend.service.accessrules.isProjectAdmin
-import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isUserAdminInProjectOfCriterion
 import se.uulm.snowballr.backend.service.accessrules.isUserInProjectOfCriterion
@@ -136,9 +134,7 @@ class CriterionService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-            isAllowedToReadProject(projectMemberRepo)
-                .andAlso(isProjectExistent(projectRepo))
-                .checkFor(currentUser, projectId)
+            isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectId)
 
             repo.getAllProjectCriteria(projectId).toGrpcCriteria()
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -12,10 +12,8 @@ import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
-import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
-import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import snowballr.Export.AvailableExportFormatsResponse
 import snowballr.Export.ExportRequest
 import snowballr.Export.ExportResponse
@@ -64,9 +62,7 @@ class ExportService(
         val format = ProjectExportManager.getSupportedFormats().first { it.toString() == request.format }
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo)
-            .andAlso(isProjectExistent(projectRepo))
-            .checkFor(currentUser, projectId)
+        isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectId)
 
         val project = projectRepo.getProjectById(projectId).getOrThrow()
         val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -17,11 +17,9 @@ import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
-import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import snowballr.Base
 import snowballr.ProjectOuterClass.Project
@@ -183,9 +181,7 @@ class InvitationService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-            isAllowedToReadProject(projectMemberRepo)
-                .andAlso(isProjectExistent(projectRepo))
-                .checkFor(currentUser, projectId)
+            isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectId)
 
             val tokens = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.dto.isActiveAndConfirmed
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
@@ -24,7 +25,6 @@ import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import snowballr.Base
 import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.User
-import snowballr.UserOuterClass.UserStatus
 import java.time.OffsetDateTime
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.UserOuterClass.User as GrpcUser
@@ -157,12 +157,10 @@ class InvitationService(
         val user = try {
             userRepo.getUserByEmail(invitationToken.email).getOrThrow()
         } catch (_: NotFoundException) {
-            throw FailedPreconditionException(
-                "The user with the email ${invitationToken.email} is not registered.",
-            )
+            throw FailedPreconditionException("The user with the email ${invitationToken.email} is not registered.")
         }
 
-        if (user.status != UserStatus.USER_STATUS_ACTIVE) {
+        if (!user.isActiveAndConfirmed()) {
             throw FailedPreconditionException(
                 "The user with the email ${invitationToken.email} has not verified their email address.",
             )

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -57,6 +57,7 @@ class PaperService(
 ) : IPaperService {
     override suspend fun getPaperById(request: Base.Id): GrpcPaper {
         val paperId = parseUUID(request.id, EntityType.PAPER)
+
         val paper = repo.getPaperById(paperId).getOrThrow()
 
         return paper.toGrpcPaper()
@@ -71,9 +72,7 @@ class PaperService(
     override suspend fun updatePaper(request: GrpcPaper.Update): GrpcPaper {
         val paperId = parseUUID(request.paper.id, EntityType.PAPER)
 
-        if (!repo.doesPaperExistById(paperId)) {
-            throw PaperNotFoundException(paperId)
-        }
+        throwIfPaperNotExists(paperId)
 
         if (request.paper.externalId.isNotEmpty()) {
             val existingPaper = repo.getPaperByExternalId(request.paper.externalId).getOrNull()
@@ -105,9 +104,8 @@ class PaperService(
      */
     private suspend fun getReferencePapers(request: Base.Id, function: suspend (UUID) -> List<UUID>): GrpcPaper.List {
         val paperId = parseUUID(request.id, EntityType.PAPER)
-        if (!repo.doesPaperExistById(paperId)) {
-            throw PaperNotFoundException(paperId)
-        }
+
+        throwIfPaperNotExists(paperId)
 
         val referenceIds = function.invoke(paperId)
         val papers = referenceIds.map {
@@ -118,4 +116,10 @@ class PaperService(
     }
 
     private suspend fun Paper.toGrpcPaper(): GrpcPaper = this.toGrpcPaperWithAuthorsAndBackwardReferences(citationRepo)
+
+    private suspend fun throwIfPaperNotExists(paperId: UUID) {
+        if (!repo.doesPaperExistById(paperId)) {
+            throw PaperNotFoundException(paperId)
+        }
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -6,7 +6,6 @@ import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toGrpcPapers
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
@@ -72,7 +71,7 @@ class PaperService(
     override suspend fun updatePaper(request: GrpcPaper.Update): GrpcPaper {
         val paperId = parseUUID(request.paper.id, EntityType.PAPER)
 
-        throwIfPaperNotExists(paperId)
+        repo.ensurePaperExists(paperId)
 
         if (request.paper.externalId.isNotEmpty()) {
             val existingPaper = repo.getPaperByExternalId(request.paper.externalId).getOrNull()
@@ -105,7 +104,7 @@ class PaperService(
     private suspend fun getReferencePapers(request: Base.Id, function: suspend (UUID) -> List<UUID>): GrpcPaper.List {
         val paperId = parseUUID(request.id, EntityType.PAPER)
 
-        throwIfPaperNotExists(paperId)
+        repo.ensurePaperExists(paperId)
 
         val referenceIds = function.invoke(paperId)
         val papers = referenceIds.map {
@@ -116,10 +115,4 @@ class PaperService(
     }
 
     private suspend fun Paper.toGrpcPaper(): GrpcPaper = this.toGrpcPaperWithAuthorsAndBackwardReferences(citationRepo)
-
-    private suspend fun throwIfPaperNotExists(paperId: UUID) {
-        if (!repo.doesPaperExistById(paperId)) {
-            throw PaperNotFoundException(paperId)
-        }
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -73,9 +73,7 @@ class ProjectMemberService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-            isAllowedToReadProject(repo)
-                .andAlso(isProjectExistent(projectRepo))
-                .checkFor(currentUser, projectId)
+            isAllowedToReadProject(projectRepo, repo).checkFor(currentUser, projectId)
 
             val projectMembersWithUsers = repo.getProjectMembersWithUsers(projectId)
             projectMembersWithUsers.toGrpcProjectMembers()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.InvitationToken
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.isProjectAdmin
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
@@ -98,7 +99,7 @@ class ProjectMemberService(
                 )
             }
 
-            if (currentMember.role == MemberRole.MEMBER_ROLE_ADMIN && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
+            if (currentMember.isProjectAdmin() && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
                 isNotLastProjectAdmin(repo, "Cannot demote the user")
                     .checkFor(user, projectId)
             }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -26,11 +26,9 @@ import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
-import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
-import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
@@ -151,9 +149,7 @@ class ProjectPaperService(
     ): GrpcProjectPaper.List = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo)
-            .andAlso(isProjectExistent(projectRepo))
-            .checkFor(currentUser, projectId)
+        isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectId)
 
         var projectPapersWithPapers = repo.getAllProjectPapersWithPapers(projectId)
         val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
@@ -195,7 +191,7 @@ class ProjectPaperService(
             val projectPaperId = parseUUID(id, EntityType.PROJECT_PAPER)
             val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-            isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+            isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
 
             val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
             val adjacentPaper = repo.getAdjacentPaper(projectId, projectPaper.localPaperId, direction).getOrThrow()
@@ -231,7 +227,7 @@ class ProjectPaperService(
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+        isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
 
         projectPaper.toGrpcProjectPaperWithData()
     }
@@ -241,9 +237,7 @@ class ProjectPaperService(
     ) { currentUser ->
         val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo)
-            .andAlso(isProjectExistent(projectRepo))
-            .checkFor(currentUser, projectId)
+        isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectId)
 
         val relativeId = request.relativeProjectPaperId.toLong()
         val projectPaper = repo.getProjectPaperByRelativeId(projectId, relativeId).getOrThrow()
@@ -303,7 +297,7 @@ class ProjectPaperService(
         val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
         val projectId = projectPaper.projectId
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
+        isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectId)
 
         val projectPapers = repo.getSubsequentProjectPapers(projectId, projectPaper.localPaperId, projectPaper.stage)
         val projectPapersWithReviewsCount = getProjectPapersWithReviewsCount(projectPapers, currentUser.id)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -8,6 +8,7 @@ import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithReviewsCount
+import se.uulm.snowballr.backend.model.dto.hasNoFinalDecision
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPaper
 import se.uulm.snowballr.backend.model.dto.toGrpcProjectPapers
 import se.uulm.snowballr.backend.model.dto.toGrpcReview
@@ -31,7 +32,6 @@ import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
 import se.uulm.snowballr.backend.service.accessrules.isProjectActive
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
 import snowballr.Base
-import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.Project
 import java.util.UUID
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
@@ -211,18 +211,6 @@ class ProjectPaperService(
     private fun sortPapersByStageAndReviewsCount(projectPapersWithReviewsCount: List<ProjectPaperWithReviewsCount>) =
         projectPapersWithReviewsCount.sorted().map { it.projectPaper }
 
-    /**
-     * Determines whether the given project paper lacks a final decision.
-     * A project paper is considered to have no final decision if its decision state
-     * is either `PAPER_DECISION_UNSPECIFIED` or `PAPER_DECISION_UNREVIEWED`.
-     *
-     * @param projectPaper The [ProjectPaper] object whose decision state is to be evaluated.
-     * @return `true` if the project paper has no final decision; otherwise, `false`.
-     */
-    private fun hasNoFinalDecision(projectPaper: ProjectPaper): Boolean =
-        projectPaper.decision == PaperDecision.PAPER_DECISION_UNSPECIFIED ||
-            projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
-
     override suspend fun getProjectPaperById(request: Base.Id): GrpcProjectPaper = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
         val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
@@ -253,11 +241,8 @@ class ProjectPaperService(
             { projectPaper, projectPaperReviewsMap, currentUserId ->
                 val isAlreadyReviewedByCurrentUser = projectPaperReviewsMap[projectPaper.projectPaper]
                     ?.any { review -> review.userId == currentUserId } == true
-                val isStillUndecided =
-                    projectPaper.projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED ||
-                        projectPaper.projectPaper.decision == PaperDecision.PAPER_DECISION_IN_REVIEW
 
-                !isAlreadyReviewedByCurrentUser && isStillUndecided
+                !isAlreadyReviewedByCurrentUser && projectPaper.hasNoFinalDecision()
             }
         return getProjectPapers(request, predicate)
     }
@@ -309,7 +294,7 @@ class ProjectPaperService(
         }
 
         val sortedPapers = sortPapersByStageAndReviewsCount(projectPapersWithReviewsCount)
-        val papersWithoutFinalDecision = sortedPapers.filter(::hasNoFinalDecision)
+        val papersWithoutFinalDecision = sortedPapers.filter(ProjectPaper::hasNoFinalDecision)
 
         (papersWithoutFinalDecision.firstOrNull() ?: sortedPapers.first()).toGrpcProjectPaperWithData()
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -20,11 +20,9 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
-import se.uulm.snowballr.backend.service.accessrules.andAlso
 import se.uulm.snowballr.backend.service.accessrules.checkFor
 import se.uulm.snowballr.backend.service.accessrules.forProperty
 import se.uulm.snowballr.backend.service.accessrules.isAllowedToReadProject
-import se.uulm.snowballr.backend.service.accessrules.isProjectExistent
 import se.uulm.snowballr.backend.service.accessrules.isServerAdmin
 import se.uulm.snowballr.backend.service.accessrules.isServerAdminOrSameUser
 import se.uulm.snowballr.backend.service.accessrules.isServerOrProjectAdmin
@@ -117,7 +115,7 @@ class ProjectService(
     override suspend fun getProjectById(request: Base.Id): GrpcProject = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
+        isAllowedToReadProject(repo, projectMemberRepo).checkFor(currentUser, projectId)
 
         repo.getProjectById(projectId).getOrThrow().toGrpcProject()
     }
@@ -194,9 +192,7 @@ class ProjectService(
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-            isAllowedToReadProject(projectMemberRepo)
-                .andAlso(isProjectExistent(repo))
-                .checkFor(currentUser, projectId)
+            isAllowedToReadProject(repo, projectMemberRepo).checkFor(currentUser, projectId)
 
             val project = repo.getProjectById(projectId).getOrThrow()
             val progress = projectPaperRepo.getProjectProgress(projectId)
@@ -228,7 +224,7 @@ class ProjectService(
     ): GrpcProjectDecisionStatistics = withUser(userRepo) { currentUser ->
         val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectId)
+        isAllowedToReadProject(repo, projectMemberRepo).checkFor(currentUser, projectId)
 
         val project = repo.getProjectById(projectId).getOrThrow()
         val maxStage = project.maxStage

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.toGrpcPapers
-import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -12,7 +11,6 @@ import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import snowballr.Base
 import snowballr.boolValue
 import snowballr.nothing
-import java.util.UUID
 import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface IReadingListService {
@@ -67,7 +65,7 @@ class ReadingListService(
     override suspend fun isPaperOnReadingList(request: Base.Id): Base.BoolValue = withUser(userRepo) { currentUser ->
         val paperId = parseUUID(request.id, EntityType.PAPER)
 
-        throwIfPaperNotExists(paperId)
+        paperRepo.ensurePaperExists(paperId)
 
         boolValue { value = repo.isPaperOnReadingList(currentUser.id, paperId) }
     }
@@ -75,7 +73,7 @@ class ReadingListService(
     override suspend fun addPaperToReadingList(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
         val paperId = parseUUID(request.id, EntityType.PAPER)
 
-        throwIfPaperNotExists(paperId)
+        paperRepo.ensurePaperExists(paperId)
 
         repo.createReadingListEntry(currentUser.id, paperId)
 
@@ -86,16 +84,10 @@ class ReadingListService(
         withUser(userRepo) { currentUser ->
             val paperId = parseUUID(request.id, EntityType.PAPER)
 
-            throwIfPaperNotExists(paperId)
+            paperRepo.ensurePaperExists(paperId)
 
             repo.removeReadingListEntry(currentUser.id, paperId)
 
             nothing { }
         }
-
-    private suspend fun throwIfPaperNotExists(id: UUID) {
-        if (!paperRepo.doesPaperExistById(id)) {
-            throw PaperNotFoundException(id)
-        }
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.toGrpcPapers
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
@@ -57,17 +56,6 @@ class ReadingListService(
     private val citationRepo: ICitationTableRepo,
     private val repo: IReadingListTableRepo,
 ) : IReadingListService {
-    /**
-     * Checks whether the paper with the given [id] exists.
-     *
-     * @throws [NotFoundException] If the paper doesn't exist.
-     */
-    private suspend fun ensurePaperExists(id: UUID) {
-        if (!paperRepo.doesPaperExistById(id)) {
-            throw PaperNotFoundException(id)
-        }
-    }
-
     override suspend fun getReadingList(): GrpcPaper.List = withUser(userRepo) { currentUser ->
         val papers = repo.getAllReadingListEntries(currentUser.id).map { paper ->
             paper.toGrpcPaperWithAuthorsAndBackwardReferences(citationRepo)
@@ -78,14 +66,16 @@ class ReadingListService(
 
     override suspend fun isPaperOnReadingList(request: Base.Id): Base.BoolValue = withUser(userRepo) { currentUser ->
         val paperId = parseUUID(request.id, EntityType.PAPER)
-        ensurePaperExists(paperId)
+
+        throwIfPaperNotExists(paperId)
 
         boolValue { value = repo.isPaperOnReadingList(currentUser.id, paperId) }
     }
 
     override suspend fun addPaperToReadingList(request: Base.Id): Base.Nothing = withUser(userRepo) { currentUser ->
         val paperId = parseUUID(request.id, EntityType.PAPER)
-        ensurePaperExists(paperId)
+
+        throwIfPaperNotExists(paperId)
 
         repo.createReadingListEntry(currentUser.id, paperId)
 
@@ -95,10 +85,17 @@ class ReadingListService(
     override suspend fun removePaperFromReadingList(request: Base.Id): Base.Nothing =
         withUser(userRepo) { currentUser ->
             val paperId = parseUUID(request.id, EntityType.PAPER)
-            ensurePaperExists(paperId)
+
+            throwIfPaperNotExists(paperId)
 
             repo.removeReadingListEntry(currentUser.id, paperId)
 
             nothing { }
         }
+
+    private suspend fun throwIfPaperNotExists(id: UUID) {
+        if (!paperRepo.doesPaperExistById(id)) {
+            throw PaperNotFoundException(id)
+        }
+    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -3,6 +3,9 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Review
+import se.uulm.snowballr.backend.model.dto.doesAcceptPaper
+import se.uulm.snowballr.backend.model.dto.doesDeclinePaper
+import se.uulm.snowballr.backend.model.dto.hasFinalDecision
 import se.uulm.snowballr.backend.model.dto.toGrpcReview
 import se.uulm.snowballr.backend.model.dto.toGrpcReviews
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
@@ -145,7 +148,7 @@ class ReviewService(
         }
 
         val decidingReview = reviews.last()
-        return if (decidingReview.decision == ReviewDecision.REVIEW_DECISION_ACCEPTED) {
+        return if (decidingReview.doesAcceptPaper()) {
             PaperDecision.PAPER_DECISION_ACCEPTED
         } else {
             PaperDecision.PAPER_DECISION_DECLINED
@@ -167,9 +170,7 @@ class ReviewService(
             throw DuplicateReviewException(projectPaperId, currentUser.id)
         }
 
-        val isPaperNotFinallyDecided = projectPaper.decision == PaperDecision.PAPER_DECISION_IN_REVIEW ||
-            projectPaper.decision == PaperDecision.PAPER_DECISION_UNREVIEWED
-        if (!isPaperNotFinallyDecided) {
+        if (projectPaper.hasFinalDecision()) {
             throw FailedPreconditionException(
                 "The project paper must be either unreviewed or still in review. " +
                     "Finally decided project papers cannot be reviewed anymore.",
@@ -183,7 +184,7 @@ class ReviewService(
             .filter { criterion -> criterion.category == CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION }
             .map { criterion -> criterion.id }
         val isAnySelectedCriteriaHardExclusion = selectedCriteriaIds.any { id -> hardExclusionCriteria.contains(id) }
-        if (isAnySelectedCriteriaHardExclusion && review.decision == ReviewDecision.REVIEW_DECISION_DECLINED) {
+        if (isAnySelectedCriteriaHardExclusion && review.doesDeclinePaper()) {
             projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
         } else {
             val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -88,7 +88,7 @@ class ReviewService(
             val projectPaperId = parseUUID(request.id, EntityType.PROJECT_PAPER)
             val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
 
-            isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+            isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
 
             val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
             val reviewSelectedCriteriaMap = mutableMapOf<Review, List<String>>()
@@ -156,7 +156,7 @@ class ReviewService(
         val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
 
-        isAllowedToReadProject(projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
+        isAllowedToReadProject(projectRepo, projectMemberRepo).checkFor(currentUser, projectPaper.projectId)
 
         val project = projectRepo.getProjectById(projectPaper.projectId).getOrThrow()
         isProjectActive().checkFor(currentUser, project)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -121,11 +121,9 @@ class UserService(
 
         isAllowedToReadUser(projectMemberRepo).checkFor(currentUser, targetUserId)
 
-        val isRequestedUser = currentUser.id == targetUserId
-
         // Don't re-request the user if it is the current user itself
         val targetUser =
-            if (isRequestedUser) {
+            if (currentUser.id == targetUserId) {
                 currentUser
             } else {
                 userRepo.getUserById(targetUserId).getOrThrow()
@@ -181,13 +179,7 @@ class UserService(
 
         // Send verification email
         val verificationLink = emailManager.createVerificationLink(verificationToken)
-        emailManager.sendVerificationEmail(
-            user.email,
-            EmailData.EmailVerification(
-                user.firstName,
-                verificationLink,
-            ),
-        )
+        emailManager.sendVerificationEmail(user.email, EmailData.EmailVerification(user.firstName, verificationLink))
 
         return Base.Nothing.getDefaultInstance()
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/GeneralAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/GeneralAccessRule.kt
@@ -2,11 +2,11 @@
 
 package se.uulm.snowballr.backend.service.accessrules
 
-import snowballr.UserOuterClass.UserRole
+import se.uulm.snowballr.backend.model.dto.isServerAdmin
 import javax.annotation.CheckReturnValue
 
 /**
  * Check whether the requesting user is a server admin.
  */
 @CheckReturnValue
-fun isServerAdmin() = AccessRule<Unit> { requester, _ -> requester.role == UserRole.USER_ROLE_ADMIN }
+fun isServerAdmin() = AccessRule<Unit> { requester, _ -> requester.isServerAdmin() }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -86,14 +86,24 @@ fun isNotLastProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, action: St
 }
 
 /**
- * Check whether the current user is a member of the specified project. If the user is not a project member,
- * the user has to be a server admin; otherwise, throws an [UnauthorizedException].
+ * Check whether the current user is allowed to read the specified project.
  *
+ * The user can read the project if the following conditions are met:
+ * 1. The project exists; otherwise a [ProjectNotFoundException] is thrown.
+ * 2. The user is a member of the project or a server admin.
+ *
+ * If neither condition is met, an [UnauthorizedReadException] is thrown.
+ *
+ * @param projectRepo The repository used to access project data.
  * @param projectMemberRepo The repository used to access project membership data.
  */
 @CheckReturnValue
-fun isAllowedToReadProject(projectMemberRepo: IProjectMemberTableRepo): AccessRule<UUID> {
-    return isProjectMember(projectMemberRepo)
+fun isAllowedToReadProject(
+    projectRepo: IProjectTableRepo,
+    projectMemberRepo: IProjectMemberTableRepo,
+): AccessRule<UUID> {
+    return isProjectExistent(projectRepo)
+        .andAlso(isProjectMember(projectMemberRepo))
         .orElse(isServerAdmin().forTarget())
         .orElseThrow { currentUser, targetId ->
             UnauthorizedReadException(currentUser.id, targetId, EntityType.PROJECT)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -6,8 +6,9 @@ import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.isActive
+import se.uulm.snowballr.backend.model.dto.isDeleted
+import se.uulm.snowballr.backend.model.dto.isServerAdmin
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.failedprecondition.EntityNotActiveException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
@@ -19,13 +20,17 @@ import java.util.UUID
 import javax.annotation.CheckReturnValue
 
 /**
- * Check whether a project with the given ID exists; otherwise, throws a [NotFoundException].
+ * Check whether a project with the given ID exists; otherwise, throws a [ProjectNotFoundException].
+ *
+ * A project is considered existent if it exists in the database and is not deleted, unless the requesting user is a
+ * server admin.
  *
  * @param projectRepo The repository used to verify project existence.
  */
 @CheckReturnValue
-fun isProjectExistent(projectRepo: IProjectTableRepo) = AccessRule<UUID> { _, projectId ->
-    projectRepo.doesProjectExistById(projectId)
+fun isProjectExistent(projectRepo: IProjectTableRepo) = AccessRule<UUID> { user, projectId ->
+    val project = projectRepo.getProjectById(projectId).getOrNull()
+    project != null && (!project.isDeleted() || user.isServerAdmin())
 }.orElseThrow { _, projectId -> ProjectNotFoundException(projectId) }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -5,6 +5,7 @@ package se.uulm.snowballr.backend.service.accessrules
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.isActive
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
@@ -14,7 +15,6 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedExcept
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
 import javax.annotation.CheckReturnValue
 
@@ -38,10 +38,8 @@ fun isProjectExistent(projectRepo: IProjectTableRepo): AccessRule<UUID> {
  */
 @CheckReturnValue
 fun isProjectActive(): AccessRule<Project> {
-    return AccessRule<Project> { _, project ->
-        project.status == ProjectStatus.PROJECT_STATUS_ACTIVE ||
-            project.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
-    }.orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id) }
+    return AccessRule<Project> { _, project -> project.isActive() }
+        .orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id) }
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ProjectAccessRule.kt
@@ -24,23 +24,17 @@ import javax.annotation.CheckReturnValue
  * @param projectRepo The repository used to verify project existence.
  */
 @CheckReturnValue
-fun isProjectExistent(projectRepo: IProjectTableRepo): AccessRule<UUID> {
-    return AccessRule<UUID> { _, projectId ->
-        projectRepo.doesProjectExistById(projectId)
-    }.orElseThrow { _, projectId ->
-        ProjectNotFoundException(projectId)
-    }
-}
+fun isProjectExistent(projectRepo: IProjectTableRepo) = AccessRule<UUID> { _, projectId ->
+    projectRepo.doesProjectExistById(projectId)
+}.orElseThrow { _, projectId -> ProjectNotFoundException(projectId) }
 
 /**
- * Check whether the project is active (or active, but settings are locked);
- * otherwise, throws an [EntityNotActiveException].
+ * Check whether the project is active (or active, but settings are locked); otherwise, throws an
+ * [EntityNotActiveException].
  */
 @CheckReturnValue
-fun isProjectActive(): AccessRule<Project> {
-    return AccessRule<Project> { _, project -> project.isActive() }
-        .orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id) }
-}
+fun isProjectActive() = AccessRule<Project> { _, project -> project.isActive() }
+    .orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id) }
 
 /**
  * Check whether the requesting user is a member of a specific project.
@@ -65,14 +59,15 @@ fun isProjectAdmin(projectMemberRepo: IProjectMemberTableRepo) = AccessRule<UUID
 }
 
 /**
- * Check whether the user is not the last project admin of a specific project; otherwise, throws a [FailedPreconditionException].
+ * Check whether the user is not the last project admin of a specific project; otherwise, throws a
+ * [FailedPreconditionException].
  *
  * @param projectMemberRepo The project member repository used to retrieve a project admins list.
  * @param action The action that is being performed and wherefore the user must not be the last project admin.
  */
 @CheckReturnValue
-fun isNotLastProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, action: String): AccessRule<UUID> {
-    return AccessRule<UUID> { user, targetId ->
+fun isNotLastProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, action: String) =
+    AccessRule<UUID> { user, targetId ->
         val projectAdmins = projectMemberRepo.getAllProjectAdmins(targetId)
         !(projectAdmins.size == 1 && projectAdmins.first().userId == user.id)
     }.orElseThrow { user, projectId ->
@@ -81,7 +76,6 @@ fun isNotLastProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, action: St
                 "is the last admin of the project with the ID '$projectId'.",
         )
     }
-}
 
 /**
  * Check whether the current user is allowed to read the specified project.
@@ -96,30 +90,25 @@ fun isNotLastProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, action: St
  * @param projectMemberRepo The repository used to access project membership data.
  */
 @CheckReturnValue
-fun isAllowedToReadProject(
-    projectRepo: IProjectTableRepo,
-    projectMemberRepo: IProjectMemberTableRepo,
-): AccessRule<UUID> {
-    return isProjectExistent(projectRepo)
+fun isAllowedToReadProject(projectRepo: IProjectTableRepo, projectMemberRepo: IProjectMemberTableRepo) =
+    isProjectExistent(projectRepo)
         .andAlso(isProjectMember(projectMemberRepo))
         .orElse(isServerAdmin().forTarget())
         .orElseThrow { currentUser, targetId ->
             UnauthorizedReadException(currentUser.id, targetId, EntityType.PROJECT)
         }
-}
 
 /**
- * Check whether the current user is an admin of the specified project. If the user is not a project admin,
- * the user has to be a server admin; otherwise, throws an [UnauthorizedException].
+ * Check whether the current user is an admin of the specified project. If the user is not a project admin, the user has
+ * to be a server admin; otherwise, throws an [UnauthorizedException].
  *
  * @param projectMemberRepo The repository used to access project membership data.
  * @param accessType The type of access that is being checked.
  */
 @CheckReturnValue
-fun isServerOrProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, accessType: AccessType): AccessRule<UUID> {
-    return isProjectAdmin(projectMemberRepo)
+fun isServerOrProjectAdmin(projectMemberRepo: IProjectMemberTableRepo, accessType: AccessType) =
+    isProjectAdmin(projectMemberRepo)
         .orElse(isServerAdmin().forTarget())
         .orElseThrow { currentUser, targetId ->
             UnauthorizedExceptionFactory.createForAccessType(accessType, currentUser.id, targetId, EntityType.PROJECT)
         }
-}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ReviewAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/ReviewAccessRule.kt
@@ -37,13 +37,7 @@ private fun isUserInProjectOfReview(
  * @param projectPaperRepo The repository used to access project-papers.
  */
 @CheckReturnValue
-fun isAllowedToReadReview(
-    projectMemberRepo: IProjectMemberTableRepo,
-    projectPaperRepo: IProjectPaperTableRepo,
-): AccessRule<Review> {
-    return isUserInProjectOfReview(projectMemberRepo, projectPaperRepo)
+fun isAllowedToReadReview(projectMemberRepo: IProjectMemberTableRepo, projectPaperRepo: IProjectPaperTableRepo) =
+    isUserInProjectOfReview(projectMemberRepo, projectPaperRepo)
         .orElse(isServerAdmin().forTarget())
-        .orElseThrow { currentUser, target ->
-            UnauthorizedReadException(currentUser.id, target.id, EntityType.REVIEW)
-        }
-}
+        .orElseThrow { currentUser, target -> UnauthorizedReadException(currentUser.id, target.id, EntityType.REVIEW) }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/UserAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/UserAccessRule.kt
@@ -5,6 +5,7 @@ package se.uulm.snowballr.backend.service.accessrules
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.isActive
 import se.uulm.snowballr.backend.model.dto.isServerAdmin
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
@@ -19,12 +20,11 @@ import javax.annotation.CheckReturnValue
 fun isSameUserById() = AccessRule<UUID> { requester, targetId -> requester.id == targetId }
 
 /**
- * Check whether the target user is active, i.e., has the status `USER_STATUS_ACTIVE` or `USER_STATUS_ACTIVE_UNCONFIRMED`.
+ * Check whether the target user is active, i.e., their status is set to [UserStatus.USER_STATUS_ACTIVE] or
+ * [UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED].
  */
 @CheckReturnValue
-fun isTargetUserActive() = AccessRule<User> { _, target ->
-    target.status == UserStatus.USER_STATUS_ACTIVE || target.status == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
-}
+fun isTargetUserActive() = AccessRule<User> { _, target -> target.isActive() }
 
 /**
  * Check whether the target user is *not* a server admin.

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/UserAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/UserAccessRule.kt
@@ -5,9 +5,9 @@ package se.uulm.snowballr.backend.service.accessrules
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.isServerAdmin
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 import javax.annotation.CheckReturnValue
@@ -31,7 +31,7 @@ fun isTargetUserActive() = AccessRule<User> { _, target ->
  * Check whether the target user is *not* a server admin.
  */
 @CheckReturnValue
-fun targetUserIsNotAdmin() = AccessRule<User> { _, target -> target.role != UserRole.USER_ROLE_ADMIN }
+fun targetUserIsNotAdmin() = AccessRule<User> { _, target -> !target.isServerAdmin() }
 
 /**
  * Check whether the requesting user is a server admin or the same user as the target user.

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/UserAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/accessrules/UserAccessRule.kt
@@ -13,8 +13,7 @@ import java.util.UUID
 import javax.annotation.CheckReturnValue
 
 /**
- * Check whether the requesting user and the target user are the same by checking
- * whether they have the same user id.
+ * Check whether the requesting user and the target user are the same by checking whether they have the same user id.
  */
 @CheckReturnValue
 fun isSameUserById() = AccessRule<UUID> { requester, targetId -> requester.id == targetId }
@@ -46,26 +45,23 @@ fun isServerAdminOrSameUser() = isServerAdmin().forTarget<UUID>().orElse(isSameU
  */
 @CheckReturnValue
 private fun isInSameProject(projectMemberRepo: IProjectMemberTableRepo) = AccessRule<UUID> { requester, targetId ->
-    projectMemberRepo
-        .getMembersInSameProjectsAsUser(targetId)
-        .any { it.userId == requester.id }
+    projectMemberRepo.getMembersInSameProjectsAsUser(targetId).any { it.userId == requester.id }
 }
 
 /**
  * Check whether the current user is allowed to read the target user based on specific access control rules.
  *
  * @param projectMemberRepo The repository to check project membership.
- * @param identifierType The identifier type used to identify the target user (used for constructing the correct exception message, defaults to [IdentifierType.ID]).
+ * @param identifierType The identifier type used to identify the target user (used for constructing the correct
+ * exception message, defaults to [IdentifierType.ID]).
  * @return An [AccessRule] that checks whether the current user has read permissions for a target user.
  */
 @CheckReturnValue
 fun isAllowedToReadUser(
     projectMemberRepo: IProjectMemberTableRepo,
     identifierType: IdentifierType = IdentifierType.ID,
-): AccessRule<UUID> {
-    return isServerAdminOrSameUser()
-        .orElse(isInSameProject(projectMemberRepo))
-        .orElseThrow { currentUser, targetUserId ->
-            UnauthorizedReadException(currentUser.id, targetUserId, EntityType.USER, identifierType)
-        }
-}
+) = isServerAdminOrSameUser()
+    .orElse(isInSameProject(projectMemberRepo))
+    .orElseThrow { currentUser, targetUserId ->
+        UnauthorizedReadException(currentUser.id, targetUserId, EntityType.USER, identifierType)
+    }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.assertThrows
@@ -17,6 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.isBetweenWithDelta
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
@@ -102,22 +104,19 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
     }
 
     @Nested
-    inner class DoesPaperExistById {
+    inner class EnsurePaperExists {
         @Test
-        fun `When a paper with the given id exists, then true returned`() = runTest {
-            val paperId =
-                insertPaperAndGetId("Test Paper")
-            val isPaperExistent = repo.doesPaperExistById(paperId)
+        fun `When a paper with the given id exists, then no exception is thrown`() = runTest {
+            val paperId = insertPaperAndGetId("Test Paper")
 
-            assertTrue(isPaperExistent)
+            assertDoesNotThrow { repo.ensurePaperExists(paperId) }
         }
 
         @Test
-        fun `When a paper with the given id does not exist, then false returned`() = runTest {
+        fun `When a paper with the given id does not exist, then a PaperNotFoundException is thrown`() = runTest {
             val paperId = UUID.randomUUID()
-            val isPaperExistent = repo.doesPaperExistById(paperId)
 
-            assertFalse(isPaperExistent)
+            assertThrows<PaperNotFoundException> { repo.ensurePaperExists(paperId) }
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass.UserRole
@@ -22,16 +23,16 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the project doesn't exist, then a NotFoundException is thrown`() = runTest {
+    fun `When the project doesn't exist, then a ProjectNotFoundException is thrown`() = runTest {
         val request = getExampleRequest()
 
         val project = DataBuilder.createExampleProject(id = projectId)
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<NotFoundException> { mainService.getAllCriteriaForProject(request) }
+        assertThrows<ProjectNotFoundException> { mainService.getAllCriteriaForProject(request) }
     }
 
     @Test
@@ -47,7 +48,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
 
         mockCurrentUser(adminUser)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
         assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
@@ -59,16 +60,13 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val request = getExampleRequest()
 
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleProjectCriterion(
-                projectId = projectId,
-                createdBy = user.id,
-            )
+            val criterion = DataBuilder.createExampleProjectCriterion(projectId = projectId, createdBy = user.id)
             val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(user)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
             assertDoesNotThrow { mainService.getAllCriteriaForProject(request) }
@@ -83,7 +81,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(user)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -29,8 +29,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
 
         assertThrows<NotFoundException> { mainService.getAllCriteriaForProject(request) }
     }
@@ -84,6 +83,7 @@ class GetAllCriteriaForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(user)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -59,6 +59,7 @@ class ExportProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
 
         assertThrows<UnauthorizedReadException> {
@@ -102,7 +103,6 @@ class ExportProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
 
         assertThrows<NotFoundException> { mainService.exportProject(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -7,8 +7,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.export.ProjectExportManager
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
@@ -35,7 +36,6 @@ class ExportProjectTest : MainServiceTest() {
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
         coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
         coEvery { projectRepoMock.getProjectById(projectId) } returns Result.success(DataBuilder.createExampleProject())
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns emptyList()
         coEvery {
@@ -53,14 +53,14 @@ class ExportProjectTest : MainServiceTest() {
     @Test
     fun `When the non-project-member exports a project, then an UnauthorizedReadException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val projectId = UUID.randomUUID()
-        val request = getExampleRequest().copy { id = projectId.toString() }
+        val project = DataBuilder.createExampleProject()
+        val request = getExampleRequest().copy { id = project.id.toString() }
 
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedReadException> {
             mainService.exportProject(request)
@@ -77,7 +77,6 @@ class ExportProjectTest : MainServiceTest() {
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
         coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
         coEvery {
             projectRepoMock.getProjectById(projectId)
         } returns Result.success(DataBuilder.createExampleProject(id = projectId))
@@ -95,7 +94,7 @@ class ExportProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the exported project doesn't exist, then a NotFoundException is thrown`() = runTest {
+    fun `When the exported project doesn't exist, then a ProjectNotFoundException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val projectId = UUID.randomUUID()
         val request = getExampleRequest().copy { id = projectId.toString() }
@@ -103,8 +102,8 @@ class ExportProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
 
-        assertThrows<NotFoundException> { mainService.exportProject(request) }
+        assertThrows<ProjectNotFoundException> { mainService.exportProject(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
@@ -41,8 +41,8 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
             val projectMember = DataBuilder.createExampleProjectMember(userId = currentUser.id, projectId = projectId)
 
             mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
             coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
             coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns emptyList()
 
             assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
@@ -103,6 +103,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
 
             mockCurrentUser(currentUser)
+            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getPendingInvitationsForProject(createRequest()) }
@@ -115,13 +116,10 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
             val nonExistentProjectId = UUID.randomUUID()
 
             mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.getProjectMembers(nonExistentProjectId) } returns emptyList()
             coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
 
             assertThrows<NotFoundException> {
-                mainService.getPendingInvitationsForProject(
-                    createRequest(nonExistentProjectId),
-                )
+                mainService.getPendingInvitationsForProject(createRequest(nonExistentProjectId))
             }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
@@ -8,8 +8,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
@@ -18,67 +19,69 @@ import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 class GetPendingInvitationsForProjectTest : MainServiceTest() {
-    private val projectId = UUID.randomUUID()
-
-    private fun createRequest(id: UUID = projectId) = Base.Id.newBuilder().setId(id.toString()).build()
+    private fun createRequest(id: UUID) = Base.Id.newBuilder().setId(id.toString()).build()
 
     @Test
     fun `When a server admin requests the pending invitations for a project, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-        coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns emptyList()
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
+        assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest(project.id)) }
     }
 
     @Test
     fun `When a project member requests the pending invitations for a project, then no exception is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val projectMember = DataBuilder.createExampleProjectMember(userId = currentUser.id, projectId = projectId)
+            val project = DataBuilder.createExampleProject()
+            val projectMember = DataBuilder.createExampleProjectMember(userId = currentUser.id, projectId = project.id)
 
             mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(projectMember)
-            coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+            coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id) } returns emptyList()
 
-            assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
+            assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest(project.id)) }
         }
 
     @Test
     fun `When a non registered user is invited, then they appear as well in the list of pending invitations but without complete user details`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val project = DataBuilder.createExampleProject()
             val registeredUser = DataBuilder.createExampleUser(
                 email = "registered@example.com",
                 status = UserStatus.USER_STATUS_ACTIVE,
             )
             val invitationTokenForRegisteredUser = DataBuilder.createExampleInvitationToken(
-                projectId = projectId,
+                projectId = project.id,
                 email = registeredUser.email,
             )
             val notRegisteredEmail = "unregistered@example.com"
             val invitationTokenForNotRegisteredUser = DataBuilder.createExampleInvitationToken(
-                projectId = projectId,
+                projectId = project.id,
                 email = notRegisteredEmail,
             )
 
             mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
-            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-            coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(projectId) } returns listOf(
-                invitationTokenForRegisteredUser,
-                invitationTokenForNotRegisteredUser,
-            )
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery {
+                invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id)
+            } returns listOf(invitationTokenForRegisteredUser, invitationTokenForNotRegisteredUser)
             coEvery { userRepoMock.getUserByEmail(registeredUser.email) } returns Result.success(registeredUser)
             coEvery {
                 userRepoMock.getUserByEmail(notRegisteredEmail)
             } returns Result.failure(UserNotFoundByEmailException(notRegisteredEmail))
 
-            val pendingInvitations = assertDoesNotThrow { mainService.getPendingInvitationsForProject(createRequest()) }
+            val pendingInvitations = assertDoesNotThrow {
+                mainService.getPendingInvitationsForProject(createRequest(project.id))
+            }
 
             val invitationForRegisteredUser = pendingInvitations.usersList.find { it.email == registeredUser.email }
             val invitationForNotRegisteredUser = pendingInvitations.usersList.find { it.email == notRegisteredEmail }
@@ -101,24 +104,29 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
     fun `When a non project member requests the pending invitations for a project, then an UnauthorizedException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val project = DataBuilder.createExampleProject()
 
             mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-            coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
-            assertThrows<UnauthorizedException> { mainService.getPendingInvitationsForProject(createRequest()) }
+            assertThrows<UnauthorizedException> {
+                mainService.getPendingInvitationsForProject(createRequest(project.id))
+            }
         }
 
     @Test
-    fun `When the pending invitations for a nonexistent project are requested, then a NotFoundException is thrown`() =
+    fun `When the pending invitations for a nonexistent project are requested, then a ProjectNotFoundException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val nonExistentProjectId = UUID.randomUUID()
 
             mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
+            coEvery {
+                projectRepoMock.getProjectById(nonExistentProjectId)
+            } returns Result.failure(TestSpecificException())
 
-            assertThrows<NotFoundException> {
+            assertThrows<ProjectNotFoundException> {
                 mainService.getPendingInvitationsForProject(createRequest(nonExistentProjectId))
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -1,6 +1,8 @@
 package se.uulm.snowballr.backend.service.paper
 
+import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -21,9 +23,9 @@ class GetBackwardReferencedPapersTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
-        assertThrows<NotFoundException> {
+    fun `When the paper doesn't exist, then a PaperNotFoundException is thrown`() = runTest {
+        coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
+        assertThrows<PaperNotFoundException> {
             mainService.getBackwardReferencedPapers(getExampleRequest())
         }
     }
@@ -33,7 +35,7 @@ class GetBackwardReferencedPapersTest : MainServiceTest() {
         val paper = DataBuilder.createExamplePaper(id = paperId)
         val backwardReferenceId = UUID.randomUUID()
 
-        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+        coEvery { paperRepoMock.ensurePaperExists(paper.id) } just Runs
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(backwardReferenceId)
@@ -52,7 +54,7 @@ class GetBackwardReferencedPapersTest : MainServiceTest() {
             val backwardReferenceId = UUID.randomUUID()
             val referencedPaper = DataBuilder.createExamplePaper(id = backwardReferenceId)
 
-            coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+            coEvery { paperRepoMock.ensurePaperExists(paper.id) } just Runs
             coEvery {
                 citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
             } returns listOf(backwardReferenceId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -1,6 +1,8 @@
 package se.uulm.snowballr.backend.service.paper
 
+import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -21,9 +23,9 @@ class GetForwardReferencedPapersTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the paper doesn't exist, then a NotFoundException is thrown`() = runTest {
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
-        assertThrows<NotFoundException> {
+    fun `When the paper doesn't exist, then a PaperNotFoundException is thrown`() = runTest {
+        coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
+        assertThrows<PaperNotFoundException> {
             mainService.getForwardReferencedPapers(getExampleRequest())
         }
     }
@@ -33,7 +35,7 @@ class GetForwardReferencedPapersTest : MainServiceTest() {
         val paper = DataBuilder.createExamplePaper(id = paperId)
         val forwardReferenceId = UUID.randomUUID()
 
-        coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+        coEvery { paperRepoMock.ensurePaperExists(paper.id) } just Runs
         coEvery {
             citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(forwardReferenceId)
@@ -52,7 +54,7 @@ class GetForwardReferencedPapersTest : MainServiceTest() {
             val forwardReferenceId = UUID.randomUUID()
             val citingPaper = DataBuilder.createExamplePaper(id = forwardReferenceId)
 
-            coEvery { paperRepoMock.doesPaperExistById(paper.id) } returns true
+            coEvery { paperRepoMock.ensurePaperExists(paper.id) } just Runs
             coEvery {
                 citationRepoMock.getForwardReferencedPaperIdsOfPaperById(paper.id)
             } returns listOf(forwardReferenceId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
@@ -1,13 +1,15 @@
 package se.uulm.snowballr.backend.service.paper
 
+import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
 import snowballr.PaperOuterClass.Paper as GrpcPaper
@@ -34,7 +36,7 @@ class UpdatePaperTest : MainServiceTest() {
         val exampleAuthor = DataBuilder.createExampleAuthor()
         val examplePaper = DataBuilder.createExamplePaper(id = paperId, authors = listOf(exampleAuthor))
 
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
+        coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
         coEvery { paperRepoMock.getPaperByExternalId(request.paper.externalId) } returns Result.failure(Exception())
         coEvery { paperRepoMock.updatePaper(request) } returns examplePaper
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
@@ -43,12 +45,12 @@ class UpdatePaperTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non-existent paper is updated, then a NotFoundException is thrown`() = runTest {
+    fun `When a non-existent paper is updated, then a PaperNotFoundException is thrown`() = runTest {
         val request = getExampleRequest()
 
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+        coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
 
-        assertThrows<NotFoundException> {
+        assertThrows<PaperNotFoundException> {
             mainService.updatePaper(request)
         }
     }
@@ -67,7 +69,7 @@ class UpdatePaperTest : MainServiceTest() {
                 externalId = "10.1000/existingdoi",
             )
 
-            coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
+            coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
             coEvery { paperRepoMock.getPaperByExternalId("10.1000/existingdoi") } returns Result.success(
                 existingPaperWithSameExternalId,
             )

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.notfound.StageNotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
@@ -32,7 +33,6 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
@@ -51,7 +51,6 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
@@ -69,7 +68,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getDecisionStatisticsForStage(request) }
@@ -85,7 +84,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<ProjectNotFoundException> { mainService.getDecisionStatisticsForStage(request) }
     }
@@ -101,7 +100,6 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -120,7 +118,6 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
 
@@ -169,7 +166,6 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.notfound.StageNotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.UserOuterClass.UserRole
@@ -32,6 +32,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
@@ -50,6 +51,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
@@ -67,24 +69,25 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getDecisionStatisticsForStage(request) }
     }
 
     @Test
-    fun `When a nonexistent project is requested, then a TestSpecificException is thrown`() = runTest {
+    fun `When a nonexistent project is requested, then a ProjectNotFoundException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val project = DataBuilder.createExampleProject()
 
         val request = validRequestBuilder
-            .setProjectId(UUID.randomUUID().toString())
+            .setProjectId(project.id.toString())
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(any()) } returns Result.failure(TestSpecificException())
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
 
-        assertThrows<TestSpecificException> { mainService.getDecisionStatisticsForStage(request) }
+        assertThrows<ProjectNotFoundException> { mainService.getDecisionStatisticsForStage(request) }
     }
 
     @Test
@@ -98,6 +101,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -116,6 +120,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
 
@@ -164,6 +169,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -27,6 +27,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val noAccessUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(noAccessUser)
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectById(request) }
@@ -39,6 +40,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(adminUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -53,6 +55,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
@@ -65,6 +68,7 @@ class GetProjectByIdTest : MainServiceTest() {
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
+import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
@@ -25,10 +27,11 @@ class GetProjectByIdTest : MainServiceTest() {
     fun `When the requesting user is not a member of the project, then an UnauthorizedException is thrown`() = runTest {
         val request = getExampleRequest()
         val noAccessUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(noAccessUser)
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectById(request) }
     }
@@ -40,9 +43,8 @@ class GetProjectByIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertDoesNotThrow { mainService.getProjectById(request) }
     }
@@ -55,23 +57,46 @@ class GetProjectByIdTest : MainServiceTest() {
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = projectId)
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
 
         assertDoesNotThrow { mainService.getProjectById(request) }
     }
 
     @Test
-    fun `When an error occurs while the project is retrieved, then a TestSpecificException is thrown`() = runTest {
+    fun `When an error occurs while the project is retrieved, then a ProjectNotFoundException is thrown`() = runTest {
         val request = getExampleRequest()
         val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
         mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { mainService.getProjectById(request) }
+        assertThrows<ProjectNotFoundException> { mainService.getProjectById(request) }
+    }
+
+    @Test
+    fun `When the project is deleted by a default user, then a ProjectNotFoundException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val request = getExampleRequest()
+        val project = DataBuilder.createExampleProject(id = projectId, status = ProjectStatus.PROJECT_STATUS_DELETED)
+
+        mockCurrentUser(user)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+        assertThrows<ProjectNotFoundException> { mainService.getProjectById(request) }
+    }
+
+    @Test
+    fun `When the project is deleted by a server admin, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val request = getExampleRequest()
+        val project = DataBuilder.createExampleProject(id = projectId, status = ProjectStatus.PROJECT_STATUS_DELETED)
+        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
+
+        mockCurrentUser(user)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
+
+        assertDoesNotThrow { mainService.getProjectById(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
@@ -7,8 +7,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import java.time.OffsetDateTime
@@ -22,15 +23,14 @@ class GetProjectInformationTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the project does not exist, then a NotFoundException is thrown`() = runTest {
+    fun `When the project does not exist, then a ProjectNotFoundException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
-        val projectId = UUID.randomUUID()
-        val member = DataBuilder.createExampleProjectMember(projectId = projectId, userId = user.id)
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<NotFoundException> { mainService.getProjectInformation(getRequest(projectId)) }
+        assertThrows<ProjectNotFoundException> { mainService.getProjectInformation(getRequest(project.id)) }
     }
 
     @Test
@@ -39,7 +39,7 @@ class GetProjectInformationTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectInformation(getRequest(project.id)) }
@@ -59,7 +59,6 @@ class GetProjectInformationTest : MainServiceTest() {
 
             mockCurrentUser(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(member)
             coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
 
@@ -83,7 +82,6 @@ class GetProjectInformationTest : MainServiceTest() {
 
             mockCurrentUser(user)
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(member)
             coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
@@ -28,7 +28,6 @@ class GetProjectInformationTest : MainServiceTest() {
         val member = DataBuilder.createExampleProjectMember(projectId = projectId, userId = user.id)
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getProjectMembers(projectId) } returns listOf(member)
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
 
         assertThrows<NotFoundException> { mainService.getProjectInformation(getRequest(projectId)) }
@@ -40,6 +39,7 @@ class GetProjectInformationTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectInformation(getRequest(project.id)) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -35,8 +35,8 @@ class GetProjectMembersTest : MainServiceTest() {
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, projectMemberUser)
 
         mockCurrentUser(adminUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
-            listOf(projectMember)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns listOf(projectMemberWithUser)
 
@@ -67,6 +67,7 @@ class GetProjectMembersTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(user)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectMembers(request) }
@@ -79,10 +80,7 @@ class GetProjectMembersTest : MainServiceTest() {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
             mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.getProjectMembers(any()) } returns emptyList()
-            coEvery {
-                projectRepoMock.doesProjectExistById(projectId)
-            } returns false
+            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
 
             assertThrows<NotFoundException> { mainService.getProjectMembers(request) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -6,9 +6,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass.UserRole
@@ -35,9 +36,8 @@ class GetProjectMembersTest : MainServiceTest() {
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, projectMemberUser)
 
         mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns listOf(projectMemberWithUser)
 
         assertDoesNotThrow { mainService.getProjectMembers(request) }
@@ -54,7 +54,7 @@ class GetProjectMembersTest : MainServiceTest() {
         mockCurrentUser(user)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             listOf(projectMember)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns listOf(projectMemberWithUser)
 
         assertDoesNotThrow { mainService.getProjectMembers(request) }
@@ -67,21 +67,21 @@ class GetProjectMembersTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> { mainService.getProjectMembers(request) }
     }
 
     @Test
-    fun `When project members are requested from a nonexistent project, then a NotFoundException is thrown`() =
+    fun `When project members are requested from a nonexistent project, then a ProjectNotFoundException is thrown`() =
         runTest {
             val request = getExampleRequest()
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
 
             mockCurrentUser(user)
-            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+            coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
 
-            assertThrows<NotFoundException> { mainService.getProjectMembers(request) }
+            assertThrows<ProjectNotFoundException> { mainService.getProjectMembers(request) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -93,6 +93,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
                 invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
             } returns Result.failure(TestSpecificException())
             coEvery { userRepoMock.getUserByEmail(currentUser.email) } returns Result.success(currentUser)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
             coEvery {
                 projectMemberRepoMock.getProjectMembers(project.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
@@ -15,7 +15,6 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.UserOuterClass.UserRole
-import snowballr.project
 import java.util.UUID
 
 class UpdateProjectMemberRoleTest : MainServiceTest() {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
@@ -8,18 +8,19 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectMemberNotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.UserOuterClass.UserRole
+import snowballr.project
 import java.util.UUID
 
 class UpdateProjectMemberRoleTest : MainServiceTest() {
     @Test
-    fun `When a server admin updates a member role of a user in a non-existent project, then a NotFoundException is thrown`() =
+    fun `When a server admin updates a member role of a user in a non-existent project, then a ProjectNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
@@ -34,9 +35,11 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
 
             mockCurrentUser(user)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(nonExistentProjectId) } returns emptyList()
-            coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
+            coEvery {
+                projectRepoMock.getProjectById(nonExistentProjectId)
+            } returns Result.failure(TestSpecificException())
 
-            assertThrows<NotFoundException> { mainService.updateProjectMemberRole(request) }
+            assertThrows<ProjectNotFoundException> { mainService.updateProjectMemberRole(request) }
         }
 
     @Test
@@ -55,7 +58,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
 
             mockCurrentUser(user)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { userRepoMock.getUserById(nonExistentUserId) } returns
                 Result.failure(TestSpecificException())
 
@@ -86,7 +89,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
         coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
             Result.success(projectMemberToBeUpdated)
@@ -126,7 +129,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
         coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
             Result.success(projectMemberToBeUpdated)
@@ -171,7 +174,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
 
             mockCurrentUser(user)
             coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
             coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
                 Result.failure(ProjectMemberNotFoundException(user.id, project.id))
@@ -198,7 +201,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
         coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
             Result.success(projectAdminMember)
@@ -239,16 +242,12 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
         coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(
             projectAdminMember1, projectAdminMember2,
         )
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { userRepoMock.getUserById(user1ToBeUpdated.id) } returns Result.success(user1ToBeUpdated)
         coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, user1ToBeUpdated.id) } returns
             Result.success(projectAdminMember1)
         coEvery {
-            projectMemberRepoMock.updateProjectMemberRole(
-                project.id,
-                user1ToBeUpdated.id,
-                newRole,
-            )
+            projectMemberRepoMock.updateProjectMemberRole(project.id, user1ToBeUpdated.id, newRole)
         } returns updatedUser
 
         assertDoesNotThrow { mainService.updateProjectMemberRole(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -60,12 +60,16 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
         mockHappyPath(true)
 
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
         mockHappyPath(false)
+
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
 
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
@@ -76,6 +80,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> {
@@ -89,7 +94,6 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
 
         assertThrows<NotFoundException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -7,9 +7,10 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.UserOuterClass.UserRole
@@ -45,7 +46,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
             } else {
                 listOf(projectMember)
             }
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
         coEvery {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
@@ -60,16 +61,12 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
         mockHappyPath(true)
 
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
 
     @Test
     fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
         mockHappyPath(false)
-
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
 
         assertDoesNotThrow { mainService.getAllProjectPapersForProject(getExampleRequest()) }
     }
@@ -80,7 +77,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> {
@@ -89,14 +86,14 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a nonexistent project is requested, then a NotFoundException is thrown`() = runTest {
+    fun `When a nonexistent project is requested, then a ProjectNotFoundException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<NotFoundException> {
+        assertThrows<ProjectNotFoundException> {
             mainService.getAllProjectPapersForProject(getExampleRequest())
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -33,6 +33,7 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -63,6 +64,7 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -89,6 +91,7 @@ class GetNextPaperTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(projectPaper.id)
             } returns Result.success(projectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getNextPaper(getExampleRequest()) }
@@ -107,6 +110,7 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -33,7 +33,6 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -64,7 +63,6 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -88,10 +86,8 @@ class GetNextPaperTest : MainServiceTest() {
             val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
 
             mockCurrentUser(currentUser)
-            coEvery {
-                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-            } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getNextPaper(getExampleRequest()) }
@@ -110,7 +106,6 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -39,7 +39,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
@@ -76,7 +76,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
@@ -104,7 +104,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(projectPaper.id)
             } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getNextPaperToReview(getExampleRequest()) }
@@ -130,7 +130,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
@@ -180,7 +180,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
@@ -242,7 +242,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
@@ -297,7 +297,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
@@ -350,7 +350,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -39,6 +39,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
@@ -75,6 +76,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
@@ -102,6 +104,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(projectPaper.id)
             } returns Result.success(projectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getNextPaperToReview(getExampleRequest()) }
@@ -127,6 +130,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
@@ -176,6 +180,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
@@ -237,6 +242,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
@@ -291,6 +297,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
@@ -343,6 +350,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
@@ -41,6 +41,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview()
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -81,6 +82,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(currentUser)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> {
@@ -109,6 +111,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery {
@@ -193,7 +196,6 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
 
         assertThrows<NotFoundException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
@@ -8,9 +8,10 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
-import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.Base
 import snowballr.ProjectOuterClass.PaperDecision
@@ -41,14 +42,13 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview()
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery {
             projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
         } returns listOf(projectPaperWithPaper)
@@ -82,7 +82,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             val project = DataBuilder.createExampleProject(id = projectId)
 
             mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> {
@@ -111,9 +111,8 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery {
             projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
         } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
@@ -161,7 +160,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
 
             mockCurrentUser(currentUser)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery {
                 projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
             } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
@@ -191,14 +190,14 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a nonexistent project is requested, then a NotFoundException is thrown`() = runTest {
+    fun `When a nonexistent project is requested, then a ProjectNotFoundException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<NotFoundException> {
+        assertThrows<ProjectNotFoundException> {
             mainService.getPapersToReviewForProject(getExampleRequest())
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -33,6 +33,7 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -63,6 +64,7 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -89,6 +91,7 @@ class GetPreviousPaperTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(projectPaper.id)
             } returns Result.success(projectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getPreviousPaper(getExampleRequest()) }
@@ -107,6 +110,7 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -33,7 +33,6 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -64,7 +63,6 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
@@ -88,10 +86,8 @@ class GetPreviousPaperTest : MainServiceTest() {
             val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
 
             mockCurrentUser(currentUser)
-            coEvery {
-                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-            } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> { mainService.getPreviousPaper(getExampleRequest()) }
@@ -110,7 +106,6 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember)
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
@@ -60,6 +60,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -118,6 +119,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         )
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
@@ -60,7 +60,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -119,7 +119,7 @@ class GetProjectPaperByIdTest : MainServiceTest() {
         )
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
@@ -59,6 +59,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
 
         mockCurrentUser(currentUser)
 
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -123,6 +124,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(projectId)
 
         mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> {
@@ -136,7 +138,6 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
 
         assertThrows<NotFoundException> { mainService.getProjectPaperByRelativeId(getExampleRequest()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
@@ -59,15 +59,13 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
 
         mockCurrentUser(currentUser)
 
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
             } else {
                 listOf(projectMember)
             }
-
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
 
         if (failAt == projectPaperRepoMock::getProjectPaperByRelativeId) {
             coEvery {
@@ -124,7 +122,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
         assertThrows<UnauthorizedException> {
@@ -138,7 +136,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         val project = DataBuilder.createExampleProject(id = projectId)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<NotFoundException> { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -1,14 +1,16 @@
 package se.uulm.snowballr.backend.service.readinglist
 
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
 
@@ -19,7 +21,7 @@ class AddPaperToReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
+        coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
         coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } returns Unit
 
         assertDoesNotThrow { mainService.addPaperToReadingList(paperId.toGrpcId()) }
@@ -27,14 +29,14 @@ class AddPaperToReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user adds a non-existent paper to their reading list, then a NotFoundException is thrown`() =
+    fun `When the user adds a non-existent paper to their reading list, then a PaperNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()
 
             mockCurrentUser(user)
-            coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+            coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
 
-            assertThrows<NotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
+            assertThrows<PaperNotFoundException> { mainService.addPaperToReadingList(paperId.toGrpcId()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -1,7 +1,9 @@
 package se.uulm.snowballr.backend.service.readinglist
 
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -9,7 +11,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
 
@@ -24,8 +26,8 @@ class IsPaperOnReadingListTest : MainServiceTest() {
             mockCurrentUser(user)
             coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
             coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
-            coEvery { paperRepoMock.doesPaperExistById(paper1.id) } returns true
-            coEvery { paperRepoMock.doesPaperExistById(paper2.id) } returns true
+            coEvery { paperRepoMock.ensurePaperExists(paper1.id) } just Runs
+            coEvery { paperRepoMock.ensurePaperExists(paper2.id) } just Runs
 
             assertTrue(mainService.isPaperOnReadingList(paper1.id.toGrpcId()).value)
             coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) }
@@ -35,15 +37,15 @@ class IsPaperOnReadingListTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user checks if a non-existent paper is on their reading list, then a NotFoundException is thrown`() =
+    fun `When the user checks if a non-existent paper is on their reading list, then a PaperNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()
 
             mockCurrentUser(user)
-            coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+            coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
 
-            assertThrows<NotFoundException> {
+            assertThrows<PaperNotFoundException> {
                 mainService.isPaperOnReadingList(paperId.toGrpcId())
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -1,14 +1,16 @@
 package se.uulm.snowballr.backend.service.readinglist
 
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.toGrpcId
-import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import java.util.UUID
 
@@ -19,7 +21,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
         val paperId = UUID.randomUUID()
 
         mockCurrentUser(user)
-        coEvery { paperRepoMock.doesPaperExistById(paperId) } returns true
+        coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
         coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } returns Unit
 
         assertDoesNotThrow { mainService.removePaperFromReadingList(paperId.toGrpcId()) }
@@ -27,15 +29,15 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes a non-existent paper on their reading list, then a NotFoundException is thrown`() =
+    fun `When the user removes a non-existent paper on their reading list, then a PaperNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()
 
             mockCurrentUser(user)
-            coEvery { paperRepoMock.doesPaperExistById(paperId) } returns false
+            coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
 
-            assertThrows<NotFoundException> {
+            assertThrows<PaperNotFoundException> {
                 mainService.removePaperFromReadingList(paperId.toGrpcId())
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -93,6 +93,7 @@ class CreateReviewTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
 
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         if (stopBefore == projectMemberRepoMock::getProjectMembers) {
             return
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -19,6 +19,7 @@ import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.PaperDecision
@@ -49,7 +50,6 @@ class CreateReviewTest : MainServiceTest() {
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
-        Arguments.of(projectRepoMock::getProjectById),
     )
 
     @Suppress("LongParameterList", "ReturnCount", "LongMethod")
@@ -93,7 +93,14 @@ class CreateReviewTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaperId) } returns Result.success(projectPaper)
 
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        if (stopBefore == projectRepoMock::getProjectById) {
+            return
+        } else if (failAt == projectRepoMock::getProjectById) {
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+            return
+        }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
         if (stopBefore == projectMemberRepoMock::getProjectMembers) {
             return
         }
@@ -103,14 +110,6 @@ class CreateReviewTest : MainServiceTest() {
             } else {
                 listOf(projectMember)
             }
-
-        if (stopBefore == projectRepoMock::getProjectById) {
-            return
-        } else if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
-            return
-        }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         if (stopBefore == reviewRepoMock::getAllReviewsForProjectPaper) {
             return
@@ -174,7 +173,8 @@ class CreateReviewTest : MainServiceTest() {
         statusName: String,
     ) = runTest {
         val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
-        mockCreateReview(project = project, stopBefore = projectRepoMock::getProjectById)
+
+        mockCreateReview(project = project, stopBefore = reviewRepoMock::getAllReviewsForProjectPaper)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
@@ -304,4 +304,13 @@ class CreateReviewTest : MainServiceTest() {
 
             assertDoesNotThrow { mainService.createReview(createReviewRequest) }
         }
+
+    @Test
+    fun `When a review is created for a non existent project, then a ProjectNotFoundException is thrown`() = runTest {
+        mockCreateReview(stopBefore = projectRepoMock::getProjectById)
+
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+
+        assertThrows<ProjectNotFoundException> { mainService.createReview(validCreateReviewRequest.build()) }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -54,6 +54,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -99,6 +100,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
 
             mockCurrentUser(currentUser)
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -54,7 +54,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
         }
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
 
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns
             if (isUserAdmin) {
                 emptyList()
@@ -100,7 +100,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
 
             mockCurrentUser(currentUser)
             coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
             coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns emptyList()
 
             assertThrows<UnauthorizedException> {


### PR DESCRIPTION
Closes #420

## What I have made

- I added the check that the project should not be deleted if it should be read
- This required me to change plenty of mocking in tests, which was a bit tedious
- I also added some helper methods on the way to reduce big status/role checks that are hard to read since the gRPC enums are very long

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [ ] I have checked the implementation against the requirements
