### PR TITLE
Replace pip based fetcher setup with uv managed workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ SMTP_HOST=mail.example.com
 SMTP_PORT=25
 SMTP_SENDER_NAME=Example
 SMTP_SENDER_EMAIL=noreply@example.com
+
+# Plugins
+PLUGIN_DIRECTORY=./plugins
+PYTHON_EXECUTABLE=python3

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -38,10 +38,10 @@ jobs:
             - uses: actions/setup-python@v6
               with:
                   python-version: "3.13"
-                  cache: "pip"
 
-            - name: Install Python Plugin Fetcher Dependencies
-              run: pip install -r ./requirements.txt
+            - uses: astral-sh/setup-uv@v8.1.0
+              with:
+                  enable-cache: true
 
             - name: Run tests and collect coverage
               run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ RUN ARCH=$(uname -m) && \
       -o grpc_health_probe \
     && chmod +x grpc_health_probe
 
-# Stage 2: Run the application
+# Stage 2: Provide uv binary
+FROM ghcr.io/astral-sh/uv:0.11.7 AS uv
+
+# Stage 3: Run the application
 FROM eclipse-temurin:21-jre-alpine-3.21 AS final
 
 WORKDIR /app
@@ -51,23 +54,25 @@ WORKDIR /app
 COPY --from=build /app/build/libs/snowballr-backend-*.jar app.jar
 # Copy grpc_health_probe
 COPY --from=build /app/grpc_health_probe grpc_health_probe
+COPY --from=uv /uv /bin/uv
 
 ENV PORT=8080
 ENV PLUGIN_DIRECTORY=/app/plugins/
+ENV PYTHON_EXECUTABLE=/app/venv/bin/python3
 
 VOLUME /app/plugins/
 
 # Healthcheck uses grpc-health-probe
 HEALTHCHECK CMD ./grpc_health_probe -addr=localhost:${PORT} -service "snowballr.SnowballR"
 
-# Install python and some common dependencies for the plugin system using venv
+# Install python and fetcher dependencies using uv
 COPY requirements.txt .
 RUN apk add --no-cache python3 libcurl
-RUN python3 -m venv /app/venv
+RUN uv venv /app/venv
 # Needed for pycurl
 ENV PYCURL_SSL_LIBRARY=openssl
 RUN apk add --no-cache --virtual .py-build-deps python3-dev build-base curl-dev
-RUN sh -c "source /app/venv/bin/activate && pip install -r requirements.txt"
+RUN uv pip sync --python /app/venv/bin/python3 requirements.txt
 RUN apk del .py-build-deps
 
 # Run the application as a non-root user.
@@ -75,4 +80,4 @@ RUN adduser -D backend-user && chown -R backend-user /app
 USER backend-user
 
 # Start execute the jar file when starting the container
-ENTRYPOINT sh -c "source /app/venv/bin/activate && java -jar app.jar"
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,7 +145,6 @@ tasks.shadowDistTar {
 
 tasks.test {
     dependsOn("syncFetcherPythonDeps")
-    environment("PYTHON_EXECUTABLE", fetcherVenvPython)
     useJUnitPlatform()
     reports.html.required.set(true)
     reports.html.outputLocation.set(layout.buildDirectory.dir("testReportHtml"))
@@ -371,5 +370,4 @@ tasks.named("processResources") {
 
 tasks.named<JavaExec>("run") {
     dependsOn("syncFetcherPythonDeps")
-    environment("PYTHON_EXECUTABLE", fetcherVenvPython)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,6 +107,34 @@ kotlin {
     jvmToolchain(21)
 }
 
+val fetcherVenvDir = layout.projectDirectory.dir(".venv").asFile
+val fetcherVenvPython = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+    fetcherVenvDir.resolve("Scripts/python.exe").absolutePath
+} else {
+    fetcherVenvDir.resolve("bin/python3").absolutePath
+}
+
+tasks.register<Exec>("createFetcherVenv") {
+    group = "application"
+    description = "Creates the local Python virtual environment for fetcher plugins."
+    workingDir = projectDir
+    commandLine("uv", "venv", "--allow-existing", ".venv")
+}
+
+tasks.register<Exec>("syncFetcherPythonDeps") {
+    group = "application"
+    description = "Synchronizes Python fetcher dependencies from requirements.txt using uv."
+    dependsOn("createFetcherVenv")
+    workingDir = projectDir
+    commandLine("uv", "pip", "sync", "--python", fetcherVenvPython, "requirements.txt")
+}
+
+tasks.register("setupFetcherPython") {
+    group = "application"
+    description = "Prepares Python tooling required by fetcher plugins."
+    dependsOn("syncFetcherPythonDeps")
+}
+
 tasks.shadowJar {
     archiveClassifier.set("") // omit the "all" suffix
 }
@@ -116,6 +144,8 @@ tasks.shadowDistTar {
 }
 
 tasks.test {
+    dependsOn("syncFetcherPythonDeps")
+    environment("PYTHON_EXECUTABLE", fetcherVenvPython)
     useJUnitPlatform()
     reports.html.required.set(true)
     reports.html.outputLocation.set(layout.buildDirectory.dir("testReportHtml"))
@@ -337,4 +367,9 @@ tasks.named("extractProto") {
 
 tasks.named("processResources") {
     dependsOn("downloadApiFiles")
+}
+
+tasks.named<JavaExec>("run") {
+    dependsOn("syncFetcherPythonDeps")
+    environment("PYTHON_EXECUTABLE", fetcherVenvPython)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend
 import com.github.jknack.handlebars.Template
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.bind
-import org.koin.core.module.dsl.createdAtStart
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import org.simplejavamail.api.mailer.Mailer
@@ -110,7 +109,7 @@ import se.uulm.snowballr.backend.service.UserService
  * The ordering ensures proper dependency resolution and initialization.
  */
 val snowballRModule =
-    module {
+    module(createdAtStart = true) {
         envDeps()
         dbDeps()
         repositoryLayerDeps()
@@ -132,7 +131,6 @@ private fun Module.envDeps() {
  */
 private fun Module.dbDeps() {
     singleOf(::Database) {
-        createdAtStart()
         bind<IDatabase>()
     }
     single<ITokenMaintenanceService> { TokenMaintenanceService() }
@@ -197,16 +195,10 @@ fun createMailer(envReader: EnvReader): Mailer {
  * Consists of all dependencies that are used by the core service layer.
  */
 private fun Module.customServicesDeps() {
-    singleOf(::JwtManager) {
-        createdAtStart()
-        bind<IJwtManager>()
-    }
+    singleOf(::JwtManager) { bind<IJwtManager>() }
     singleOf(::PythonPluginFetcherManager) { bind<IFetcherManager>() }
     singleOf(::CookieManager) { bind<ICookieManager>() }
-    singleOf(::EmailManager) {
-        createdAtStart()
-        bind<IEmailManager>()
-    }
+    singleOf(::EmailManager) { bind<IEmailManager>() }
     singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
 }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/Env.kt
@@ -62,5 +62,6 @@ data class Env(
 
     data class Plugins(
         val pluginDirectory: Path,
+        val pythonExecutable: String,
     )
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -39,6 +39,7 @@ private const val VERIFICATION_TOKEN_LIFETIME_IN_DAYS = "VERIFICATION_TOKEN_LIFE
 
 // Plugins
 private const val PLUGIN_DIRECTORY = "PLUGIN_DIRECTORY"
+private const val PYTHON_EXECUTABLE = "PYTHON_EXECUTABLE"
 
 // Default values
 private val DEFAULT_PROFILE = AppProfile.PRODUCTION
@@ -49,6 +50,7 @@ private const val DEFAULT_DATABASE_HOST = "localhost"
 private const val DEFAULT_INVITATION_TOKEN_LIFETIME_IN_DAYS = 7
 private const val DEFAULT_VERIFICATION_TOKEN_LIFETIME_IN_DAYS = 1
 private val DEFAULT_PLUGIN_DIRECTORY = Path.of("./plugins")
+private const val DEFAULT_PYTHON_EXECUTABLE = "python3"
 
 private val logger = KotlinLogging.logger {}
 
@@ -205,6 +207,7 @@ class EnvReader(
     private fun buildPlugins(): Env.Plugins {
         return Env.Plugins(
             pluginDirectory = envService.getPathOrDefault(PLUGIN_DIRECTORY, DEFAULT_PLUGIN_DIRECTORY),
+            pythonExecutable = envService.getStringOrDefault(PYTHON_EXECUTABLE, DEFAULT_PYTHON_EXECUTABLE),
         )
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -33,6 +33,10 @@ class PythonPluginFetcherManager(
     private val pythonExecutable = envReader.env.plugins.pythonExecutable
 
     init {
+        logger.info {
+            "Python fetcher setup: pythonExecutable='$pythonExecutable', pluginDirectory='${root.toAbsolutePath()}'"
+        }
+
         for (resource in resources) {
             val target = root.resolve(resource.removePrefix("/plugins/fetchers/"))
             val stream = this::class.java.getResourceAsStream(resource)

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -30,6 +30,7 @@ class PythonPluginFetcherManager(
     envReader: EnvReader,
 ) : IFetcherManager {
     private val root = envReader.env.plugins.pluginDirectory.resolve("fetchers")
+    private val pythonExecutable = envReader.env.plugins.pythonExecutable
 
     init {
         for (resource in resources) {
@@ -111,7 +112,7 @@ class PythonPluginFetcherManager(
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
     ): String {
         val fetcherPath = resolveFetcherPath(fetcher)
-        val process = ProcessBuilder("python3", fetcherPath.toString(), *args)
+        val process = ProcessBuilder(pythonExecutable, fetcherPath.toString(), *args)
             .redirectOutput(ProcessBuilder.Redirect.PIPE)
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .also { it.environment().put("PYTHONPATH", root.resolve("lib").toAbsolutePath().toString()) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -225,6 +225,7 @@ class PythonPluginFetcherManagerTest {
     private fun createEnvReader(pluginDirectory: Path): EnvReader {
         val pluginEnv = mockk<Env.Plugins>()
         every { pluginEnv.pluginDirectory } returns pluginDirectory
+        every { pluginEnv.pythonExecutable } returns "python3"
 
         val env = mockk<Env>()
         every { env.plugins } returns pluginEnv

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -46,6 +46,7 @@ The `PROFILE` variable determines the default behavior of the application.
 | `INVITATION_TOKEN_LIFETIME_IN_DAYS`    |                 :x:                  |       7       | Lifetime of invitation tokens in days.                                                                     |
 | `VERIFICATION_TOKEN_LIFETIME_IN_DAYS`  |                 :x:                  |       1       | Lifetime of verification tokens in days.                                                                   |
 | `PLUGIN_DIRECTORY`                     |                 :x:                  | `./plugins`   | The directory in which the plugins reside. The directory is relative to the root directory of the project. |
+| `PYTHON_EXECUTABLE`                    |                 :x:                  |   `python3`   | Python executable used to run fetchers (for example `.venv/bin/python3`).                                  |
 
 \* only used when using the docker compose profiles.
 

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -37,23 +37,24 @@ to a running SnowballR backend instance.
 ### Prerequisites
 
 - A working Python installation (Version >= 3.12).
-- A properly set-up and activated [Python virtual environment](https://docs.python.org/3/library/venv.html).
+- [uv](https://docs.astral.sh/uv/) for managing the Python virtual environment
+  and dependencies.
 - Your favourite code editor.
 
 The plugin system requires a base set of python dependencies to work. Install
-them using the following command (again, make sure you're in the same `venv` the
-SnowballR backend will later be executed in):
+them using the following commands:
 
 ```bash
-pip install -r requirements.txt
+uv venv .venv
+uv pip sync --python .venv/bin/python requirements.txt
 ```
 
 The list of required packages can be also found in the [requirements.txt](https://github.com/SE-UUlm/snowballr-backend/blob/develop/requirements.txt).
 
 > [!IMPORTANT]
-> The plugin system makes use of the environments `python` installation. Again,
-> make sure to execute the backend in the correct `venv`, where the required
-> packages were also installed.
+> The plugin system uses the configured python executable (`PYTHON_EXECUTABLE`,
+> default `python3`). Make sure it points to the environment where the required
+> packages are installed.
 
 To get proper autocomplete and type checking for the SnowballR types, add the
 `./plugins/fetchers/lib/` directory to your python path. This can be done by

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -79,7 +79,7 @@ To build the project from source, run the following commands:
 4. Run the application:
 
     ```bash
-    PYTHON_EXECUTABLE=.venv/bin/python3 java -jar build/libs/snowballr-backend-<version>.jar
+    java -jar build/libs/snowballr-backend-<version>.jar
     ```
 
     Remember to provide the environment variables either via a `.env` file or by writing them in front of the command.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -68,18 +68,18 @@ To build the project from source, run the following commands:
 
    The built JAR file can be found in the `build/libs` directory, named `snowballr-backend-<version>.jar`.
 
-3. Setup [Python venv](https://docs.python.org/3/library/venv.html) for the plugin system:
+3. Setup Python dependencies for the plugin system using
+   [uv](https://docs.astral.sh/uv/):
 
     ```bash
-    python3 -m venv .venv
-    source .venv/bin/activate # choose correct script (.fish, .csh, .ps1)
-    pip install -r requirements.txt
+    uv venv .venv
+    uv pip sync --python .venv/bin/python3 requirements.txt
     ```
 
 4. Run the application:
 
     ```bash
-    java -jar build/libs/snowballr-backend-<version>.jar
+    PYTHON_EXECUTABLE=.venv/bin/python3 java -jar build/libs/snowballr-backend-<version>.jar
     ```
 
     Remember to provide the environment variables either via a `.env` file or by writing them in front of the command.
@@ -96,9 +96,8 @@ can run Gradle commands directly from the project root directory. For example, t
 ./gradlew run
 ```
 
-> [!INFO]
-> At the moment the provided run configuration is not working, as the backend would be started without a Python virtual
-> environment. Either manually change the run configuration or start it manually.
+This command automatically prepares `.venv` and synchronizes `requirements.txt`
+with `uv` before startup.
 
 If you're using IntelliJ IDEA, you can use the provided run configuration "Run Backend", which does the same as
 executing `./gradlew run`.


### PR DESCRIPTION
Closes #468 

## What I have made

- Replaced manual pip-based fetcher dependency setup with uv-managed setup in Gradle:
  - Added `createFetcherVenv`, `syncFetcherPythonDeps`, `setupFetcherPython`
  - Wired `run` and `test` to ensure fetcher deps are synced and `PYTHON_EXECUTABLE` is set
- Made fetcher runtime use configured python executable:
  - Added `PYTHON_EXECUTABLE` env support in `Env`/`EnvReader`
  - Updated `PythonPluginFetcherManager` to use configured executable instead of hardcoded `python3`
- Migrated CI and Docker setup from pip to uv:
  - CI test workflow now sets up `uv`
  - Dockerfile now creates/syncs fetcher env via `uv` and sets `PYTHON_EXECUTABLE`
- Updated documentation and examples

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does
not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

### Reviewer

- [x] I have checked the implementation against the requirements
