### PR TITLE
Fetcher execution flow is not robust enough in edge cases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Setup
-              uses: ./.github/workflows/setup/
+            - name: Setup Java and Gradle
+              uses: ./.github/workflows/setup-java-gradle/
 
             - name: Build the jar file
               run: ./gradlew shadowJar --stacktrace

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -44,9 +44,7 @@ jobs:
                   enable-cache: true
 
             - name: Run tests and collect coverage
-              run: |
-                  ./gradlew test
-                  ./gradlew koverPrintCoverage
+              run: ./gradlew test
 
             - name: Upload report
               if: failure() || success()

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -16,8 +16,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Setup
-              uses: ./.github/workflows/setup/
+            - name: Setup Java and Gradle
+              uses: ./.github/workflows/setup-java-gradle/
 
             - name: Check linting
               run: ./gradlew lint
@@ -32,16 +32,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Setup
-              uses: ./.github/workflows/setup/
+            - name: Setup Java and Gradle
+              uses: ./.github/workflows/setup-java-gradle/
 
-            - uses: actions/setup-python@v6
-              with:
-                  python-version: "3.13"
-
-            - uses: astral-sh/setup-uv@v8.1.0
-              with:
-                  enable-cache: true
+            - name: Setup Python and uv
+              uses: ./.github/workflows/setup-python-uv/
 
             - name: Run tests and collect coverage
               run: ./gradlew test
@@ -81,8 +76,11 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Setup
-              uses: ./.github/workflows/setup/
+            - name: Setup Java and Gradle
+              uses: ./.github/workflows/setup-java-gradle/
+
+            - name: Setup Python and uv
+              uses: ./.github/workflows/setup-python-uv/
 
             - name: Run integration tests
               run: ./gradlew integrationTest
@@ -130,8 +128,8 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup
-              uses: ./.github/workflows/setup/
+            - name: Setup Java and Gradle
+              uses: ./.github/workflows/setup-java-gradle/
 
             - name: Download coverage report
               uses: actions/download-artifact@v8

--- a/.github/workflows/setup-java-gradle/action.yml
+++ b/.github/workflows/setup-java-gradle/action.yml
@@ -1,5 +1,5 @@
-name: Setup
-description: Setup Backend CI/CD pipeline
+name: Setup Java and Gradle
+description: Setup Java and Gradle for Backend CI/CD pipeline
 runs:
     using: composite
     steps:

--- a/.github/workflows/setup-python-uv/action.yml
+++ b/.github/workflows/setup-python-uv/action.yml
@@ -1,0 +1,14 @@
+name: Setup Python and uv
+description: Setup Python and uv for fetcher-related tasks
+runs:
+    using: composite
+    steps:
+        - name: Setup Python
+          uses: actions/setup-python@v6
+          with:
+              python-version: "3.13"
+
+        - name: Setup uv
+          uses: astral-sh/setup-uv@v8.1.0
+          with:
+              enable-cache: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,28 +153,28 @@ tasks.test {
     reports.junitXml.required.set(false)
     finalizedBy(tasks.koverHtmlReport)
     finalizedBy(tasks.koverXmlReport)
+    finalizedBy(tasks.koverPrintCoverage)
 }
 
 tasks.register<Test>("integrationTest") {
-    testClassesDirs = sourceSets["test"].output.classesDirs
-    classpath = sourceSets["test"].runtimeClasspath
+    dependsOn("syncFetcherPythonDeps")
     useJUnitPlatform {
         includeTags("integration")
     }
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
     reports.html.required.set(true)
     reports.html.outputLocation.set(layout.buildDirectory.dir("integrationTestReportHtml"))
     reports.junitXml.required.set(false)
 }
 
-tasks.koverHtmlReport {
-    dependsOn(tasks.test)
-}
-
-tasks.koverXmlReport {
-    dependsOn(tasks.test)
-}
-
 kover {
+    currentProject {
+        instrumentation {
+            disabledForTestTasks.add("integrationTest")
+        }
+    }
+
     reports {
         filters {
             excludes {
@@ -223,7 +223,7 @@ kover {
             log {
                 onCheck.set(true)
                 header.set(null as String?)
-                format.set("<entity> line coverage: <value>%")
+                format.set("<entity> instruction coverage: <value>%")
                 groupBy.set(GroupingEntityType.APPLICATION)
                 coverageUnits.set(CoverageUnit.INSTRUCTION)
                 aggregationForGroup.set(AggregationType.COVERED_PERCENTAGE)

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -196,7 +196,7 @@ private fun createMailer(envReader: EnvReader): Mailer {
  */
 private fun Module.customServicesDeps() {
     singleOf(::JwtManager) { bind<IJwtManager>() }
-    singleOf(::PythonPluginFetcherManager) { bind<IFetcherManager>() }
+    single<IFetcherManager> { PythonPluginFetcherManager(get()) }
     singleOf(::CookieManager) { bind<ICookieManager>() }
     singleOf(::EmailManager) { bind<IEmailManager>() }
     singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcherManager.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.fetcher
 
-class FetcherException(stderr: String) : Exception(stderr)
+class FetcherException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 /**
  * Delegate requests to multiple fetchers using their names.

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcherManager.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.fetcher
 
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 
-class FetcherException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
-
 /**
  * Delegate requests to multiple fetchers using their names.
  */

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/IFetcherManager.kt
@@ -1,5 +1,7 @@
 package se.uulm.snowballr.backend.fetcher
 
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+
 class FetcherException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import se.uulm.snowballr.backend.env.EnvReader
@@ -38,6 +40,19 @@ private data class ProcessResult(
     val returnCode: Int,
 )
 
+@Serializable
+private data class QueryPayload(
+    @SerialName("search_query")
+    val searchQuery: String,
+    val options: Map<String, String>,
+)
+
+@Serializable
+private data class ReferencePayload(
+    val paper: FetcherPaper,
+    val options: Map<String, String>,
+)
+
 class PythonPluginFetcherManager(
     envReader: EnvReader,
     private val executionTimeoutMillis: Long = 30_000L,
@@ -66,7 +81,7 @@ class PythonPluginFetcherManager(
         .toSet()
 
     override suspend fun getAvailableOptions(fetcher: String): Map<String, String> =
-        decodeFetcherJson(fetcher, execFetcher(fetcher, "options"))
+        decodeFetcherJson(fetcher, execFetcher(fetcher, action = "options"))
 
     override suspend fun searchPapers(
         fetcher: String,
@@ -76,9 +91,8 @@ class PythonPluginFetcherManager(
         fetcher,
         execFetcher(
             fetcher,
-            "query",
-            searchQuery,
-            Json.encodeToString(options),
+            action = "query",
+            payload = Json.encodeToString(QueryPayload(searchQuery = searchQuery, options = options)),
         ),
     )
 
@@ -90,9 +104,8 @@ class PythonPluginFetcherManager(
         fetcher,
         execFetcher(
             fetcher,
-            "forwards",
-            Json.encodeToString(paper),
-            Json.encodeToString(options),
+            action = "forwards",
+            payload = Json.encodeToString(ReferencePayload(paper = paper, options = options)),
         ),
     )
 
@@ -104,9 +117,8 @@ class PythonPluginFetcherManager(
         fetcher,
         execFetcher(
             fetcher,
-            "backwards",
-            Json.encodeToString(paper),
-            Json.encodeToString(options),
+            action = "backwards",
+            payload = Json.encodeToString(ReferencePayload(paper = paper, options = options)),
         ),
     )
 
@@ -116,23 +128,24 @@ class PythonPluginFetcherManager(
      * to a single line) is then returned.
      *
      * The current contract expects the fetcher to return a single line of JSON.
-     * Furthermore, the first command line argument represents the action to be
-     * performed (query, forwards, backwards) and the rest of the cli arguments
-     * are the JSON serialized representations of the action arguments:
+     * The first command line argument represents the action to be performed.
+     * Action payloads are serialized JSON and sent over stdin.
      *
      * - python fetcher.py options
-     * - python fetcher.py query <SEARCH_QUERY> <OPTIONS>
-     * - python fetcher.py backwards <PAPER> <OPTIONS>
-     * - python fetcher.py forwards <PAPER> <OPTIONS>
+     * - python fetcher.py query
+     * - python fetcher.py backwards
+     * - python fetcher.py forwards
      */
     @Suppress("ThrowsCount")
     private suspend fun execFetcher(
         fetcher: String,
-        vararg args: String,
+        action: String,
+        payload: String = "",
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
     ): String {
         val fetcherPath = resolveFetcherPath(fetcher)
-        val process = createProcess(fetcherPath, args, dispatcher)
+        val process = createProcess(fetcherPath, action, dispatcher)
+        writePayload(process, payload, dispatcher)
         val processResult = awaitProcessResult(fetcher, process, dispatcher)
         return parseProcessResult(fetcher, processResult)
     }
@@ -140,18 +153,27 @@ class PythonPluginFetcherManager(
     /**
      * Creates and starts a Python fetcher process with the expected environment.
      */
-    private suspend fun createProcess(
-        fetcherPath: Path,
-        args: Array<out String>,
-        dispatcher: CoroutineDispatcher,
-    ): Process {
-        @Suppress("SpreadOperator")
-        val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), *args)
+    private suspend fun createProcess(fetcherPath: Path, action: String, dispatcher: CoroutineDispatcher): Process {
+        val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), action)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
+            .redirectInput(ProcessBuilder.Redirect.PIPE)
             .also { it.environment()["PYTHONPATH"] = root.resolve("lib").toAbsolutePath().toString() }
         return withContext(dispatcher) {
             processBuilder.start()
+        }
+    }
+
+    /**
+     * Writes a JSON payload to the process stdin and then closes the input stream.
+     */
+    private suspend fun writePayload(process: Process, payload: String, dispatcher: CoroutineDispatcher) {
+        withContext(dispatcher) {
+            process.outputWriter().use { writer ->
+                if (payload.isNotEmpty()) {
+                    writer.write(payload)
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -6,13 +6,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
+import se.uulm.snowballr.backend.model.fetcher.FetcherAction
+import se.uulm.snowballr.backend.model.fetcher.ProcessResult
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.InvalidPathException
@@ -36,25 +36,6 @@ private val resources = buildResources(FETCHER_RESOURCES_ROOT) {
         file("snowballr.py")
     }
 }
-
-private data class ProcessResult(
-    val stdout: String,
-    val stderr: String,
-    val returnCode: Int,
-)
-
-@Serializable
-private data class QueryPayload(
-    @SerialName("search_query")
-    val searchQuery: String,
-    val options: Map<String, String>,
-)
-
-@Serializable
-private data class ReferencePayload(
-    val paper: FetcherPaper,
-    val options: Map<String, String>,
-)
 
 class PythonPluginFetcherManager(
     envReader: EnvReader,
@@ -92,47 +73,58 @@ class PythonPluginFetcherManager(
         .map { it.nameWithoutExtension }
         .toSet()
 
-    override suspend fun getAvailableOptions(fetcher: String): Map<String, String> =
-        decodeFetcherJson(fetcher, execFetcher(fetcher, action = "options"))
+    override suspend fun getAvailableOptions(fetcher: String): Map<String, String> {
+        val action = FetcherAction.OPTIONS
+        return decodeFetcherJson(fetcher, execFetcher(fetcher, action = action, payload = action.payload()))
+    }
 
     override suspend fun searchPapers(
         fetcher: String,
         searchQuery: String,
         options: Map<String, String>,
-    ): Set<FetcherPaper> = decodeFetcherJson(
-        fetcher,
-        execFetcher(
+    ): Set<FetcherPaper> {
+        val action = FetcherAction.QUERY
+        return decodeFetcherJson(
             fetcher,
-            action = "query",
-            payload = Json.encodeToString(QueryPayload(searchQuery = searchQuery, options = options)),
-        ),
-    )
+            execFetcher(
+                fetcher,
+                action = action,
+                payload = action.payload(searchQuery = searchQuery, options = options),
+            ),
+        )
+    }
 
     override suspend fun fetchForwardReferences(
         fetcher: String,
         paper: FetcherPaper,
         options: Map<String, String>,
-    ): Set<FetcherPaper> = decodeFetcherJson(
-        fetcher,
-        execFetcher(
+    ): Set<FetcherPaper> {
+        val action = FetcherAction.FORWARDS
+        return decodeFetcherJson(
             fetcher,
-            action = "forwards",
-            payload = Json.encodeToString(ReferencePayload(paper = paper, options = options)),
-        ),
-    )
+            execFetcher(
+                fetcher,
+                action = action,
+                payload = action.payload(paper = paper, options = options),
+            ),
+        )
+    }
 
     override suspend fun fetchBackwardReferences(
         fetcher: String,
         paper: FetcherPaper,
         options: Map<String, String>,
-    ): Set<FetcherPaper> = decodeFetcherJson(
-        fetcher,
-        execFetcher(
+    ): Set<FetcherPaper> {
+        val action = FetcherAction.BACKWARDS
+        return decodeFetcherJson(
             fetcher,
-            action = "backwards",
-            payload = Json.encodeToString(ReferencePayload(paper = paper, options = options)),
-        ),
-    )
+            execFetcher(
+                fetcher,
+                action = action,
+                payload = action.payload(paper = paper, options = options),
+            ),
+        )
+    }
 
     /**
      * Executes the python script of a given fetcher with the given command
@@ -151,7 +143,7 @@ class PythonPluginFetcherManager(
     @Suppress("ThrowsCount")
     private suspend fun execFetcher(
         fetcher: String,
-        action: String,
+        action: FetcherAction,
         payload: String = "",
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
     ): String {
@@ -165,8 +157,12 @@ class PythonPluginFetcherManager(
     /**
      * Creates and starts a Python fetcher process with the expected environment.
      */
-    private suspend fun createProcess(fetcherPath: Path, action: String, dispatcher: CoroutineDispatcher): Process {
-        val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), action)
+    private suspend fun createProcess(
+        fetcherPath: Path,
+        action: FetcherAction,
+        dispatcher: CoroutineDispatcher,
+    ): Process {
+        val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), action.command)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .redirectInput(ProcessBuilder.Redirect.PIPE)

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -75,7 +75,7 @@ class PythonPluginFetcherManager(
 
     override suspend fun getAvailableOptions(fetcher: String): Map<String, String> {
         val action = FetcherAction.OPTIONS
-        return decodeFetcherJson(fetcher, execFetcher(fetcher, action = action, payload = action.payload()))
+        return executeFetcher(fetcher, action, action.payload())
     }
 
     override suspend fun searchPapers(
@@ -84,13 +84,10 @@ class PythonPluginFetcherManager(
         options: Map<String, String>,
     ): Set<FetcherPaper> {
         val action = FetcherAction.QUERY
-        return decodeFetcherJson(
+        return executeFetcher(
             fetcher,
-            execFetcher(
-                fetcher,
-                action = action,
-                payload = action.payload(searchQuery = searchQuery, options = options),
-            ),
+            action,
+            action.payload(searchQuery = searchQuery, options = options),
         )
     }
 
@@ -100,13 +97,10 @@ class PythonPluginFetcherManager(
         options: Map<String, String>,
     ): Set<FetcherPaper> {
         val action = FetcherAction.FORWARDS
-        return decodeFetcherJson(
+        return executeFetcher(
             fetcher,
-            execFetcher(
-                fetcher,
-                action = action,
-                payload = action.payload(paper = paper, options = options),
-            ),
+            action,
+            action.payload(paper = paper, options = options),
         )
     }
 
@@ -116,13 +110,10 @@ class PythonPluginFetcherManager(
         options: Map<String, String>,
     ): Set<FetcherPaper> {
         val action = FetcherAction.BACKWARDS
-        return decodeFetcherJson(
+        return executeFetcher(
             fetcher,
-            execFetcher(
-                fetcher,
-                action = action,
-                payload = action.payload(paper = paper, options = options),
-            ),
+            action,
+            action.payload(paper = paper, options = options),
         )
     }
 
@@ -175,7 +166,7 @@ class PythonPluginFetcherManager(
     /**
      * Writes a JSON payload to the process stdin and then closes the input stream.
      */
-    private suspend fun writePayload(process: Process, payload: String, dispatcher: CoroutineDispatcher) {
+    private suspend fun writePayload(process: Process, payload: String, dispatcher: CoroutineDispatcher) =
         withContext(dispatcher) {
             process.outputWriter().use { writer ->
                 if (payload.isNotEmpty()) {
@@ -183,7 +174,6 @@ class PythonPluginFetcherManager(
                 }
             }
         }
-    }
 
     /**
      * Waits for the process to finish, enforcing timeout and force-kill grace period.
@@ -279,9 +269,14 @@ class PythonPluginFetcherManager(
     }
 
     /**
-     * Decodes fetcher JSON output and maps parse failures to a fetcher-specific exception.
+     * Executes a fetcher action, decodes the JSON output, and maps parse failures to a fetcher-specific exception.
      */
-    private inline fun <reified T> decodeFetcherJson(fetcher: String, input: String): T = try {
+    private suspend inline fun <reified T> executeFetcher(
+        fetcher: String,
+        action: FetcherAction,
+        payload: String = "",
+    ): T = try {
+        val input = execFetcher(fetcher = fetcher, action = action, payload = payload)
         Json.decodeFromString<T>(input)
     } catch (exception: SerializationException) {
         throw FetcherException("Fetcher '$fetcher' returned invalid JSON.", exception)

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -6,11 +6,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import se.uulm.snowballr.backend.env.EnvReader
+import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
+import java.io.IOException
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.extension
-import kotlin.io.path.isRegularFile
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.writeText
@@ -137,13 +139,42 @@ class PythonPluginFetcherManager(
         }
     }
 
+    /**
+     * Resolves the on-disk path and validates that it is safe to execute.
+     *
+     * The script must be a direct child of the configured fetchers directory. Symlinks are allowed,
+     * but the fully resolved target must still reside in that directory.
+     *
+     * @param fetcher Base name of the fetcher script (without `.py` extension)
+     * @return Path to the validated fetcher script
+     * @throws UnauthorizedFetcherPathException if the fetcher path traverses outside the configured directory.
+     * @throws FetcherNotFoundException for missing fetchers and all other path resolution errors.
+     */
+    @Suppress("ThrowsCount")
     private fun resolveFetcherPath(fetcher: String): Path {
-        val root = root.normalize()
-        val fetcherPath = root.resolve("$fetcher.py").normalize()
-        if (fetcherPath.parent != root || !fetcherPath.isRegularFile()) {
-            throw FetcherNotFoundException(fetcher)
-        }
+        return runCatching {
+            val normalizedRoot = root.normalize()
+            val fetcherPath = normalizedRoot.resolve("$fetcher.py").normalize()
 
-        return fetcherPath
+            if (fetcherPath.parent != normalizedRoot) {
+                throw UnauthorizedFetcherPathException(fetcher)
+            }
+
+            val rootReal = normalizedRoot.toRealPath()
+            val fetcherReal = fetcherPath.toRealPath()
+
+            if (fetcherReal.parent != rootReal) {
+                throw UnauthorizedFetcherPathException(fetcher)
+            }
+
+            fetcherPath
+        }.getOrElse { exception ->
+            when (exception) {
+                is UnauthorizedFetcherPathException -> throw exception
+                is InvalidPathException -> throw FetcherNotFoundException(fetcher)
+                is IOException -> throw FetcherNotFoundException(fetcher)
+                else -> throw exception
+            }
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import se.uulm.snowballr.backend.env.EnvReader
+import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
 import se.uulm.snowballr.backend.model.fetcher.FetcherAction

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
@@ -59,15 +60,14 @@ class PythonPluginFetcherManager(
         .toSet()
 
     override suspend fun getAvailableOptions(fetcher: String): Map<String, String> =
-        Json.decodeFromString<Map<String, String>>(
-            execFetcher(fetcher, "options"),
-        )
+        decodeFetcherJson(fetcher, execFetcher(fetcher, "options"))
 
     override suspend fun searchPapers(
         fetcher: String,
         searchQuery: String,
         options: Map<String, String>,
-    ): Set<FetcherPaper> = Json.decodeFromString<Set<FetcherPaper>>(
+    ): Set<FetcherPaper> = decodeFetcherJson(
+        fetcher,
         execFetcher(
             fetcher,
             "query",
@@ -80,7 +80,8 @@ class PythonPluginFetcherManager(
         fetcher: String,
         paper: FetcherPaper,
         options: Map<String, String>,
-    ): Set<FetcherPaper> = Json.decodeFromString<Set<FetcherPaper>>(
+    ): Set<FetcherPaper> = decodeFetcherJson(
+        fetcher,
         execFetcher(
             fetcher,
             "forwards",
@@ -93,7 +94,8 @@ class PythonPluginFetcherManager(
         fetcher: String,
         paper: FetcherPaper,
         options: Map<String, String>,
-    ): Set<FetcherPaper> = Json.decodeFromString<Set<FetcherPaper>>(
+    ): Set<FetcherPaper> = decodeFetcherJson(
+        fetcher,
         execFetcher(
             fetcher,
             "backwards",
@@ -117,6 +119,7 @@ class PythonPluginFetcherManager(
      * - python fetcher.py backwards <PAPER> <OPTIONS>
      * - python fetcher.py forwards <PAPER> <OPTIONS>
      */
+    @Suppress("ThrowsCount")
     private suspend fun execFetcher(
         fetcher: String,
         vararg args: String,
@@ -152,7 +155,11 @@ class PythonPluginFetcherManager(
 
         if (returnCode == 0) {
             if (!stderr.isBlank()) logger.info { "Fetcher '$fetcher' encountered a problem: $stderr" }
-            return stdout.lineSequence().first()
+            val output = stdout.lineSequence().firstOrNull()?.trim().orEmpty()
+            if (output.isBlank()) {
+                throw FetcherException("Fetcher '$fetcher' returned no JSON output.")
+            }
+            return output
         } else {
             logger.error { "Could not correctly execute fetcher '$fetcher':\n$stderr" }
             throw FetcherException(stderr)
@@ -196,5 +203,21 @@ class PythonPluginFetcherManager(
                 else -> throw exception
             }
         }
+    }
+
+    /**
+     * Decodes the JSON payload returned by a fetcher and normalizes parse failures
+     * into [FetcherException] so callers get a stable fetcher-specific error.
+     *
+     * @param T Type of the JSON payload
+     * @param fetcher Name of the fetcher that returned the JSON
+     * @param input JSON payload returned by the fetcher
+     * @return Decoded JSON payload
+     * @throws FetcherException if the JSON payload could not be decoded
+     */
+    private inline fun <reified T> decodeFetcherJson(fetcher: String, input: String): T = try {
+        Json.decodeFromString<T>(input)
+    } catch (exception: SerializationException) {
+        throw FetcherException("Fetcher '$fetcher' returned invalid JSON.", exception)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -25,9 +25,11 @@ import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.writeText
 
 private val logger = KotlinLogging.logger {}
+private const val FETCHER_RESOURCES_ROOT = "/plugins/fetchers"
+private const val FETCHER_RESOURCES_PREFIX = "$FETCHER_RESOURCES_ROOT/"
 
 // Bundled python scripts and libraries to bootstrap python fetcher infrastructure.
-private val resources = buildResources("/plugins/fetchers") {
+private val resources = buildResources(FETCHER_RESOURCES_ROOT) {
     file("IEEEXplore.py")
     dir("lib") {
         file("xploreapi.py")
@@ -79,7 +81,7 @@ class PythonPluginFetcherManager(
                 error("Bundled fetcher resource '$resource' is missing from classpath.")
             }
 
-            val target = root.resolve(resource.removePrefix("/plugins/fetchers/"))
+            val target = root.resolve(resource.removePrefix(FETCHER_RESOURCES_PREFIX))
             target.parent.createDirectories()
             stream.bufferedReader().use { target.writeText(it.readText()) }
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -32,6 +32,12 @@ private val resources = buildResources("/plugins/fetchers") {
     }
 }
 
+private data class ProcessResult(
+    val stdout: String,
+    val stderr: String,
+    val returnCode: Int,
+)
+
 class PythonPluginFetcherManager(
     envReader: EnvReader,
     private val executionTimeoutMillis: Long = 30_000L,
@@ -126,33 +132,66 @@ class PythonPluginFetcherManager(
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
     ): String {
         val fetcherPath = resolveFetcherPath(fetcher)
+        val process = createProcess(fetcherPath, args, dispatcher)
+        val processResult = awaitProcessResult(fetcher, process, dispatcher)
+        return parseProcessResult(fetcher, processResult)
+    }
+
+    /**
+     * Creates and starts a Python fetcher process with the expected environment.
+     */
+    private suspend fun createProcess(
+        fetcherPath: Path,
+        args: Array<out String>,
+        dispatcher: CoroutineDispatcher,
+    ): Process {
+        @Suppress("SpreadOperator")
         val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), *args)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .also { it.environment()["PYTHONPATH"] = root.resolve("lib").toAbsolutePath().toString() }
-        val process = withContext(dispatcher) { processBuilder.start() }
+        return withContext(dispatcher) {
+            processBuilder.start()
+        }
+    }
 
-        val (stdout, stderr, returnCode) = coroutineScope {
-            val stdoutDeferred = async(dispatcher) { process.inputReader().use { it.readText() } }
-            val stderrDeferred = async(dispatcher) { process.errorReader().use { it.readText() } }
+    /**
+     * Waits for the process to finish, enforcing timeout and force-kill grace period.
+     */
+    private suspend fun awaitProcessResult(
+        fetcher: String,
+        process: Process,
+        dispatcher: CoroutineDispatcher,
+    ): ProcessResult = coroutineScope {
+        val stdoutDeferred = async(dispatcher) { process.inputReader().use { it.readText() } }
+        val stderrDeferred = async(dispatcher) { process.errorReader().use { it.readText() } }
 
-            val finishedInTime = withContext(dispatcher) {
-                process.waitFor(executionTimeoutMillis, TimeUnit.MILLISECONDS)
-            }
-
-            if (!finishedInTime) {
-                process.destroy()
-                withContext(dispatcher) {
-                    if (!process.waitFor(forceKillGraceMillis, TimeUnit.MILLISECONDS)) {
-                        process.destroyForcibly()
-                    }
-                }
-                throw FetcherException("Fetcher '$fetcher' timed out after ${executionTimeoutMillis}ms.")
-            }
-
-            Triple(stdoutDeferred.await(), stderrDeferred.await(), process.exitValue())
+        val finishedInTime = withContext(dispatcher) {
+            process.waitFor(executionTimeoutMillis, TimeUnit.MILLISECONDS)
         }
 
+        if (!finishedInTime) {
+            process.destroy()
+            withContext(dispatcher) {
+                if (!process.waitFor(forceKillGraceMillis, TimeUnit.MILLISECONDS)) {
+                    process.destroyForcibly()
+                }
+            }
+            throw FetcherException("Fetcher '$fetcher' timed out after ${executionTimeoutMillis}ms.")
+        }
+
+        ProcessResult(
+            stdout = stdoutDeferred.await(),
+            stderr = stderrDeferred.await(),
+            returnCode = process.exitValue(),
+        )
+    }
+
+    /**
+     * Interprets the finished process result and returns the fetcher payload line.
+     */
+    private fun parseProcessResult(fetcher: String, processResult: ProcessResult): String {
+        val (stdout, stderr, returnCode) = processResult
         if (returnCode == 0) {
             if (!stderr.isBlank()) logger.info { "Fetcher '$fetcher' encountered a problem: $stderr" }
             val output = stdout.lineSequence().firstOrNull()?.trim().orEmpty()
@@ -206,14 +245,7 @@ class PythonPluginFetcherManager(
     }
 
     /**
-     * Decodes the JSON payload returned by a fetcher and normalizes parse failures
-     * into [FetcherException] so callers get a stable fetcher-specific error.
-     *
-     * @param T Type of the JSON payload
-     * @param fetcher Name of the fetcher that returned the JSON
-     * @param input JSON payload returned by the fetcher
-     * @return Decoded JSON payload
-     * @throws FetcherException if the JSON payload could not be decoded
+     * Decodes fetcher JSON output and maps parse failures to a fetcher-specific exception.
      */
     private inline fun <reified T> decodeFetcherJson(fetcher: String, input: String): T = try {
         Json.decodeFromString<T>(input)

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -12,6 +12,7 @@ import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
 import se.uulm.snowballr.backend.model.fetcher.FetcherAction
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import se.uulm.snowballr.backend.model.fetcher.ProcessResult
 import java.io.IOException
 import java.io.InputStream

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -126,7 +126,7 @@ class PythonPluginFetcherManager(
         val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), *args)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
-            .also { it.environment().put("PYTHONPATH", root.resolve("lib").toAbsolutePath().toString()) }
+            .also { it.environment()["PYTHONPATH"] = root.resolve("lib").toAbsolutePath().toString() }
         val process = withContext(dispatcher) { processBuilder.start() }
 
         val (stdout, stderr, returnCode) = coroutineScope {

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -14,6 +14,7 @@ import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
 import java.io.IOException
+import java.io.InputStream
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
@@ -55,6 +56,9 @@ private data class ReferencePayload(
 
 class PythonPluginFetcherManager(
     envReader: EnvReader,
+    resourceLoader: (String) -> InputStream? = { resource ->
+        PythonPluginFetcherManager::class.java.getResourceAsStream(resource)
+    },
     private val executionTimeoutMillis: Long = 30_000L,
     private val forceKillGraceMillis: Long = 1_000L,
 ) : IFetcherManager {
@@ -66,12 +70,18 @@ class PythonPluginFetcherManager(
             "Python fetcher setup: pythonExecutable='$pythonExecutable', pluginDirectory='${root.toAbsolutePath()}'"
         }
 
-        for (resource in resources) {
-            val target = root.resolve(resource.removePrefix("/plugins/fetchers/"))
-            val stream = this::class.java.getResourceAsStream(resource)
+        root.createDirectories()
 
+        for (resource in resources) {
+            val stream = resourceLoader(resource)
+            if (stream == null) {
+                logger.error { "Bundled fetcher resource '$resource' is missing from classpath." }
+                error("Bundled fetcher resource '$resource' is missing from classpath.")
+            }
+
+            val target = root.resolve(resource.removePrefix("/plugins/fetchers/"))
             target.parent.createDirectories()
-            target.writeText(stream.bufferedReader().readText())
+            stream.bufferedReader().use { target.writeText(it.readText()) }
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -265,6 +265,10 @@ class PythonPluginFetcherManager(
                 throw UnauthorizedFetcherPathException(fetcher)
             }
 
+            if (!java.nio.file.Files.isRegularFile(fetcherReal)) {
+                throw FetcherNotFoundException(fetcher)
+            }
+
             fetcherPath
         }.getOrElse { exception ->
             when (exception) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -3,6 +3,8 @@ package se.uulm.snowballr.backend.fetcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import se.uulm.snowballr.backend.env.EnvReader
@@ -11,6 +13,7 @@ import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundExcepti
 import java.io.IOException
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.createDirectories
 import kotlin.io.path.extension
 import kotlin.io.path.listDirectoryEntries
@@ -30,6 +33,8 @@ private val resources = buildResources("/plugins/fetchers") {
 
 class PythonPluginFetcherManager(
     envReader: EnvReader,
+    private val executionTimeoutMillis: Long = 30_000L,
+    private val forceKillGraceMillis: Long = 1_000L,
 ) : IFetcherManager {
     private val root = envReader.env.plugins.pluginDirectory.resolve("fetchers")
     private val pythonExecutable = envReader.env.plugins.pythonExecutable
@@ -118,21 +123,36 @@ class PythonPluginFetcherManager(
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
     ): String {
         val fetcherPath = resolveFetcherPath(fetcher)
-        val process = ProcessBuilder(pythonExecutable, fetcherPath.toString(), *args)
+        val processBuilder = ProcessBuilder(pythonExecutable, fetcherPath.toString(), *args)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .also { it.environment().put("PYTHONPATH", root.resolve("lib").toAbsolutePath().toString()) }
-            .start()
+        val process = withContext(dispatcher) { processBuilder.start() }
 
-        val returnCode = withContext(dispatcher) {
-            process.waitFor()
+        val (stdout, stderr, returnCode) = coroutineScope {
+            val stdoutDeferred = async(dispatcher) { process.inputReader().use { it.readText() } }
+            val stderrDeferred = async(dispatcher) { process.errorReader().use { it.readText() } }
+
+            val finishedInTime = withContext(dispatcher) {
+                process.waitFor(executionTimeoutMillis, TimeUnit.MILLISECONDS)
+            }
+
+            if (!finishedInTime) {
+                process.destroy()
+                withContext(dispatcher) {
+                    if (!process.waitFor(forceKillGraceMillis, TimeUnit.MILLISECONDS)) {
+                        process.destroyForcibly()
+                    }
+                }
+                throw FetcherException("Fetcher '$fetcher' timed out after ${executionTimeoutMillis}ms.")
+            }
+
+            Triple(stdoutDeferred.await(), stderrDeferred.await(), process.exitValue())
         }
-
-        val stderr = process.errorReader().use { it.readText() }
 
         if (returnCode == 0) {
             if (!stderr.isBlank()) logger.info { "Fetcher '$fetcher' encountered a problem: $stderr" }
-            return process.inputReader().use { it.readLines().first() }
+            return stdout.lineSequence().first()
         } else {
             logger.error { "Could not correctly execute fetcher '$fetcher':\n$stderr" }
             throw FetcherException(stderr)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/FetcherException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/FetcherException.kt
@@ -1,0 +1,3 @@
+package se.uulm.snowballr.backend.model.exception
+
+class FetcherException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedFetcherPathException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedFetcherPathException.kt
@@ -1,0 +1,11 @@
+package se.uulm.snowballr.backend.model.exception
+
+import io.grpc.Status
+
+/**
+ * Represents an exception that occurs when a fetcher path traverses outside the configured fetchers directory.
+ */
+class UnauthorizedFetcherPathException(fetcher: String) : SnowballRException(
+    Status.INTERNAL,
+    "Fetcher \"$fetcher\" is outside the configured fetchers directory.",
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherAction.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherAction.kt
@@ -1,0 +1,52 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+import kotlinx.serialization.json.Json
+import se.uulm.snowballr.backend.fetcher.FetcherPaper
+
+/**
+ * Lists all supported fetcher actions and their command/payload mapping.
+ * Payload builder overloads are overridden per action; unsupported combinations fail fast.
+ *
+ * @property command CLI action string passed as the first argument to the Python fetcher.
+ */
+enum class FetcherAction(
+    val command: String,
+) {
+    /** Returns the fetcher's available option definitions. */
+    OPTIONS("options") {
+        override fun payload(): String = ""
+    },
+
+    /** Searches for papers using a text query and options. */
+    QUERY("query") {
+        override fun payload(searchQuery: String, options: Map<String, String>): String =
+            Json.encodeToString(QueryPayload(searchQuery = searchQuery, options = options))
+    },
+
+    /** Fetches papers that cite the provided source paper. */
+    FORWARDS("forwards") {
+        override fun payload(paper: FetcherPaper, options: Map<String, String>): String =
+            Json.encodeToString(ReferencePayload(paper = paper, options = options))
+    },
+
+    /** Fetches papers cited by the provided source paper. */
+    BACKWARDS("backwards") {
+        override fun payload(paper: FetcherPaper, options: Map<String, String>): String =
+            Json.encodeToString(ReferencePayload(paper = paper, options = options))
+    },
+    ;
+
+    /** Builds a payload for actions that do not require additional input. */
+    open fun payload(): String = unsupportedPayload("no payload")
+
+    /** Builds a payload for query actions. */
+    open fun payload(searchQuery: String, options: Map<String, String>): String = unsupportedPayload("query payload")
+
+    /** Builds a payload for reference actions. */
+    open fun payload(paper: FetcherPaper, options: Map<String, String>): String =
+        unsupportedPayload("reference payload")
+
+    private fun unsupportedPayload(payloadType: String): Nothing {
+        error("Action '$command' does not support $payloadType.")
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherAction.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherAction.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.fetcher
 
 import kotlinx.serialization.json.Json
-import se.uulm.snowballr.backend.fetcher.FetcherPaper
 
 /**
  * Lists all supported fetcher actions and their command/payload mapping.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherPaper.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.fetcher
+package se.uulm.snowballr.backend.model.fetcher
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/ProcessResult.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/ProcessResult.kt
@@ -1,0 +1,14 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+/**
+ * Captures the full output of a finished fetcher process.
+ *
+ * @property stdout Standard output emitted by the process.
+ * @property stderr Standard error emitted by the process.
+ * @property returnCode Exit code returned by the process.
+ */
+data class ProcessResult(
+    val stdout: String,
+    val stderr: String,
+    val returnCode: Int,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/QueryPayload.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/QueryPayload.kt
@@ -1,0 +1,17 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request payload for fetcher query actions.
+ *
+ * @property searchQuery Raw text query sent to the fetcher.
+ * @property options Fetcher-specific option key/value pairs.
+ */
+@Serializable
+data class QueryPayload(
+    @SerialName("search_query")
+    val searchQuery: String,
+    val options: Map<String, String>,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/ReferencePayload.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/ReferencePayload.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.fetcher
 
 import kotlinx.serialization.Serializable
-import se.uulm.snowballr.backend.fetcher.FetcherPaper
 
 /**
  * Request payload for fetcher reference actions.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/ReferencePayload.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/ReferencePayload.kt
@@ -1,0 +1,16 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+import kotlinx.serialization.Serializable
+import se.uulm.snowballr.backend.fetcher.FetcherPaper
+
+/**
+ * Request payload for fetcher reference actions.
+ *
+ * @property paper Source paper for which references are requested.
+ * @property options Fetcher-specific option key/value pairs.
+ */
+@Serializable
+data class ReferencePayload(
+    val paper: FetcherPaper,
+    val options: Map<String, String>,
+)

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -44,6 +44,22 @@ type Options = dict[str, str]
 type QueryFn = Callable[[str, Options], list[Paper]]
 type ReferenceFn = Callable[[Paper, Options], list[Paper]]
 
+def _read_stdin_payload() -> dict:
+    if sys.stdin is None or sys.stdin.closed:
+        return {}
+    if sys.stdin.isatty():
+        return {}
+
+    try:
+        payload = sys.stdin.read()
+    except OSError:
+        return {}
+
+    if payload == "":
+        return {}
+
+    return json.loads(payload)
+
 def fetcher_plugin(
     options: dict[str, str],
     query: QueryFn,
@@ -51,45 +67,61 @@ def fetcher_plugin(
     backwards: ReferenceFn,
 ):
     if len(sys.argv) < 2:
-        print("The fetcher was called without an action.")
-        print("python fetcher.py <ACTION> <...ARGS>")
+        print("The fetcher was called without an action.", file=sys.stderr)
+        print("python fetcher.py <ACTION> <...ARGS>", file=sys.stderr)
         exit(1)
+
+    payload = _read_stdin_payload()
 
     match sys.argv[1]:
         case EventType.OPTIONS:
             print(json.dumps(options))
 
         case EventType.QUERY:
-            if len(sys.argv) != 4:
-                print("The fetcher was called with an incorrect number of arguments.")
-                print("python fetcher.py query <SEARCH_QUERY> <OPTIONS>")
+            if payload:
+                query_arg: str = payload["search_query"]
+                options_arg: Options = payload.get("options", {})
+            elif len(sys.argv) == 4:
+                query_arg = sys.argv[2]
+                options_arg = json.loads(sys.argv[3])
+            else:
+                print("The fetcher was called with an incorrect number of arguments.", file=sys.stderr)
+                print("python fetcher.py query <SEARCH_QUERY> <OPTIONS>", file=sys.stderr)
                 exit(1)
 
-            options: Options = json.loads(sys.argv[3])
-            result = query(sys.argv[2], options)
+            result = query(query_arg, options_arg)
             print(Paper.list_to_json(result))
 
         case EventType.FORWARDS:
-            if len(sys.argv) < 4:
-                print("The fetcher was called with an incorrect number of arguments.")
-                print("python fetcher.py forwards <PAPER> <OPTIONS>")
+            if payload:
+                paper_arg: Paper = fromdict(Paper, payload["paper"])
+                options_arg: Options = payload.get("options", {})
+            elif len(sys.argv) == 4:
+                paper_arg = Paper.from_json(sys.argv[2])
+                options_arg = json.loads(sys.argv[3])
+            else:
+                print("The fetcher was called with an incorrect number of arguments.", file=sys.stderr)
+                print("python fetcher.py forwards <PAPER> <OPTIONS>", file=sys.stderr)
                 exit(1)
 
-            paper: Paper = Paper.from_json(sys.argv[2])
-            options: Options = json.loads(sys.argv[3])
-            result = forwards(paper, options)
+            result = forwards(paper_arg, options_arg)
             print(Paper.list_to_json(result))
 
         case EventType.BACKWARDS:
-            if len(sys.argv) < 4:
-                print("The fetcher was called with an incorrect number of arguments.")
-                print("python fetcher.py backwards <PAPER> <OPTIONS>")
+            if payload:
+                paper_arg: Paper = fromdict(Paper, payload["paper"])
+                options_arg: Options = payload.get("options", {})
+            elif len(sys.argv) == 4:
+                paper_arg = Paper.from_json(sys.argv[2])
+                options_arg = json.loads(sys.argv[3])
+            else:
+                print("The fetcher was called with an incorrect number of arguments.", file=sys.stderr)
+                print("python fetcher.py backwards <PAPER> <OPTIONS>", file=sys.stderr)
                 exit(1)
 
-            paper: Paper = Paper.from_json(sys.argv[2])
-            options: Options = json.loads(sys.argv[3])
-            result = backwards(paper, options)
+            result = backwards(paper_arg, options_arg)
             print(Paper.list_to_json(result))
 
         case _:
-            print("ERROR")
+            print("Unknown fetcher action.", file=sys.stderr)
+            exit(1)

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/FetcherPaperTest.kt
@@ -2,6 +2,8 @@ package se.uulm.snowballr.backend.fetcher
 
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.dto.Author
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import se.uulm.snowballr.backend.model.fetcher.toPaper
 import java.time.OffsetDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.fetcher
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -17,8 +18,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
+import kotlin.io.path.readText
 import kotlin.io.path.writeText
+import kotlin.jvm.optionals.getOrElse
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PythonPluginFetcherManagerTest {
     private lateinit var pluginDirectory: Path
@@ -262,6 +266,86 @@ class PythonPluginFetcherManagerTest {
     }
 
     @Test
+    fun `When a fetcher exceeds the configured timeout, then a timeout FetcherException is thrown`() = runTest {
+        val timeoutFetcherManager = PythonPluginFetcherManager(
+            createEnvReader(pluginDirectory),
+            executionTimeoutMillis = 100L,
+            forceKillGraceMillis = 50L,
+        )
+
+        writeFetcher(
+            "slow_fetcher",
+            """
+            import sys
+            import time
+
+            if sys.argv[1] == "options":
+                time.sleep(10)
+            """.trimIndent(),
+        )
+
+        val exception = assertThrows<FetcherException> {
+            timeoutFetcherManager.getAvailableOptions("slow_fetcher")
+        }
+
+        assertThat(exception.message).contains("Fetcher 'slow_fetcher' timed out after 100ms.")
+    }
+
+    @Test
+    fun `When a timed out fetcher ignores SIGTERM, then it is force killed after grace period`() = runTest {
+        val timeoutFetcherManager = PythonPluginFetcherManager(
+            createEnvReader(pluginDirectory),
+            executionTimeoutMillis = 100L,
+            forceKillGraceMillis = 100L,
+        )
+        val pidFile = fetcherDirectory.resolve("stuck_fetcher.pid")
+        val escapedPidFilePath = pidFile.toString().replace("\\", "\\\\")
+
+        writeFetcher(
+            "stuck_fetcher",
+            """
+            import os
+            import signal
+            import sys
+            import time
+
+            pid_file = "$escapedPidFilePath"
+            with open(pid_file, "w", encoding="utf-8") as file:
+                file.write(str(os.getpid()))
+
+            def ignore_sigterm(_signal_number, _frame):
+                return
+
+            signal.signal(signal.SIGTERM, ignore_sigterm)
+
+            if sys.argv[1] == "options":
+                while True:
+                    time.sleep(0.05)
+            """.trimIndent(),
+        )
+
+        val exception = assertThrows<FetcherException> {
+            timeoutFetcherManager.getAvailableOptions("stuck_fetcher")
+        }
+        assertThat(exception.message).contains("Fetcher 'stuck_fetcher' timed out after 100ms.")
+
+        assertTrue(
+            waitUntil(
+                timeoutMillis = 1_500L,
+                condition = { pidFile.exists() },
+            ),
+        )
+        val pid = pidFile.readText().trim().toLong()
+        val processHandle = ProcessHandle.of(pid)
+
+        val isProcessTerminated = waitUntil(
+            timeoutMillis = 3_000L,
+            condition = { processHandle.map { !it.isAlive }.getOrElse { true } },
+        )
+        assertTrue(isProcessTerminated)
+    }
+
+    @Test
     fun `When a fetcher writes to stderr but exits successfully, then the result is still returned`() = runTest {
         writeFetcher(
             "warning_fetcher",
@@ -298,6 +382,19 @@ class PythonPluginFetcherManagerTest {
 
     private fun writeFetcher(name: String, source: String) {
         fetcherDirectory.resolve("$name.py").writeText(source.trimIndent())
+    }
+
+    private suspend fun waitUntil(
+        timeoutMillis: Long,
+        pollIntervalMillis: Long = 25L,
+        condition: () -> Boolean,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMillis
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return true
+            delay(pollIntervalMillis)
+        }
+        return condition()
     }
 
     private fun createEnvReader(pluginDirectory: Path): EnvReader {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -14,6 +14,7 @@ import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -159,6 +159,69 @@ class PythonPluginFetcherManagerTest {
     }
 
     @Test
+    fun `When querying papers, then payload is sent via stdin and not as CLI args`() = runTest {
+        writeFetcher(
+            "stdin_payload_fetcher",
+            """
+            import json
+            import sys
+
+            paper = [{
+                "title": "stdin title",
+                "external_id": "stdin-1",
+                "abstract": "stdin abstract",
+                "year": 2024,
+                "publisher": "stdin publisher",
+                "publication_type": "journal",
+                "publication_name": "stdin publication",
+                "authors": [{"first_name": "Grace", "last_name": "Hopper"}],
+                "metadata": {"id": "stdin-meta"}
+            }]
+
+            if sys.argv[1] == "query":
+                if len(sys.argv) != 2:
+                    print("query payload leaked to CLI", file=sys.stderr)
+                    sys.exit(1)
+
+                payload = json.loads(sys.stdin.read())
+                if payload.get("search_query") != "find-me":
+                    print("missing query payload", file=sys.stderr)
+                    sys.exit(1)
+                if payload.get("options", {}).get("api_key") != "super-secret":
+                    print("missing options payload", file=sys.stderr)
+                    sys.exit(1)
+
+                print(json.dumps(paper))
+            elif sys.argv[1] == "options":
+                print(json.dumps({"api_key": "required"}))
+            else:
+                print("unsupported", file=sys.stderr)
+                sys.exit(1)
+            """.trimIndent(),
+        )
+
+        val expectedPaper = FetcherPaper(
+            title = "stdin title",
+            externalId = "stdin-1",
+            abstract = "stdin abstract",
+            year = 2024,
+            publisher = "stdin publisher",
+            publicationType = "journal",
+            publicationName = "stdin publication",
+            authors = listOf(Author("Grace", "Hopper")),
+            metadata = mapOf("id" to "stdin-meta"),
+        )
+
+        val queryResult = fetcherManager.searchPapers(
+            "stdin_payload_fetcher",
+            "find-me",
+            mapOf("api_key" to "super-secret"),
+        )
+
+        assertEquals(setOf(expectedPaper), queryResult)
+    }
+
+    @Test
     fun `When a fetcher script is missing, then a FetcherNotFoundException is thrown`() = runTest {
         val exception = assertThrows<FetcherNotFoundException> {
             fetcherManager.getAvailableOptions("does_not_exist")

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -266,6 +266,41 @@ class PythonPluginFetcherManagerTest {
     }
 
     @Test
+    fun `When a fetcher returns invalid JSON, then a FetcherException is thrown`() = runTest {
+        writeFetcher(
+            "invalid_json_fetcher",
+            """
+            if True:
+                print("{invalid-json")
+            """.trimIndent(),
+        )
+
+        val exception = assertThrows<FetcherException> {
+            fetcherManager.getAvailableOptions("invalid_json_fetcher")
+        }
+
+        assertThat(exception.message).contains("Fetcher 'invalid_json_fetcher' returned invalid JSON.")
+        assertThat(exception.cause).isNotNull()
+    }
+
+    @Test
+    fun `When a fetcher returns no stdout payload, then a FetcherException is thrown`() = runTest {
+        writeFetcher(
+            "empty_output_fetcher",
+            """
+            if True:
+                print("")
+            """.trimIndent(),
+        )
+
+        val exception = assertThrows<FetcherException> {
+            fetcherManager.getAvailableOptions("empty_output_fetcher")
+        }
+
+        assertThat(exception.message).contains("Fetcher 'empty_output_fetcher' returned no JSON output.")
+    }
+
+    @Test
     fun `When a fetcher exceeds the configured timeout, then a timeout FetcherException is thrown`() = runTest {
         val timeoutFetcherManager = PythonPluginFetcherManager(
             createEnvReader(pluginDirectory),

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.env.Env
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.dto.Author
+import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -23,6 +24,11 @@ class PythonPluginFetcherManagerTest {
     private lateinit var pluginDirectory: Path
     private lateinit var fetcherDirectory: Path
     private lateinit var fetcherManager: PythonPluginFetcherManager
+
+    private fun createSymlink(link: Path, target: Path) {
+        Files.deleteIfExists(link)
+        Files.createSymbolicLink(link, target)
+    }
 
     @BeforeEach
     fun setUp() {
@@ -157,12 +163,84 @@ class PythonPluginFetcherManagerTest {
     }
 
     @Test
-    fun `When a fetcher path traverses outside root, then a FetcherNotFoundException is thrown`() = runTest {
-        val exception = assertThrows<FetcherNotFoundException> {
+    fun `When a fetcher path traverses outside root, then an UnauthorizedFetcherPathException is thrown`() = runTest {
+        val exception = assertThrows<UnauthorizedFetcherPathException> {
             fetcherManager.getAvailableOptions("../outside")
         }
 
-        assertThat(exception.message).contains("Fetcher \"../outside\" not found.")
+        assertThat(exception.message).contains("Fetcher \"../outside\" is outside the configured fetchers directory.")
+    }
+
+    @Test
+    fun `When a fetcher symlink points outside root, then an UnauthorizedFetcherPathException is thrown`() = runTest {
+        val outsideDir = Files.createTempDirectory("python-fetcher-outside")
+        val outsideTarget = outsideDir.resolve("outside_fetcher.py").apply {
+            writeText(
+                """
+                import json
+                import sys
+                if sys.argv[1] == "options":
+                    print(json.dumps({"ok": "nope"}))
+                """.trimIndent(),
+            )
+        }
+
+        // Link inside fetcherDirectory -> target outside
+        createSymlink(
+            link = fetcherDirectory.resolve("symlink_outside.py"),
+            target = outsideTarget,
+        )
+
+        val exception = assertThrows<UnauthorizedFetcherPathException> {
+            fetcherManager.getAvailableOptions("symlink_outside")
+        }
+        assertThat(exception.message)
+            .contains("Fetcher \"symlink_outside\" is outside the configured fetchers directory.")
+
+        outsideDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `When a fetcher is a symlink to a file inside root, then it is allowed`() = runTest {
+        writeFetcher(
+            "target_fetcher",
+            """
+            import json
+            import sys
+            if sys.argv[1] == "options":
+                print(json.dumps({"foo": "bar"}))
+            """.trimIndent(),
+        )
+
+        // Link inside fetcherDirectory -> target inside
+        createSymlink(
+            link = fetcherDirectory.resolve("symlink_inside.py"),
+            target = fetcherDirectory.resolve("target_fetcher.py"),
+        )
+
+        val options = fetcherManager.getAvailableOptions("symlink_inside")
+        assertEquals(mapOf("foo" to "bar"), options)
+    }
+
+    @Test
+    fun `When a fetcher name contains invalid path characters, then a FetcherNotFoundException is thrown`() = runTest {
+        val exception = assertThrows<FetcherNotFoundException> {
+            fetcherManager.getAvailableOptions("invalid\u0000name")
+        }
+
+        assertThat(exception.message).contains("Fetcher \"invalid")
+        assertThat(exception.message).contains("not found.")
+    }
+
+    @Test
+    fun `When the configured fetchers directory is missing, then a FetcherNotFoundException is thrown`() = runTest {
+        fetcherDirectory.toFile().deleteRecursively()
+
+        val exception = assertThrows<FetcherNotFoundException> {
+            fetcherManager.getAvailableOptions("IEEEXplore")
+        }
+
+        assertThat(exception.message).contains("Fetcher \"IEEEXplore\" not found.")
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -230,6 +230,17 @@ class PythonPluginFetcherManagerTest {
     }
 
     @Test
+    fun `When a fetcher path resolves to a directory, then a FetcherNotFoundException is thrown`() = runTest {
+        fetcherDirectory.resolve("not_a_file.py").createDirectories()
+
+        val exception = assertThrows<FetcherNotFoundException> {
+            fetcherManager.getAvailableOptions("not_a_file")
+        }
+
+        assertThat(exception.message).contains("Fetcher \"not_a_file\" not found.")
+    }
+
+    @Test
     fun `When a fetcher path traverses outside root, then an UnauthorizedFetcherPathException is thrown`() = runTest {
         val exception = assertThrows<UnauthorizedFetcherPathException> {
             fetcherManager.getAvailableOptions("../outside")

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.env.Env
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.dto.Author
+import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 import se.uulm.snowballr.backend.model.exception.notfound.FetcherNotFoundException
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -97,7 +97,7 @@ open class IntegrationTest : KoinTest {
             createdAtStart()
             bind<IJwtManager>()
         }
-        singleOf(::PythonPluginFetcherManager) { bind<IFetcherManager>() }
+        single<IFetcherManager> { PythonPluginFetcherManager(get()) }
         singleOf(::CookieManager) { bind<ICookieManager>() }
         singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
     }

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -72,6 +72,9 @@ file directly contained within the `fetchers` directory will be treated as a
 fetcher. If you would like to create a reusable module/library, put it inside a
 subdirectory like the `lib` folder or create a new one.
 
+Fetcher names are strictly resolved to direct children of this directory.
+Path traversal and symlink targets outside this directory are rejected.
+
 ### Fetcher Contract
 
 Every fetcher is required to follow an implicit contract to be compatible with

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -101,6 +101,26 @@ fetcher_plugin(
 Everything regarding the protocol will be taken care of by calling `fetcher_plugin`.
 Just provide implementations for the functions and you're off to go.
 
+#### Invocation Protocol
+
+Fetchers are invoked with the action as the only command-line argument:
+
+```bash
+python fetcher.py options
+python fetcher.py query
+python fetcher.py forwards
+python fetcher.py backwards
+```
+
+For `query`, `forwards`, and `backwards`, SnowballR sends the request payload as
+JSON via `stdin`:
+
+- `query`: `{"search_query":"...","options":{...}}`
+- `forwards` / `backwards`: `{"paper":{...},"options":{...}}`
+
+This avoids exposing secrets (for example API keys in `options`) through process
+lists, where command-line arguments can otherwise be visible.
+
 To accommodate for API secrets and other variables, each fetcher is configurable
 using a string-to-string dictionary. The `options` set serves as a hint
 to the frontend, which options this fetcher accepts. There could, however, at


### PR DESCRIPTION
Closes #451 
Closes #437 

## What I have made

- Fetcher path resolution was hardened against escapes
  - Resolution now enforces that scripts (including symlink targets) stay inside the configured fetcher root.
  - A dedicated unauthorized-path exception and tests were added, and the plugin docs were updated accordingly.

- Timeout and grace-period enforcement was implemented
  - Fetchers now time out deterministically, receive a graceful termination attempt, and are force-killed after grace expiry.
  - Process startup was moved onto the dispatcher path, with new tests for timeout and forced termination behavior.

- JSON output validation and error normalization were strengthened
  - Invalid JSON and empty output are now handled explicitly with consistent `FetcherException` messages.
  - Exception handling was improved to preserve causes, and dedicated tests were added for these cases.

- Fetcher process execution was split into clear stages
  - The execution path was refactored into separate create/write/wait/parse steps to isolate responsibilities and simplify future changes.
  - Behavior remained aligned while making timeout and failure handling easier to reason about.

- Stdin payloads replaced CLI payload args for fetcher actions
  - Query/reference payloads (including options/API keys) are now written to process stdin instead of command-line args to prevent secret exposure via process lists.
  - The Python helper and docs were updated to the same contract, and tests now assert payload is stdin-based and not leaked into sys.argv.

@Merseleo I was not able to test my code, since I don't have the time to fully read the documentation to fully set up the python stuff. I'm hoping you're able to simply try the full flow (requesting/fetching papers) to verify everything is still working. If not, I will have to do it myself.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [ ] I have checked the implementation against the requirements
