### PR TITLE
Removed `assertDoesNotThrow`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-# Asset IDs of v0.4.38 release of grpc-health-probe
+# Version of grpc-health-probe to download
 # https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.38
-ARG AMD64_ID=251600596
-ARG ARM64_ID=251600609
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.38
 
 # Stage 1: Build the application
 FROM gradle:9.5.1-jdk25-alpine AS build
@@ -27,24 +26,20 @@ RUN --mount=type=cache,target=/root/.gradle \
 # Stage 2: Download grpc-health-probe (runs in parallel with build)
 FROM alpine:3.21 AS grpc-health-probe
 
-ARG AMD64_ID
-ARG ARM64_ID
+ARG GRPC_HEALTH_PROBE_VERSION
 
 # Download binaries of grpc-health-probe based on the architecture and make them executable
 RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
-      export ASSET_ID=${AMD64_ID}; \
+      export ARCH_SUFFIX=amd64; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      export ASSET_ID=${ARM64_ID}; \
+      export ARCH_SUFFIX=arm64; \
     else \
-      # unsupported architecture
       exit 1; \
     fi && \
-    curl -L \
-      -H "Accept:application/octet-stream" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      https://api.github.com/repos/grpc-ecosystem/grpc-health-probe/releases/assets/${ASSET_ID} \
+    curl -fsSL \
+      https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${ARCH_SUFFIX} \
       -o /grpc_health_probe \
     && chmod +x /grpc_health_probe
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python /app/.venv/bin/python -r requirements.txt
 RUN apk del .py-build-deps && chown -R backend-user /app/.venv
 
+RUN mkdir -p /app/plugins && chown backend-user:backend-user /app/plugins
+USER backend-user
+
 VOLUME /app/plugins/
 
 # Healthcheck uses grpc-health-probe
@@ -83,8 +86,6 @@ HEALTHCHECK CMD ./grpc_health_probe -addr=localhost:${PORT} -service "snowballr.
 # Copy build artifacts last — source changes only invalidate layers below this point
 COPY --chown=backend-user:backend-user --from=build /app/build/libs/snowballr-backend-*.jar app.jar
 COPY --chown=backend-user:backend-user --from=grpc-health-probe /grpc_health_probe grpc_health_probe
-
-USER backend-user
 
 # Start execute the jar file when starting the container
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
@@ -22,16 +22,12 @@ data class UserSettings(
  * Creates a [UserSettingsOuterClass.UserSettings] from this [UserSettings].
  */
 fun UserSettings.toGrpcUserSettings(
-    criteria: List<CriterionOuterClass.Criterion>,
+    criteria: CriterionOuterClass.Criterion.List,
 ): UserSettingsOuterClass.UserSettings = UserSettingsOuterClass.UserSettings
     .newBuilder()
     .setShowHotkeys(this.areHotkeysShown)
     .setReviewMode(this.isReviewModeEnabled)
-    .setDefaultCriteria(
-        CriterionOuterClass.Criterion.List.newBuilder()
-            .addAllCriteria(criteria)
-            .build(),
-    )
+    .setDefaultCriteria(criteria)
     .setDefaultProjectSettings(
         ProjectOuterClass.Project.Settings.newBuilder()
             .setSimilarityThreshold(this.similarityThreshold)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -11,6 +11,7 @@ import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.UserIdentifierType
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.toGrpcUserSettings
 import se.uulm.snowballr.backend.model.dto.toGrpcUsers
@@ -24,7 +25,6 @@ import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import snowballr.Authentication
 import snowballr.ProjectOuterClass.ProjectStatus
 import java.util.UUID
-import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.UserOuterClass.User as GrpcUser
 import snowballr.UserSettingsOuterClass.UserSettings as GrpcUserSettings
 
@@ -199,19 +199,6 @@ class UserService(
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val defaultUserCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        val criteria = mutableListOf<GrpcCriterion>()
-        for (criterion in defaultUserCriteria) {
-            criteria.add(
-                GrpcCriterion
-                    .newBuilder()
-                    .setTag(criterion.tag)
-                    .setName(criterion.name)
-                    .setDescription(criterion.description)
-                    .setCategory(criterion.category)
-                    .build(),
-            )
-        }
-
-        userSettings.toGrpcUserSettings(criteria)
+        userSettings.toGrpcUserSettings(defaultUserCriteria.toGrpcCriteria())
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/PaperValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/PaperValidator.kt
@@ -19,8 +19,8 @@ import java.time.LocalDate
 @Suppress("TooManyFunctions")
 object PaperValidator {
     const val EXTERNAL_ID_MAX_LENGTH = 100
-    const val TITLE_MAX_LENGTH = 200
-    const val ABSTRACT_MAX_LENGTH = 3000
+    const val TITLE_MAX_LENGTH = 250
+    const val ABSTRACT_MAX_LENGTH = 3500
     const val YEAR_MIN_VALUE = 0
     const val PUBLISHER_MAX_LENGTH = 200
     const val PUBLICATION_NAME_MAX_LENGTH = 200

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -36,9 +36,9 @@ class ProjectExportManagerTest {
 
     @Nested
     inner class ExportProject {
-        @ParameterizedTest(name = "When exporting a project in the {0} format, then no exception is thrown")
+        @ParameterizedTest(name = "When exporting a project in the {0} format, then returned data is not empty")
         @MethodSource("se.uulm.snowballr.backend.export.ProjectExportManagerTest#supportedFormats")
-        fun `When exporting a project in a format, then no exception is thrown`(format: ExportFormat) {
+        fun `When exporting a project in a format, then returned data is not empty`(format: ExportFormat) {
             val project = DataBuilder.createExampleProject(name = "Exported Project")
             val projectMembers = listOf(DataBuilder.createExampleProjectMemberWithUser())
             val projectPapers = listOf(DataBuilder.createExampleProjectPaperFull())

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -51,7 +50,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             val criterionId = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
 
-            val result = assertDoesNotThrow { repo.getCriterionById(criterionId) }
+            val result = repo.getCriterionById(criterionId)
 
             val criterion = assertResultSuccess(result)
             assertIs<ProjectCriterion>(criterion)
@@ -65,7 +64,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
         @Test
         fun `When a criterion is not found, then a failed result with a NotFoundException is returned`() = runTest {
-            val result = assertDoesNotThrow { repo.getCriterionById(UUID.randomUUID()) }
+            val result = repo.getCriterionById(UUID.randomUUID())
 
             assertResultFailure<NotFoundException>(result)
         }
@@ -87,7 +86,8 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .setCategory(category)
                         .setProjectId(projectId.toString())
                         .build()
-                val criterion = assertDoesNotThrow { repo.createCriterion(request, testUserId) }
+
+                val criterion = repo.createCriterion(request, testUserId)
 
                 assertIs<ProjectCriterion>(criterion)
                 assertEquals("Test Tag", criterion.tag)
@@ -109,7 +109,8 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                         .setDescription("Test Description")
                         .setCategory(category)
                         .build()
-                val criterion = assertDoesNotThrow { repo.createCriterion(request, testUserId) }
+
+                val criterion = repo.createCriterion(request, testUserId)
 
                 assertIs<UserCriterion>(criterion)
                 assertEquals("Test Tag", criterion.tag)
@@ -148,8 +149,9 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                     .setCategory(CriterionCategory.CRITERION_CATEGORY_EXCLUSION)
                     .setProjectId(projectId.toString())
                     .build()
-            val criterion1 = assertDoesNotThrow { repo.createCriterion(request, testUserId) }
-            val criterion2 = assertDoesNotThrow { repo.createCriterion(request, testUserId) }
+
+            val criterion1 = repo.createCriterion(request, testUserId)
+            val criterion2 = repo.createCriterion(request, testUserId)
 
             assertNotEquals(criterion2.id, criterion1.id)
         }
@@ -196,7 +198,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val userCriterion2 = repo.createCriterion(userCriterionRequest, userId)
                 val projectCriterion = repo.createCriterion(projectCriterionRequest, testUserId)
 
-                val userCriteria = assertDoesNotThrow { repo.getAllUserCriteria(testUserId) as List<Criterion> }
+                val userCriteria = repo.getAllUserCriteria(testUserId) as List<Criterion>
 
                 assertThat(userCriteria).hasSize(1)
                 assertThat(userCriteria).containsExactly(userCriterion1)
@@ -226,9 +228,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
                 val projectCriterion = repo.createCriterion(projectCriterionRequest, testUserId)
 
-                val userCriteria = assertDoesNotThrow {
-                    repo.getCriteriaByIds(listOf(userCriterion.id, projectCriterion.id))
-                }
+                val userCriteria = repo.getCriteriaByIds(listOf(userCriterion.id, projectCriterion.id))
 
                 assertThat(userCriteria).hasSize(2)
                 assertThat(userCriteria).containsExactlyInAnyOrder(userCriterion, projectCriterion)
@@ -247,9 +247,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
                 val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
 
-                val userCriteria = assertDoesNotThrow {
-                    repo.getCriteriaByIds(listOf(userCriterion.id, UUID.randomUUID()))
-                }
+                val userCriteria = repo.getCriteriaByIds(listOf(userCriterion.id, UUID.randomUUID()))
 
                 assertThat(userCriteria).hasSize(1)
                 assertThat(userCriteria).containsExactlyInAnyOrder(userCriterion)
@@ -257,13 +255,13 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
         @Test
         fun `When all the input list is empty, then an empty list is returned`() = runTest {
-            val userCriteria = assertDoesNotThrow { repo.getCriteriaByIds(emptyList()) }
+            val userCriteria = repo.getCriteriaByIds(emptyList())
             assertThat(userCriteria).isEmpty()
         }
 
         @Test
         fun `When no criteria of the input list exist, then an empty list is returned`() = runTest {
-            val userCriteria = assertDoesNotThrow { repo.getCriteriaByIds(listOf(UUID.randomUUID())) }
+            val userCriteria = repo.getCriteriaByIds(listOf(UUID.randomUUID()))
             assertThat(userCriteria).isEmpty()
         }
 
@@ -279,9 +277,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
             val userCriterion = repo.createCriterion(userCriterionRequest, testUserId)
 
-            val userCriteria = assertDoesNotThrow {
-                repo.getCriteriaByIds(listOf(userCriterion.id, userCriterion.id))
-            }
+            val userCriteria = repo.getCriteriaByIds(listOf(userCriterion.id, userCriterion.id))
 
             assertThat(userCriteria).hasSize(1)
             assertThat(userCriteria).containsExactlyInAnyOrder(userCriterion)
@@ -311,7 +307,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 .setMask(FieldMaskUtil.fromStringList(fieldMask))
                 .build()
 
-            val updatedCriterion = assertDoesNotThrow { repo.updateCriterion(request) }
+            val updatedCriterion = repo.updateCriterion(request)
 
             if ("criterion.tag" in fieldMask) {
                 assertEquals("Updated Tag", updatedCriterion.tag)
@@ -346,7 +342,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
             val idsToDelete = listOf(criterionId1, criterionId3)
 
-            assertDoesNotThrow { repo.deleteCriteriaByIds(idsToDelete) }
+            repo.deleteCriteriaByIds(idsToDelete)
 
             assertResultFailure<NotFoundException>(repo.getCriterionById(criterionId1))
             assertResultFailure<NotFoundException>(repo.getCriterionById(criterionId3))
@@ -359,7 +355,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
             val idsToDelete = emptyList<UUID>()
 
-            assertDoesNotThrow { repo.deleteCriteriaByIds(idsToDelete) }
+            repo.deleteCriteriaByIds(idsToDelete)
 
             assertResultSuccess(repo.getCriterionById(criterionId1))
         }
@@ -371,7 +367,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
         fun `When a user ID is given, then all user criteria associated with this user should be deleted`() = runTest {
             val criterionId = insertCriterionAndGetId(createdBy = testUserId)
 
-            assertDoesNotThrow { repo.deleteUserCriteriaByUserId(testUserId) }
+            repo.deleteUserCriteriaByUserId(testUserId)
 
             assertResultFailure<NotFoundException>(repo.getCriterionById(criterionId))
         }
@@ -403,7 +399,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
                 val projectCriterion1 = repo.createCriterion(projectCriterionRequest1, testUserId)
                 val projectCriterion2 = repo.createCriterion(projectCriterionRequest2, testUserId)
 
-                val userCriteria = assertDoesNotThrow { repo.getAllProjectCriteria(projectId1) }
+                val userCriteria = repo.getAllProjectCriteria(projectId1)
 
                 assertThat(userCriteria).hasSize(1)
                 assertThat(userCriteria).containsExactly(projectCriterion1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/InvitationTokenTableRepoTest.kt
@@ -148,9 +148,8 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             insertActiveTestToken(projectId2, "token-in-another-project")
             insertInactiveTestToken(projectId)
 
-            val activeInvitationTokenInProject = assertDoesNotThrow {
-                repo.getActiveInvitationTokensForProject(projectId)
-            }
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(projectId)
+
             assertThat(activeInvitationTokenInProject).hasSize(1)
             assertEquals("an-active-token", activeInvitationTokenInProject.first().token)
         }
@@ -160,9 +159,8 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             insertInactiveTestToken(projectId)
 
-            val activeInvitationTokenInProject = assertDoesNotThrow {
-                repo.getActiveInvitationTokensForProject(projectId)
-            }
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(projectId)
+
             assertThat(activeInvitationTokenInProject).isEmpty()
         }
 
@@ -171,9 +169,8 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             val projectId = insertProjectAndGetId(createdBy = testUserId)
             insertActiveTestToken(projectId, "token-in-another-project")
 
-            val activeInvitationTokenInProject = assertDoesNotThrow {
-                repo.getActiveInvitationTokensForProject(UUID.randomUUID())
-            }
+            val activeInvitationTokenInProject = repo.getActiveInvitationTokensForProject(UUID.randomUUID())
+
             assertThat(activeInvitationTokenInProject).isEmpty()
         }
     }
@@ -189,7 +186,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
 
             assertResultSuccess(repo.getInvitationTokenByValue(tokenValue))
 
-            assertDoesNotThrow { repo.deleteInvitationToken(tokenValue) }
+            repo.deleteInvitationToken(tokenValue)
 
             assertResultFailure<InvitationTokenNotFoundException>(repo.getInvitationTokenByValue(tokenValue))
         }
@@ -210,7 +207,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
 
             insertTestInvitationToken(testEmail, projectId, "token-in-project")
 
-            assertDoesNotThrow { repo.deleteExpiredInvitationTokens() }
+            repo.deleteExpiredInvitationTokens()
 
             assertResultSuccess(repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId))
         }
@@ -226,13 +223,10 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
                 OffsetDateTime.now().minusDays(1),
             )
 
-            assertDoesNotThrow { repo.deleteExpiredInvitationTokens() }
+            repo.deleteExpiredInvitationTokens()
 
             assertResultFailure<InvitationTokenNotFoundException>(
-                repo.getInvitationTokenByEmailAndProjectId(
-                    testEmail,
-                    projectId,
-                ),
+                repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId),
             )
         }
     }
@@ -245,7 +239,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
 
             insertTestInvitationToken(testEmail, projectId, "token-to-be-deleted")
 
-            assertDoesNotThrow { repo.deleteInvitationTokensForProject(projectId) }
+            repo.deleteInvitationTokensForProject(projectId)
 
             assertResultFailure<InvitationTokenNotFoundException>(
                 repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId),
@@ -267,7 +261,7 @@ class InvitationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, ProjectTa
             insertTestInvitationToken(testEmail, projectId1, "token-in-project-1")
             insertTestInvitationToken(testEmail, projectId2, "token-in-project-2")
 
-            assertDoesNotThrow { repo.deleteInvitationTokensForProject(projectId1) }
+            repo.deleteInvitationTokensForProject(projectId1)
 
             assertResultFailure<InvitationTokenNotFoundException>(
                 repo.getInvitationTokenByEmailAndProjectId(testEmail, projectId1),

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -106,14 +106,14 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
     @Nested
     inner class EnsurePaperExists {
         @Test
-        fun `When a paper with the given id exists, then no exception is thrown`() = runTest {
+        fun `When a paper with the given ID exists, then no exception is thrown`() = runTest {
             val paperId = insertPaperAndGetId("Test Paper")
 
             assertDoesNotThrow { repo.ensurePaperExists(paperId) }
         }
 
         @Test
-        fun `When a paper with the given id does not exist, then a PaperNotFoundException is thrown`() = runTest {
+        fun `When a paper with the given ID does not exist, then a PaperNotFoundException is thrown`() = runTest {
             val paperId = UUID.randomUUID()
 
             assertThrows<PaperNotFoundException> { repo.ensurePaperExists(paperId) }
@@ -123,7 +123,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
     @Nested
     inner class DoesPaperExistByExternalId {
         @Test
-        fun `When a paper with the given external id exists, then true is returned`() = runTest {
+        fun `When a paper with the given external ID exists, then true is returned`() = runTest {
             val externalId = "ExternalId"
             insertPaperAndGetId(externalId = externalId)
 
@@ -133,7 +133,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
         }
 
         @Test
-        fun `When a paper with the given external id does not exist, then false returned`() = runTest {
+        fun `When a paper with the given external ID does not exist, then false returned`() = runTest {
             val externalId = "NonExistentExternalId"
 
             val isPaperExistent = repo.doesPaperExistByExternalId(externalId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -576,7 +576,7 @@ class ProjectTableRepoTest :
         }
 
         @Test
-        fun `When the project to be soft-deleted is not found, then nothing happens`() = runTest {
+        fun `When the project to be soft-deleted is not found, then no exception is thrown`() = runTest {
             val projectId = UUID.randomUUID()
 
             assertDoesNotThrow { repo.softDeleteProject(projectId) }
@@ -589,7 +589,7 @@ class ProjectTableRepoTest :
         fun `When no soft-deleted projects exist, then no project are cleared`() = runTest {
             val projectId = insertProjectAndGetId(status = ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
 
-            assertDoesNotThrow { repo.clearSoftDeletedProjects(defaultThresholdDate) }
+            repo.clearSoftDeletedProjects(defaultThresholdDate)
 
             val project = assertResultSuccess(repo.getProjectById(projectId))
             assertEquals(ProjectStatus.PROJECT_STATUS_ACTIVE, project.status)
@@ -603,7 +603,7 @@ class ProjectTableRepoTest :
                     insertProjectAndGetId(status = ProjectStatus.PROJECT_STATUS_ACTIVE, createdBy = testUserId)
                 repo.softDeleteProject(projectId)
 
-                assertDoesNotThrow { repo.clearSoftDeletedProjects(defaultThresholdDate) }
+                repo.clearSoftDeletedProjects(defaultThresholdDate)
 
                 val project = assertResultSuccess(repo.getProjectById(projectId))
                 assertEquals(ProjectStatus.PROJECT_STATUS_DELETED, project.status)
@@ -628,7 +628,7 @@ class ProjectTableRepoTest :
                     createdBy = testUserId,
                 )
 
-                assertDoesNotThrow { repo.clearSoftDeletedProjects(defaultThresholdDate) }
+                repo.clearSoftDeletedProjects(defaultThresholdDate)
 
                 val project1 = assertResultSuccess(repo.getProjectById(projectId1))
                 assertEquals(ProjectStatus.PROJECT_STATUS_UNSPECIFIED, project1.status)
@@ -652,7 +652,7 @@ class ProjectTableRepoTest :
                 val projectId2 = insertProjectAndGetId(name = "Project2", createdBy = testUserId)
                 repo.softDeleteProject(projectId1)
 
-                assertDoesNotThrow { repo.hardDeleteClearedProjects() }
+                repo.hardDeleteClearedProjects()
 
                 val project1 = assertResultSuccess(repo.getProjectById(projectId1))
                 assertEquals(ProjectStatus.PROJECT_STATUS_DELETED, project1.status)
@@ -686,7 +686,7 @@ class ProjectTableRepoTest :
                 )
                 repo.clearSoftDeletedProjects(defaultThresholdDate)
 
-                assertDoesNotThrow { repo.hardDeleteClearedProjects() }
+                repo.hardDeleteClearedProjects()
 
                 assertResultFailure<NotFoundException>(repo.getProjectById(projectId1))
                 assertResultFailure<NotFoundException>(criterionRepo.getCriterionById(criterionId1))
@@ -715,7 +715,7 @@ class ProjectTableRepoTest :
                     }
                 }
 
-                assertDoesNotThrow { repo.hardDeleteClearedProjects() }
+                repo.hardDeleteClearedProjects()
 
                 val project = assertResultSuccess(repo.getProjectById(projectId))
                 assertEquals(ProjectStatus.PROJECT_STATUS_UNSPECIFIED, project.status)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignCriterionToReview
@@ -227,7 +226,7 @@ class ReviewTableRepoTest : RepositoryTest(
                 insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
             val userId = insertUserAndGetId(email = "existing.reviewer@example.com")
 
-            val review = assertDoesNotThrow { repo.createReview(createReviewRequest(projectPaperId).build(), userId) }
+            val review = repo.createReview(createReviewRequest(projectPaperId).build(), userId)
 
             assertEquals(projectPaperId, review.projectPaperId)
             assertEquals(ReviewDecision.REVIEW_DECISION_ACCEPTED, review.decision)
@@ -274,7 +273,7 @@ class ReviewTableRepoTest : RepositoryTest(
                     .addSelectedCriteriaIds(selectedCriterion.toString())
                     .build()
 
-                val review = assertDoesNotThrow { repo.createReview(createReviewWithCriteriaRequest, userId) }
+                val review = repo.createReview(createReviewWithCriteriaRequest, userId)
 
                 val selectedCriteria = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
                 assertThat(selectedCriteria).hasSize(1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -58,7 +58,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         @Test
         fun `When a user is found by their ID, then a successful result with the correct user is returned`() = runTest {
             val userId = insertUserAndGetId()
-            val result = assertDoesNotThrow { repo.getUserById(userId) }
+            val result = repo.getUserById(userId)
 
             val user = assertResultSuccess(result)
             assertEquals(userId, user.id)
@@ -72,7 +72,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         @Test
         fun `When a user is not found by their ID, then a failed result with a NotFoundException is returned`() =
             runTest {
-                val result = assertDoesNotThrow { repo.getUserById(UUID.randomUUID()) }
+                val result = repo.getUserById(UUID.randomUUID())
 
                 assertResultFailure<NotFoundException>(result)
             }
@@ -84,7 +84,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         fun `When a user is found by their email, then a successful result with the correct user is returned`() =
             runTest {
                 val userId = insertUserAndGetId()
-                val result = assertDoesNotThrow { repo.getUserByEmail("test.user@example.com") }
+                val result = repo.getUserByEmail("test.user@example.com")
 
                 val user = assertResultSuccess(result)
                 assertEquals(userId, user.id)
@@ -98,7 +98,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         @Test
         fun `When a user is not found by their email, then a failed result with a NotFoundException is returned`() =
             runTest {
-                val result = assertDoesNotThrow { repo.getUserByEmail("nonexistent email") }
+                val result = repo.getUserByEmail("nonexistent email")
 
                 assertResultFailure<NotFoundException>(result)
             }
@@ -141,7 +141,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             val userId1 = insertUserAndGetId(email = "test.user1@example.com", lastName = "User 2")
             val userId2 = insertUserAndGetId(email = "test.user2@example.com", lastName = "User 1")
 
-            val users = assertDoesNotThrow { repo.getAllUsers() }
+            val users = repo.getAllUsers()
 
             assertThat(users).hasSize(2)
             val firstUser = users.find { it.id == userId1 }
@@ -155,7 +155,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             val userId1 = insertUserAndGetId(email = "test.user1@example.com", lastName = "User 1")
             val userId2 = insertUserAndGetId(email = "", firstName = "", lastName = "")
 
-            val users = assertDoesNotThrow { repo.getAllUsers() }
+            val users = repo.getAllUsers()
 
             assertThat(users).hasSize(1)
             val firstUser = users.find { it.id == userId1 }
@@ -177,7 +177,8 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                     .setLastName("Smith")
                     .setPassword("AAbb__00")
                     .build()
-            val user = assertDoesNotThrow { repo.createUser(request, "hashedPassword") }
+
+            val user = repo.createUser(request, "hashedPassword")
 
             assertEquals("alice.smith@example.com", user.email)
             assertEquals("Alice", user.firstName)
@@ -196,7 +197,8 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                     .setLastName("Smith")
                     .setPassword("AAbb__00")
                     .build()
-            assertDoesNotThrow { repo.createUser(request, "hashedPassword") }
+
+            repo.createUser(request, "hashedPassword")
 
             assertThrows<SQLException> {
                 repo.createUser(request, "hashedPassword2")
@@ -213,7 +215,9 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                     .setLastName("Smith")
                     .setPassword("AAbb__00")
                     .build()
-            val user1 = assertDoesNotThrow { repo.createUser(request1, "hashedPassword1") }
+
+            val user1 = repo.createUser(request1, "hashedPassword1")
+
             val request2 =
                 Authentication.RegisterRequest
                     .newBuilder()
@@ -222,7 +226,8 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                     .setLastName("Smith")
                     .setPassword("BBaa__00")
                     .build()
-            val user2 = assertDoesNotThrow { repo.createUser(request2, "hashedPassword2") }
+
+            val user2 = repo.createUser(request2, "hashedPassword2")
 
             assertNotEquals(user2.id, user1.id)
         }
@@ -251,7 +256,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                 .setMask(FieldMaskUtil.fromStringList(fieldMask))
                 .build()
 
-            val updatedUser = assertDoesNotThrow { repo.updateUser(request) }
+            val updatedUser = repo.updateUser(request)
 
             if ("user.email" in fieldMask) {
                 assertEquals("updated.user@example.com", updatedUser.email)
@@ -307,7 +312,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             val userId1 = insertUserAndGetId()
             val before = OffsetDateTime.now()
 
-            assertDoesNotThrow { repo.softDeleteUser(userId1) }
+            repo.softDeleteUser(userId1)
 
             val after = OffsetDateTime.now()
             val deletedUser = repo.getUserById(userId1).getOrThrow()
@@ -328,7 +333,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         fun `When no soft-deleted users exist, then no users are cleared`() = runTest {
             val userId = insertUserAndGetId(status = UserStatus.USER_STATUS_ACTIVE)
 
-            assertDoesNotThrow { repo.clearSoftDeletedUsers(defaultThresholdDate) }
+            repo.clearSoftDeletedUsers(defaultThresholdDate)
 
             val user = assertResultSuccess(repo.getUserById(userId))
             assertEquals(UserStatus.USER_STATUS_ACTIVE, user.status)
@@ -341,7 +346,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                 val userId = insertUserAndGetId(status = UserStatus.USER_STATUS_ACTIVE)
                 repo.softDeleteUser(userId)
 
-                assertDoesNotThrow { repo.clearSoftDeletedUsers(defaultThresholdDate) }
+                repo.clearSoftDeletedUsers(defaultThresholdDate)
 
                 val user = assertResultSuccess(repo.getUserById(userId))
                 assertEquals(UserStatus.USER_STATUS_DELETED, user.status)
@@ -363,7 +368,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                 val criteria1 = RepositoryHelper.insertCriterionAndGetId(createdBy = userId1)
                 val criteria2 = RepositoryHelper.insertCriterionAndGetId(createdBy = userId2)
 
-                assertDoesNotThrow { repo.clearSoftDeletedUsers(defaultThresholdDate) }
+                repo.clearSoftDeletedUsers(defaultThresholdDate)
 
                 val user1 = assertResultSuccess(repo.getUserById(userId1))
                 assertEquals(UserStatus.USER_STATUS_UNSPECIFIED, user1.status)
@@ -384,7 +389,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
     inner class GetUserIdsToDelete {
         @Test
         fun `When no cleared users exist, then an empty list is returned`() = runTest {
-            val userIdsToDelete = assertDoesNotThrow { repo.getUserIdsToDelete() }
+            val userIdsToDelete = repo.getUserIdsToDelete()
 
             assertThat(userIdsToDelete).isEmpty()
         }
@@ -400,7 +405,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             insertUserAndGetId(email = "user2@test.de", status = UserStatus.USER_STATUS_ACTIVE)
             repo.clearSoftDeletedUsers(defaultThresholdDate)
 
-            val userIdsToDelete = assertDoesNotThrow { repo.getUserIdsToDelete() }
+            val userIdsToDelete = repo.getUserIdsToDelete()
 
             assertThat(userIdsToDelete).hasSize(1)
             assertThat(userIdsToDelete).containsExactly(userId1)
@@ -417,7 +422,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                 repo.softDeleteUser(userId1)
                 val usersToDelete = repo.getUserIdsToDelete()
 
-                assertDoesNotThrow { repo.hardDeleteClearedUsers(usersToDelete) }
+                repo.hardDeleteClearedUsers(usersToDelete)
 
                 val user1 = assertResultSuccess(repo.getUserById(userId1))
                 assertEquals(UserStatus.USER_STATUS_DELETED, user1.status)
@@ -443,7 +448,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                 repo.clearSoftDeletedUsers(defaultThresholdDate)
                 val usersToDelete = repo.getUserIdsToDelete()
 
-                assertDoesNotThrow { repo.hardDeleteClearedUsers(usersToDelete) }
+                repo.hardDeleteClearedUsers(usersToDelete)
 
                 assertResultFailure<NotFoundException>(repo.getUserById(userId1))
 
@@ -464,7 +469,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             repo.clearSoftDeletedUsers(defaultThresholdDate)
             val usersToDelete = repo.getUserIdsToDelete()
 
-            assertDoesNotThrow { repo.hardDeleteClearedUsers(usersToDelete) }
+            repo.hardDeleteClearedUsers(usersToDelete)
 
             val user = assertResultSuccess(repo.getUserById(userId))
             assertEquals(UserStatus.USER_STATUS_UNSPECIFIED, user.status)
@@ -501,7 +506,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             val userId = insertUserAndGetId(email = "test.user@example.com", passwordHash = "oldHash")
             val newHash = "newHash"
 
-            assertDoesNotThrow { repo.updatePasswordHash(userId, newHash) }
+            repo.updatePasswordHash(userId, newHash)
 
             val updatedHash = assertResultSuccess(repo.getPasswordHashByEmail("test.user@example.com"))
             assertEquals(newHash, updatedHash)
@@ -521,7 +526,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         fun `When a user is found, then a successful result with the user settings is returned`() = runTest {
             val userId = insertUserAndGetId()
 
-            val result = assertDoesNotThrow { repo.getUserSettings(userId) }
+            val result = repo.getUserSettings(userId)
 
             val userSettings = assertResultSuccess(result)
             assertTrue(userSettings.areHotkeysShown)
@@ -552,9 +557,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             val userId2 = insertUserAndGetId(lastName = "John", email = "doe.john@example.com")
             val userId3 = insertUserAndGetId(email = "john@example.com")
 
-            val matchingUsers = assertDoesNotThrow {
-                repo.getUsersMatchingSearchQuery("john", emptySet())
-            }
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 
             assertThat(matchingUsers).hasSize(3)
 
@@ -565,9 +568,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         fun `When a deleted user is matching the search query, then this user is not returned`() = runTest {
             insertUserAndGetId(firstName = "john", lastName = "doe", status = UserStatus.USER_STATUS_DELETED)
 
-            val matchingUsers = assertDoesNotThrow {
-                repo.getUsersMatchingSearchQuery("john", emptySet())
-            }
+            val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 
             assertThat(matchingUsers).hasSize(0)
         }
@@ -576,9 +577,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         fun `When no user is matching the search query, then an empty list is returned`() = runTest {
             insertUserAndGetId(firstName = "johnathan")
 
-            val matchingUsers = assertDoesNotThrow {
-                repo.getUsersMatchingSearchQuery("nonexistent", emptySet())
-            }
+            val matchingUsers = repo.getUsersMatchingSearchQuery("nonexistent", emptySet())
 
             assertThat(matchingUsers).hasSize(0)
         }
@@ -590,9 +589,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                     insertUserAndGetId(firstName = "John the $i-th", email = "john$i@example.com")
                 }
 
-                val matchingUsers = assertDoesNotThrow {
-                    repo.getUsersMatchingSearchQuery("john", emptySet())
-                }
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john", emptySet())
 
                 assertThat(matchingUsers).hasSize(10)
             }
@@ -603,9 +600,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
                 val userEmail = "johnathan@example.com"
                 insertUserAndGetId(email = userEmail, firstName = "johnathan")
 
-                val matchingUsers = assertDoesNotThrow {
-                    repo.getUsersMatchingSearchQuery("john", setOf(userEmail))
-                }
+                val matchingUsers = repo.getUsersMatchingSearchQuery("john", setOf(userEmail))
 
                 assertThat(matchingUsers).hasSize(0)
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/VerificationTokenTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/VerificationTokenTableRepoTest.kt
@@ -67,7 +67,7 @@ class VerificationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, Verific
 
             assertResultSuccess(repo.getVerificationTokenByValue(tokenValue))
 
-            assertDoesNotThrow { repo.deleteVerificationToken(tokenValue) }
+            repo.deleteVerificationToken(tokenValue)
 
             assertResultFailure<VerificationTokenNotFoundException>(repo.getVerificationTokenByValue(tokenValue))
         }
@@ -86,7 +86,7 @@ class VerificationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, Verific
         fun `When no expired tokens exist, then no tokens are deleted`() = runTest {
             insertTestVerificationToken(testUserId, "valid-token")
 
-            assertDoesNotThrow { repo.deleteExpiredVerificationTokens() }
+            repo.deleteExpiredVerificationTokens()
 
             assertResultSuccess(repo.getVerificationTokenByValue("valid-token"))
         }
@@ -99,7 +99,7 @@ class VerificationTokenTableRepoTest : RepositoryTest(arrayOf(UserTable, Verific
                 expiresAt = OffsetDateTime.now().minusDays(1),
             )
 
-            assertDoesNotThrow { repo.deleteExpiredVerificationTokens() }
+            repo.deleteExpiredVerificationTokens()
 
             assertResultFailure<VerificationTokenNotFoundException>(
                 repo.getVerificationTokenByValue("expired-token"),

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectMemberTableRepoTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -389,8 +388,9 @@ class ProjectMemberTableRepoTest : RepositoryTest(arrayOf(ProjectTable, ProjectM
         fun `When a project member is not found, nothing happens`() = runTest {
             val (projectId, members) = setupProject()
 
-            assertDoesNotThrow { repo.removeProjectMember(projectId, UUID.randomUUID()) }
-            assertDoesNotThrow { repo.removeProjectMember(UUID.randomUUID(), members[0].userId) }
+            repo.removeProjectMember(projectId, UUID.randomUUID())
+            repo.removeProjectMember(UUID.randomUUID(), members[0].userId)
+
             assertTrue(repo.getProjectMemberByComposedId(projectId, members[0].userId).isSuccess)
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -348,7 +347,8 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     .setStage(0)
                     .build()
 
-                val projectPaper = assertDoesNotThrow { repo.addPaperToProject(request, testUserId) }
+                val projectPaper = repo.addPaperToProject(request, testUserId)
+
                 assertEquals(paperId, projectPaper.paperId)
                 assertEquals(projectId, projectPaper.projectId)
                 assertEquals(0, projectPaper.localPaperId)
@@ -375,8 +375,9 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     .setStage(0)
                     .build()
 
-                assertDoesNotThrow { repo.addPaperToProject(request1, testUserId) }
-                val projectPaper2 = assertDoesNotThrow { repo.addPaperToProject(request2, testUserId) }
+                repo.addPaperToProject(request1, testUserId)
+                val projectPaper2 = repo.addPaperToProject(request2, testUserId)
+
                 assertEquals(1, projectPaper2.localPaperId)
             }
 
@@ -399,8 +400,9 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     .setStage(0)
                     .build()
 
-                val projectPaper1 = assertDoesNotThrow { repo.addPaperToProject(request1, testUserId) }
-                val projectPaper2 = assertDoesNotThrow { repo.addPaperToProject(request2, testUserId) }
+                val projectPaper1 = repo.addPaperToProject(request1, testUserId)
+                val projectPaper2 = repo.addPaperToProject(request2, testUserId)
+
                 assertEquals(0, projectPaper1.localPaperId)
                 assertEquals(0, projectPaper2.localPaperId)
             }
@@ -432,7 +434,7 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                     .setStage(0)
                     .build()
 
-                val projectPaper = assertDoesNotThrow { repo.addPaperToProject(request, testUserId) }
+                val projectPaper = repo.addPaperToProject(request, testUserId)
 
                 assertEquals(6, projectPaper.localPaperId)
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ReadingListTableRepoTest.kt
@@ -51,8 +51,10 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             runTest {
                 val paperId = insertPaperAndGetId()
                 val userId = insertUserAndGetId("test.user@example.com")
+
                 repo.createReadingListEntry(userId, paperId)
                 assertThat(repo.getAllReadingListEntries(userId)).hasSize(1)
+
                 repo.removeReadingListEntry(userId, paperId)
                 assertThat(repo.getAllReadingListEntries(userId)).hasSize(0)
             }
@@ -62,6 +64,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             runTest {
                 val paperId = insertPaperAndGetId()
                 val userId = insertUserAndGetId("test.user@example.com")
+
                 assertDoesNotThrow {
                     repo.removeReadingListEntry(userId, paperId)
                 }
@@ -71,6 +74,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
         fun `When a paper is removed from the reading list of a nonexistent user, then no exception is thrown`() =
             runTest {
                 val paperId = insertPaperAndGetId()
+
                 assertDoesNotThrow {
                     repo.removeReadingListEntry(UUID.randomUUID(), paperId)
                 }
@@ -80,6 +84,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
         fun `When a nonexistent paper is removed from the reading list of a user, then no exception is thrown`() =
             runTest {
                 val userId = insertUserAndGetId("test.user@example.com")
+
                 assertDoesNotThrow {
                     repo.removeReadingListEntry(userId, UUID.randomUUID())
                 }
@@ -92,7 +97,9 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
         fun `When a paper is on the reading list of a user, then isPaperOnReadingList returns true`() = runTest {
             val paperId = insertPaperAndGetId()
             val userId = insertUserAndGetId("test.user@example.com")
+
             repo.createReadingListEntry(userId, paperId)
+
             assertTrue(repo.isPaperOnReadingList(userId, paperId))
         }
 
@@ -100,18 +107,21 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
         fun `When a paper is not on the reading list of a user, then isPaperOnReadingList returns false`() = runTest {
             val paperId = insertPaperAndGetId()
             val userId = insertUserAndGetId("test.user@example.com")
+
             assertFalse(repo.isPaperOnReadingList(userId, paperId))
         }
 
         @Test
         fun `When a nonexistent paper is provided to isPaperOnReadingList, then it returns false`() = runTest {
             val userId = insertUserAndGetId("test.user@example.com")
+
             assertFalse(repo.isPaperOnReadingList(userId, UUID.randomUUID()))
         }
 
         @Test
         fun `When a nonexistent user is provided to isPaperOnReadingList, then it returns false`() = runTest {
             val paperId = insertPaperAndGetId()
+
             assertFalse(repo.isPaperOnReadingList(UUID.randomUUID(), paperId))
         }
     }
@@ -122,6 +132,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
         fun `When there are no papers on a user's reading list, then getAllReadingListEntries returns an empty list`() =
             runTest {
                 val userId = insertUserAndGetId("test.user@example.com")
+
                 assertThat(repo.getAllReadingListEntries(userId)).isEmpty()
             }
 
@@ -130,6 +141,7 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
             runTest {
                 val paperId = insertPaperAndGetId()
                 val userId = insertUserAndGetId("test.user@example.com")
+
                 repo.createReadingListEntry(userId, paperId)
 
                 val actualReadingListEntries = repo.getAllReadingListEntries(userId)
@@ -143,10 +155,12 @@ class ReadingListTableRepoTest : RepositoryTest(arrayOf(UserTable, PaperTable, R
                 val paperId1 = insertPaperAndGetId(externalId = "1")
                 val paperId2 = insertPaperAndGetId(externalId = "2")
                 val userId = insertUserAndGetId("test.user@example.com")
+
                 repo.createReadingListEntry(userId, paperId1)
                 repo.createReadingListEntry(userId, paperId2)
 
                 val actualReadingListEntries = repo.getAllReadingListEntries(userId)
+
                 assertThat(actualReadingListEntries).hasSize(2)
                 assertThat(actualReadingListEntries).containsExactlyInAnyOrder(
                     paperRepo.getPaperById(paperId1).getOrThrow(),

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceHelperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceHelperTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -49,10 +48,8 @@ class ServiceHelperTest {
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
 
-            assertDoesNotThrow {
-                withUser(userRepoMock) {
-                    assertEquals(currentUser, it)
-                }
+            withUser(userRepoMock) {
+                assertEquals(currentUser, it)
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/ChangePasswordTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/ChangePasswordTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -78,7 +77,7 @@ class ChangePasswordTest : AuthenticationServiceTest() {
         coEvery { userRepoMock.getPasswordHashByEmail(currentUser.email) } returns Result.success(storedPasswordHash)
         coJustRun { userRepoMock.updatePasswordHash(currentUser.id, capture(passwordHashSlot)) }
 
-        assertDoesNotThrow { service.changePassword(request) }
+        service.changePassword(request)
 
         assertNotNull(passwordHashSlot.captured)
         assertTrue(PasswordUtils.verifyPassword(newPassword, passwordHashSlot.captured))

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
@@ -5,7 +5,6 @@ import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import se.uulm.snowballr.backend.DataBuilder
@@ -123,7 +122,7 @@ class LoginTest : AuthenticationServiceTest() {
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns Result.success(passwordHash)
         every { jwtManagerMock.generateAuthTokens(testUser.id) } returns tokens
 
-        assertDoesNotThrow { service.login(request) }
+        service.login(request)
 
         assertEquals(tokens.accessToken, cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
         assertEquals(tokens.refreshToken, cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LogoutTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LogoutTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.authentication
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import se.uulm.snowballr.backend.GrpcTestContextExtension
 import se.uulm.snowballr.backend.auth.GrpcContext
@@ -16,7 +15,7 @@ class LogoutTest : AuthenticationServiceTest() {
             // Simulate setting cookies via login
             GrpcContext.setAuthCookiesInContext("testAccessToken", "testRefreshToken")
 
-            assertDoesNotThrow { service.logout() }
+            service.logout()
 
             assertEquals("", cookiesMap[GrpcContext.ACCESS_TOKEN_COOKIE_NAME])
             assertEquals("", cookiesMap[GrpcContext.REFRESH_TOKEN_COOKIE_NAME])

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
@@ -2,10 +2,10 @@ package se.uulm.snowballr.backend.service.authentication
 
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -55,17 +55,22 @@ class VerifyEmailTest : AuthenticationServiceTest() {
     }
 
     @Test
-    fun `When a valid token is provided and all operations succeed, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
-        val token = DataBuilder.createExampleVerificationToken(userId = user.id)
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
-        val userUpdateSlot = slot<GrpcUser.Update>()
+    fun `When a valid token is provided and all operations succeed, then the token is successfully deleted afterwards`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
+            val token = DataBuilder.createExampleVerificationToken(userId = user.id)
+            val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
+            val userUpdateSlot = slot<GrpcUser.Update>()
 
-        coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns Result.success(token)
-        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-        coEvery { userRepoMock.updateUser(capture(userUpdateSlot)) } returns user
-        coJustRun { verificationTokenRepoMock.deleteVerificationToken(token.token) }
+            coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns Result.success(token)
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+            coEvery { userRepoMock.updateUser(capture(userUpdateSlot)) } returns user
+            coJustRun { verificationTokenRepoMock.deleteVerificationToken(token.token) }
 
-        assertDoesNotThrow { service.verifyEmail(request) }
-    }
+            service.verifyEmail(request)
+
+            coVerify(exactly = 1) {
+                verificationTokenRepoMock.deleteVerificationToken(token.token)
+            }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -32,19 +31,22 @@ class CreateCriterionTest : CriterionServiceTest() {
     }
 
     @Test
-    fun `When a user creates a project criterion and has access, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
+    fun `When a user creates a project criterion and has access, then the created criterion has the correct values`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
-        val request = getProjectCriterionRequest(project.id.toString())
+            val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
+            val request = getProjectCriterionRequest(project.id.toString())
 
-        mockCurrentUser(user)
-        coJustRun { criterionAccessCheckerMock.isAllowedToCreateProjectCriterion(user, project.id) }
-        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
+            mockCurrentUser(user)
+            coJustRun { criterionAccessCheckerMock.isAllowedToCreateProjectCriterion(user, project.id) }
+            coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
 
-        assertDoesNotThrow { service.createCriterion(request) }
-    }
+            val result = service.createCriterion(request)
+
+            assertCriterionEquality(criterion, result)
+        }
 
     @Test
     fun `When a user creates a project criterion, but has no access, then a TestSpecificException is thrown`() =
@@ -63,15 +65,18 @@ class CreateCriterionTest : CriterionServiceTest() {
         }
 
     @Test
-    fun `When a user creates a user criterion and has access, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
+    fun `When a user creates a user criterion and has access, then the created criterion has the correct values`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
 
-        val criterion = DataBuilder.createExampleUserCriterion()
-        val request = getUserCriterionRequest()
+            val criterion = DataBuilder.createExampleUserCriterion()
+            val request = getUserCriterionRequest()
 
-        mockCurrentUser(user)
-        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
+            mockCurrentUser(user)
+            coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
 
-        assertDoesNotThrow { service.createCriterion(request) }
-    }
+            val result = service.createCriterion(request)
+
+            assertCriterionEquality(criterion, result)
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CriterionServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CriterionServiceTest.kt
@@ -6,12 +6,15 @@ import io.mockk.mockk
 import se.uulm.snowballr.backend.access.ICriterionAccessChecker
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.CriterionService
 import se.uulm.snowballr.backend.service.withUser
+import snowballr.CriterionOuterClass
+import kotlin.test.assertEquals
 
 /**
  * Base test class for the [CriterionService].
@@ -44,5 +47,12 @@ sealed class CriterionServiceTest : BaseServiceTest {
     protected fun mockCurrentUser(currentUser: User) {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+    }
+
+    protected fun assertCriterionEquality(expected: Criterion, actual: CriterionOuterClass.Criterion) {
+        assertEquals(expected.tag, actual.tag)
+        assertEquals(expected.name, actual.name)
+        assertEquals(expected.description, actual.description)
+        assertEquals(expected.category, actual.category)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -3,8 +3,8 @@ package se.uulm.snowballr.backend.service.criterion
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -23,7 +23,7 @@ class GetAllCriteriaForProjectTest : CriterionServiceTest() {
         }
 
     @Test
-    fun `When a user retrieves all criteria for a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user retrieves all criteria for a project and has access, then all criteria are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id, createdBy = user.id)
@@ -32,6 +32,10 @@ class GetAllCriteriaForProjectTest : CriterionServiceTest() {
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
-        assertDoesNotThrow { service.getAllCriteriaForProject(project.id) }
+        val result = service.getAllCriteriaForProject(project.id)
+
+        assertEquals(1, result.criteriaCount)
+        val resultElement = result.criteriaList.first()
+        assertCriterionEquality(criterion, resultElement)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -34,7 +33,7 @@ class GetCriterionByIdTest : CriterionServiceTest() {
     }
 
     @Test
-    fun `When a user retrieves a criterion and has access, then no exception is thrown`() = runTest {
+    fun `When a user retrieves a criterion and has access, then the criterion is returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val criterion = DataBuilder.createExampleUserCriterion()
 
@@ -42,6 +41,8 @@ class GetCriterionByIdTest : CriterionServiceTest() {
         coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
         coJustRun { criterionAccessCheckerMock.isAllowedToReadCriterion(user, criterion) }
 
-        assertDoesNotThrow { service.getCriterionById(criterion.id) }
+        val result = service.getCriterionById(criterion.id)
+
+        assertCriterionEquality(criterion, result)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -55,7 +54,7 @@ class UpdateCriterionTest : CriterionServiceTest() {
     }
 
     @Test
-    fun `When a user updates a criterion and has access, then no exception is thrown`() = runTest {
+    fun `When a user updates a criterion and has access, then the updated criterion is returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val criterion = DataBuilder.createExampleProjectCriterion()
 
@@ -66,6 +65,8 @@ class UpdateCriterionTest : CriterionServiceTest() {
         coJustRun { criterionAccessCheckerMock.isAllowedToUpdateCriterion(user, criterion) }
         coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
 
-        assertDoesNotThrow { service.updateCriterion(request) }
+        val result = service.updateCriterion(request)
+
+        assertCriterionEquality(criterion, result)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -16,6 +16,7 @@ import snowballr.UserOuterClass.UserRole
 import snowballr.copy
 import snowballr.exportRequest
 import java.util.UUID
+import kotlin.test.assertEquals
 
 class ExportProjectTest : ExportServiceTest() {
     fun getExampleRequest() = exportRequest {
@@ -24,7 +25,7 @@ class ExportProjectTest : ExportServiceTest() {
     }
 
     @Test
-    fun `When a user exports a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user exports a project and has access, then the result has the correct values`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectId = UUID.randomUUID()
         val request = getExampleRequest().copy { id = projectId.toString() }
@@ -44,7 +45,10 @@ class ExportProjectTest : ExportServiceTest() {
             ProjectExportManager.exportProject(any(), any(), any(), any(), any())
         } returns FileExport(ByteArray(0), "test.json")
 
-        service.exportProject(request)
+        val result = service.exportProject(request)
+
+        assertEquals("test.json", result.fileName)
+        assertEquals(ByteArray(0).toList(), result.data.toByteArray().toList())
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
@@ -4,16 +4,18 @@ import io.mockk.every
 import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.model.export.ExportFormat
+import kotlin.test.assertEquals
 
 class GetAvailableExportFormatsTest : ExportServiceTest() {
     @Test
-    fun `When available export formats are requested, then no exception is thrown`() = runTest {
+    fun `When available export formats are requested, then the correct values are returned`() = runTest {
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns ExportFormat.entries.toSet()
 
-        assertDoesNotThrow { service.getAvailableExportFormats() }
+        val formats = service.getAvailableExportFormats()
+
+        assertEquals(ExportFormat.entries.map { it.toString() }.toSet(), formats.formatsList.toSet())
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
@@ -21,7 +21,7 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         .build()
 
     @Test
-    fun `When a user searches papers and has access, then no exception is thrown`() = runTest {
+    fun `When a user searches papers and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(
             fetchers = mapOf(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
@@ -18,7 +18,7 @@ class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
         .build()
 
     @Test
-    fun `When a user searches papers and has access, then no exception is thrown`() = runTest {
+    fun `When a user searches papers and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/AcceptProjectInvitationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/AcceptProjectInvitationTest.kt
@@ -2,9 +2,9 @@ package se.uulm.snowballr.backend.service.invitation
 
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -103,23 +103,26 @@ class AcceptProjectInvitationTest : InvitationServiceTest() {
     }
 
     @Test
-    fun `When a valid token is provided and all operations succeed, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE)
-        val token = DataBuilder.createExampleInvitationToken(email = user.email)
-        val userMember = ProjectMember(
-            projectId = token.projectId,
-            userId = user.id,
-            role = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT,
-            createdAt = OffsetDateTime.now(),
-            modifiedAt = null,
-        )
-        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
+    fun `When a valid token is provided and all operations succeed, then the token is successfully deleted afterwards`() =
+        runTest {
+            val user = DataBuilder.createExampleUser(status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE)
+            val token = DataBuilder.createExampleInvitationToken(email = user.email)
+            val userMember = ProjectMember(
+                projectId = token.projectId,
+                userId = user.id,
+                role = ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT,
+                createdAt = OffsetDateTime.now(),
+                modifiedAt = null,
+            )
+            val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
-        coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
-        coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
-        coEvery { projectMemberRepoMock.addUserToProject(user.id, token.projectId) } returns userMember
-        coJustRun { invitationTokenRepoMock.deleteInvitationToken(token.token) }
+            coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
+            coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
+            coEvery { projectMemberRepoMock.addUserToProject(user.id, token.projectId) } returns userMember
+            coJustRun { invitationTokenRepoMock.deleteInvitationToken(token.token) }
 
-        assertDoesNotThrow { service.acceptProjectInvitation(request) }
-    }
+            service.acceptProjectInvitation(request)
+
+            coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationToken(token.token) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertNull
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
@@ -56,7 +55,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
 
         val shortGetInviteCandidatesRequest = validGetInviteCandidatesRequestBuilder.setQuery("jo")
 
-        val candidates = assertDoesNotThrow { service.getInviteCandidates(shortGetInviteCandidatesRequest.build()) }
+        val candidates = service.getInviteCandidates(shortGetInviteCandidatesRequest.build())
         assertThat(candidates.usersList).isEmpty()
     }
 
@@ -69,7 +68,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
 
         val requestWithInvalidProjectId = validGetInviteCandidatesRequestBuilder.setProjectId("invalid-uuid")
 
-        assertDoesNotThrow { service.getInviteCandidates(requestWithInvalidProjectId.build()) }
+        service.getInviteCandidates(requestWithInvalidProjectId.build())
         coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembersWithUsers(any()) }
         coVerify(exactly = 0) { invitationTokenRepoMock.getActiveInvitationTokensForProject(any()) }
     }
@@ -78,7 +77,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
     fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
         mockGetInviteCandidates()
 
-        assertDoesNotThrow { service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build()) }
+        service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
         coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(requestingUserEmail)) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetPendingInvitationsForProjectTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -16,16 +15,31 @@ import snowballr.UserOuterClass.UserStatus
 
 class GetPendingInvitationsForProjectTest : InvitationServiceTest() {
     @Test
-    fun `When a user requests the pending invitations for a project and has access, then no exception is thrown`() =
+    fun `When a user requests the pending invitations for a project and has access, then the correct values are returned`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject()
+            val registeredUser = DataBuilder.createExampleUser(
+                email = "registered@example.com",
+                status = UserStatus.USER_STATUS_ACTIVE,
+            )
+            val invitationTokenForRegisteredUser = DataBuilder.createExampleInvitationToken(
+                projectId = project.id,
+                email = registeredUser.email,
+            )
 
             mockCurrentUser(currentUser)
             coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
-            coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id) } returns emptyList()
+            coEvery {
+                invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id)
+            } returns listOf(invitationTokenForRegisteredUser)
+            coEvery { userRepoMock.getUserByEmail(registeredUser.email) } returns Result.success(registeredUser)
 
-            assertDoesNotThrow { service.getPendingInvitationsForProject(project.id) }
+            val result = service.getPendingInvitationsForProject(project.id)
+
+            assertEquals(1, result.usersCount)
+            val resultElement = result.usersList.first()
+            assertEquals(registeredUser.email, resultElement.email)
         }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/InviteUserToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/InviteUserToProjectTest.kt
@@ -157,7 +157,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
         every { envReaderMock.env.lifetime.invitationTokenLifeTimeInDays } returns 30
         coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, capture(emailDataSlot)) }
 
-        assertDoesNotThrow { service.inviteUserToProject(validInviteUserRequest.build()) }
+        service.inviteUserToProject(validInviteUserRequest.build())
 
         val capturedToken = tokenSlot.captured
         assertThat(capturedToken).isNotBlank()
@@ -182,7 +182,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
 
         val inviteNonExistentUserRequest = validInviteUserRequest.setUserEmail(emailOfNonExistentUser)
 
-        assertDoesNotThrow { service.inviteUserToProject(inviteNonExistentUserRequest.build()) }
+        service.inviteUserToProject(inviteNonExistentUserRequest.build())
 
         assertEquals("User", emailDataSlot.captured.inviteeFirstName)
     }
@@ -200,7 +200,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
                 projectMemberRepoMock.getProjectMembersWithUsers(projectId)
             } returns listOf(projectMemberWithUser)
 
-            assertDoesNotThrow { service.inviteUserToProject(validInviteUserRequest.build()) }
+            service.inviteUserToProject(validInviteUserRequest.build())
 
             coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, any()) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/InviteUserToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/InviteUserToProjectTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -110,14 +109,15 @@ class InviteUserToProjectTest : InvitationServiceTest() {
     }
 
     @Test
-    fun `When a user is already invited, then no exception is thrown, but also no invitation sent`() = runTest {
+    fun `When a user is already invited, then no invitation is sent`() = runTest {
         val invitationToken = DataBuilder.createExampleInvitationToken(email = invitedUserEmail)
         mockInviteUserToProject(stopBefore = invitationTokenRepoMock::getInvitationTokenByEmailAndProjectId)
         coEvery {
             invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(invitedUserEmail, projectId)
         } returns Result.success(invitationToken)
 
-        assertDoesNotThrow { service.inviteUserToProject(validInviteUserRequest.build()) }
+        service.inviteUserToProject(validInviteUserRequest.build())
+
         coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/CreatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/CreatePaperTest.kt
@@ -4,26 +4,26 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.dto.toGrpcPaper
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
 import snowballr.PaperOuterClass
 import java.util.UUID
 
 class CreatePaperTest : PaperServiceTest() {
     @Test
-    fun `When a paper is created, then no exception is thrown`() = runTest {
-        val request = PaperOuterClass.Paper.newBuilder()
-            .setExternalId("new-external-id")
-            .build()
-        val paperId = UUID.randomUUID()
+    fun `When a paper is created, then the created paper has the correct values`() = runTest {
+        val paper = DataBuilder.createExamplePaper(title = "Test Paper Title", externalId = "new-external-id")
+        val request = paper.toGrpcPaper(emptyList())
 
         coEvery { paperRepoMock.doesPaperExistByExternalId(request.externalId) } returns false
-        coEvery { paperRepoMock.createPaper(request) } returns DataBuilder.createExamplePaper(id = paperId)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
+        coEvery { paperRepoMock.createPaper(request) } returns paper
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
 
-        assertDoesNotThrow { service.createPaper(request) }
+        val result = service.createPaper(request)
+
+        assertPaperEquality(paper, result)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/CreatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/CreatePaperTest.kt
@@ -48,7 +48,7 @@ class CreatePaperTest : PaperServiceTest() {
             coEvery { paperRepoMock.createPaper(request) } returns DataBuilder.createExamplePaper(id = paperId)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-            assertDoesNotThrow { service.createPaper(request) }
+            service.createPaper(request)
             coVerify(exactly = 0) { paperRepoMock.doesPaperExistByExternalId(request.externalId) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -5,12 +5,12 @@ import io.mockk.coEvery
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import java.util.UUID
+import kotlin.test.assertEquals
 
 class GetBackwardReferencedPapersTest : PaperServiceTest() {
     @Test
@@ -40,7 +40,7 @@ class GetBackwardReferencedPapersTest : PaperServiceTest() {
     }
 
     @Test
-    fun `When the backward references of an existent paper are retrieved successfully, then no exception is thrown`() =
+    fun `When the backward references of an existent paper are retrieved successfully, then the correct values are returned`() =
         runTest {
             val author = DataBuilder.createExampleAuthor()
             val paper = DataBuilder.createExamplePaper(authors = listOf(author))
@@ -56,6 +56,10 @@ class GetBackwardReferencedPapersTest : PaperServiceTest() {
             } returns listOf(UUID.randomUUID())
             coEvery { paperRepoMock.getPaperById(backwardReferenceId) } returns Result.success(referencedPaper)
 
-            assertDoesNotThrow { service.getBackwardReferencedPapers(paper.id) }
+            val result = service.getBackwardReferencedPapers(paper.id)
+
+            assertEquals(1, result.papersCount)
+            val resultElement = result.papersList.first()
+            assertPaperEquality(referencedPaper, resultElement)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -5,12 +5,12 @@ import io.mockk.coEvery
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import java.util.UUID
+import kotlin.test.assertEquals
 
 class GetForwardReferencedPapersTest : PaperServiceTest() {
     @Test
@@ -41,7 +41,7 @@ class GetForwardReferencedPapersTest : PaperServiceTest() {
     }
 
     @Test
-    fun `When the forward references of an existent paper are retrieved successfully, then no exception is thrown`() =
+    fun `When the forward references of an existent paper are retrieved successfully, then the correct values are returned`() =
         runTest {
             val author = DataBuilder.createExampleAuthor()
             val paper = DataBuilder.createExamplePaper(authors = listOf(author))
@@ -57,6 +57,10 @@ class GetForwardReferencedPapersTest : PaperServiceTest() {
                 citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(forwardReferenceId)
             } returns listOf(UUID.randomUUID())
 
-            assertDoesNotThrow { service.getForwardReferencedPapers(paper.id) }
+            val result = service.getForwardReferencedPapers(paper.id)
+
+            assertEquals(1, result.papersCount)
+            val resultElement = result.papersList.first()
+            assertPaperEquality(citingPaper, resultElement)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetPaperByIdTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.paper
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -20,7 +19,7 @@ class GetPaperByIdTest : PaperServiceTest() {
     }
 
     @Test
-    fun `When a paper is retrieved successfully, then no exception is thrown`() = runTest {
+    fun `When a paper is retrieved successfully, then the correct values are returned`() = runTest {
         val author = DataBuilder.createExampleAuthor()
         val paper = DataBuilder.createExamplePaper(authors = listOf(author))
 
@@ -29,6 +28,8 @@ class GetPaperByIdTest : PaperServiceTest() {
             citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
         } returns listOf(UUID.randomUUID())
 
-        assertDoesNotThrow { service.getPaperById(paper.id) }
+        val result = service.getPaperById(paper.id)
+
+        assertPaperEquality(paper, result)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/PaperServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/PaperServiceTest.kt
@@ -1,10 +1,14 @@
 package se.uulm.snowballr.backend.service.paper
 
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import se.uulm.snowballr.backend.model.dto.Author
+import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.PaperService
+import snowballr.PaperOuterClass
 
 /**
  * Base test class for the [PaperService].
@@ -21,4 +25,23 @@ sealed class PaperServiceTest : BaseServiceTest {
     )
 
     override fun getAllMocks(): Array<Any> = allMocks
+
+    protected fun assertPaperEquality(expected: Paper, actual: PaperOuterClass.Paper) {
+        assertEquals(expected.title, actual.title)
+        assertEquals(expected.externalId, actual.externalId)
+        assertEquals(expected.abstract, actual.abstrakt)
+        assertEquals(expected.year, actual.year)
+        assertEquals(expected.publisher, actual.publisher)
+        assertEquals(expected.publicationType, actual.publicationType)
+        assertEquals(expected.publicationName, actual.publicationName)
+        for (i in expected.authors.indices) {
+            assertAuthorEquality(expected.authors[i], actual.authorsList[i])
+        }
+        assertEquals(expected.fetcherMetadata, actual.fetcherMetadataMap)
+    }
+
+    private fun assertAuthorEquality(expected: Author, actual: PaperOuterClass.Author) {
+        assertEquals(expected.firstName, actual.firstName)
+        assertEquals(expected.lastName, actual.lastName)
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
@@ -6,7 +6,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
@@ -31,7 +30,7 @@ class UpdatePaperTest : PaperServiceTest() {
         .build()
 
     @Test
-    fun `When an existent paper is updated, then no exception is thrown`() = runTest {
+    fun `When an existent paper is updated, then the updated paper is returned`() = runTest {
         val request = getExampleRequest()
         val exampleAuthor = DataBuilder.createExampleAuthor()
         val examplePaper = DataBuilder.createExamplePaper(id = paperId, authors = listOf(exampleAuthor))
@@ -41,7 +40,9 @@ class UpdatePaperTest : PaperServiceTest() {
         coEvery { paperRepoMock.updatePaper(request) } returns examplePaper
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-        assertDoesNotThrow { service.updatePaper(request) }
+        val result = service.updatePaper(request)
+
+        assertPaperEquality(examplePaper, result)
     }
 
     @Test
@@ -78,23 +79,26 @@ class UpdatePaperTest : PaperServiceTest() {
         }
 
     @Test
-    fun `When a paper is updated with an external ID that belongs to itself, then no exception is thrown`() = runTest {
-        val request = getExampleRequest()
-        val exampleAuthor = DataBuilder.createExampleAuthor()
-        val existingPaperWithSameExternalId = DataBuilder.createExamplePaper(
-            id = paperId,
-            externalId = request.paper.externalId,
-            authors = listOf(exampleAuthor),
-        )
+    fun `When a paper is updated with an external ID that belongs to itself, then the updated paper is returned`() =
+        runTest {
+            val request = getExampleRequest()
+            val exampleAuthor = DataBuilder.createExampleAuthor()
+            val existingPaperWithSameExternalId = DataBuilder.createExamplePaper(
+                id = paperId,
+                externalId = request.paper.externalId,
+                authors = listOf(exampleAuthor),
+            )
 
-        coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-        coEvery { paperRepoMock.getPaperByExternalId(request.paper.externalId) } returns
-            Result.success(existingPaperWithSameExternalId)
-        coEvery { paperRepoMock.updatePaper(request) } returns existingPaperWithSameExternalId
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
+            coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
+            coEvery { paperRepoMock.getPaperByExternalId(request.paper.externalId) } returns
+                Result.success(existingPaperWithSameExternalId)
+            coEvery { paperRepoMock.updatePaper(request) } returns existingPaperWithSameExternalId
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-        assertDoesNotThrow { service.updatePaper(request) }
-    }
+            val result = service.updatePaper(request)
+
+            assertPaperEquality(existingPaperWithSameExternalId, result)
+        }
 
     @Test
     fun `When a paper is updated without external ID, then duplicate lookup by external ID is skipped`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
@@ -113,7 +113,7 @@ class UpdatePaperTest : PaperServiceTest() {
         coEvery { paperRepoMock.updatePaper(request) } returns updatedPaper
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-        assertDoesNotThrow { service.updatePaper(request) }
+        service.updatePaper(request)
         coVerify(exactly = 0) { paperRepoMock.getPaperByExternalId(any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -6,7 +6,6 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.User
@@ -30,7 +29,7 @@ class CreateProjectTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a project is correctly created, then no exception is thrown`() = runTest {
+    fun `When a project is correctly created, then the created project has the correct values`() = runTest {
         val project = DataBuilder.createExampleProject()
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val userSettings = DataBuilder.createExampleUserSettings()
@@ -41,7 +40,9 @@ class CreateProjectTest : ProjectServiceTest() {
         coEvery { projectRepoMock.createProject(getExampleRequest(), user.id, userSettings) } returns project
         mockProjectAdminCreation(project, user)
 
-        assertDoesNotThrow { service.createProject(getExampleRequest()) }
+        val result = service.createProject(getExampleRequest())
+
+        assertProjectEquality(project, result)
 
         coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), user.id) }
         coVerify(exactly = 1) { projectMemberRepoMock.addUserToProject(user.id, project.id) }
@@ -51,7 +52,7 @@ class CreateProjectTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a project is correctly created and the user has default criteria, then no exception is thrown`() =
+    fun `When a project is correctly created and the user has default criteria, then the created project has the correct values`() =
         runTest {
             val project = DataBuilder.createExampleProject()
             val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
@@ -74,7 +75,9 @@ class CreateProjectTest : ProjectServiceTest() {
             coEvery { criterionRepoMock.createCriterion(criterionCreateRequest, user.id) } returns criterion
             mockProjectAdminCreation(project, user)
 
-            assertDoesNotThrow { service.createProject(getExampleRequest()) }
+            val result = service.createProject(getExampleRequest())
+
+            assertProjectEquality(project, result)
             assertEquals(listOf(criterion.id), criteriaIdsSlot.captured)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -4,11 +4,11 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import snowballr.ProjectOuterClass.ProjectStatus
+import kotlin.test.assertEquals
 
 class GetAllArchivedProjectsForUserTest : ProjectServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED)
@@ -40,16 +40,21 @@ class GetAllArchivedProjectsForUserTest : ProjectServiceTest() {
         }
 
     @Test
-    fun `When a user retrieves another user's archived projects and has access, then no exception is thrown`() =
+    fun `When a user retrieves another user's archived projects and has access, then the correct values are returned`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val requestedUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
             coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
-            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
+            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns listOf(project)
 
-            assertDoesNotThrow { service.getAllArchivedProjectsForUser(requestedUser.id) }
+            val result = service.getAllArchivedProjectsForUser(requestedUser.id)
+
+            assertEquals(1, result.projectsCount)
+            val resultElement = result.projectsList.first()
+            assertProjectEquality(project, resultElement)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -4,11 +4,11 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import snowballr.ProjectOuterClass.ProjectStatus
+import kotlin.test.assertEquals
 
 class GetAllDeletedProjectsForUserTest : ProjectServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_DELETED)
@@ -40,16 +40,21 @@ class GetAllDeletedProjectsForUserTest : ProjectServiceTest() {
         }
 
     @Test
-    fun `When a user retrieves another user's deleted projects and has access, then no exception is thrown`() =
+    fun `When a user retrieves another user's deleted projects and has access, then the correct values are returned`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val requestedUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
             coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
-            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
+            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns listOf(project)
 
-            assertDoesNotThrow { service.getAllDeletedProjectsForUser(requestedUser.id) }
+            val result = service.getAllDeletedProjectsForUser(requestedUser.id)
+
+            assertEquals(1, result.projectsCount)
+            val resultElement = result.projectsList.first()
+            assertProjectEquality(project, resultElement)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -4,11 +4,11 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import snowballr.ProjectOuterClass.ProjectStatus
+import kotlin.test.assertEquals
 
 class GetAllProjectsForUserTest : ProjectServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
@@ -40,15 +40,21 @@ class GetAllProjectsForUserTest : ProjectServiceTest() {
         }
 
     @Test
-    fun `When a user retrieves another user's projects and has access, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser()
+    fun `When a user retrieves another user's projects and has access, then the correct values are returned`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val requestedUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
-        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
+            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns listOf(project)
 
-        assertDoesNotThrow { service.getAllProjectsForUser(requestedUser.id) }
-    }
+            val result = service.getAllProjectsForUser(requestedUser.id)
+
+            assertEquals(1, result.projectsCount)
+            val resultElement = result.projectsList.first()
+            assertProjectEquality(project, resultElement)
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -4,10 +4,10 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import kotlin.test.assertEquals
 
 class GetAllProjectsTest : ProjectServiceTest() {
     @Test
@@ -21,13 +21,18 @@ class GetAllProjectsTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a user retrieves all projects and has access, then no exception is thrown`() = runTest {
+    fun `When a user retrieves all projects and has access, then the correct values are returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(currentUser)
         coJustRun { projectAccessCheckerMock.isAllowedToReadAllProjects(currentUser) }
-        coEvery { projectRepoMock.getAllProjects() } returns emptyList()
+        coEvery { projectRepoMock.getAllProjects() } returns listOf(project)
 
-        assertDoesNotThrow { service.getAllProjects() }
+        val result = service.getAllProjects()
+
+        assertEquals(1, result.projectsCount)
+        val resultElement = result.projectsList.first()
+        assertProjectEquality(project, resultElement)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -21,21 +20,27 @@ class GetDecisionStatisticsForStageTest : ProjectServiceTest() {
         .setStage(0)
 
     @Test
-    fun `When a user retrieves the decision statistics and has access, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
+    fun `When a user retrieves the decision statistics and has access, then the correct values are returned`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        val request = getRequest()
-            .setProjectId(project.id.toString())
-            .build()
+            val request = getRequest()
+                .setProjectId(project.id.toString())
+                .build()
 
-        mockCurrentUser(user)
-        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
 
-        assertDoesNotThrow { service.getDecisionStatisticsForStage(request) }
-    }
+            val result = service.getDecisionStatisticsForStage(request).statisticsList
+
+            assertEquals(4, result.size)
+            for (statistic in result) {
+                assertEquals(0, statistic.count)
+            }
+        }
 
     @Test
     fun `When a user retrieves the decision statistics, but has no access, then an TestSpecificException is thrown`() =
@@ -87,7 +92,7 @@ class GetDecisionStatisticsForStageTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When the highest valid stage is requested, then no exception is thrown`() = runTest {
+    fun `When the highest valid stage is requested, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(maxStage = 1)
 
@@ -101,7 +106,12 @@ class GetDecisionStatisticsForStageTest : ProjectServiceTest() {
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
 
-        assertDoesNotThrow { service.getDecisionStatisticsForStage(request) }
+        val result = service.getDecisionStatisticsForStage(request).statisticsList
+
+        assertEquals(4, result.size)
+        for (statistic in result) {
+            assertEquals(0, statistic.count)
+        }
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
@@ -151,7 +151,7 @@ class GetDecisionStatisticsForStageTest : ProjectServiceTest() {
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns
             projectPapers + papersInOtherStage
 
-        val statistics = assertDoesNotThrow { service.getDecisionStatisticsForStage(request) }
+        val statistics = service.getDecisionStatisticsForStage(request)
 
         val statsByDecision = statistics.statisticsList.associateBy { it.decision }
         paperCountsByDecision.forEach { (decision, expectedCount) ->

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -34,7 +33,7 @@ class GetProjectByIdTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a user requests a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests a project and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
@@ -42,6 +41,8 @@ class GetProjectByIdTest : ProjectServiceTest() {
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
-        assertDoesNotThrow { service.getProjectById(project.id) }
+        val result = service.getProjectById(project.id)
+
+        assertProjectEquality(project, result)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/ProjectServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/ProjectServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
@@ -15,6 +16,8 @@ import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ProjectService
 import se.uulm.snowballr.backend.service.withUser
+import snowballr.ProjectOuterClass
+import kotlin.test.assertEquals
 
 /**
  * Base test class for the [ProjectService].
@@ -56,5 +59,20 @@ sealed class ProjectServiceTest : BaseServiceTest {
     protected fun mockCurrentUser(currentUser: User) {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+    }
+
+    protected fun assertProjectEquality(expected: Project, actual: ProjectOuterClass.Project) {
+        assertEquals(expected.name, actual.name)
+        assertEquals(expected.status, actual.status)
+        assertEquals(expected.currentStage, actual.currentStage)
+        assertEquals(expected.maxStage, actual.maxStage)
+        assertEquals(expected.similarityThreshold, actual.settings.similarityThreshold)
+        assertEquals(expected.snowballingType, actual.settings.snowballingType)
+        assertEquals(expected.reviewMaybeAllowed, actual.settings.reviewMaybeAllowed)
+        assertEquals(expected.reviewDecisionMatrix, actual.settings.decisionMatrix)
+        assertEquals(
+            expected.fetchers,
+            actual.settings.fetchersMap.mapValues { options -> options.value.optionsMap.mapValues { it.toString() } },
+        )
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -45,19 +45,20 @@ class SoftDeleteProjectTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a user deletes a project and has access, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val projectId = UUID.randomUUID()
+    fun `When a user deletes a project and has access, the the project and any invitation tokens for it are deleted successfully`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val projectId = UUID.randomUUID()
 
-        mockCurrentUser(user)
-        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, projectId, AccessType.DELETE) }
-        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
-        coJustRun { projectRepoMock.softDeleteProject(projectId) }
-        coJustRun { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, projectId, AccessType.DELETE) }
+            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+            coJustRun { projectRepoMock.softDeleteProject(projectId) }
+            coJustRun { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
 
-        service.softDeleteProject(projectId)
+            service.softDeleteProject(projectId)
 
-        coVerify(exactly = 1) { projectRepoMock.softDeleteProject(projectId) }
-        coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
-    }
+            coVerify(exactly = 1) { projectRepoMock.softDeleteProject(projectId) }
+            coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -45,7 +45,7 @@ class SoftDeleteProjectTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a user deletes a project and has access, the the project and any invitation tokens for it are deleted successfully`() =
+    fun `When a user deletes a project and has access, then the project and any invitation tokens for it are deleted successfully`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val projectId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -16,7 +15,6 @@ import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import snowballr.ProjectOuterClass.ProjectStatus
-import kotlin.test.assertEquals
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class UpdateProjectTest : ProjectServiceTest() {
@@ -56,7 +54,7 @@ class UpdateProjectTest : ProjectServiceTest() {
     }
 
     @Test
-    fun `When a user updates a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user updates a project and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
@@ -68,7 +66,9 @@ class UpdateProjectTest : ProjectServiceTest() {
         coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
         coEvery { projectRepoMock.updateProject(request) } returns project
 
-        assertDoesNotThrow { service.updateProject(request) }
+        val result = service.updateProject(request)
+
+        assertProjectEquality(project, result)
     }
 
     @Test
@@ -120,7 +120,7 @@ class UpdateProjectTest : ProjectServiceTest() {
 
     @ParameterizedTest
     @ValueSource(strings = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_ACTIVE_LOCKED"])
-    fun `When a user updates an archived project (only active status), then no exception is thrown`(
+    fun `When a user updates an archived project (only active status), then the correct values are returned`(
         statusName: String,
     ) = runTest {
         val status = ProjectStatus.valueOf(statusName)
@@ -137,28 +137,29 @@ class UpdateProjectTest : ProjectServiceTest() {
             (updatedProject.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
         coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-        val resultProject = service.updateProject(request)
+        val result = service.updateProject(request)
 
-        assertEquals(status, resultProject.status)
+        assertProjectEquality(updatedProject, result)
     }
 
     @Test
-    fun `When a user updates an archived project (only archived status), then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+    fun `When a user updates an archived project (only archived status), then the correct values are returned`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
 
-        val updatedProject = project.copy(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
-        val request = getRequest(updatedProject, listOf("project.status"))
+            val updatedProject = project.copy(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+            val request = getRequest(updatedProject, listOf("project.status"))
 
-        mockCurrentUser(user)
-        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-        val resultProject = service.updateProject(request)
+            val result = service.updateProject(request)
 
-        assertEquals(ProjectStatus.PROJECT_STATUS_ARCHIVED, resultProject.status)
-    }
+            assertProjectEquality(updatedProject, result)
+        }
 
     @Test
     fun `When a user updates an archived project (only unsupported status), then a FailedPreconditionException is thrown`() =
@@ -193,24 +194,27 @@ class UpdateProjectTest : ProjectServiceTest() {
         }
 
     @Test
-    fun `When a user updates an active locked project (not project settings), then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+    fun `When a user updates an active locked project (not project settings), then the correct values are returned`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
 
-        val updatedProject = project.copy(name = "Updated Name")
-        val request = getRequest(updatedProject, listOf("project.name"))
+            val updatedProject = project.copy(name = "Updated Name")
+            val request = getRequest(updatedProject, listOf("project.name"))
 
-        mockCurrentUser(user)
-        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectRepoMock.isProjectLocked(project.id) } returns true
-        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectRepoMock.isProjectLocked(project.id) } returns true
+            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-        assertDoesNotThrow { service.updateProject(request) }
-    }
+            val result = service.updateProject(request)
+
+            assertProjectEquality(updatedProject, result)
+        }
 
     @Test
-    fun `When a user updates an active project, then no exception is thrown`() = runTest {
+    fun `When a user updates an active project, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
 
@@ -223,7 +227,9 @@ class UpdateProjectTest : ProjectServiceTest() {
         coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
         coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-        assertDoesNotThrow { service.updateProject(request) }
+        val result = service.updateProject(request)
+
+        assertProjectEquality(updatedProject, result)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 
 class GetProjectMembersTest : ProjectMemberServiceTest() {
     @Test
-    fun `When a user requests the project members and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the project members and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -22,7 +22,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         .build()
 
     @Test
-    fun `When a user removes a project member, then no exception is thrown`() = runTest {
+    fun `When a user removes a project member, then the member is successfully deleted`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
         val project = DataBuilder.createExampleProject()
@@ -128,7 +128,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
     }
 
     @Test
-    fun `When a user removes an invitation and has access, then no exception is thrown`() = runTest {
+    fun `When a user removes an invitation and has access, then the invitation is successfully deleted`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val invitationToken = DataBuilder.createExampleInvitationToken()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
@@ -24,48 +24,53 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
         .build()
 
     @Test
-    fun `When a user adds a paper to a project and has access, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val projectResult = Result.success(project)
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+    fun `When a user adds a paper to a project and has access, then the created project paper has the correct values`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+            val projectResult = Result.success(project)
+            val paper = DataBuilder.createExamplePaper()
+            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
 
-        val backwardReferences = listOf(UUID.randomUUID(), UUID.randomUUID())
-        val reviews = listOf(DataBuilder.createExampleReview(), DataBuilder.createExampleReview())
-        val criteriaIds0 = listOf(UUID.randomUUID(), UUID.randomUUID())
-        val criteriaIds1 = listOf(UUID.randomUUID(), UUID.randomUUID())
+            val backwardReferences = listOf(UUID.randomUUID(), UUID.randomUUID())
+            val reviews = listOf(DataBuilder.createExampleReview(), DataBuilder.createExampleReview())
+            val criteriaIds0 = listOf(UUID.randomUUID(), UUID.randomUUID())
+            val criteriaIds1 = listOf(UUID.randomUUID(), UUID.randomUUID())
 
-        val request = getRequest(project.id, paper.id)
+            val request = getRequest(project.id, paper.id)
 
-        mockCurrentUser(user)
-        coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
-        coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
-        coEvery { projectPaperRepoMock.addPaperToProject(request, user.id) } returns projectPaper
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns backwardReferences
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns reviews
-        coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[0].id) } returns criteriaIds0
-        coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[1].id) } returns criteriaIds1
+            mockCurrentUser(user)
+            coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+            coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
+            coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
+            coEvery { projectPaperRepoMock.addPaperToProject(request, user.id) } returns projectPaper
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns backwardReferences
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns reviews
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[0].id)
+            } returns criteriaIds0
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[1].id)
+            } returns criteriaIds1
 
-        val addedProjectPaper = service.addPaperToProject(request)
+            val addedProjectPaper = service.addPaperToProject(request)
 
-        assertEquals(2, addedProjectPaper.reviewsCount)
-        val review0 = addedProjectPaper.getReviews(0)
-        val review1 = addedProjectPaper.getReviews(1)
-        assertEquals(review0.id, reviews[0].id.toString())
-        assertEquals(review1.id, reviews[1].id.toString())
+            assertEquals(2, addedProjectPaper.reviewsCount)
+            val review0 = addedProjectPaper.getReviews(0)
+            val review1 = addedProjectPaper.getReviews(1)
+            assertEquals(review0.id, reviews[0].id.toString())
+            assertEquals(review1.id, reviews[1].id.toString())
 
-        val criteriaIdsReview0 = review0.selectedCriteriaIdsList
-        val criteriaIdsReview1 = review1.selectedCriteriaIdsList
-        assertEquals(2, criteriaIdsReview0.size)
-        assertEquals(2, criteriaIdsReview1.size)
-        assertEquals(criteriaIds0[0].toString(), criteriaIdsReview0[0].toString())
-        assertEquals(criteriaIds0[1].toString(), criteriaIdsReview0[1].toString())
-        assertEquals(criteriaIds1[0].toString(), criteriaIdsReview1[0].toString())
-        assertEquals(criteriaIds1[1].toString(), criteriaIdsReview1[1].toString())
-    }
+            val criteriaIdsReview0 = review0.selectedCriteriaIdsList
+            val criteriaIdsReview1 = review1.selectedCriteriaIdsList
+            assertEquals(2, criteriaIdsReview0.size)
+            assertEquals(2, criteriaIdsReview1.size)
+            assertEquals(criteriaIds0[0].toString(), criteriaIdsReview0[0].toString())
+            assertEquals(criteriaIds0[1].toString(), criteriaIdsReview0[1].toString())
+            assertEquals(criteriaIds1[0].toString(), criteriaIdsReview1[0].toString())
+            assertEquals(criteriaIds1[1].toString(), criteriaIdsReview1[1].toString())
+        }
 
     @Test
     fun `When a user adds a paper to a project, but has no access, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertEquals
 class GetAllProjectPapersForProjectTest : ProjectPaperServiceTest() {
     @Test
     @Suppress("LongMethod")
-    fun `When a user requests all project papers for a project and has access, then no exception is thrown`() =
+    fun `When a user requests all project papers for a project and has access, then the correct values are returned`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -8,16 +8,16 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
-import kotlin.test.assertEquals
 
 class GetNextPaperTest : ProjectPaperServiceTest() {
     @Test
-    fun `When a user requests the next project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the next project paper and has access, then the correct values are returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
+        val otherPaper = DataBuilder.createExamplePaper()
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper(paperId = otherPaper.id)
 
         mockCurrentUser(currentUser)
         coEvery {
@@ -28,13 +28,13 @@ class GetNextPaperTest : ProjectPaperServiceTest() {
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(project.id, projectPaper.localPaperId, PaperNavigationDirection.NEXT)
         } returns Result.success(nextProjectPaper)
-        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(otherPaper)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(otherPaper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
 
         val nextPaper = service.getNextPaper(projectPaper.id)
 
-        assertEquals(nextProjectPaper.id.toString(), nextPaper.id)
+        assertProjectPaperEquality(nextProjectPaper, nextPaper)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -155,7 +155,7 @@ class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
             coEvery { paperRepoMock.getPaperById(paper2.id) } returns Result.success(paper2)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns emptyList()
 
-            assertDoesNotThrow { service.getNextPaperToReview(currentProjectPaper.id) }
+            service.getNextPaperToReview(currentProjectPaper.id)
             coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
             coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
         }
@@ -216,7 +216,7 @@ class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
         coEvery { paperRepoMock.getPaperById(paper3.id) } returns Result.success(paper3)
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper3.id) } returns emptyList()
 
-        assertDoesNotThrow { service.getNextPaperToReview(currentProjectPaper.id) }
+        service.getNextPaperToReview(currentProjectPaper.id)
         coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
         coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
         coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) }
@@ -269,7 +269,7 @@ class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
             coEvery { paperRepoMock.getPaperById(paper2.id) } returns Result.success(paper2)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper2.id) } returns emptyList()
 
-            assertDoesNotThrow { service.getNextPaperToReview(currentProjectPaper.id) }
+            service.getNextPaperToReview(currentProjectPaper.id)
             coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
             coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
         }
@@ -322,7 +322,7 @@ class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
 
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper1.id) } returns emptyList()
 
-            assertDoesNotThrow { service.getNextPaperToReview(currentProjectPaper.id) }
+            service.getNextPaperToReview(currentProjectPaper.id)
             coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
             coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -15,7 +14,7 @@ import java.util.UUID
 
 class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
     @Test
-    fun `When a user requests the next project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the next project paper and has access, then the correct values are returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -25,7 +24,12 @@ class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
             stage = 0,
             localPaperId = 0,
         )
-        val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
+        val otherPaper = DataBuilder.createExamplePaper()
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper(
+            stage = 0,
+            localPaperId = 1,
+            paperId = otherPaper.id,
+        )
         val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
 
         mockCurrentUser(currentUser)
@@ -39,11 +43,13 @@ class GetNextPaperToReviewTest : ProjectPaperServiceTest() {
         coEvery {
             reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
         } returns listOf(review)
-        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(otherPaper)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(otherPaper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { service.getNextPaperToReview(projectPaper.id) }
+        val result = service.getNextPaperToReview(projectPaper.id)
+
+        assertProjectPaperEquality(nextProjectPaper, result)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
@@ -6,14 +6,12 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
 import snowballr.ProjectOuterClass.PaperDecision
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPapersToReviewForProjectTest : ProjectPaperServiceTest() {
@@ -55,8 +53,7 @@ class GetPapersToReviewForProjectTest : ProjectPaperServiceTest() {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns listOf(UUID.randomUUID())
 
-        var projectPapers: GrpcProjectPaper.List
-        assertDoesNotThrow { projectPapers = service.getPapersToReviewForProject(project.id) }
+        val projectPapers = service.getPapersToReviewForProject(project.id)
         assertThat(projectPapers.projectPapersList).hasSize(1)
         assertThat(projectPapers.projectPapersList).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
         assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
@@ -105,8 +102,7 @@ class GetPapersToReviewForProjectTest : ProjectPaperServiceTest() {
                 reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviewByOtherUser.id)
             } returns listOf(UUID.randomUUID())
 
-            var projectPapers: GrpcProjectPaper.List
-            assertDoesNotThrow { projectPapers = service.getPapersToReviewForProject(project.id) }
+            val projectPapers = service.getPapersToReviewForProject(project.id)
             assertThat(projectPapers.projectPapersList).hasSize(1)
             assertThat(projectPapers.projectPapersList)
                 .anyMatch { it.id == projectPaperWithoutCurrentUserReview.id.toString() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -8,38 +8,39 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
-import kotlin.test.assertEquals
 
 class GetPreviousPaperTest : ProjectPaperServiceTest() {
     @Test
-    fun `When a user requests the previous project paper and has access, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val previousProjectPaper = DataBuilder.createExampleProjectPaper()
+    fun `When a user requests the previous project paper and has access, then the correct values are returned`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+            val paper = DataBuilder.createExamplePaper()
+            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+            val otherPaper = DataBuilder.createExamplePaper()
+            val previousProjectPaper = DataBuilder.createExampleProjectPaper(paperId = otherPaper.id)
 
-        mockCurrentUser(currentUser)
-        coEvery {
-            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-        } returns Result.success(projectPaper)
-        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
-        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
-        coEvery {
-            projectPaperRepoMock.getAdjacentPaper(
-                project.id,
-                projectPaper.localPaperId,
-                PaperNavigationDirection.PREVIOUS,
-            )
-        } returns Result.success(previousProjectPaper)
-        coEvery { paperRepoMock.getPaperById(previousProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(previousProjectPaper.id) } returns emptyList()
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.success(projectPaper)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+            coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
+            coEvery {
+                projectPaperRepoMock.getAdjacentPaper(
+                    project.id,
+                    projectPaper.localPaperId,
+                    PaperNavigationDirection.PREVIOUS,
+                )
+            } returns Result.success(previousProjectPaper)
+            coEvery { paperRepoMock.getPaperById(previousProjectPaper.paperId) } returns Result.success(otherPaper)
+            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(otherPaper.id) } returns emptyList()
+            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(previousProjectPaper.id) } returns emptyList()
 
-        val previousPaper = service.getPreviousPaper(projectPaper.id)
+            val previousPaper = service.getPreviousPaper(projectPaper.id)
 
-        assertEquals(previousProjectPaper.id.toString(), previousPaper.id)
-    }
+            assertProjectPaperEquality(previousProjectPaper, previousPaper)
+        }
 
     @Test
     fun `When retrieving the project paper fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -13,7 +12,7 @@ import se.uulm.snowballr.backend.TestSpecificException
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByIdTest : ProjectPaperServiceTest() {
     @Test
-    fun `When a user requests a project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests a project paper and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(paperId = paper.id)
@@ -25,7 +24,9 @@ class GetProjectPaperByIdTest : ProjectPaperServiceTest() {
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { service.getProjectPaperById(projectPaper.id) }
+        val result = service.getProjectPaperById(projectPaper.id)
+
+        assertProjectPaperEquality(projectPaper, result)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -21,7 +20,7 @@ class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
         .build()
 
     @Test
-    fun `When a user request the project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user request the project paper and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val relativeId = 1L
@@ -39,7 +38,9 @@ class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { service.getProjectPaperByRelativeId(request) }
+        val result = service.getProjectPaperByRelativeId(request)
+
+        assertProjectPaperEquality(projectPaper, result)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/ProjectPaperServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/ProjectPaperServiceTest.kt
@@ -3,9 +3,11 @@ package se.uulm.snowballr.backend.service.projectpaper
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IProjectPaperAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -17,6 +19,7 @@ import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTable
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ProjectPaperService
 import se.uulm.snowballr.backend.service.withUser
+import snowballr.ProjectOuterClass
 
 /**
  * Base test class for [ProjectPaperService].
@@ -64,5 +67,12 @@ sealed class ProjectPaperServiceTest : BaseServiceTest {
     protected fun mockCurrentUser(currentUser: User) {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+    }
+
+    protected fun assertProjectPaperEquality(expected: ProjectPaper, actual: ProjectOuterClass.Project.Paper) {
+        assertEquals(expected.paperId.toString(), actual.paper.id)
+        assertEquals(expected.localPaperId.toString(), actual.localId)
+        assertEquals(expected.stage, actual.stage)
+        assertEquals(expected.decision, actual.decision)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -7,7 +7,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
@@ -23,7 +22,7 @@ class AddPaperToReadingListTest : ReadingListServiceTest() {
         coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
         coJustRun { readingListRepoMock.createReadingListEntry(user.id, paperId) }
 
-        assertDoesNotThrow { service.addPaperToReadingList(paperId) }
+        service.addPaperToReadingList(paperId)
         coVerify(exactly = 1) { readingListRepoMock.createReadingListEntry(user.id, paperId) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -7,7 +7,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
@@ -23,7 +22,7 @@ class RemovePaperFromReadingListTest : ReadingListServiceTest() {
         coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
         coJustRun { readingListRepoMock.removeReadingListEntry(user.id, paperId) }
 
-        assertDoesNotThrow { service.removePaperFromReadingList(paperId) }
+        service.removePaperFromReadingList(paperId)
         coVerify(exactly = 1) { readingListRepoMock.removeReadingListEntry(user.id, paperId) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -30,6 +30,7 @@ import snowballr.ReviewOuterClass.ReviewDecision
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
+import kotlin.test.assertEquals
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -148,10 +149,14 @@ class CreateReviewTest : ReviewServiceTest() {
     }
 
     @Test
-    fun `When a user creates a review and has access, then no exception is thrown`() = runTest {
+    fun `When a user creates a review and has access, then the created review has the correct values`() = runTest {
         mockCreateReview()
 
-        assertDoesNotThrow { service.createReview(validCreateReviewRequest.build()) }
+        val review = service.createReview(validCreateReviewRequest.build())
+
+        assertEquals(userId.toString(), review.userId)
+        assertEquals(decision, review.decision)
+        assertEquals(selectedCriteriaIds.map { it.toString() }, review.selectedCriteriaIdsList)
 
         coVerify(exactly = 1) {
             projectRepoMock.updateProject(getUpdateProjectStatusRequest(project.id))
@@ -184,7 +189,7 @@ class CreateReviewTest : ReviewServiceTest() {
     }
 
     @Test
-    fun `When another user reviewed the project paper but not finally decided it, then no exception is thrown and the paper decision is updated accordingly to the review decision matrix`() =
+    fun `When another user reviewed the project paper but not finally decided it, then the paper decision is updated accordingly to the review decision matrix`() =
         runTest {
             val reviewByAnotherUser = DataBuilder.createExampleReview(
                 projectPaperId = projectPaperId,
@@ -197,7 +202,11 @@ class CreateReviewTest : ReviewServiceTest() {
                 updatedPaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
             )
 
-            assertDoesNotThrow { service.createReview(validCreateReviewRequest.build()) }
+            service.createReview(validCreateReviewRequest.build())
+
+            coVerify(exactly = 1) {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+            }
         }
 
     @Test
@@ -219,7 +228,11 @@ class CreateReviewTest : ReviewServiceTest() {
                 updatedPaperDecision = PaperDecision.PAPER_DECISION_ACCEPTED,
             )
 
-            assertDoesNotThrow { service.createReview(validCreateReviewRequest.build()) }
+            service.createReview(validCreateReviewRequest.build())
+
+            coVerify(exactly = 1) {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_ACCEPTED)
+            }
         }
 
     @Test
@@ -280,7 +293,11 @@ class CreateReviewTest : ReviewServiceTest() {
             }
             coJustRun { projectRepoMock.updateProject(getUpdateProjectStatusRequest(project.id)) }
 
-            assertDoesNotThrow { service.createReview(createReviewRequest) }
+            service.createReview(createReviewRequest)
+
+            coVerify(exactly = 1) {
+                projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+            }
         }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -7,7 +7,6 @@ import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -237,7 +237,7 @@ class CreateReviewTest : ReviewServiceTest() {
             )
             mockCreateReview(project = project)
 
-            assertDoesNotThrow { service.createReview(validCreateReviewRequest.build()) }
+            service.createReview(validCreateReviewRequest.build())
             coVerify(exactly = 1) {
                 projectPaperRepoMock.updateProjectPaperDecision(
                     projectPaperId,
@@ -325,7 +325,7 @@ class CreateReviewTest : ReviewServiceTest() {
             }
             coJustRun { projectRepoMock.updateProject(getUpdateProjectStatusRequest(project.id)) }
 
-            assertDoesNotThrow { service.createReview(createReviewRequest) }
+            service.createReview(createReviewRequest)
             coVerify(exactly = 1) {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
             }
@@ -360,7 +360,7 @@ class CreateReviewTest : ReviewServiceTest() {
             }
             coJustRun { projectRepoMock.updateProject(getUpdateProjectStatusRequest(project.id)) }
 
-            assertDoesNotThrow { service.createReview(createReviewRequest) }
+            service.createReview(createReviewRequest)
             coVerify(exactly = 1) {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllReviewsForProjectPaperTest : ReviewServiceTest() {
     @Test
-    fun `When a user requests all reviews and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests all reviews and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectPaper = DataBuilder.createExampleProjectPaper()
         val review = DataBuilder.createExampleReview()
@@ -35,6 +35,7 @@ class GetAllReviewsForProjectPaperTest : ReviewServiceTest() {
         assertEquals(1, reviews[0].selectedCriteriaIdsCount)
         val selectedCriterionId = reviews[0].selectedCriteriaIdsList[0]
         assertEquals(selectedCriteriaIds[0].toString(), selectedCriterionId)
+        assertReviewEquality(review, reviews[0])
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetReviewByIdTest : ReviewServiceTest() {
     @Test
-    fun `When a user requests a review and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests a review and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val review = DataBuilder.createExampleReview()
         val selectedCriteriaIds = listOf(UUID.randomUUID())
@@ -32,6 +32,7 @@ class GetReviewByIdTest : ReviewServiceTest() {
         assertEquals(1, reviewResult.selectedCriteriaIdsCount)
         val selectedCriterionId = reviewResult.selectedCriteriaIdsList[0]
         assertEquals(selectedCriteriaIds[0].toString(), selectedCriterionId)
+        assertReviewEquality(review, reviewResult)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IReviewAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
+import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -17,6 +18,8 @@ import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTable
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ReviewService
 import se.uulm.snowballr.backend.service.withUser
+import snowballr.ReviewOuterClass
+import kotlin.test.assertEquals
 
 /**
  * Base test class for the [ReviewService].
@@ -64,5 +67,10 @@ sealed class ReviewServiceTest : BaseServiceTest {
     protected fun mockCurrentUser(currentUser: User) {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+    }
+
+    protected fun assertReviewEquality(expected: Review, actual: ReviewOuterClass.Review) {
+        assertEquals(expected.userId.toString(), actual.userId)
+        assertEquals(expected.decision, actual.decision)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -2,16 +2,18 @@ package se.uulm.snowballr.backend.service.user
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
+import kotlin.test.assertEquals
 
 class GetCurrentUserTest : UserServiceTest() {
     @Test
-    fun `When retrieving the current user, then no exception is thrown`() = runTest {
+    fun `When retrieving the current user, then the correct user is returned`() = runTest {
         val user = DataBuilder.createExampleUser()
 
         mockCurrentUser(user)
 
-        assertDoesNotThrow { service.getCurrentUser() }
+        val result = service.getCurrentUser()
+
+        assertEquals(user.id.toString(), result.id)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service.user
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -20,29 +19,33 @@ class GetUserSettingsTest : UserServiceTest() {
     }
 
     @Test
-    fun `When retrieving current user settings is correct, but not default criteria exist, then no exception is thrown`() =
+    fun `When retrieving current user settings is correct, but no default criteria exists, then the correct values are returned`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val userSettings = DataBuilder.createExampleUserSettings()
 
             mockCurrentUser(user)
-            coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
             coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
+            coEvery { criterionRepoMock.getCriteriaByIds(emptyList()) } returns emptyList()
 
-            assertDoesNotThrow { service.getUserSettings() }
+            val result = service.getUserSettings()
+
+            assertUserSettingsEquality(userSettings, result)
         }
 
     @Test
-    fun `When retrieving current user settings is correct and default criteria exist, then no exception is thrown`() =
+    fun `When retrieving current user settings is correct and default criteria exists, then the correct values are returned`() =
         runTest {
             val user = DataBuilder.createExampleUser()
-            val criterion = DataBuilder.createExampleProjectCriterion()
+            val criterion = DataBuilder.createExampleUserCriterion()
             val userSettings = DataBuilder.createExampleUserSettings(criteriaIds = listOf(criterion.id))
 
             mockCurrentUser(user)
-            coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
             coEvery { userRepoMock.getUserSettings(user.id) } returns Result.success(userSettings)
+            coEvery { criterionRepoMock.getCriteriaByIds(listOf(criterion.id)) } returns listOf(criterion)
 
-            assertDoesNotThrow { service.getUserSettings() }
+            val result = service.getUserSettings()
+
+            assertUserSettingsEquality(userSettings, result)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -72,7 +71,7 @@ class RegisterTest : UserServiceTest() {
             every { envReaderMock.env.lifetime.verificationTokenLifeTimeInDays } returns 7
             coJustRun { emailManagerMock.sendVerificationEmail(user.email, capture(emailDataSlot)) }
 
-            assertDoesNotThrow { service.register(getExampleRequest(user)) }
+            service.register(getExampleRequest(user))
 
             val capturedToken = tokenSlot.captured
             assertThat(capturedToken).isNotBlank()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -2,9 +2,9 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -55,18 +55,21 @@ class SoftDeleteUserTest : UserServiceTest() {
         }
 
     @Test
-    fun `When a user soft-deletes another user and has access, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val userToDelete = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
+    fun `When a user soft-deletes another user and has access, then the other user is successfully deleted`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val userToDelete = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
-        coJustRun { userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete) }
-        coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns listOf(project)
-        coJustRun { userRepoMock.softDeleteUser(userToDelete.id) }
-        coJustRun { projectAccessCheckerMock.isNotLastProjectAdmin(userToDelete, project.id, any()) }
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
+            coJustRun { userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete) }
+            coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns listOf(project)
+            coJustRun { userRepoMock.softDeleteUser(userToDelete.id) }
+            coJustRun { projectAccessCheckerMock.isNotLastProjectAdmin(userToDelete, project.id, any()) }
 
-        assertDoesNotThrow { service.softDeleteUser(userToDelete.id) }
-    }
+            service.softDeleteUser(userToDelete.id)
+
+            coVerify(exactly = 1) { userRepoMock.softDeleteUser(userToDelete.id) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UserServiceTest.kt
@@ -9,6 +9,7 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -16,6 +17,8 @@ import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.UserService
 import se.uulm.snowballr.backend.service.withUser
+import snowballr.UserSettingsOuterClass
+import kotlin.test.assertEquals
 
 /**
  * Base test class for the [UserService].
@@ -60,5 +63,19 @@ sealed class UserServiceTest : BaseServiceTest {
     protected fun mockCurrentUser(currentUser: User) {
         every { GrpcContext.getUserIdFromContext() } returns currentUser.id
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
+    }
+
+    protected fun assertUserSettingsEquality(expected: UserSettings, actual: UserSettingsOuterClass.UserSettings) {
+        assertEquals(expected.areHotkeysShown, actual.showHotkeys)
+        assertEquals(expected.isReviewModeEnabled, actual.reviewMode)
+        assertEquals(expected.criteriaIds.map { it.toString() }, actual.defaultCriteria.criteriaList.map { it.id })
+        assertEquals(expected.similarityThreshold, actual.defaultProjectSettings.similarityThreshold)
+        assertEquals(expected.decisionMatrix, actual.defaultProjectSettings.decisionMatrix)
+        assertEquals(
+            expected.fetchers,
+            actual.defaultProjectSettings.fetchersMap.mapValues { options -> options.value.optionsMap },
+        )
+        assertEquals(expected.snowballingType, actual.defaultProjectSettings.snowballingType)
+        assertEquals(expected.reviewMaybeAllowed, actual.defaultProjectSettings.reviewMaybeAllowed)
     }
 }

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -123,7 +123,7 @@ class. A service test class has the following structure:
 ```kotlin
 class CreateExampleTest : ExampleServiceTest() {
     @Test
-    fun `When an example is correctly created, then no exception is thrown`() =
+    fun `When an example is correctly created, then the created example has the correct values`() =
         runTest {
             val request = ExampleOuterClass.Example.Create.getDefaultInstance()
             val example = ExampleOuterClass.Example.getDefaultInstance()
@@ -132,7 +132,9 @@ class CreateExampleTest : ExampleServiceTest() {
             coEvery { exampleRepoMock.createExample(any()) } returns Result.success(example)
 
             // Assert service behavior
-            assertDoesNotThrow { service.createExample(request) }
+            val result = service.createExample(request)
+
+            assertEquals(example.property, result.property)
         }
 
     @Test


### PR DESCRIPTION
Closes #458

## What I have made

As discussed, we remove the redundant `assertDoesNotThrow`.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- ~~[ ] I have updated the documentation accordingly and commented my code~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

### Reviewer

- [x] I have checked the implementation against the requirements
