### PR TITLE
Mock access checkers in service tests

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -115,6 +115,7 @@ val snowballRModule =
         repositoryLayerDeps()
         mailServiceDeps()
         customServicesDeps()
+        accessCheckerDeps()
         serviceLayerDeps()
     }
 
@@ -203,12 +204,9 @@ private fun Module.customServicesDeps() {
 }
 
 /**
- * Module declaration of the core service layer.
- *
- * Consists of the [MainService] and all its direct service dependencies.
+ * Module declaration of all access checkers.
  */
-fun Module.serviceLayerDeps() {
-    // Access Checkers
+fun Module.accessCheckerDeps() {
     singleOf(::ProjectAccessChecker) { bind<IProjectAccessChecker>() }
     singleOf(::UserAccessChecker) { bind<IUserAccessChecker>() }
     singleOf(::CriterionAccessChecker) { bind<ICriterionAccessChecker>() }
@@ -216,7 +214,14 @@ fun Module.serviceLayerDeps() {
     singleOf(::ProjectMemberAccessChecker) { bind<IProjectMemberAccessChecker>() }
     singleOf(::ProjectPaperAccessChecker) { bind<IProjectPaperAccessChecker>() }
     singleOf(::InvitationAccessChecker) { bind<IInvitationAccessChecker>() }
+}
 
+/**
+ * Module declaration of the core service layer.
+ *
+ * Consists of the [MainService] and all its direct service dependencies.
+ */
+fun Module.serviceLayerDeps() {
     // All services that are directly used by the MainService
     singleOf(::ProjectService) { bind<IProjectService>() }
     singleOf(::CriterionService) { bind<ICriterionService>() }
@@ -230,6 +235,7 @@ fun Module.serviceLayerDeps() {
     singleOf(::InvitationService) { bind<IInvitationService>() }
     singleOf(::ProjectMemberService) { bind<IProjectMemberService>() }
     singleOf(::ExportService) { bind<IExportService>() }
+
     // The main service comes last
     singleOf(::MainService) { bind<IMainService>() }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.service
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.viascom.nanoid.NanoId
 import se.uulm.snowballr.backend.access.IInvitationAccessChecker
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
@@ -28,6 +29,8 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.UserOuterClass.User as GrpcUser
+
+val Logger = KotlinLogging.logger { }
 
 interface IInvitationService {
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -76,7 +76,7 @@ class ProjectMemberService(
 
             val user = userRepo.getUserById(userId).getOrThrow()
 
-            val currentMember = try {
+            val member = try {
                 repo.getProjectMemberByComposedId(projectId, userId).getOrThrow()
             } catch (_: NotFoundException) {
                 throw FailedPreconditionException(
@@ -84,7 +84,7 @@ class ProjectMemberService(
                 )
             }
 
-            if (currentMember.isProjectAdmin() && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
+            if (member.isProjectAdmin() && request.newRole != MemberRole.MEMBER_ROLE_ADMIN) {
                 projectAccessChecker.isNotLastProjectAdmin(user, projectId, "Cannot demote the user")
             }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -74,6 +74,9 @@ interface IProjectPaperService {
     suspend fun getNextPaperToReview(projectPaperId: UUID): GrpcProjectPaper
 }
 
+private typealias ProjectPaperFilter =
+    (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean)
+
 /**
  * The [ProjectPaperService] class handles operations related to project papers by implementing the
  * [IProjectPaperService] interface.
@@ -229,7 +232,7 @@ class ProjectPaperService(
      */
     private suspend fun getProjectPapers(
         projectId: UUID,
-        predicate: (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean)? = null,
+        predicate: ProjectPaperFilter? = null,
     ): GrpcProjectPaper.List = withUser(userRepo) { currentUser ->
         projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -267,7 +267,8 @@ class ProjectService(
         requestedStatus: ProjectStatus,
         fieldMask: List<String>,
     ) {
-        require(!(fieldMask.contains("project.status") && requestedStatus == ProjectStatus.PROJECT_STATUS_DELETED)) {
+        val isStatusUpdate = fieldMask.contains("project.status")
+        require(!(isStatusUpdate && requestedStatus == ProjectStatus.PROJECT_STATUS_DELETED)) {
             "The project status cannot be set to DELETED via the update method. Use SoftDeleteProject instead."
         }
 
@@ -279,12 +280,13 @@ class ProjectService(
             }
 
             ProjectStatus.PROJECT_STATUS_ARCHIVED -> {
-                val isOnlyStatusUpdate = fieldMask.size == 1 && fieldMask.contains("project.status")
+                val isOnlyStatusUpdate = fieldMask.size == 1 && isStatusUpdate
                 if (!isOnlyStatusUpdate) {
                     throw FailedPreconditionException(
                         "The project is archived and therefore only the 'status' field can be updated.",
                     )
                 }
+
                 if (
                     requestedStatus != ProjectStatus.PROJECT_STATUS_ACTIVE &&
                     requestedStatus != ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED &&

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -98,6 +98,44 @@ class ReviewService(
             reviews.toGrpcReviews(reviewSelectedCriteriaMap)
         }
 
+    override suspend fun createReview(request: GrpcReview.Create): GrpcReview = withUser(userRepo) { currentUser ->
+        val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
+        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
+
+        val projectResult = projectRepo.getProjectById(projectPaper.projectId)
+        accessChecker.isAllowedToCreateReview(currentUser, projectPaper.projectId, projectResult)
+        val project = projectResult.getOrThrow()
+
+        val reviewsForProjectPaper = repo.getAllReviewsForProjectPaper(projectPaperId)
+        val hasUserAlreadyReviewed = reviewsForProjectPaper.any { review -> review.userId == currentUser.id }
+        if (hasUserAlreadyReviewed) {
+            throw DuplicateReviewException(projectPaperId, currentUser.id)
+        }
+
+        if (projectPaper.hasFinalDecision()) {
+            throw FailedPreconditionException(
+                "The project paper must be either unreviewed or still in review. " +
+                    "Finally decided project papers cannot be reviewed anymore.",
+            )
+        }
+
+        val review = repo.createReview(request, currentUser.id)
+        val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+
+        val hardExclusionCriteria = criteriaRepo.getAllProjectCriteria(project.id)
+            .filter { criterion -> criterion.category == CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION }
+            .map { criterion -> criterion.id }
+        val isAnySelectedCriteriaHardExclusion = selectedCriteriaIds.any { id -> hardExclusionCriteria.contains(id) }
+        if (isAnySelectedCriteriaHardExclusion && review.doesDeclinePaper()) {
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
+        } else {
+            val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
+            projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)
+        }
+
+        review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+    }
+
     /**
      * Determines the final paper decision based on the given list of reviews.
      *
@@ -144,43 +182,5 @@ class ReviewService(
         } else {
             PaperDecision.PAPER_DECISION_DECLINED
         }
-    }
-
-    override suspend fun createReview(request: GrpcReview.Create): GrpcReview = withUser(userRepo) { currentUser ->
-        val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
-        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
-
-        val projectResult = projectRepo.getProjectById(projectPaper.projectId)
-        accessChecker.isAllowedToCreateReview(currentUser, projectPaper.projectId, projectResult)
-        val project = projectResult.getOrThrow()
-
-        val reviewsForProjectPaper = repo.getAllReviewsForProjectPaper(projectPaperId)
-        val hasUserAlreadyReviewed = reviewsForProjectPaper.any { review -> review.userId == currentUser.id }
-        if (hasUserAlreadyReviewed) {
-            throw DuplicateReviewException(projectPaperId, currentUser.id)
-        }
-
-        if (projectPaper.hasFinalDecision()) {
-            throw FailedPreconditionException(
-                "The project paper must be either unreviewed or still in review. " +
-                    "Finally decided project papers cannot be reviewed anymore.",
-            )
-        }
-
-        val review = repo.createReview(request, currentUser.id)
-        val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
-
-        val hardExclusionCriteria = criteriaRepo.getAllProjectCriteria(project.id)
-            .filter { criterion -> criterion.category == CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION }
-            .map { criterion -> criterion.id }
-        val isAnySelectedCriteriaHardExclusion = selectedCriteriaIds.any { id -> hardExclusionCriteria.contains(id) }
-        if (isAnySelectedCriteriaHardExclusion && review.doesDeclinePaper()) {
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
-        } else {
-            val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
-            projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)
-        }
-
-        review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.viascom.nanoid.NanoId
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IUserAccessChecker
@@ -28,8 +27,6 @@ import java.util.UUID
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 import snowballr.UserOuterClass.User as GrpcUser
 import snowballr.UserSettingsOuterClass.UserSettings as GrpcUserSettings
-
-val Logger = KotlinLogging.logger { }
 
 interface IUserService {
     /**

--- a/src/test/kotlin/se/uulm/snowballr/backend/access/InvitationAccessCheckerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/access/InvitationAccessCheckerTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.access
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
@@ -25,7 +26,7 @@ class InvitationAccessCheckerTest {
             val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
             val projectResult = Result.success(project)
 
-            coEvery { projectAccessChecker.isProjectOrServerAdmin(user, project.id, AccessType.READ) } returns Unit
+            coJustRun { projectAccessChecker.isProjectOrServerAdmin(user, project.id, AccessType.READ) }
 
             assertDoesNotThrow { accessChecker.isAllowedToInviteUserToProject(user, project.id, projectResult) }
         }
@@ -52,7 +53,7 @@ class InvitationAccessCheckerTest {
                 val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
                 val projectResult = Result.success(project)
 
-                coEvery { projectAccessChecker.isProjectOrServerAdmin(user, project.id, AccessType.READ) } returns Unit
+                coJustRun { projectAccessChecker.isProjectOrServerAdmin(user, project.id, AccessType.READ) }
 
                 assertThrows<EntityNotActiveException> {
                     accessChecker.isAllowedToInviteUserToProject(user, project.id, projectResult)

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -406,7 +406,7 @@ class PythonPluginFetcherManagerTest {
     fun `When a timed out fetcher ignores SIGTERM, then it is force killed after grace period`() = runTest {
         val timeoutFetcherManager = PythonPluginFetcherManager(
             createEnvReader(pluginDirectory),
-            executionTimeoutMillis = 100L,
+            executionTimeoutMillis = 2_000L,
             forceKillGraceMillis = 100L,
         )
         val pidFile = fetcherDirectory.resolve("stuck_fetcher.pid")
@@ -438,7 +438,7 @@ class PythonPluginFetcherManagerTest {
         val exception = assertThrows<FetcherException> {
             timeoutFetcherManager.getAvailableOptions("stuck_fetcher")
         }
-        assertThat(exception.message).contains("Fetcher 'stuck_fetcher' timed out after 100ms.")
+        assertThat(exception.message).contains("Fetcher 'stuck_fetcher' timed out after 2000ms.")
 
         assertTrue(
             waitUntil(

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -164,7 +164,7 @@ open class IntegrationTest : KoinTest {
         val link = "https://example.com/verify"
         coEvery { emailManagerMock.createVerificationLink(capture(verificationToken)) } returns link
         val verificationData = EmailData.EmailVerification(user.firstName, link, "tomorrow")
-        coEvery { emailManagerMock.sendVerificationEmail(any(), verificationData) } returns Unit
+        coJustRun { emailManagerMock.sendVerificationEmail(any(), verificationData) }
 
         // Register user
         val registerUserRequest = Authentication.RegisterRequest.newBuilder()

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -25,6 +25,7 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 import se.uulm.snowballr.backend.TestDatabase
+import se.uulm.snowballr.backend.accessCheckerDeps
 import se.uulm.snowballr.backend.auth.AuthenticationManager
 import se.uulm.snowballr.backend.auth.CookieManager
 import se.uulm.snowballr.backend.auth.GrpcContext
@@ -94,6 +95,7 @@ open class IntegrationTest : KoinTest {
         repositoryLayerDeps()
         mailServiceDeps()
         customServicesDeps()
+        accessCheckerDeps()
         serviceLayerDeps()
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.integration.services
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
@@ -62,7 +63,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
         fun `When a registered but unverified user attempts to login, then login fails`() = runTest {
             val tokenSlot = slot<String>()
             coEvery { emailManagerMock.createVerificationLink(capture(tokenSlot)) } returns "https://example.com/verify"
-            coEvery { emailManagerMock.sendVerificationEmail(any(), any()) } returns Unit
+            coJustRun { emailManagerMock.sendVerificationEmail(any(), any()) }
 
             val newUser = DataBuilder.createExampleUser(email = "unverified.user@example.com")
             mainService.register(

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.integration.services
 
 import com.google.protobuf.FieldMask
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
@@ -28,7 +29,7 @@ class UserIntegrationTest : IntegrationTest() {
             val tokenSlot = slot<String>()
 
             coEvery { emailManagerMock.createVerificationLink(capture(tokenSlot)) } returns "https://example.com/verify"
-            coEvery { emailManagerMock.sendVerificationEmail(any(), any()) } returns Unit
+            coJustRun { emailManagerMock.sendVerificationEmail(any(), any()) }
 
             mainService.register(
                 Authentication.RegisterRequest.newBuilder()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/MainServiceTest.kt
@@ -16,6 +16,13 @@ import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 import org.simplejavamail.api.mailer.Mailer
+import se.uulm.snowballr.backend.access.ICriterionAccessChecker
+import se.uulm.snowballr.backend.access.IInvitationAccessChecker
+import se.uulm.snowballr.backend.access.IProjectAccessChecker
+import se.uulm.snowballr.backend.access.IProjectMemberAccessChecker
+import se.uulm.snowballr.backend.access.IProjectPaperAccessChecker
+import se.uulm.snowballr.backend.access.IReviewAccessChecker
+import se.uulm.snowballr.backend.access.IUserAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.IJwtManager
 import se.uulm.snowballr.backend.env.EnvReader
@@ -100,6 +107,15 @@ open class MainServiceTest : KoinTest {
     val verificationTokenRepoMock = mockk<IVerificationTokenTableRepo>()
     val invitationTokenRepoMock = mockk<IInvitationTokenTableRepo>()
 
+    // Access checker layer mocks
+    val criterionAccessCheckerMock = mockk<ICriterionAccessChecker>()
+    val invitationAccessCheckerMock = mockk<IInvitationAccessChecker>()
+    val projectAccessCheckerMock = mockk<IProjectAccessChecker>()
+    val projectMemberAccessCheckerMock = mockk<IProjectMemberAccessChecker>()
+    val projectPaperAccessCheckerMock = mockk<IProjectPaperAccessChecker>()
+    val reviewAccessCheckerMock = mockk<IReviewAccessChecker>()
+    val userAccessCheckerMock = mockk<IUserAccessChecker>()
+
     // Custom services / manager / clients mocks
     val jwtManagerMock = mockk<IJwtManager>()
     val emailManagerMock = mockk<IEmailManager>()
@@ -127,6 +143,13 @@ open class MainServiceTest : KoinTest {
         fetcherManagerMock,
         mailerMock,
         emailTemplateManagerMock,
+        criterionAccessCheckerMock,
+        invitationAccessCheckerMock,
+        projectAccessCheckerMock,
+        projectMemberAccessCheckerMock,
+        projectPaperAccessCheckerMock,
+        reviewAccessCheckerMock,
+        userAccessCheckerMock,
     )
 
     val mainService: IMainService by inject()
@@ -162,6 +185,15 @@ open class MainServiceTest : KoinTest {
         single { fetcherManagerMock }
         single { mailerMock }
         single { emailTemplateManagerMock }
+
+        // Access checker layer
+        single { criterionAccessCheckerMock }
+        single { invitationAccessCheckerMock }
+        single { projectAccessCheckerMock }
+        single { projectMemberAccessCheckerMock }
+        single { projectPaperAccessCheckerMock }
+        single { reviewAccessCheckerMock }
+        single { userAccessCheckerMock }
 
         // The base service layer is the same as in production
         serviceLayerDeps()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceHelperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/ServiceHelperTest.kt
@@ -44,7 +44,7 @@ class ServiceHelperTest {
         }
 
         @Test
-        fun `When the user is retrieved successfully, then the block is executed with the current user`() = runTest {
+        fun `When a user is retrieved successfully, then the block is executed with the current user`() = runTest {
             val currentUser = DataBuilder.createExampleUser()
             every { GrpcContext.getUserIdFromContext() } returns currentUser.id
             coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.authentication
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -38,7 +39,7 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(expiredToken.token) } returns Result.success(
             expiredToken,
         )
-        coEvery { verificationTokenRepoMock.deleteVerificationToken(expiredToken.token) } returns Unit
+        coJustRun { verificationTokenRepoMock.deleteVerificationToken(expiredToken.token) }
 
         assertThrows<VerificationTokenNotFoundException> { mainService.verifyEmail(request) }
     }
@@ -64,7 +65,7 @@ class VerifyEmailTest : MainServiceTest() {
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery { userRepoMock.updateUser(capture(userUpdateSlot)) } returns user
-        coEvery { verificationTokenRepoMock.deleteVerificationToken(token.token) } returns Unit
+        coJustRun { verificationTokenRepoMock.deleteVerificationToken(token.token) }
 
         assertDoesNotThrow { mainService.verifyEmail(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -1,18 +1,15 @@
 package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
 import snowballr.CriterionOuterClass.CriterionCategory
-import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 class CreateCriterionTest : MainServiceTest() {
@@ -36,76 +33,39 @@ class CreateCriterionTest : MainServiceTest() {
     }
 
     @Test
-    fun `When an admin user creates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-
-        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
-        val request = getProjectCriterionRequest(project.id.toString())
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
-
-        assertDoesNotThrow { mainService.createCriterion(request) }
-    }
-
-    @Test
-    fun `When a project admin creates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-
-        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
-        val request = getProjectCriterionRequest(project.id.toString())
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
-
-        assertDoesNotThrow { mainService.createCriterion(request) }
-    }
-
-    @Test
-    fun `When a non project admin creates a project criterion, then an UnauthorizedException is thrown`() = runTest {
+    fun `When a user creates a project criterion and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
+        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id)
         val request = getProjectCriterionRequest(project.id.toString())
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coJustRun { criterionAccessCheckerMock.isAllowedToCreateProjectCriterion(user, project.id) }
+        coEvery { criterionRepoMock.createCriterion(request, user.id) } returns criterion
 
-        assertThrows<UnauthorizedException> { mainService.createCriterion(request) }
-    }
-
-    @GrpcEnumSourceTest(
-        ProjectStatus::class,
-        excludes = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_ACTIVE_LOCKED", "PROJECT_STATUS_UNSPECIFIED"],
-    )
-    fun `When a project admin creates a project criterion for a non active project, then a FailedPreconditionException is thrown`(
-        status: ProjectStatus,
-    ) = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = status,
-        )
-        val projectAdmin = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-
-        val request = getProjectCriterionRequest(project.id.toString())
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-
-        assertThrows<FailedPreconditionException> { mainService.createCriterion(request) }
+        assertDoesNotThrow { mainService.createCriterion(request) }
     }
 
     @Test
-    fun `When an user creates a user criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When a user creates a project criterion, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+
+            val request = getProjectCriterionRequest(project.id.toString())
+
+            mockCurrentUser(user)
+            coEvery {
+                criterionAccessCheckerMock.isAllowedToCreateProjectCriterion(user, project.id)
+            } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { mainService.createCriterion(request) }
+        }
+
+    @Test
+    fun `When an user creates a user criterion and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
 
         val criterion = DataBuilder.createExampleUserCriterion()
         val request = getUserCriterionRequest()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CreateCriterionTest.kt
@@ -64,7 +64,7 @@ class CreateCriterionTest : MainServiceTest() {
         }
 
     @Test
-    fun `When an user creates a user criterion and has access, then no exception is thrown`() = runTest {
+    fun `When a user creates a user criterion and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
 
         val criterion = DataBuilder.createExampleUserCriterion()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetAllCriteriaForProjectTest.kt
@@ -1,68 +1,38 @@
 package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 
 class GetAllCriteriaForProjectTest : MainServiceTest() {
     @Test
-    fun `When the project doesn't exist, then a ProjectNotFoundException is thrown`() = runTest {
-        val project = DataBuilder.createExampleProject()
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When a user retrieves all criteria for a project, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+            mockCurrentUser(user)
+            coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertThrows<ProjectNotFoundException> { mainService.getAllCriteriaForProject(project.id) }
-    }
+            assertThrows<TestSpecificException> { mainService.getAllCriteriaForProject(project.id) }
+        }
 
     @Test
-    fun `When the requesting user is a server admin, then no exception is thrown`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When a user retrieves all criteria for a project and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id, createdBy = adminUser.id)
+        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id, createdBy = user.id)
 
-        mockCurrentUser(adminUser)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, adminUser.id) } returns false
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
 
         assertDoesNotThrow { mainService.getAllCriteriaForProject(project.id) }
     }
-
-    @Test
-    fun `When the requesting user is a project member and wants to retrieve all project criteria, then no exception is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-            val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id, createdBy = user.id)
-
-            mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(criterion)
-
-            assertDoesNotThrow { mainService.getAllCriteriaForProject(project.id) }
-        }
-
-    @Test
-    fun `When the requesting user is a non project member and wants to retrieve all project criteria, then an UnauthorizedException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
-
-            assertThrows<UnauthorizedException> { mainService.getAllCriteriaForProject(project.id) }
-        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/GetCriterionByIdTest.kt
@@ -1,105 +1,48 @@
 package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 
 class GetCriterionByIdTest : MainServiceTest() {
     @Test
-    fun `When the requesting user is a server admin, then a project criterion can be retrieved`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-        val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id, createdBy = adminUser.id)
-
-        mockCurrentUser(adminUser)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, adminUser.id) } returns false
-        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
-
-        assertDoesNotThrow { mainService.getCriterionById(criterion.id) }
-    }
-
-    @Test
-    fun `When the requesting user is a project member and wants to retrieve a project criterion, then the criterion can be retrieved`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-            val criterion = DataBuilder.createExampleProjectCriterion(projectId = project.id, createdBy = user.id)
-
-            mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
-            coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
-
-            assertDoesNotThrow { mainService.getCriterionById(criterion.id) }
-        }
-
-    @Test
-    fun `When the requesting user is not a member of the project and wants to retrieve a project criterion, then an UnauthorizedException is thrown`() =
-        runTest {
-            val noAccessUser = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject()
-            val criterion = DataBuilder.createExampleProjectCriterion(
-                projectId = project.id,
-                createdBy = noAccessUser.id,
-            )
-
-            mockCurrentUser(noAccessUser)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, noAccessUser.id) } returns false
-            coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
-
-            assertThrows<UnauthorizedException> { mainService.getCriterionById(criterion.id) }
-        }
-
-    @Test
-    fun `When the requesting user is a server admin, then a user criterion can be retrieved`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion = DataBuilder.createExampleUserCriterion(createdBy = UUID.randomUUID())
-
-        mockCurrentUser(adminUser)
-        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
-
-        assertDoesNotThrow { mainService.getCriterionById(criterion.id) }
-    }
-
-    @Test
-    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he created himself, then the criterion can be retrieved`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion = DataBuilder.createExampleUserCriterion(createdBy = user.id)
-
-            mockCurrentUser(user)
-            coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
-
-            assertDoesNotThrow { mainService.getCriterionById(criterion.id) }
-        }
-
-    @Test
-    fun `When the requesting user is not a server admin and wants to retrieve a user criterion, which he did not create himself, then an UnauthorizedException is thrown`() =
-        runTest {
-            val noAccessUser = DataBuilder.createExampleUser()
-            val criterion = DataBuilder.createExampleUserCriterion(createdBy = UUID.randomUUID())
-
-            mockCurrentUser(noAccessUser)
-            coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
-
-            assertThrows<UnauthorizedException> { mainService.getCriterionById(criterion.id) }
-        }
-
-    @Test
-    fun `When an error occurs while the criterion is retrieved, then a TestSpecificException is thrown`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When retrieving the criterion fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val criterion = DataBuilder.createExampleUserCriterion()
 
-        mockCurrentUser(adminUser)
+        mockCurrentUser(user)
         coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getCriterionById(criterion.id) }
+    }
+
+    @Test
+    fun `When a user retrieves a criterion, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val criterion = DataBuilder.createExampleUserCriterion()
+
+        mockCurrentUser(user)
+        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
+        coEvery { criterionAccessCheckerMock.isAllowedToReadCriterion(user, criterion) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getCriterionById(criterion.id) }
+    }
+
+    @Test
+    fun `When a user retrieves a criterion and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val criterion = DataBuilder.createExampleUserCriterion()
+
+        mockCurrentUser(user)
+        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
+        coJustRun { criterionAccessCheckerMock.isAllowedToReadCriterion(user, criterion) }
+
+        assertDoesNotThrow { mainService.getCriterionById(criterion.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/UpdateCriterionTest.kt
@@ -2,188 +2,71 @@ package se.uulm.snowballr.backend.service.criterion
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.toGrpcCriterion
-import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.CriterionOuterClass.CriterionCategory
-import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 import snowballr.CriterionOuterClass.Criterion as GrpcCriterion
 
 class UpdateCriterionTest : MainServiceTest() {
-    private val criterionId = UUID.randomUUID()
-
-    private fun getExampleRequest(): GrpcCriterion.Update {
-        val updatedCriterion = DataBuilder.createExampleProjectCriterion(
-            id = criterionId,
-            tag = "Updated Tag",
-            name = "Updated Criterion",
-            description = "Updated Description",
-            category = CriterionCategory.CRITERION_CATEGORY_INCLUSION,
-        )
-
+    private fun getExampleRequest(criterion: Criterion): GrpcCriterion.Update {
         val updateFieldMask = FieldMaskUtil.fromStringList(
             listOf("tag", "name", "description", "category"),
         )
 
         return GrpcCriterion.Update.newBuilder()
-            .setCriterion(updatedCriterion.toGrpcCriterion())
+            .setCriterion(criterion.toGrpcCriterion())
             .setMask(updateFieldMask)
             .build()
     }
 
     @Test
-    fun `When a server admin updates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectStatus.PROJECT_STATUS_ACTIVE,
-        )
-        val criterion = DataBuilder.createExampleProjectCriterion(
-            id = criterionId,
-            projectId = project.id,
-            createdBy = user.id,
-        )
+    fun `When retrieving the criterion fails, then the a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val criterion = DataBuilder.createExampleProjectCriterion()
 
-        val request = getExampleRequest()
+        val request = getExampleRequest(criterion)
 
         mockCurrentUser(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
-
-        assertDoesNotThrow { mainService.updateCriterion(request) }
-    }
-
-    @Test
-    fun `When a project admin updates a project criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectStatus.PROJECT_STATUS_ACTIVE,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-        val criterion = DataBuilder.createExampleProjectCriterion(
-            id = criterionId,
-            projectId = project.id,
-            createdBy = user.id,
-        )
-
-        val request = getExampleRequest()
-
-        mockCurrentUser(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
-
-        assertDoesNotThrow { mainService.updateCriterion(request) }
-    }
-
-    @Test
-    fun `When a project admin updates a project criterion of a non-active project, then a FailedPreconditionException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(
-                status = ProjectStatus.PROJECT_STATUS_ARCHIVED,
-            )
-            val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-            val criterion = DataBuilder.createExampleProjectCriterion(
-                id = criterionId,
-                projectId = project.id,
-                createdBy = user.id,
-            )
-
-            val request = getExampleRequest()
-
-            mockCurrentUser(user)
-            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-
-            assertThrows<FailedPreconditionException> { mainService.updateCriterion(request) }
-        }
-
-    @Test
-    fun `When a project member updates a project criterion, then an UnauthorizedException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(
-            status = ProjectStatus.PROJECT_STATUS_ACTIVE,
-        )
-        val criterion = DataBuilder.createExampleProjectCriterion(
-            id = criterionId,
-            projectId = project.id,
-            createdBy = user.id,
-        )
-
-        val request = getExampleRequest()
-
-        mockCurrentUser(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-        assertThrows<UnauthorizedException> { mainService.updateCriterion(request) }
-    }
-
-    @Test
-    fun `When a server admin updates a user criterion, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val criterion = DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
-
-        val request = getExampleRequest()
-
-        mockCurrentUser(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
-
-        assertDoesNotThrow { mainService.updateCriterion(request) }
-    }
-
-    @Test
-    fun `When a user updates a user criterion, which he created himself, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val criterion =
-            DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = user.id)
-
-        val request = getExampleRequest()
-
-        mockCurrentUser(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
-
-        assertDoesNotThrow { mainService.updateCriterion(request) }
-    }
-
-    @Test
-    fun `When a user updates a user criterion, which he did not created himself, then an UnauthorizedException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val criterion =
-                DataBuilder.createExampleUserCriterion(id = criterionId, createdBy = UUID.randomUUID())
-
-            val request = getExampleRequest()
-
-            mockCurrentUser(user)
-            coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.success(criterion)
-
-            assertThrows<UnauthorizedException> { mainService.updateCriterion(request) }
-        }
-
-    @Test
-    fun `When an error occurs while the criterion is retrieved, then a TestSpecificException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val request = getExampleRequest()
-
-        mockCurrentUser(user)
-        coEvery { criterionRepoMock.getCriterionById(criterionId) } returns Result.failure(TestSpecificException())
+        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a user updates a criterion, but has no access, then the a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val criterion = DataBuilder.createExampleProjectCriterion()
+
+        val request = getExampleRequest(criterion)
+
+        mockCurrentUser(user)
+        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
+        coEvery {
+            criterionAccessCheckerMock.isAllowedToUpdateCriterion(user, criterion)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateCriterion(request) }
+    }
+
+    @Test
+    fun `When a user updates a criterion and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val criterion = DataBuilder.createExampleProjectCriterion()
+
+        val request = getExampleRequest(criterion)
+
+        mockCurrentUser(user)
+        coEvery { criterionRepoMock.getCriterionById(criterion.id) } returns Result.success(criterion)
+        coJustRun { criterionAccessCheckerMock.isAllowedToUpdateCriterion(user, criterion) }
+        coEvery { criterionRepoMock.updateCriterion(request) } returns criterion
+
+        assertDoesNotThrow { mainService.updateCriterion(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -25,7 +25,7 @@ class ExportProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user exports a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user exports a project and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectId = UUID.randomUUID()
         val request = getExampleRequest().copy { id = projectId.toString() }
@@ -49,7 +49,7 @@ class ExportProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user exports a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user exports a project, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val request = getExampleRequest().copy { id = project.id.toString() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.export
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.every
 import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
@@ -9,8 +10,6 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.export.ProjectExportManager
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
-import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadException
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.service.MainServiceTest
@@ -26,7 +25,7 @@ class ExportProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When exporting a project is successful, then no exception is thrown`() = runTest {
+    fun `When the user exports a project and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectId = UUID.randomUUID()
         val request = getExampleRequest().copy { id = projectId.toString() }
@@ -34,7 +33,7 @@ class ExportProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectMemberRepoMock.isProjectMember(projectId, user.id) } returns true
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, projectId) }
         coEvery { projectRepoMock.getProjectById(projectId) } returns Result.success(DataBuilder.createExampleProject())
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns emptyList()
         coEvery {
@@ -50,7 +49,7 @@ class ExportProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the non-project-member exports a project, then an UnauthorizedReadException is thrown`() = runTest {
+    fun `When the user exports a project, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
         val project = DataBuilder.createExampleProject()
         val request = getExampleRequest().copy { id = project.id.toString() }
@@ -58,51 +57,23 @@ class ExportProjectTest : MainServiceTest() {
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
+        coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertThrows<UnauthorizedReadException> {
-            mainService.exportProject(request)
-        }
+        assertThrows<TestSpecificException> { mainService.exportProject(request) }
     }
 
     @Test
-    fun `When a server admin export a project, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val projectId = UUID.randomUUID()
-        val request = getExampleRequest().copy { id = projectId.toString() }
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val project = DataBuilder.createExampleProject()
+        val request = getExampleRequest().copy { id = project.id.toString() }
 
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectMemberRepoMock.isProjectMember(projectId, user.id) } returns false
-        coEvery {
-            projectRepoMock.getProjectById(projectId)
-        } returns Result.success(DataBuilder.createExampleProject(id = projectId))
-        coEvery { projectMemberRepoMock.getProjectMembersWithUsers(projectId) } returns emptyList()
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(projectId)
-        } returns listOf(DataBuilder.createExampleProjectPaperWithPaper())
-        coEvery { reviewRepoMock.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(any()) } returns emptyList()
-        coEvery { criterionRepoMock.getAllProjectCriteria(any()) } returns emptyList()
-        every {
-            ProjectExportManager.exportProject(any(), any(), any(), any(), any())
-        } returns FileExport(ByteArray(0), "test.json")
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        mainService.exportProject(request)
-    }
-
-    @Test
-    fun `When the exported project doesn't exist, then a ProjectNotFoundException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val projectId = UUID.randomUUID()
-        val request = getExampleRequest().copy { id = projectId.toString() }
-
-        mockCurrentUser(user)
-        mockkObject(ProjectExportManager)
-        every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
-        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
-
-        assertThrows<ProjectNotFoundException> { mainService.exportProject(request) }
+        assertThrows<TestSpecificException> { mainService.exportProject(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/GetAvailableFetcherOptionsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/GetAvailableFetcherOptionsTest.kt
@@ -10,13 +10,14 @@ import kotlin.test.assertEquals
 class GetAvailableFetcherOptionsTest : MainServiceTest() {
     @Test
     fun `When the fetcherManager returns fetcher options, then the FetcherService returns them properly`() = runTest {
-        val fetcherOptions = mapOf("foo" to "bar")
-        coEvery { fetcherManagerMock.getAvailableOptions("foobar") } returns fetcherOptions
-        assertEquals(
-            fetcherOptions,
-            mainService.getAvailableFetcherOptions(
-                GetAvailableFetcherOptionsRequest.newBuilder().setFetcherName("foobar").build(),
-            ).optionsMap,
-        )
+        val expectedOptions = mapOf("foo" to "bar")
+
+        coEvery { fetcherManagerMock.getAvailableOptions("foobar") } returns expectedOptions
+
+        val actualOptions = mainService.getAvailableFetcherOptions(
+            GetAvailableFetcherOptionsRequest.newBuilder().setFetcherName("foobar").build(),
+        ).optionsMap
+
+        assertEquals(expectedOptions, actualOptions)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/GetAvailableFetchersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/GetAvailableFetchersTest.kt
@@ -10,7 +10,9 @@ class GetAvailableFetchersTest : MainServiceTest() {
     @Test
     fun `When the fetcherManager has fetchers registered, then the FetcherService returns them properly`() = runTest {
         val fetchers = setOf("foo")
+
         coEvery { fetcherManagerMock.getAvailableFetchers() } returns fetchers
+
         assertEquals(fetchers, mainService.getAvailableFetchers().fetcherNamesList.toSet())
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/AcceptProjectInvitationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/AcceptProjectInvitationTest.kt
@@ -15,11 +15,12 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import java.time.OffsetDateTime
+import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class AcceptProjectInvitationTest : MainServiceTest() {
     @Test
     fun `When the invitation token is not found, then a InvitationTokenNotFoundException is thrown`() = runTest {
-        val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken("non-existent-token").build()
+        val request = GrpcProjectMember.Accept.newBuilder().setToken("non-existent-token").build()
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(any()) } returns Result.failure(
             InvitationTokenNotFoundException(),
         )
@@ -32,7 +33,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
         val expiredToken = DataBuilder.createExampleInvitationToken(
             expiresAt = OffsetDateTime.now().minusDays(1),
         )
-        val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken(expiredToken.token).build()
+        val request = GrpcProjectMember.Accept.newBuilder().setToken(expiredToken.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(expiredToken.token) } returns Result.success(
             expiredToken,
@@ -46,7 +47,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
     fun `When the user associated with the token is not registered, then a FailedPreconditionException is thrown`() =
         runTest {
             val token = DataBuilder.createExampleInvitationToken()
-            val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken(token.token).build()
+            val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
             coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
             coEvery { userRepoMock.getUserByEmail(token.email) } returns
@@ -59,7 +60,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
     fun `When the user has not verified their email, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED)
         val token = DataBuilder.createExampleInvitationToken(email = user.email)
-        val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken(token.token).build()
+        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
@@ -71,7 +72,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
     fun `When adding the user to the project fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE)
         val token = DataBuilder.createExampleInvitationToken(email = user.email)
-        val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken(token.token).build()
+        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
@@ -91,7 +92,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
             createdAt = OffsetDateTime.now(),
             modifiedAt = null,
         )
-        val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken(token.token).build()
+        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
@@ -112,7 +113,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
             createdAt = OffsetDateTime.now(),
             modifiedAt = null,
         )
-        val request = ProjectOuterClass.Project.Member.Accept.newBuilder().setToken(token.token).build()
+        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/AcceptProjectInvitationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/AcceptProjectInvitationTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.invitations
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -38,7 +39,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(expiredToken.token) } returns Result.success(
             expiredToken,
         )
-        coEvery { invitationTokenRepoMock.deleteInvitationToken(expiredToken.token) } returns Unit
+        coJustRun { invitationTokenRepoMock.deleteInvitationToken(expiredToken.token) }
 
         assertThrows<InvitationTokenNotFoundException> { mainService.acceptProjectInvitation(request) }
     }
@@ -118,7 +119,7 @@ class AcceptProjectInvitationTest : MainServiceTest() {
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
         coEvery { projectMemberRepoMock.addUserToProject(user.id, token.projectId) } returns userMember
-        coEvery { invitationTokenRepoMock.deleteInvitationToken(token.token) } returns Unit
+        coJustRun { invitationTokenRepoMock.deleteInvitationToken(token.token) }
 
         assertDoesNotThrow { mainService.acceptProjectInvitation(request) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/GetPendingInvitationsForProjectTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.invitations
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -9,37 +10,20 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
-import java.util.UUID
 
 class GetPendingInvitationsForProjectTest : MainServiceTest() {
     @Test
-    fun `When a server admin requests the pending invitations for a project, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id) } returns emptyList()
-
-        assertDoesNotThrow { mainService.getPendingInvitationsForProject(project.id) }
-    }
-
-    @Test
-    fun `When a project member requests the pending invitations for a project, then no exception is thrown`() =
+    fun `When a user requests the pending invitations for a project and has access, then no exception is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
             val project = DataBuilder.createExampleProject()
 
             mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
             coEvery { invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id) } returns emptyList()
 
             assertDoesNotThrow { mainService.getPendingInvitationsForProject(project.id) }
@@ -48,7 +32,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
     @Test
     fun `When a non registered user is invited, then they appear as well in the list of pending invitations but without complete user details`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
             val registeredUser = DataBuilder.createExampleUser(
                 email = "registered@example.com",
@@ -65,8 +49,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
             )
 
             mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
             coEvery {
                 invitationTokenRepoMock.getActiveInvitationTokensForProject(project.id)
             } returns listOf(invitationTokenForRegisteredUser, invitationTokenForNotRegisteredUser)
@@ -75,7 +58,7 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
                 userRepoMock.getUserByEmail(notRegisteredEmail)
             } returns Result.failure(UserNotFoundByEmailException(notRegisteredEmail))
 
-            val pendingInvitations = assertDoesNotThrow { mainService.getPendingInvitationsForProject(project.id) }
+            val pendingInvitations = mainService.getPendingInvitationsForProject(project.id)
 
             val invitationForRegisteredUser = pendingInvitations.usersList.find { it.email == registeredUser.email }
             val invitationForNotRegisteredUser = pendingInvitations.usersList.find { it.email == notRegisteredEmail }
@@ -95,31 +78,16 @@ class GetPendingInvitationsForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a non project member requests the pending invitations for a project, then an UnauthorizedException is thrown`() =
+    fun `When a user requests the pending invitations for a project, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
 
             mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-
-            assertThrows<UnauthorizedException> { mainService.getPendingInvitationsForProject(project.id) }
-        }
-
-    @Test
-    fun `When the pending invitations for a nonexistent project are requested, then a ProjectNotFoundException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val nonExistentProjectId = UUID.randomUUID()
-
-            mockCurrentUser(currentUser)
             coEvery {
-                projectRepoMock.getProjectById(nonExistentProjectId)
-            } returns Result.failure(TestSpecificException())
+                projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id)
+            } throws TestSpecificException()
 
-            assertThrows<ProjectNotFoundException> {
-                mainService.getPendingInvitationsForProject(nonExistentProjectId)
-            }
+            assertThrows<TestSpecificException> { mainService.getPendingInvitationsForProject(project.id) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/InviteUserToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/InviteUserToProjectTest.kt
@@ -65,7 +65,7 @@ class InviteUserToProjectTest : MainServiceTest() {
         if (stopBefore == invitationTokenRepoMock::saveInvitationToken) {
             return
         }
-        coEvery { invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, any()) } returns Unit
+        coJustRun { invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, any()) }
         if (stopBefore == userRepoMock::getUserByEmail) {
             return
         }
@@ -74,7 +74,7 @@ class InviteUserToProjectTest : MainServiceTest() {
         if (stopBefore == emailManagerMock::sendAcceptProjectInvitationEmail) {
             return
         }
-        coEvery { emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, any()) } returns Unit
+        coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, any()) }
     }
 
     @Test
@@ -149,16 +149,12 @@ class InviteUserToProjectTest : MainServiceTest() {
         val emailDataSlot = slot<EmailData.AcceptProjectInvitation>()
 
         mockInviteUserToProject(stopBefore = invitationTokenRepoMock::saveInvitationToken)
-        coEvery {
-            invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, capture(tokenSlot))
-        } returns Unit
+        coJustRun { invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, capture(tokenSlot)) }
         coEvery { userRepoMock.getUserByEmail(invitedUserEmail) } returns Result.success(invitedUser)
         every { emailManagerMock.createAcceptProjectInvitationLink(any()) } answers {
             "https://link/${firstArg<String>()}"
         }
-        coEvery {
-            emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, capture(emailDataSlot))
-        } returns Unit
+        coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, capture(emailDataSlot)) }
 
         assertDoesNotThrow { mainService.inviteUserToProject(validInviteUserRequest.build()) }
 
@@ -180,7 +176,7 @@ class InviteUserToProjectTest : MainServiceTest() {
         val emailNotFoundException = UserNotFoundByEmailException(emailOfNonExistentUser)
         coEvery { userRepoMock.getUserByEmail(emailOfNonExistentUser) } returns Result.failure(emailNotFoundException)
         every { emailManagerMock.createAcceptProjectInvitationLink(any()) } returns "http://invitation-link"
-        coEvery { emailManagerMock.sendAcceptProjectInvitationEmail(any(), capture(emailDataSlot)) } returns Unit
+        coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(any(), capture(emailDataSlot)) }
 
         val inviteNonExistentUserRequest = validInviteUserRequest.setUserEmail(emailOfNonExistentUser)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/InviteUserToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitations/InviteUserToProjectTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.invitations
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.slot
@@ -12,13 +13,12 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.email.EmailData
-import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
-import snowballr.UserOuterClass.UserRole
+import snowballr.ProjectOuterClass.MemberRole
 import java.util.UUID
 import kotlin.reflect.KFunction
 
@@ -31,33 +31,27 @@ class InviteUserToProjectTest : MainServiceTest() {
 
     @Suppress("ReturnCount")
     private fun mockInviteUserToProject(
-        useAdminUser: Boolean = true,
         invitedUserEmail: String = this.invitedUserEmail,
         projectId: UUID = this.projectId,
         stopBefore: KFunction<*>? = null,
     ) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (useAdminUser) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
+        val currentUser = DataBuilder.createExampleUser()
         val invitedUser = DataBuilder.createExampleUser(email = invitedUserEmail)
         val project = DataBuilder.createExampleProject(id = projectId)
         val projectAdmin = DataBuilder.createExampleProjectMember(
             projectId = project.id,
             userId = currentUser.id,
-            role = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN,
+            role = MemberRole.MEMBER_ROLE_ADMIN,
         )
         val projectAdminWithUser = DataBuilder.createExampleProjectMemberWithUser(projectAdmin, currentUser)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.success(project)
+        val projectResult = Result.success(project)
+        coEvery { projectRepoMock.getProjectById(projectId) } returns projectResult
         if (stopBefore == projectMemberRepoMock::getAllProjectAdmins) {
             return
         }
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns listOf(projectAdmin)
+        coJustRun { invitationAccessCheckerMock.isAllowedToInviteUserToProject(currentUser, projectId, projectResult) }
         if (stopBefore == projectMemberRepoMock::getProjectMembersWithUsers) {
             return
         }
@@ -84,35 +78,34 @@ class InviteUserToProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When neither a server admin nor a project admin invites another user, then an UnauthorizedException is thrown`() =
-        runTest {
-            mockInviteUserToProject(useAdminUser = false, stopBefore = projectMemberRepoMock::getAllProjectAdmins)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
+    fun `When a user invites another user, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = projectId)
+        val projectResult = Result.success(project)
 
-            assertThrows<UnauthorizedException> { mainService.inviteUserToProject(validInviteUserRequest.build()) }
-            coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
-        }
-
-    @Test
-    fun `When the project is not found, then a TestSpecificException is thrown`() = runTest {
-        mockInviteUserToProject(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
-        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
+        mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+        coEvery {
+            invitationAccessCheckerMock.isAllowedToInviteUserToProject(currentUser, project.id, projectResult)
+        } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.inviteUserToProject(validInviteUserRequest.build()) }
         coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
     }
 
     @Test
-    fun `When the project is not active, then a FailedPreconditionException is thrown`() = runTest {
-        val inactiveProject = DataBuilder.createExampleProject(
-            id = projectId,
-            status = ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED,
-        )
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(id = projectId)
+        val projectResult = Result.failure<Project>(TestSpecificException())
 
-        mockInviteUserToProject(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
-        coEvery { projectRepoMock.getProjectById(inactiveProject.id) } returns Result.success(inactiveProject)
+        mockCurrentUser(currentUser)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+        coJustRun {
+            invitationAccessCheckerMock.isAllowedToInviteUserToProject(currentUser, project.id, projectResult)
+        }
 
-        assertThrows<FailedPreconditionException> { mainService.inviteUserToProject(validInviteUserRequest.build()) }
+        assertThrows<TestSpecificException> { mainService.inviteUserToProject(validInviteUserRequest.build()) }
         coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
     }
 
@@ -157,11 +150,7 @@ class InviteUserToProjectTest : MainServiceTest() {
 
         mockInviteUserToProject(stopBefore = invitationTokenRepoMock::saveInvitationToken)
         coEvery {
-            invitationTokenRepoMock.saveInvitationToken(
-                invitedUserEmail,
-                projectId,
-                capture(tokenSlot),
-            )
+            invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, capture(tokenSlot))
         } returns Unit
         coEvery { userRepoMock.getUserByEmail(invitedUserEmail) } returns Result.success(invitedUser)
         every { emailManagerMock.createAcceptProjectInvitationLink(any()) } answers {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/CreateProjectTest.kt
@@ -26,11 +26,7 @@ class CreateProjectTest : MainServiceTest() {
 
         coEvery { projectMemberRepoMock.addUserToProject(user.id, project.id) } returns projectMember
         coEvery {
-            projectMemberRepoMock.updateProjectMemberRole(
-                project.id,
-                user.id,
-                MemberRole.MEMBER_ROLE_ADMIN,
-            )
+            projectMemberRepoMock.updateProjectMemberRole(project.id, user.id, MemberRole.MEMBER_ROLE_ADMIN)
         } returns projectAdmin
     }
 
@@ -51,11 +47,7 @@ class CreateProjectTest : MainServiceTest() {
         coVerify(exactly = 0) { criterionRepoMock.createCriterion(any(), user.id) }
         coVerify(exactly = 1) { projectMemberRepoMock.addUserToProject(user.id, project.id) }
         coVerify(exactly = 1) {
-            projectMemberRepoMock.updateProjectMemberRole(
-                project.id,
-                user.id,
-                MemberRole.MEMBER_ROLE_ADMIN,
-            )
+            projectMemberRepoMock.updateProjectMemberRole(project.id, user.id, MemberRole.MEMBER_ROLE_ADMIN)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -1,16 +1,15 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
 
 class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ARCHIVED)
@@ -27,37 +26,31 @@ class GetAllArchivedProjectsForUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non-admin retrieves another user's archived projects, then an UnauthorizedException is thrown`() =
+    fun `When a user retrieves another user's archived projects, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val requestedUser = DataBuilder.createExampleUser()
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.getAllArchivedProjectsForUser(requestedUser.id) }
+            assertThrows<TestSpecificException> { mainService.getAllArchivedProjectsForUser(requestedUser.id) }
         }
 
     @Test
-    fun `When archived projects are retrieved by an admin, then they are returned successfully`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser()
+    fun `When a user retrieves another user's archived projects and has access, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val requestedUser = DataBuilder.createExampleUser()
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
+            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(requestedUser.id) }
-    }
-
-    @Test
-    fun `When a user retrieves its own archived projects, then they are returned successfully`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
-
-        assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(requestedUser.id) }
-    }
+            assertDoesNotThrow { mainService.getAllArchivedProjectsForUser(requestedUser.id) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -1,16 +1,15 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
 
 class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_DELETED)
@@ -27,37 +26,31 @@ class GetAllDeletedProjectsForUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a non-admin retrieves another user's deleted projects, then an UnauthorizedException is thrown`() =
+    fun `When a user retrieves another user's deleted projects, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val requestedUser = DataBuilder.createExampleUser()
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.getAllDeletedProjectsForUser(requestedUser.id) }
+            assertThrows<TestSpecificException> { mainService.getAllDeletedProjectsForUser(requestedUser.id) }
         }
 
     @Test
-    fun `When deleted projects are retrieved by an admin, then they are returned successfully`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser()
+    fun `When a user retrieves another user's deleted projects and has access, then no exception is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val requestedUser = DataBuilder.createExampleUser()
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
+            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(requestedUser.id) }
-    }
-
-    @Test
-    fun `When a user retrieves its own deleted projects, then they are returned successfully`() = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
-
-        assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(requestedUser.id) }
-    }
+            assertDoesNotThrow { mainService.getAllDeletedProjectsForUser(requestedUser.id) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -1,16 +1,15 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
 
 class GetAllProjectsForUserTest : MainServiceTest() {
     private val statusFilters = setOf(ProjectStatus.PROJECT_STATUS_ACTIVE, ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
@@ -27,37 +26,28 @@ class GetAllProjectsForUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When all user projects are retrieved by another non-admin user, then an UnauthorizedException is thrown`() =
+    fun `When a user retrieves another user's projects, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val requestedUser = DataBuilder.createExampleUser()
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.getAllProjectsForUser(requestedUser.id) }
+            assertThrows<TestSpecificException> { mainService.getAllProjectsForUser(requestedUser.id) }
         }
 
     @Test
-    fun `When the user projects are retrieved by an admin, then all user projects are returned successfully`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val requestedUser = DataBuilder.createExampleUser()
-
-            mockCurrentUser(currentUser)
-            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-            coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
-
-            assertDoesNotThrow { mainService.getAllProjectsForUser(requestedUser.id) }
-        }
-
-    @Test
-    fun `When a user retrieves its own projects, then all projects are returned successfully`() = runTest {
+    fun `When a user retrieves another user's projects and has access, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id)
+        val requestedUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadUserProjects(currentUser, requestedUser.id) }
         coEvery { projectRepoMock.getUserProjects(requestedUser.id, statusFilters) } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjectsForUser(requestedUser.id) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -1,30 +1,32 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 
 class GetAllProjectsTest : MainServiceTest() {
     @Test
-    fun `When all projects are retrieved by a non-admin, then an UnauthorizedException is thrown`() = runTest {
-        val nonAdminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When a user retrieves all projects, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
 
-        mockCurrentUser(nonAdminUser)
+        mockCurrentUser(currentUser)
+        coEvery { projectAccessCheckerMock.isAllowedToReadAllProjects(currentUser) } throws TestSpecificException()
 
-        assertThrows<UnauthorizedException> { mainService.getAllProjects() }
+        assertThrows<TestSpecificException> { mainService.getAllProjects() }
     }
 
     @Test
-    fun `When all projects are retrieved by an admin, then no exception is thrown`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When a user retrieves all projects and has access, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
 
-        mockCurrentUser(adminUser)
+        mockCurrentUser(currentUser)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadAllProjects(currentUser) }
         coEvery { projectRepoMock.getAllProjects() } returns emptyList()
 
         assertDoesNotThrow { mainService.getAllProjects() }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
@@ -1,18 +1,16 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.notfound.StageNotFoundException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.PaperDecision
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import kotlin.test.assertEquals
 import snowballr.ProjectOuterClass.Project.Information as GrpcProjectInformation
@@ -24,8 +22,8 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
         .setStage(0)
 
     @Test
-    fun `When a server admin retrieves the decision statistics, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When a user retrieves the decision statistics and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
         val request = validRequestBuilder
@@ -33,7 +31,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
 
@@ -41,41 +39,24 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a project member retrieves the decision statistics, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
+    fun `When a user retrieves the decision statistics, but has no access, then an TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        val request = validRequestBuilder
-            .setProjectId(project.id.toString())
-            .build()
+            val request = validRequestBuilder
+                .setProjectId(project.id.toString())
+                .build()
 
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
+            mockCurrentUser(user)
+            coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertDoesNotThrow { mainService.getDecisionStatisticsForStage(request) }
-    }
-
-    @Test
-    fun `When a non member retrieves the decision statistics, then an UnauthorizedException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-
-        val request = validRequestBuilder
-            .setProjectId(project.id.toString())
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
-
-        assertThrows<UnauthorizedException> { mainService.getDecisionStatisticsForStage(request) }
-    }
+            assertThrows<TestSpecificException> { mainService.getDecisionStatisticsForStage(request) }
+        }
 
     @Test
-    fun `When a nonexistent project is requested, then a ProjectNotFoundException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
         val request = validRequestBuilder
@@ -83,14 +64,15 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<ProjectNotFoundException> { mainService.getDecisionStatisticsForStage(request) }
+        assertThrows<TestSpecificException> { mainService.getDecisionStatisticsForStage(request) }
     }
 
     @Test
     fun `When a stage above the maximum is requested, then a StageNotFoundException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(maxStage = 1)
 
         val request = validRequestBuilder
@@ -99,7 +81,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
         assertThrows<StageNotFoundException> { mainService.getDecisionStatisticsForStage(request) }
@@ -107,7 +89,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
 
     @Test
     fun `When the highest valid stage is requested, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(maxStage = 1)
 
         val request = validRequestBuilder
@@ -116,8 +98,8 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns emptyList()
 
         assertDoesNotThrow { mainService.getDecisionStatisticsForStage(request) }
@@ -125,7 +107,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
 
     @Test
     fun `When a valid stage is requested, then the correct statistics are returned`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(maxStage = 1)
         val stage = 0L
 
@@ -165,7 +147,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
             .build()
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectPaperRepoMock.getAllProjectPapersForProject(project.id) } returns
             projectPapers + papersInOtherStage
@@ -175,10 +157,7 @@ class GetDecisionStatisticsForStageTest : MainServiceTest() {
         val statsByDecision = statistics.statisticsList.associateBy { it.decision }
         paperCountsByDecision.forEach { (decision, expectedCount) ->
             val actual = statsByDecision[decision]?.count ?: -1
-            assertEquals(
-                expectedCount,
-                actual.toInt(),
-            )
+            assertEquals(expectedCount, actual.toInt())
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -12,7 +12,7 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 
 class GetProjectByIdTest : MainServiceTest() {
     @Test
-    fun `When the user requests a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user requests a project, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
@@ -35,7 +35,7 @@ class GetProjectByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests a project and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectByIdTest.kt
@@ -1,86 +1,47 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
-import java.util.UUID
 
 class GetProjectByIdTest : MainServiceTest() {
     @Test
-    fun `When the requesting user is not a member of the project, then an UnauthorizedException is thrown`() = runTest {
-        val noAccessUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(noAccessUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, noAccessUser.id) } returns false
-
-        assertThrows<UnauthorizedException> { mainService.getProjectById(project.id) }
-    }
-
-    @Test
-    fun `When the requesting user is a server admin, then the project can be retrieved`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, adminUser.id) } returns false
-
-        assertDoesNotThrow { mainService.getProjectById(project.id) }
-    }
-
-    @Test
-    fun `When the requesting user is a project member, then the project can be retrieved`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When the user requests a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
+        coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertDoesNotThrow { mainService.getProjectById(project.id) }
+        assertThrows<TestSpecificException> { mainService.getProjectById(project.id) }
     }
 
     @Test
-    fun `When an error occurs while the project is retrieved, then a ProjectNotFoundException is thrown`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val projectId = UUID.randomUUID()
-
-        mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
-
-        assertThrows<ProjectNotFoundException> { mainService.getProjectById(projectId) }
-    }
-
-    @Test
-    fun `When the project is deleted by a default user, then a ProjectNotFoundException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_DELETED)
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<ProjectNotFoundException> { mainService.getProjectById(project.id) }
+        assertThrows<TestSpecificException> { mainService.getProjectById(project.id) }
     }
 
     @Test
-    fun `When the project is deleted by a server admin, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_DELETED)
+    fun `When the user requests a project and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
 
         assertDoesNotThrow { mainService.getProjectById(project.id) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
@@ -2,14 +2,15 @@ package se.uulm.snowballr.backend.service.project
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass
 import java.time.OffsetDateTime
@@ -23,74 +24,31 @@ class GetProjectInformationTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the project does not exist, then a ProjectNotFoundException is thrown`() = runTest {
+    fun `When the user requests project information, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+
+            mockCurrentUser(user)
+            coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { mainService.getProjectInformation(getRequest(project.id)) }
+        }
+
+    @Test
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<ProjectNotFoundException> { mainService.getProjectInformation(getRequest(project.id)) }
+        assertThrows<TestSpecificException> { mainService.getProjectInformation(getRequest(project.id)) }
     }
 
     @Test
-    fun `When the user is not a member of the project, then an UnauthorizedException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
-
-        assertThrows<UnauthorizedException> { mainService.getProjectInformation(getRequest(project.id)) }
-    }
-
-    @Test
-    fun `When the user is a member of the project and no field mask is given, then all fields are correctly returned`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val createdAt = OffsetDateTime.now()
-            val stageStartedAt = OffsetDateTime.now()
-            val project = DataBuilder.createExampleProject(
-                createdAt = createdAt,
-                currentStageStartedAt = stageStartedAt,
-            )
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
-            coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
-
-            val response = mainService.getProjectInformation(getRequest(project.id))
-            assertEquals(0.5f, response.projectProgress)
-            assertEquals(createdAt.toEpochSecond(), response.creationDate.seconds)
-            assertEquals(stageStartedAt.toEpochSecond(), response.lastStageStarted.seconds)
-        }
-
-    @Test
-    fun `When the user is a member of the project and a field mask is given, then the specified fields are correctly returned`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val createdAt = OffsetDateTime.now()
-            val stageStartedAt = OffsetDateTime.now()
-            val project = DataBuilder.createExampleProject(
-                createdAt = createdAt,
-                currentStageStartedAt = stageStartedAt,
-            )
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
-            coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
-
-            val response = mainService.getProjectInformation(getRequest(project.id, listOf("project_progress")))
-            assertEquals(0.5f, response.projectProgress)
-            assertEquals(0, response.creationDate.seconds)
-            assertEquals(0, response.lastStageStarted.seconds)
-        }
-
-    @Test
-    fun `When field mask excludes project progress, then project progress is not populated`() = runTest {
+    fun `When no field mask is given, then all fields are correctly returned`() = runTest {
         val user = DataBuilder.createExampleUser()
         val createdAt = OffsetDateTime.now()
         val stageStartedAt = OffsetDateTime.now()
@@ -101,12 +59,73 @@ class GetProjectInformationTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
 
-        val response = mainService.getProjectInformation(getRequest(project.id, listOf("creation_date")))
-        assertEquals(0f, response.projectProgress)
+        val response = mainService.getProjectInformation(getRequest(project.id))
+
+        assertEquals(0.5f, response.projectProgress)
         assertEquals(createdAt.toEpochSecond(), response.creationDate.seconds)
-        assertEquals(0, response.lastStageStarted.seconds)
+        assertEquals(stageStartedAt.toEpochSecond(), response.lastStageStarted.seconds)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["project_progress", "creation_date", "last_stage_started"])
+    fun `When a field mask is given with a path, then the specified fields are correctly returned`(path: String) =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val createdAt = OffsetDateTime.now()
+            val stageStartedAt = OffsetDateTime.now()
+            val project = DataBuilder.createExampleProject(
+                createdAt = createdAt,
+                currentStageStartedAt = stageStartedAt,
+            )
+
+            mockCurrentUser(user)
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+            coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
+
+            val response = mainService.getProjectInformation(getRequest(project.id, listOf(path)))
+
+            if (path == "project_progress") {
+                assertEquals(0.5f, response.projectProgress)
+            } else {
+                assertEquals(0f, response.projectProgress)
+            }
+
+            if (path == "creation_date") {
+                assertEquals(createdAt.toEpochSecond(), response.creationDate.seconds)
+            } else {
+                assertEquals(0, response.creationDate.seconds)
+            }
+
+            if (path == "last_stage_started") {
+                assertEquals(stageStartedAt.toEpochSecond(), response.lastStageStarted.seconds)
+            } else {
+                assertEquals(0, response.lastStageStarted.seconds)
+            }
+        }
+
+    @Test
+    fun `When a field mask is given without a path, then all fields are correctly returned`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val createdAt = OffsetDateTime.now()
+        val stageStartedAt = OffsetDateTime.now()
+        val project = DataBuilder.createExampleProject(
+            createdAt = createdAt,
+            currentStageStartedAt = stageStartedAt,
+        )
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectPaperRepoMock.getProjectProgress(project.id) } returns 0.5f
+
+        val response = mainService.getProjectInformation(getRequest(project.id, emptyList()))
+
+        assertEquals(0.5f, response.projectProgress)
+        assertEquals(createdAt.toEpochSecond(), response.creationDate.seconds)
+        assertEquals(stageStartedAt.toEpochSecond(), response.lastStageStarted.seconds)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetProjectInformationTest.kt
@@ -24,7 +24,7 @@ class GetProjectInformationTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the user requests project information, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests project information, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/SoftDeleteProjectTest.kt
@@ -1,88 +1,64 @@
 package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
-import kotlin.reflect.KFunction
 
 class SoftDeleteProjectTest : MainServiceTest() {
-    private fun mockSoftDeleteProject(useAdminUser: Boolean, projectId: UUID, stopBefore: KFunction<*>? = null) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (useAdminUser) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val projectAdmin = DataBuilder.createExampleProjectMember(
-            projectId = projectId,
-            userId = currentUser.id,
-            role = ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN,
-        )
+    @Test
+    fun `When a user deletes a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectId = UUID.randomUUID()
 
-        mockCurrentUser(currentUser)
+        mockCurrentUser(user)
+        coEvery {
+            projectAccessCheckerMock.isProjectOrServerAdmin(user, projectId, AccessType.DELETE)
+        } throws TestSpecificException()
 
-        if (stopBefore == projectMemberRepoMock::getAllProjectAdmins) {
-            return
-        }
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns listOf(projectAdmin)
+        assertThrows<TestSpecificException> { mainService.softDeleteProject(projectId) }
 
-        if (stopBefore == projectRepoMock::doesProjectExistById) {
-            return
-        }
+        coVerify(exactly = 0) { projectRepoMock.softDeleteProject(projectId) }
+        coVerify(exactly = 0) { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
+    }
+
+    @Test
+    fun `When a user deletes a non-existent project, then a ProjectNotFoundException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectId = UUID.randomUUID()
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, projectId, AccessType.DELETE) }
+        coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
+
+        assertThrows<ProjectNotFoundException> { mainService.softDeleteProject(projectId) }
+
+        coVerify(exactly = 0) { projectRepoMock.softDeleteProject(projectId) }
+        coVerify(exactly = 0) { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
+    }
+
+    @Test
+    fun `When a user deletes a project and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectId = UUID.randomUUID()
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, projectId, AccessType.DELETE) }
         coEvery { projectRepoMock.doesProjectExistById(projectId) } returns true
+        coJustRun { projectRepoMock.softDeleteProject(projectId) }
+        coJustRun { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
 
-        coEvery { projectRepoMock.softDeleteProject(projectId) } returns Unit
-        coEvery { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) } returns Unit
-    }
+        mainService.softDeleteProject(projectId)
 
-    @Test
-    fun `When a server admin deletes a project, then no exception is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-
-        mockSoftDeleteProject(true, projectId)
-
-        assertDoesNotThrow { mainService.softDeleteProject(projectId) }
-    }
-
-    @Test
-    fun `When a project admin deletes a project, then no exception is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-
-        mockSoftDeleteProject(false, projectId)
-
-        assertDoesNotThrow { mainService.softDeleteProject(projectId) }
-    }
-
-    @Test
-    fun `When a normal project member deletes a project, then an UnauthorizedException is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-
-        mockSoftDeleteProject(false, projectId, stopBefore = projectMemberRepoMock::getAllProjectAdmins)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
-
-        assertThrows<UnauthorizedException> { mainService.softDeleteProject(projectId) }
-        coVerify(exactly = 0) { projectRepoMock.softDeleteProject(any()) }
-    }
-
-    @Test
-    fun `When the project to delete does not exist, then a NotFoundException is thrown`() = runTest {
-        val nonExistentProjectId = UUID.randomUUID()
-
-        mockSoftDeleteProject(false, nonExistentProjectId, stopBefore = projectRepoMock::doesProjectExistById)
-        coEvery { projectRepoMock.doesProjectExistById(nonExistentProjectId) } returns false
-
-        assertThrows<NotFoundException> { mainService.softDeleteProject(nonExistentProjectId) }
-        coVerify(exactly = 0) { projectRepoMock.softDeleteProject(any()) }
+        coVerify(exactly = 1) { projectRepoMock.softDeleteProject(projectId) }
+        coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationTokensForProject(projectId) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -28,7 +28,7 @@ class UpdateProjectTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the user updates a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user updates a project, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
@@ -57,7 +57,7 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user updates a project and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
@@ -73,7 +73,7 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates a project to the project status DELETED, then a IllegalArgumentException is thrown`() =
+    fun `When a user updates a project to the project status DELETED, then a IllegalArgumentException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
@@ -89,7 +89,7 @@ class UpdateProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
+    fun `When a user updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_DELETED)
 
@@ -104,7 +104,7 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates an archived project (not only status), then a FailedPreconditionException is thrown`() =
+    fun `When a user updates an archived project (not only status), then a FailedPreconditionException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
@@ -121,7 +121,7 @@ class UpdateProjectTest : MainServiceTest() {
 
     @ParameterizedTest
     @ValueSource(strings = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_ACTIVE_LOCKED"])
-    fun `When the user updates an archived project (only active status), then no exception is thrown`(
+    fun `When a user updates an archived project (only active status), then no exception is thrown`(
         statusName: String,
     ) = runTest {
         val status = ProjectStatus.valueOf(statusName)
@@ -144,7 +144,7 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates an archived project (only archived status), then no exception is thrown`() = runTest {
+    fun `When a user updates an archived project (only archived status), then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
 
@@ -162,7 +162,7 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates an archived project (only unsupported status), then a FailedPreconditionException is thrown`() =
+    fun `When a user updates an archived project (only unsupported status), then a FailedPreconditionException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
@@ -178,7 +178,7 @@ class UpdateProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user updates an active locked project (project settings), then a FailedPreconditionException is thrown`() =
+    fun `When a user updates an active locked project (project settings), then a FailedPreconditionException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
@@ -194,25 +194,24 @@ class UpdateProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user updates an active locked project (not project settings), then no exception is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+    fun `When a user updates an active locked project (not project settings), then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
 
-            val updatedProject = project.copy(name = "Updated Name")
-            val request = getRequest(updatedProject, listOf("project.name"))
+        val updatedProject = project.copy(name = "Updated Name")
+        val request = getRequest(updatedProject, listOf("project.name"))
 
-            mockCurrentUser(user)
-            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectRepoMock.isProjectLocked(project.id) } returns true
-            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectRepoMock.isProjectLocked(project.id) } returns true
+        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-            assertDoesNotThrow { mainService.updateProject(request) }
-        }
+        assertDoesNotThrow { mainService.updateProject(request) }
+    }
 
     @Test
-    fun `When the user updates an active project, then no exception is thrown`() = runTest {
+    fun `When a user updates an active project, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
 
@@ -230,7 +229,7 @@ class UpdateProjectTest : MainServiceTest() {
 
     @ParameterizedTest
     @ValueSource(strings = ["PROJECT_STATUS_UNSPECIFIED", "UNRECOGNIZED"])
-    fun `When the user updates a project with unsupported status, then an IllegalStateException is thrown`(
+    fun `When a user updates a project with unsupported status, then an IllegalStateException is thrown`(
         statusName: String,
     ) = runTest {
         val status = ProjectStatus.valueOf(statusName)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -2,322 +2,226 @@ package se.uulm.snowballr.backend.service.project
 
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toGrpcProject
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.ProjectStatus
-import snowballr.UserOuterClass.UserRole
+import kotlin.test.assertEquals
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 class UpdateProjectTest : MainServiceTest() {
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            "PROJECT_STATUS_ACTIVE",
-            "PROJECT_STATUS_ACTIVE_LOCKED",
-            "PROJECT_STATUS_ARCHIVED",
-        ],
-    )
-    fun `When a server admin updates an existent project, then no exception is thrown`(statusName: String) = runTest {
-        val status = ProjectStatus.valueOf(statusName)
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(status = status)
-        val updatedProject = DataBuilder.createExampleProject(id = project.id)
-
-        val updateFieldMask = FieldMaskUtil.fromString("project.status")
-        val request = GrpcProject.Update
-            .newBuilder()
-            .setProject(updatedProject.toGrpcProject())
-            .setMask(updateFieldMask)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
-        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
-
-        assertDoesNotThrow { mainService.updateProject(request) }
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            "PROJECT_STATUS_ACTIVE",
-            "PROJECT_STATUS_ACTIVE_LOCKED",
-            "PROJECT_STATUS_ARCHIVED",
-        ],
-    )
-    fun `When a project admin updates an existent project, then no exception is thrown`(statusName: String) = runTest {
-        val status = ProjectStatus.valueOf(statusName)
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(status = status)
-        val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
-
-        val updatedProject = DataBuilder.createExampleProject(id = project.id)
-
-        val updateFieldMask = FieldMaskUtil.fromString("project.status")
-        val request = GrpcProject.Update
-            .newBuilder()
-            .setProject(updatedProject.toGrpcProject())
-            .setMask(updateFieldMask)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
-        coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
-        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
-
-        assertDoesNotThrow { mainService.updateProject(request) }
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            "PROJECT_STATUS_ACTIVE",
-            "PROJECT_STATUS_ACTIVE_LOCKED",
-            "PROJECT_STATUS_ARCHIVED",
-        ],
-    )
-    fun `When a project member updates a project, then an UnauthorizedException is thrown`(statusName: String) =
-        runTest {
-            val status = ProjectStatus.valueOf(statusName)
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(status = status)
-            val updatedProject = DataBuilder.createExampleProject(id = project.id)
-
-            val updateFieldMask = FieldMaskUtil.fromString("project.status")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-            assertThrows<UnauthorizedException> { mainService.updateProject(request) }
-        }
+    private fun getRequest(project: Project, paths: List<String>? = null) = GrpcProject.Update
+        .newBuilder()
+        .setProject(project.toGrpcProject())
+        .also { if (paths != null) it.setMask(FieldMaskUtil.fromStringList(paths)) }
+        .build()
 
     @Test
-    fun `When a server admin updates project to the project status DELETED, then a IllegalArgumentException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
-            val updatedProject = DataBuilder.createExampleProject(
-                id = project.id,
-                status = ProjectStatus.PROJECT_STATUS_DELETED,
-            )
+    fun `When the user updates a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
-            val updateFieldMask = FieldMaskUtil.fromString("project.status")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
+        val request = getRequest(project)
+
+        mockCurrentUser(user)
+        coEvery {
+            projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateProject(request) }
+    }
+
+    @Test
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+
+        val request = getRequest(project)
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.updateProject(request) }
+    }
+
+    @Test
+    fun `When the user updates a project and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+
+        val request = getRequest(project)
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
+        coEvery { projectRepoMock.updateProject(request) } returns project
+
+        assertDoesNotThrow { mainService.updateProject(request) }
+    }
+
+    @Test
+    fun `When the user updates a project to the project status DELETED, then a IllegalArgumentException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+
+            val updatedProject = project.copy(status = ProjectStatus.PROJECT_STATUS_DELETED)
+            val request = getRequest(updatedProject, listOf("project.status"))
 
             mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<IllegalArgumentException> { mainService.updateProject(request) }
         }
 
     @Test
-    fun `When a server admin updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When the user updates a deleted project, then a FailedPreconditionException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_DELETED)
-        val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
 
-        val updateFieldMask = FieldMaskUtil.fromString("project.name")
-        val request = GrpcProject.Update
-            .newBuilder()
-            .setProject(updatedProject.toGrpcProject())
-            .setMask(updateFieldMask)
-            .build()
+        val updatedProject = project.copy(name = "Updated Name")
+        val request = getRequest(updatedProject, listOf("project.name"))
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
         assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
     }
 
     @Test
-    fun `When a server admin updates an archived project except the status, then a FailedPreconditionException is thrown`() =
+    fun `When the user updates an archived project (not only status), then a FailedPreconditionException is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val updatedProject =
-                DataBuilder.createExampleProject(id = project.id, name = "Updated Project", reviewMaybeAllowed = false)
 
-            val updateFieldMask =
-                FieldMaskUtil.fromStringList(listOf("project.name", "project.settings.reviewMaybeAllowed"))
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
+            val updatedProject = project.copy(name = "Updated Name", status = ProjectStatus.PROJECT_STATUS_ACTIVE)
+            val request = getRequest(updatedProject, listOf("project.name", "project.status"))
 
             mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
             coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
 
             assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
         }
 
     @ParameterizedTest
-    @CsvSource(
-        value = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_ACTIVE_LOCKED"],
-    )
-    fun `When a server admin updates an archived project to an active status, then no exception is thrown`(
+    @ValueSource(strings = ["PROJECT_STATUS_ACTIVE", "PROJECT_STATUS_ACTIVE_LOCKED"])
+    fun `When the user updates an archived project (only active status), then no exception is thrown`(
         statusName: String,
     ) = runTest {
         val status = ProjectStatus.valueOf(statusName)
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
-        val updatedProject = DataBuilder.createExampleProject(id = project.id, status = status)
 
-        val updateFieldMask = FieldMaskUtil.fromString("project.status")
-        val request = GrpcProject.Update
-            .newBuilder()
-            .setProject(updatedProject.toGrpcProject())
-            .setMask(updateFieldMask)
-            .build()
+        val updatedProject = project.copy(status = status)
+        val request = getRequest(updatedProject, listOf("project.status"))
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
         coEvery { projectRepoMock.isProjectLocked(project.id) } returns
             (updatedProject.status == ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
         coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
-        assertDoesNotThrow { mainService.updateProject(request) }
+        val resultProject = mainService.updateProject(request)
+
+        assertEquals(status, resultProject.status)
     }
 
     @Test
-    fun `When a server admin updates an archived project to the archived status, then no exception is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val updatedProject = DataBuilder.createExampleProject(
-                id = project.id,
-                status = ProjectStatus.PROJECT_STATUS_ARCHIVED,
-            )
+    fun `When the user updates an archived project (only archived status), then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
 
-            val updateFieldMask = FieldMaskUtil.fromString("project.status")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
-
-            assertDoesNotThrow { mainService.updateProject(request) }
-        }
-
-    @Test
-    fun `When a server admin updates an archived project to an unsupported status, then a FailedPreconditionException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
-            val updatedProject = DataBuilder.createExampleProject(
-                id = project.id,
-                status = ProjectStatus.PROJECT_STATUS_UNSPECIFIED,
-            )
-
-            val updateFieldMask = FieldMaskUtil.fromString("project.status")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
-        }
-
-    @Test
-    fun `When a server admin updates the project settings of an active locked project, then a FailedPreconditionException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-            val updatedProject = DataBuilder.createExampleProject(id = project.id, reviewMaybeAllowed = false)
-
-            val updateFieldMask = FieldMaskUtil.fromString("project.settings.reviewMaybeAllowed")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
-        }
-
-    @Test
-    fun `When a server admin updates an active locked project except the project settings, then no exception is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
-            val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
-
-            val updateFieldMask = FieldMaskUtil.fromString("project.name")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
-            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
-
-            assertDoesNotThrow { mainService.updateProject(request) }
-        }
-
-    @Test
-    fun `When a server admin updates active project, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
-        val updatedProject = DataBuilder.createExampleProject(
-            id = project.id,
-            name = "Updated Project",
-            reviewMaybeAllowed = false,
-        )
-
-        val updateFieldMask =
-            FieldMaskUtil.fromStringList(listOf("project.name", "project.settings.reviewMaybeAllowed"))
-        val request = GrpcProject.Update
-            .newBuilder()
-            .setProject(updatedProject.toGrpcProject())
-            .setMask(updateFieldMask)
-            .build()
+        val updatedProject = project.copy(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+        val request = getRequest(updatedProject, listOf("project.status"))
 
         mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+
+        val resultProject = mainService.updateProject(request)
+
+        assertEquals(ProjectStatus.PROJECT_STATUS_ARCHIVED, resultProject.status)
+    }
+
+    @Test
+    fun `When the user updates an archived project (only unsupported status), then a FailedPreconditionException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ARCHIVED)
+
+            val updatedProject = project.copy(status = ProjectStatus.PROJECT_STATUS_UNSPECIFIED)
+            val request = getRequest(updatedProject, listOf("project.status"))
+
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When the user updates an active locked project (project settings), then a FailedPreconditionException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+
+            val updatedProject = project.copy(reviewMaybeAllowed = false)
+            val request = getRequest(updatedProject, listOf("project.settings.review_maybe_allowed"))
+
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+
+            assertThrows<FailedPreconditionException> { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When the user updates an active locked project (not project settings), then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED)
+
+            val updatedProject = project.copy(name = "Updated Name")
+            val request = getRequest(updatedProject, listOf("project.name"))
+
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coEvery { projectRepoMock.isProjectLocked(project.id) } returns true
+            coEvery { projectRepoMock.updateProject(request) } returns updatedProject
+
+            assertDoesNotThrow { mainService.updateProject(request) }
+        }
+
+    @Test
+    fun `When the user updates an active project, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(status = ProjectStatus.PROJECT_STATUS_ACTIVE)
+
+        val updatedProject = project.copy(name = "Updated Name")
+        val request = getRequest(updatedProject, listOf("project.name"))
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery { projectRepoMock.isProjectLocked(project.id) } returns false
         coEvery { projectRepoMock.updateProject(request) } returns updatedProject
 
@@ -325,30 +229,21 @@ class UpdateProjectTest : MainServiceTest() {
     }
 
     @ParameterizedTest
-    @CsvSource(
-        value = [
-            "PROJECT_STATUS_UNSPECIFIED",
-            "UNRECOGNIZED",
-        ],
-    )
-    fun `When a project has an unspecified status, then an IllegalStateException is thrown`(statusName: String) =
-        runTest {
-            val status = ProjectStatus.valueOf(statusName)
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val project = DataBuilder.createExampleProject(status = status)
-            val updatedProject = DataBuilder.createExampleProject(id = project.id, name = "Updated Project")
+    @ValueSource(strings = ["PROJECT_STATUS_UNSPECIFIED", "UNRECOGNIZED"])
+    fun `When the user updates a project with unsupported status, then an IllegalStateException is thrown`(
+        statusName: String,
+    ) = runTest {
+        val status = ProjectStatus.valueOf(statusName)
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(status = status)
 
-            val updateFieldMask = FieldMaskUtil.fromString("project.name")
-            val request = GrpcProject.Update
-                .newBuilder()
-                .setProject(updatedProject.toGrpcProject())
-                .setMask(updateFieldMask)
-                .build()
+        val updatedProject = project.copy(name = "Updated Name", status = ProjectStatus.PROJECT_STATUS_ACTIVE)
+        val request = getRequest(updatedProject, listOf("project.name"))
 
-            mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isProjectOrServerAdmin(user, project.id, AccessType.UPDATE) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
 
-            assertThrows<IllegalStateException> { mainService.updateProject(request) }
-        }
+        assertThrows<IllegalStateException> { mainService.updateProject(request) }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 
 class GetProjectMembersTest : MainServiceTest() {
     @Test
-    fun `When the user requests the project members and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the project members and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
@@ -32,7 +32,7 @@ class GetProjectMembersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests the project members, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests the project members, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val projectId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -1,75 +1,45 @@
 package se.uulm.snowballr.backend.service.projectmember
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.ProjectMemberWithUser
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import kotlin.test.assertEquals
 
 class GetProjectMembersTest : MainServiceTest() {
     @Test
-    fun `When a server admin requests the project members, then no exception is thrown`() = runTest {
-        val adminUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val projectMemberUser = DataBuilder.createExampleUser()
-        val project = DataBuilder.createExampleProject()
-        val projectMember = DataBuilder.createExampleProjectMember(
-            userId = projectMemberUser.id,
-            projectId = project.id,
-        )
-        val projectMemberWithUser = ProjectMemberWithUser(projectMember, projectMemberUser)
-
-        mockCurrentUser(adminUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, adminUser.id) } returns true
-        coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns listOf(projectMemberWithUser)
-
-        assertDoesNotThrow { mainService.getProjectMembers(project.id) }
-    }
-
-    @Test
-    fun `When a project member requests the project members, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When the user requests the project members and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val projectMember = DataBuilder.createExampleProjectMember(userId = user.id, projectId = project.id)
         val projectMemberWithUser = ProjectMemberWithUser(projectMember, user)
 
         mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns true
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectMemberRepoMock.getProjectMembersWithUsers(project.id) } returns listOf(projectMemberWithUser)
 
-        assertDoesNotThrow { mainService.getProjectMembers(project.id) }
+        val projectMembers = mainService.getProjectMembers(project.id)
+
+        assertEquals(1, projectMembers.membersCount)
+        val actualProjectMember = projectMembers.membersList.first()
+        assertEquals(projectMember.userId.toString(), actualProjectMember.user.id)
     }
 
     @Test
-    fun `When a non project member requests the project members, then an UnauthorizedException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(user)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, user.id) } returns false
-
-        assertThrows<UnauthorizedException> { mainService.getProjectMembers(project.id) }
-    }
-
-    @Test
-    fun `When project members are requested from a nonexistent project, then a ProjectNotFoundException is thrown`() =
+    fun `When the user requests the project members, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val user = DataBuilder.createExampleUser()
             val projectId = UUID.randomUUID()
 
             mockCurrentUser(user)
-            coEvery { projectRepoMock.getProjectById(projectId) } returns Result.failure(TestSpecificException())
+            coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, projectId) } throws TestSpecificException()
 
-            assertThrows<ProjectNotFoundException> { mainService.getProjectMembers(projectId) }
+            assertThrows<TestSpecificException> { mainService.getProjectMembers(projectId) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -23,7 +23,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the user removes a project member, then no exception is thrown`() = runTest {
+    fun `When a user removes a project member, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
         val project = DataBuilder.createExampleProject()
@@ -62,7 +62,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes a non-project member, then nothing happens`() = runTest {
+    fun `When a user removes a non-project member, then nothing happens`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
         val project = DataBuilder.createExampleProject()
@@ -80,32 +80,31 @@ class RemoveProjectMemberTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes a user of a non-existent project, then a ProjectNotFoundException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser()
-            val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
-            val project = DataBuilder.createExampleProject()
+    fun `When a user removes a user of a non-existent project, then a ProjectNotFoundException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
+        val project = DataBuilder.createExampleProject()
 
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns true
-            coJustRun {
-                projectMemberAccessCheckerMock.isAllowedToRemoveMember(
-                    currentUser,
-                    userToRemove.id,
-                    project.id,
-                )
-            }
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
-
-            assertThrows<ProjectNotFoundException> { mainService.removeProjectMember(getExampleRequest(project.id)) }
+        mockCurrentUser(currentUser)
+        coEvery {
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
+        } returns Result.failure(TestSpecificException())
+        coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
+        coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns true
+        coJustRun {
+            projectMemberAccessCheckerMock.isAllowedToRemoveMember(
+                currentUser,
+                userToRemove.id,
+                project.id,
+            )
         }
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+
+        assertThrows<ProjectNotFoundException> { mainService.removeProjectMember(getExampleRequest(project.id)) }
+    }
 
     @Test
-    fun `When the user removes the last project member, then the project is soft-deleted`() = runTest {
+    fun `When a user removes the last project member, then the project is soft-deleted`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
         val project = DataBuilder.createExampleProject()
@@ -130,7 +129,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes an invitation and has access, then no exception is thrown`() = runTest {
+    fun `When a user removes an invitation and has access, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val invitationToken = DataBuilder.createExampleInvitationToken()
@@ -148,7 +147,7 @@ class RemoveProjectMemberTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes an invitation, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user removes an invitation, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val invitationToken = DataBuilder.createExampleInvitationToken()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -1,309 +1,166 @@
 package se.uulm.snowballr.backend.service.projectmember
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
-import snowballr.UserOuterClass
+import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
+import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class RemoveProjectMemberTest : MainServiceTest() {
-    private val projectId = UUID.randomUUID()
     private val userEmail = "user@example.com"
 
-    private fun getExampleRequest() = ProjectOuterClass.Project.Member.Remove.newBuilder()
+    private fun getExampleRequest(projectId: UUID = UUID.randomUUID()) = GrpcProjectMember.Remove.newBuilder()
         .setProjectId(projectId.toString())
         .setUserEmail(userEmail)
         .build()
 
     @Test
-    fun `When a server admin removes a project member, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val userToRemove = DataBuilder.createExampleUser(
-            email = userEmail,
-            status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE,
-        )
-        val project = DataBuilder.createExampleProject(id = projectId)
+    fun `When the user removes a project member, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
+        val project = DataBuilder.createExampleProject()
         val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userToRemove.id)
         val projectMember2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = UUID.randomUUID())
 
         mockCurrentUser(currentUser)
         coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
         } returns Result.failure(TestSpecificException())
         coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
-        coEvery { projectMemberRepoMock.isProjectMember(projectId, userToRemove.id) } returns true
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
+        coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns true
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToRemoveMember(currentUser, userToRemove.id, project.id) }
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-        coEvery {
-            projectMemberRepoMock.getProjectMembers(project.id)
-        } returns listOf(projectMember1, projectMember2)
-        coEvery { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) } returns Unit
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember1, projectMember2)
+        coJustRun { projectAccessCheckerMock.isNotLastProjectAdmin(userToRemove, project.id, any()) }
+        coJustRun { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
 
-        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+        mainService.removeProjectMember(getExampleRequest(project.id))
+
+        coVerify(exactly = 1) { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
     }
 
     @Test
-    fun `When a project admin removes another project member, then no exception is thrown`() = runTest {
+    fun `When retrieving the user to remove fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val userToRemove = DataBuilder.createExampleUser(
-            email = userEmail,
-            status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE,
-        )
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userToRemove.id)
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(currentUser)
         coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-        } returns Result.failure(TestSpecificException())
-        coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
-        coEvery { projectMemberRepoMock.isProjectMember(projectId, userToRemove.id) } returns true
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
-        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-        coEvery {
-            projectMemberRepoMock.getProjectMembers(project.id)
-        } returns listOf(projectMember, projectAdmin)
-        coEvery { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) } returns Unit
-
-        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a project admin removes themselves and they are not the last project admin, then no exception is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(email = userEmail)
-            val otherUser = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject(id = projectId)
-            val projectAdmin1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-            val projectAdmin2 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = otherUser.id)
-
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(currentUser.email) } returns Result.success(currentUser)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-            coEvery {
-                projectMemberRepoMock.getProjectMembers(project.id)
-            } returns listOf(projectAdmin1, projectAdmin2)
-            coEvery {
-                projectMemberRepoMock.getAllProjectAdmins(project.id)
-            } returns listOf(projectAdmin1, projectAdmin2)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-            coEvery {
-                projectMemberRepoMock.removeProjectMember(project.id, currentUser.id)
-            } returns Unit
-
-            assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
-        }
-
-    @Test
-    fun `When a non project admin removes themselves and they are not the last project member, then no exception is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(email = userEmail)
-            val otherUser = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject(id = projectId)
-            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = otherUser.id)
-
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(currentUser)
-            coEvery { projectMemberRepoMock.isProjectMember(projectId, currentUser.id) } returns true
-            coEvery {
-                projectMemberRepoMock.getProjectMembers(project.id)
-            } returns listOf(projectMember, projectAdmin)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-            coEvery {
-                projectMemberRepoMock.removeProjectMember(project.id, currentUser.id)
-            } returns Unit
-
-            assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
-        }
-
-    @Test
-    fun `When a project admin removes a project member from a non-existent project, then a NotFoundException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(currentUser)
-            coEvery { projectMemberRepoMock.isProjectMember(projectId, currentUser.id) } returns true
-            coEvery { projectRepoMock.doesProjectExistById(projectId) } returns false
-
-            assertThrows<NotFoundException> {
-                mainService.removeProjectMember(getExampleRequest())
-            }
-        }
-
-    @Test
-    fun `When a non-existent project member is removed, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-
-        mockCurrentUser(currentUser)
-        coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
         } returns Result.failure(TestSpecificException())
         coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> {
-            mainService.removeProjectMember(getExampleRequest())
-        }
+        assertThrows<TestSpecificException> { mainService.removeProjectMember(getExampleRequest(project.id)) }
     }
 
     @Test
-    fun `When a normal project member removes another project member, then an UnauthorizedException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-            val otherUser = DataBuilder.createExampleUser(
-                email = userEmail,
-                status = UserOuterClass.UserStatus.USER_STATUS_ACTIVE,
-            )
-            val project = DataBuilder.createExampleProject(id = projectId)
-
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(otherUser.email) } returns Result.success(otherUser)
-            coEvery { projectMemberRepoMock.isProjectMember(projectId, otherUser.id) } returns true
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-            assertThrows<UnauthorizedException> {
-                mainService.removeProjectMember(getExampleRequest())
-            }
-        }
-
-    @Test
-    fun `When a project admin removes themselves, but is the last project admin in the project, then a FailedPreconditionException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(email = userEmail)
-            val otherUser = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject(id = projectId)
-            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
-            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = otherUser.id)
-
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(currentUser)
-            coEvery { projectMemberRepoMock.isProjectMember(projectId, currentUser.id) } returns true
-            coEvery {
-                projectMemberRepoMock.getProjectMembers(project.id)
-            } returns listOf(projectAdmin, projectMember)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-
-            assertThrows<FailedPreconditionException> {
-                mainService.removeProjectMember(getExampleRequest())
-            }
-        }
-
-    @Test
-    fun `When a project member to be deleted is the last member, then no exception is thrown and the project is marked as deleted`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(email = userEmail)
-            val project = DataBuilder.createExampleProject(id = projectId)
-            val lastProjectMember = DataBuilder.createExampleProjectMember(
-                projectId = project.id,
-                userId = currentUser.id,
-            )
-
-            mockCurrentUser(currentUser)
-            coEvery {
-                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-            } returns Result.failure(TestSpecificException())
-            coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(currentUser)
-            coEvery { projectMemberRepoMock.isProjectMember(projectId, currentUser.id) } returns true
-            coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(lastProjectMember)
-            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
-            coEvery { projectRepoMock.softDeleteProject(project.id) } returns Unit
-            coEvery {
-                projectMemberRepoMock.removeProjectMember(project.id, currentUser.id)
-            } returns Unit
-
-            assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
-            coVerify(exactly = 1) { projectRepoMock.softDeleteProject(project.id) }
-        }
-
-    @Test
-    fun `When a project admin removes an invitee, then the invitee is removed`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val projectAdmin = DataBuilder.createExampleProjectMember(projectId = projectId, userId = currentUser.id)
-        val token = DataBuilder.createExampleInvitationToken(email = userEmail, projectId = projectId)
+    fun `When the user removes a non-project member, then nothing happens`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(currentUser)
         coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-        } returns Result.success(token)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns listOf(projectAdmin)
-        coEvery { invitationTokenRepoMock.deleteInvitationToken(token.token) } returns Unit
-
-        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a server admin removes an invitee, then the invitee is removed`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_ADMIN)
-        val token = DataBuilder.createExampleInvitationToken(email = userEmail, projectId = projectId)
-
-        mockCurrentUser(currentUser)
-        coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-        } returns Result.success(token)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
-        coEvery { invitationTokenRepoMock.deleteInvitationToken(token.token) } returns Unit
-
-        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a normal project member removes an invitee, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val token = DataBuilder.createExampleInvitationToken(email = userEmail, projectId = projectId)
-
-        mockCurrentUser(currentUser)
-        coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
-        } returns Result.success(token)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(projectId) } returns emptyList()
-
-        assertThrows<UnauthorizedException> {
-            mainService.removeProjectMember(getExampleRequest())
-        }
-    }
-
-    @Test
-    fun `When the user to be removed is not a project member nor an invitee, then nothing is removed`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserOuterClass.UserRole.USER_ROLE_DEFAULT)
-        val otherUser = DataBuilder.createExampleUser(email = userEmail)
-
-        mockCurrentUser(currentUser)
-        coEvery {
-            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, projectId)
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
         } returns Result.failure(TestSpecificException())
-        coEvery { userRepoMock.getUserByEmail(otherUser.email) } returns Result.success(otherUser)
-        coEvery { projectMemberRepoMock.isProjectMember(projectId, otherUser.id) } returns false
+        coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
+        coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns false
 
-        assertDoesNotThrow { mainService.removeProjectMember(getExampleRequest()) }
+        mainService.removeProjectMember(getExampleRequest(project.id))
+
+        coVerify(exactly = 0) { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
+    }
+
+    @Test
+    fun `When the user removes a user of a non-existent project, then a ProjectNotFoundException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
+            val project = DataBuilder.createExampleProject()
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
+            } returns Result.failure(TestSpecificException())
+            coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
+            coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns true
+            coJustRun {
+                projectMemberAccessCheckerMock.isAllowedToRemoveMember(
+                    currentUser,
+                    userToRemove.id,
+                    project.id,
+                )
+            }
+            coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
+
+            assertThrows<ProjectNotFoundException> { mainService.removeProjectMember(getExampleRequest(project.id)) }
+        }
+
+    @Test
+    fun `When the user removes the last project member, then the project is soft-deleted`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val userToRemove = DataBuilder.createExampleUser(email = userEmail, status = UserStatus.USER_STATUS_ACTIVE)
+        val project = DataBuilder.createExampleProject()
+        val projectMember1 = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userToRemove.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
+        } returns Result.failure(TestSpecificException())
+        coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
+        coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns true
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToRemoveMember(currentUser, userToRemove.id, project.id) }
+        coEvery { projectRepoMock.doesProjectExistById(project.id) } returns true
+        coEvery { projectMemberRepoMock.getProjectMembers(project.id) } returns listOf(projectMember1)
+        coJustRun { projectRepoMock.softDeleteProject(project.id) }
+        coJustRun { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
+
+        mainService.removeProjectMember(getExampleRequest(project.id))
+
+        coVerify(exactly = 1) { projectRepoMock.softDeleteProject(project.id) }
+        coVerify(exactly = 1) { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
+    }
+
+    @Test
+    fun `When the user removes an invitation and has access, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val invitationToken = DataBuilder.createExampleInvitationToken()
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
+        } returns Result.success(invitationToken)
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToRemoveInvitation(currentUser, project.id) }
+        coJustRun { invitationTokenRepoMock.deleteInvitationToken(invitationToken.token) }
+
+        mainService.removeProjectMember(getExampleRequest(project.id))
+
+        coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationToken(invitationToken.token) }
+    }
+
+    @Test
+    fun `When the user removes an invitation, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val invitationToken = DataBuilder.createExampleInvitationToken()
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(userEmail, project.id)
+        } returns Result.success(invitationToken)
+        coEvery {
+            projectMemberAccessCheckerMock.isAllowedToRemoveInvitation(currentUser, project.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.removeProjectMember(getExampleRequest(project.id)) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
@@ -26,7 +26,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
             .build()
 
     @Test
-    fun `When the user updates a member role, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user updates a member role, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = createExampleUser()
         val user = createExampleUser()
         val project = DataBuilder.createExampleProject()
@@ -42,20 +42,19 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates a member role of a non-existent user, then a TestSpecificException is thrown`() =
-        runTest {
-            val currentUser = createExampleUser()
-            val user = createExampleUser()
-            val project = DataBuilder.createExampleProject()
+    fun `When a user updates a member role of a non-existent user, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = createExampleUser()
+        val user = createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
-            val request = getRequest(user.id, project.id)
+        val request = getRequest(user.id, project.id)
 
-            mockCurrentUser(currentUser)
-            coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
-            coEvery { userRepoMock.getUserById(user.id) } returns Result.failure(TestSpecificException())
+        mockCurrentUser(currentUser)
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.failure(TestSpecificException())
 
-            assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
-        }
+        assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
+    }
 
     @Test
     fun `When retrieving the project member fails, then a FailedPreconditionException is thrown`() = runTest {
@@ -76,7 +75,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user demotes the last project admin, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user demotes the last project admin, then a TestSpecificException is thrown`() = runTest {
         val currentUser = createExampleUser()
         val user = createExampleUser()
         val project = DataBuilder.createExampleProject()
@@ -98,7 +97,7 @@ class UpdateProjectMemberRoleTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user re-promotes an admin, then last-admin check is skipped`() = runTest {
+    fun `When a user re-promotes an admin, then last-admin check is skipped`() = runTest {
         val currentUser = createExampleUser()
         val user = createExampleUser()
         val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
@@ -1,287 +1,147 @@
 package se.uulm.snowballr.backend.service.projectmember
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.DataBuilder.createExampleUser
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectMemberNotFoundException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass
 import snowballr.ProjectOuterClass.MemberRole
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class UpdateProjectMemberRoleTest : MainServiceTest() {
-    @Test
-    fun `When a server admin updates a member role of a user in a non-existent project, then a ProjectNotFoundException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val nonExistentProjectId = UUID.randomUUID()
-
-            val request = ProjectOuterClass.Project.Member.Update
-                .newBuilder()
-                .setProjectId(nonExistentProjectId.toString())
-                .setUserId(userToBeUpdated.id.toString())
-                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(nonExistentProjectId) } returns emptyList()
-            coEvery {
-                projectRepoMock.getProjectById(nonExistentProjectId)
-            } returns Result.failure(TestSpecificException())
-
-            assertThrows<ProjectNotFoundException> { mainService.updateProjectMemberRole(request) }
-        }
+    private fun getRequest(userId: UUID, projectId: UUID, newRole: MemberRole = MemberRole.MEMBER_ROLE_ADMIN) =
+        GrpcProjectMember.Update
+            .newBuilder()
+            .setProjectId(projectId.toString())
+            .setUserId(userId.toString())
+            .setNewRole(newRole)
+            .build()
 
     @Test
-    fun `When a server admin updates a member role of a non-existent user, then a TestSpecificException is thrown`() =
+    fun `When the user updates a member role, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = createExampleUser()
+        val user = createExampleUser()
+        val project = DataBuilder.createExampleProject()
+
+        val request = getRequest(user.id, project.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
+    }
+
+    @Test
+    fun `When the user updates a member role of a non-existent user, then a TestSpecificException is thrown`() =
         runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val nonExistentUserId = UUID.randomUUID()
+            val currentUser = createExampleUser()
+            val user = createExampleUser()
             val project = DataBuilder.createExampleProject()
 
-            val request = ProjectOuterClass.Project.Member.Update
-                .newBuilder()
-                .setProjectId(project.id.toString())
-                .setUserId(nonExistentUserId.toString())
-                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
-                .build()
+            val request = getRequest(user.id, project.id)
 
-            mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { userRepoMock.getUserById(nonExistentUserId) } returns
-                Result.failure(TestSpecificException())
+            mockCurrentUser(currentUser)
+            coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
+            coEvery { userRepoMock.getUserById(user.id) } returns Result.failure(TestSpecificException())
 
             assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
         }
 
     @Test
-    fun `When a server admin updates another member's role, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the project member fails, then a FailedPreconditionException is thrown`() = runTest {
+        val currentUser = createExampleUser()
+        val user = createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val projectMemberToBeUpdated =
-            DataBuilder.createExampleProjectMember(userId = userToBeUpdated.id, projectId = project.id)
 
-        val newRole = MemberRole.MEMBER_ROLE_ADMIN
-        val updatedUser = DataBuilder.createExampleProjectMember(
-            userId = userToBeUpdated.id,
-            projectId = project.id,
-            role = newRole,
-        )
+        val request = getRequest(user.id, project.id)
 
-        val request = ProjectOuterClass.Project.Member.Update
-            .newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserId(userToBeUpdated.id.toString())
-            .setNewRole(newRole)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
-        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
-            Result.success(projectMemberToBeUpdated)
-        coEvery { projectMemberRepoMock.updateProjectMemberRole(project.id, userToBeUpdated.id, newRole) } returns
-            updatedUser
-
-        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
-    }
-
-    @Test
-    fun `When a project admin updates another member's role, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val projectAdminMember = DataBuilder.createExampleProjectMember(
-            role = MemberRole.MEMBER_ROLE_ADMIN,
-            userId = user.id,
-        )
-        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-        val projectMemberToBeUpdated = DataBuilder.createExampleProjectMember(
-            userId = userToBeUpdated.id,
-            projectId = project.id,
-        )
-
-        val newRole = MemberRole.MEMBER_ROLE_ADMIN
-        val updatedUser = DataBuilder.createExampleProjectMember(
-            userId = userToBeUpdated.id,
-            projectId = project.id,
-            role = newRole,
-        )
-
-        val request = ProjectOuterClass.Project.Member.Update
-            .newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserId(userToBeUpdated.id.toString())
-            .setNewRole(newRole)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
-        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
-            Result.success(projectMemberToBeUpdated)
-        coEvery { projectMemberRepoMock.updateProjectMemberRole(project.id, userToBeUpdated.id, newRole) } returns
-            updatedUser
-
-        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
-    }
-
-    @Test
-    fun `When a project member updates another member's role, then an UnauthorizedException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-
-        val request = ProjectOuterClass.Project.Member.Update
-            .newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserId(userToBeUpdated.id.toString())
-            .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-        assertThrows<UnauthorizedException> { mainService.updateProjectMemberRole(request) }
-    }
-
-    @Test
-    fun `When an admin updates the member role of a user who is not a member of the project, then a FailedPrecondition is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-
-            val request = ProjectOuterClass.Project.Member.Update
-                .newBuilder()
-                .setProjectId(project.id.toString())
-                .setUserId(userToBeUpdated.id.toString())
-                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
-                .build()
-
-            mockCurrentUser(user)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
-            coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
-                Result.failure(ProjectMemberNotFoundException(user.id, project.id))
-
-            assertThrows<FailedPreconditionException> { mainService.updateProjectMemberRole(request) }
-        }
-
-    @Test
-    fun `When a server admin demotes the last project admin, then a FailedPreconditionException is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-        val projectAdminMember = DataBuilder.createExampleProjectMember(
-            role = MemberRole.MEMBER_ROLE_ADMIN,
-            userId = userToBeUpdated.id,
-        )
-
-        val request = ProjectOuterClass.Project.Member.Update
-            .newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserId(userToBeUpdated.id.toString())
-            .setNewRole(MemberRole.MEMBER_ROLE_DEFAULT)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
-        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
-            Result.success(projectAdminMember)
+        mockCurrentUser(currentUser)
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        coEvery {
+            projectMemberRepoMock.getProjectMemberByComposedId(project.id, user.id)
+        } returns Result.failure(ProjectMemberNotFoundException(user.id, project.id))
 
         assertThrows<FailedPreconditionException> { mainService.updateProjectMemberRole(request) }
     }
 
     @Test
-    fun `When multiple admins exist and one is demoted, then no exception is thrown`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val user1ToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val user2ToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When the user demotes the last project admin, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = createExampleUser()
+        val user = createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val projectAdminMember1 = DataBuilder.createExampleProjectMember(
-            role = MemberRole.MEMBER_ROLE_ADMIN,
-            userId = user1ToBeUpdated.id,
-        )
-        val projectAdminMember2 = DataBuilder.createExampleProjectMember(
-            role = MemberRole.MEMBER_ROLE_ADMIN,
-            userId = user2ToBeUpdated.id,
-        )
+        val projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_ADMIN)
 
-        val newRole = MemberRole.MEMBER_ROLE_DEFAULT
-        val updatedUser = DataBuilder.createExampleProjectMember(
-            userId = user1ToBeUpdated.id,
-            projectId = project.id,
-            role = newRole,
-        )
+        val request = getRequest(user.id, project.id, MemberRole.MEMBER_ROLE_DEFAULT)
 
-        val request = ProjectOuterClass.Project.Member.Update
-            .newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserId(user1ToBeUpdated.id.toString())
-            .setNewRole(newRole)
-            .build()
-
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(
-            projectAdminMember1, projectAdminMember2,
-        )
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { userRepoMock.getUserById(user1ToBeUpdated.id) } returns Result.success(user1ToBeUpdated)
-        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, user1ToBeUpdated.id) } returns
-            Result.success(projectAdminMember1)
+        mockCurrentUser(currentUser)
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery {
-            projectMemberRepoMock.updateProjectMemberRole(project.id, user1ToBeUpdated.id, newRole)
-        } returns updatedUser
+            projectMemberRepoMock.getProjectMemberByComposedId(project.id, user.id)
+        } returns Result.success(projectMember)
+        coEvery {
+            projectAccessCheckerMock.isNotLastProjectAdmin(user, project.id, any())
+        } throws TestSpecificException()
 
-        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
+        assertThrows<TestSpecificException> { mainService.updateProjectMemberRole(request) }
     }
 
     @Test
-    fun `When an admin member is updated to admin again, then last-admin check is skipped`() = runTest {
-        val user = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val userToBeUpdated = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When the user re-promotes an admin, then last-admin check is skipped`() = runTest {
+        val currentUser = createExampleUser()
+        val user = createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val projectAdminMember = DataBuilder.createExampleProjectMember(
-            role = MemberRole.MEMBER_ROLE_ADMIN,
-            userId = userToBeUpdated.id,
-            projectId = project.id,
-        )
+        val projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_ADMIN)
 
-        val request = ProjectOuterClass.Project.Member.Update
-            .newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserId(userToBeUpdated.id.toString())
-            .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
-            .build()
+        val request = getRequest(user.id, project.id, MemberRole.MEMBER_ROLE_ADMIN)
 
-        mockCurrentUser(user)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdminMember)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { userRepoMock.getUserById(userToBeUpdated.id) } returns Result.success(userToBeUpdated)
-        coEvery { projectMemberRepoMock.getProjectMemberByComposedId(project.id, userToBeUpdated.id) } returns
-            Result.success(projectAdminMember)
+        mockCurrentUser(currentUser)
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
         coEvery {
-            projectMemberRepoMock.updateProjectMemberRole(project.id, userToBeUpdated.id, MemberRole.MEMBER_ROLE_ADMIN)
-        } returns projectAdminMember
+            projectMemberRepoMock.getProjectMemberByComposedId(project.id, user.id)
+        } returns Result.success(projectMember)
+        coEvery {
+            projectMemberRepoMock.updateProjectMemberRole(project.id, user.id, MemberRole.MEMBER_ROLE_ADMIN)
+        } returns projectMember
 
-        assertDoesNotThrow { mainService.updateProjectMemberRole(request) }
-        coVerify(exactly = 1) { projectMemberRepoMock.getAllProjectAdmins(project.id) }
+        mainService.updateProjectMemberRole(request)
+
+        coVerify(exactly = 0) { projectAccessCheckerMock.isNotLastProjectAdmin(user, project.id, any()) }
+    }
+
+    @Test
+    fun `When multiple admins exist and one is demoted, then no exception is thrown`() = runTest {
+        val currentUser = createExampleUser()
+        val user = createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectMember = DataBuilder.createExampleProjectMember(role = MemberRole.MEMBER_ROLE_DEFAULT)
+
+        val request = getRequest(user.id, project.id, MemberRole.MEMBER_ROLE_ADMIN)
+
+        mockCurrentUser(currentUser)
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToUpdateMemberRole(currentUser, project.id) }
+        coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
+        coEvery {
+            projectMemberRepoMock.getProjectMemberByComposedId(project.id, user.id)
+        } returns Result.success(projectMember)
+        coEvery {
+            projectMemberRepoMock.updateProjectMemberRole(project.id, user.id, MemberRole.MEMBER_ROLE_ADMIN)
+        } returns projectMember
+
+        mainService.updateProjectMemberRole(request)
+
+        coVerify(exactly = 0) { projectAccessCheckerMock.isNotLastProjectAdmin(user, project.id, any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
@@ -1,163 +1,156 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateProjectPaperException
 import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRangeException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass.MemberRole
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
+import kotlin.test.assertEquals
 import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AddPaperToProjectTest : MainServiceTest() {
-    private val projectId = UUID.randomUUID()
-    private val paperId = UUID.randomUUID()
-    private fun getExampleRequest() = GrpcProject.Paper.Add.newBuilder()
+    private fun getRequest(projectId: UUID, paperId: UUID, stage: Long = 0) = GrpcProject.Paper.Add.newBuilder()
         .setProjectId(projectId.toString())
         .setPaperId(paperId.toString())
-        .setStage(0)
+        .setStage(stage)
         .build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(paperRepoMock::getPaperById),
-    )
+    @Test
+    fun `When the user adds a paper to a project and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectResult = Result.success(project)
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
 
-    @Suppress("LongMethod", "ReturnCount", "CyclomaticComplexMethod")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(id = paperId, authors = listOf(author))
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val projectMember = DataBuilder.createExampleProjectMember(
-            projectId = project.id,
-            userId = currentUser.id,
-            role = MemberRole.MEMBER_ROLE_ADMIN,
-        )
-        val review = DataBuilder.createExampleReview()
+        val backwardReferences = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val reviews = listOf(DataBuilder.createExampleReview(), DataBuilder.createExampleReview())
+        val criteriaIds0 = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val criteriaIds1 = listOf(UUID.randomUUID(), UUID.randomUUID())
 
-        mockCurrentUser(currentUser)
-        if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
-            return
-        }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns
-            if (isUserAdmin) {
-                emptyList()
-            } else {
-                listOf(projectMember)
-            }
+        val request = getRequest(project.id, paper.id)
 
-        if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.failure(TestSpecificException())
-            return
-        }
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
-
+        mockCurrentUser(user)
+        coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
-        coEvery {
-            projectPaperRepoMock.addPaperToProject(getExampleRequest(), currentUser.id)
-        } returns projectPaper
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
+        coEvery { projectPaperRepoMock.addPaperToProject(request, user.id) } returns projectPaper
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns backwardReferences
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns reviews
+        coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[0].id) } returns criteriaIds0
+        coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[1].id) } returns criteriaIds1
+
+        val addedProjectPaper = mainService.addPaperToProject(request)
+
+        assertEquals(2, addedProjectPaper.reviewsCount)
+        val review0 = addedProjectPaper.getReviews(0)
+        val review1 = addedProjectPaper.getReviews(1)
+        assertEquals(review0.id, reviews[0].id.toString())
+        assertEquals(review1.id, reviews[1].id.toString())
+
+        val criteriaIdsReview0 = review0.selectedCriteriaIdsList
+        val criteriaIdsReview1 = review1.selectedCriteriaIdsList
+        assertEquals(2, criteriaIdsReview0.size)
+        assertEquals(2, criteriaIdsReview1.size)
+        assertEquals(criteriaIds0[0].toString(), criteriaIdsReview0[0].toString())
+        assertEquals(criteriaIds0[1].toString(), criteriaIdsReview0[1].toString())
+        assertEquals(criteriaIds1[0].toString(), criteriaIdsReview1[0].toString())
+        assertEquals(criteriaIds1[1].toString(), criteriaIdsReview1[1].toString())
     }
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt, true)
-        assertThrows<TestSpecificException> {
-            mainService.addPaperToProject(getExampleRequest())
+    @Test
+    fun `When the user adds a paper to a project, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+            val projectResult = Result.success(project)
+            val paper = DataBuilder.createExamplePaper()
+
+            val request = getRequest(project.id, paper.id)
+
+            mockCurrentUser(user)
+            coEvery {
+                projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult)
+            } throws TestSpecificException()
+            coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+
+            assertThrows<TestSpecificException> { mainService.addPaperToProject(request) }
         }
+
+    @Test
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectResult = Result.failure<Project>(TestSpecificException())
+        val paper = DataBuilder.createExamplePaper()
+
+        val request = getRequest(project.id, paper.id)
+
+        mockCurrentUser(user)
+        coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+
+        assertThrows<TestSpecificException> { mainService.addPaperToProject(request) }
     }
 
     @Test
-    fun `When a server admin adds a paper to a project, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, true)
-        assertDoesNotThrow { mainService.addPaperToProject(getExampleRequest()) }
+    fun `When retrieving the paper fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectResult = Result.success(project)
+        val paper = DataBuilder.createExamplePaper()
+
+        val request = getRequest(project.id, paper.id)
+
+        mockCurrentUser(user)
+        coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+        coEvery { paperRepoMock.getPaperById(paper.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.addPaperToProject(request) }
     }
 
     @Test
-    fun `When a project admin adds a paper to a project, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, false)
-        assertDoesNotThrow { mainService.addPaperToProject(getExampleRequest()) }
-    }
+    fun `When the project paper already exists, then a DuplicateProjectPaperException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectResult = Result.success(project)
+        val paper = DataBuilder.createExamplePaper()
 
-    @Test
-    fun `When a non project admin adds a paper to a project, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = projectId)
+        val request = getRequest(project.id, paper.id)
 
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(projectId) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-
-        assertThrows<UnauthorizedException> { mainService.addPaperToProject(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a project paper already exists, then a DuplicateProjectPaperException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val paper = DataBuilder.createExamplePaper(id = paperId)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns emptyList()
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        mockCurrentUser(user)
+        coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns true
 
-        assertThrows<DuplicateProjectPaperException> {
-            mainService.addPaperToProject(getExampleRequest())
-        }
+        assertThrows<DuplicateProjectPaperException> { mainService.addPaperToProject(request) }
     }
 
     @Test
-    fun `When the requested stage is greater than the projects max stage, then an StageOutOfRangeException is thrown`() =
+    fun `When the requested stage is greater than the projects max stage, then a StageOutOfRangeException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject(id = projectId)
-            val paper = DataBuilder.createExamplePaper(id = paperId)
-            val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+            val projectResult = Result.success(project)
+            val paper = DataBuilder.createExamplePaper()
 
-            val request = GrpcProject.Paper.Add.newBuilder()
-                .setProjectId(projectId.toString())
-                .setPaperId(paperId.toString())
-                .setStage(1)
-                .build()
+            val request = getRequest(project.id, paper.id, stage = 1)
 
-            mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+            mockCurrentUser(user)
+            coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+            coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
             coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
             coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
 
@@ -166,20 +159,16 @@ class AddPaperToProjectTest : MainServiceTest() {
 
     @Test
     fun `When the requested stage is negative, then a StageOutOfRangeException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val paper = DataBuilder.createExamplePaper(id = paperId)
-        val projectMember = DataBuilder.createExampleProjectMember(projectId = project.id, userId = currentUser.id)
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectResult = Result.success(project)
+        val paper = DataBuilder.createExamplePaper()
 
-        val request = GrpcProject.Paper.Add.newBuilder()
-            .setProjectId(projectId.toString())
-            .setPaperId(paperId.toString())
-            .setStage(-1)
-            .build()
+        val request = getRequest(project.id, paper.id, stage = -1)
 
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectMember)
+        mockCurrentUser(user)
+        coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
@@ -25,7 +25,7 @@ class AddPaperToProjectTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the user adds a paper to a project and has access, then no exception is thrown`() = runTest {
+    fun `When a user adds a paper to a project and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val projectResult = Result.success(project)
@@ -69,23 +69,22 @@ class AddPaperToProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user adds a paper to a project, but has no access, then a TestSpecificException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject()
-            val projectResult = Result.success(project)
-            val paper = DataBuilder.createExamplePaper()
+    fun `When a user adds a paper to a project, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val projectResult = Result.success(project)
+        val paper = DataBuilder.createExamplePaper()
 
-            val request = getRequest(project.id, paper.id)
+        val request = getRequest(project.id, paper.id)
 
-            mockCurrentUser(user)
-            coEvery {
-                projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult)
-            } throws TestSpecificException()
-            coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+        mockCurrentUser(user)
+        coEvery {
+            projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult)
+        } throws TestSpecificException()
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
 
-            assertThrows<TestSpecificException> { mainService.addPaperToProject(request) }
-        }
+        assertThrows<TestSpecificException> { mainService.addPaperToProject(request) }
+    }
 
     @Test
     fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -1,93 +1,113 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllProjectPapersForProjectTest : MainServiceTest() {
+    @Test
     @Suppress("LongMethod")
-    private fun mockHappyPath(isUserAdmin: Boolean, projectId: UUID) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(id = projectId, authors = listOf(author))
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val review = DataBuilder.createExampleReview()
+    fun `When the user requests all project papers for a project and has access, then no exception is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+            val projectPaper0 = DataBuilder.createExampleProjectPaperWithPaper()
+            val projectPaper0Refs = listOf(UUID.randomUUID(), UUID.randomUUID())
+            val projectPaper0Review0 = DataBuilder.createExampleReview()
+            val projectPaper0Review1 = DataBuilder.createExampleReview()
+            val projectPaper1 = DataBuilder.createExampleProjectPaperWithPaper()
+            val projectPaper1Refs = listOf(UUID.randomUUID(), UUID.randomUUID())
+            val projectPaper1Review0 = DataBuilder.createExampleReview()
+            val projectPaper1Review1 = DataBuilder.createExampleReview()
+            val projectPapersWithPapers = listOf(projectPaper0, projectPaper1)
+            val criterion0 = DataBuilder.createExampleProjectCriterion()
+            val criterion1 = DataBuilder.createExampleProjectCriterion()
+            val criterion2 = DataBuilder.createExampleProjectCriterion()
 
-        mockCurrentUser(currentUser)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !isUserAdmin
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-    }
+            mockCurrentUser(user)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+            coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns projectPapersWithPapers
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(projectPaper0.paper.id)
+            } returns projectPaper0Refs
+            coEvery {
+                citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(projectPaper1.paper.id)
+            } returns projectPaper1Refs
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper0.projectPaper.id)
+            } returns listOf(projectPaper0Review0, projectPaper0Review1)
+            coEvery {
+                reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.projectPaper.id)
+            } returns listOf(projectPaper1Review0, projectPaper1Review1)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(projectPaper0Review0.id)
+            } returns listOf(criterion0.id, criterion1.id)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(projectPaper0Review1.id)
+            } returns listOf(criterion2.id, criterion1.id)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(projectPaper1Review0.id)
+            } returns listOf(criterion2.id, criterion0.id)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(projectPaper1Review1.id)
+            } returns listOf(criterion0.id, criterion2.id)
 
-    @Test
-    fun `When a server admin requests the project papers, then no exception is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
+            val projectPapers = mainService.getAllProjectPapersForProject(project.id).projectPapersList
 
-        mockHappyPath(true, projectId)
-
-        assertDoesNotThrow { mainService.getAllProjectPapersForProject(projectId) }
-    }
-
-    @Test
-    fun `When a project member requests the project papers, then no exception is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-
-        mockHappyPath(false, projectId)
-
-        assertDoesNotThrow { mainService.getAllProjectPapersForProject(projectId) }
-    }
-
-    @Test
-    fun `When a non project member requests the project papers, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-
-        assertThrows<UnauthorizedException> {
-            mainService.getAllProjectPapersForProject(project.id)
+            assertEquals(2, projectPapers.size)
+            assertEquals(projectPaper0.projectPaper.id.toString(), projectPapers[0].id)
+            assertEquals(projectPaper1.projectPaper.id.toString(), projectPapers[1].id)
+            val projectPaper0Result = projectPapers[0]
+            val projectPaper1Result = projectPapers[1]
+            val backwardRefs0 = projectPaper0Result.paper.backwardReferencedIdsList
+            val backwardRefs1 = projectPaper1Result.paper.backwardReferencedIdsList
+            assertEquals(projectPaper0Refs.size, backwardRefs0.size)
+            assertEquals(projectPaper1Refs.size, backwardRefs1.size)
+            projectPaper0Refs.forEach { refId -> assertContains(backwardRefs0, refId.toString()) }
+            projectPaper1Refs.forEach { refId -> assertContains(backwardRefs1, refId.toString()) }
+            val reviews0 = projectPaper0Result.reviewsList
+            val reviews1 = projectPaper1Result.reviewsList
+            assertEquals(2, reviews0.size)
+            assertEquals(2, reviews1.size)
+            val review0CriterionIds0 = reviews0[0].selectedCriteriaIdsList
+            val review0CriterionIds1 = reviews0[1].selectedCriteriaIdsList
+            val review1CriterionIds0 = reviews1[0].selectedCriteriaIdsList
+            val review1CriterionIds1 = reviews1[1].selectedCriteriaIdsList
+            assertEquals(2, review0CriterionIds0.size)
+            assertEquals(2, review0CriterionIds1.size)
+            assertEquals(2, review1CriterionIds0.size)
+            assertEquals(2, review1CriterionIds1.size)
+            assertContains(review0CriterionIds0, criterion0.id.toString())
+            assertContains(review0CriterionIds0, criterion1.id.toString())
+            assertContains(review0CriterionIds1, criterion2.id.toString())
+            assertContains(review0CriterionIds1, criterion1.id.toString())
+            assertContains(review1CriterionIds0, criterion2.id.toString())
+            assertContains(review1CriterionIds0, criterion0.id.toString())
+            assertContains(review1CriterionIds1, criterion0.id.toString())
+            assertContains(review1CriterionIds1, criterion2.id.toString())
         }
-    }
 
     @Test
-    fun `When a nonexistent project is requested, then a ProjectNotFoundException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
+    fun `When the user requests all project papers for a project, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
 
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+            mockCurrentUser(user)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(user, project.id)
+            } throws TestSpecificException()
 
-        assertThrows<ProjectNotFoundException> {
-            mainService.getAllProjectPapersForProject(project.id)
+            assertThrows<TestSpecificException> { mainService.getAllProjectPapersForProject(project.id) }
         }
-    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 class GetAllProjectPapersForProjectTest : MainServiceTest() {
     @Test
     @Suppress("LongMethod")
-    fun `When the user requests all project papers for a project and has access, then no exception is thrown`() =
+    fun `When a user requests all project papers for a project and has access, then no exception is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
@@ -98,7 +98,7 @@ class GetAllProjectPapersForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user requests all project papers for a project, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests all project papers for a project, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 
 class GetNextPaperTest : MainServiceTest() {
     @Test
-    fun `When the user requests the next project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the next project paper and has access, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -54,7 +54,7 @@ class GetNextPaperTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests the next project paper, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests the next project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperTest.kt
@@ -1,24 +1,22 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
+import kotlin.test.assertEquals
 
 class GetNextPaperTest : MainServiceTest() {
     @Test
-    fun `When a server admin requests the next project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When the user requests the next project paper and has access, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(authors = listOf(author))
+        val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val nextProjectPaper = DataBuilder.createExampleProjectPaper()
 
@@ -26,7 +24,7 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(project.id, projectPaper.localPaperId, PaperNavigationDirection.NEXT)
@@ -35,52 +33,48 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getNextPaper(projectPaper.id) }
+        val nextPaper = mainService.getNextPaper(projectPaper.id)
+
+        assertEquals(nextProjectPaper.id.toString(), nextPaper.id)
     }
 
     @Test
-    fun `When a project member requests the next project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(authors = listOf(author))
+        val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
 
         mockCurrentUser(currentUser)
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-        } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
-        coEvery {
-            projectPaperRepoMock.getAdjacentPaper(project.id, projectPaper.localPaperId, PaperNavigationDirection.NEXT)
-        } returns Result.success(nextProjectPaper)
-        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+        } returns Result.failure(TestSpecificException())
 
-        assertDoesNotThrow { mainService.getNextPaper(projectPaper.id) }
+        assertThrows<TestSpecificException> { mainService.getNextPaper(projectPaper.id) }
     }
 
     @Test
-    fun `When a non project member requests the next project paper, then an UnauthorizedException is thrown`() =
+    fun `When the user requests the next project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
-            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id)
+            val paper = DataBuilder.createExamplePaper()
+            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
 
             mockCurrentUser(currentUser)
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.success(projectPaper)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.getNextPaper(projectPaper.id) }
+            assertThrows<TestSpecificException> { mainService.getNextPaper(projectPaper.id) }
         }
 
     @Test
-    fun `When no next paper exists, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
@@ -89,11 +83,50 @@ class GetNextPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getNextPaper(projectPaper.id) }
+    }
+
+    @Test
+    fun `When retrieving the next project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(project.id, projectPaper.localPaperId, PaperNavigationDirection.NEXT)
         } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getNextPaper(projectPaper.id) }
+    }
+
+    @Test
+    fun `When retrieving the next paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val nextProjectPaper = DataBuilder.createExampleProjectPaper()
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery {
+            projectPaperRepoMock.getAdjacentPaper(project.id, projectPaper.localPaperId, PaperNavigationDirection.NEXT)
+        } returns Result.success(nextProjectPaper)
+        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getNextPaper(projectPaper.id) }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 
 class GetNextPaperToReviewTest : MainServiceTest() {
     @Test
-    fun `When the user requests the next project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the next project paper and has access, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -64,7 +64,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests the next project paper, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests the next project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
@@ -113,7 +113,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests the next project paper, then the project papers without own review are filtered out correctly`() =
+    fun `When a user requests the next project paper, then the project papers without own review are filtered out correctly`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
@@ -164,7 +164,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user requests the next project paper, then the project papers are sorted correctly`() = runTest {
+    fun `When a user requests the next project paper, then the project papers are sorted correctly`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val currentPaper = DataBuilder.createExamplePaper()
@@ -224,7 +224,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests the next project paper, then the already decided paper are correctly filtered`() =
+    fun `When a user requests the next project paper, then the already decided paper are correctly filtered`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
@@ -274,7 +274,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user requests the next project paper and only already decided papers are left, then an already decided paper is returned`() =
+    fun `When a user requests the next project paper and only already decided papers are left, then an already decided paper is returned`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetNextPaperToReviewTest.kt
@@ -1,23 +1,23 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.PaperDecision
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class GetNextPaperToReviewTest : MainServiceTest() {
     @Test
-    fun `When a server admin requests the next project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When the user requests the next project paper and has access, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(
@@ -33,8 +33,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
                 project.id, projectPaper.localPaperId, projectPaper.stage,
@@ -51,44 +50,23 @@ class GetNextPaperToReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a project member requests the next project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            projectId = project.id,
-            paperId = paper.id,
-            stage = 0,
-            localPaperId = 0,
-        )
-        val nextProjectPaper = DataBuilder.createExampleProjectPaper(stage = 0, localPaperId = 1)
-        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper.id)
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id)
 
         mockCurrentUser(currentUser)
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-        } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-        coEvery {
-            projectPaperRepoMock.getSubsequentProjectPapers(
-                project.id, projectPaper.localPaperId, projectPaper.stage,
-            )
-        } returns listOf(nextProjectPaper)
-        coEvery {
-            reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id)
-        } returns listOf(review)
-        coEvery { paperRepoMock.getPaperById(nextProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(nextProjectPaper.id) } returns emptyList()
+        } returns Result.failure(TestSpecificException())
 
-        assertDoesNotThrow { mainService.getNextPaperToReview(projectPaper.id) }
+        assertThrows<TestSpecificException> { mainService.getNextPaperToReview(projectPaper.id) }
     }
 
     @Test
-    fun `When a non project member requests the next project paper, then an UnauthorizedException is thrown`() =
+    fun `When the user requests the next project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
             val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id)
 
@@ -96,15 +74,16 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(projectPaper.id)
             } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.getNextPaperToReview(projectPaper.id) }
+            assertThrows<TestSpecificException> { mainService.getNextPaperToReview(projectPaper.id) }
         }
 
     @Test
     fun `When no next paper to review exists, then a FailedPreconditionException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(
@@ -120,8 +99,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
         coEvery {
             projectPaperRepoMock.getSubsequentProjectPapers(
                 project.id, projectPaper.localPaperId, projectPaper.stage,
@@ -135,9 +113,9 @@ class GetNextPaperToReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a project member requests the next project paper, then the project papers without own review are filtered out correctly`() =
+    fun `When the user requests the next project paper, then the project papers without own review are filtered out correctly`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
             val currentPaper = DataBuilder.createExamplePaper()
             val paper1 = DataBuilder.createExamplePaper()
@@ -168,8 +146,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
@@ -187,71 +164,69 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a project member requests the next project paper, then the project papers are sorted correctly`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-            val currentPaper = DataBuilder.createExamplePaper()
-            val paper1 = DataBuilder.createExamplePaper()
-            val paper2 = DataBuilder.createExamplePaper()
-            val paper3 = DataBuilder.createExamplePaper()
-            val currentProjectPaper = DataBuilder.createExampleProjectPaper(
-                projectId = project.id,
-                paperId = currentPaper.id,
-                stage = 0,
-                localPaperId = 0,
-            )
-            val projectPaper1 = DataBuilder.createExampleProjectPaper(
-                projectId = project.id,
-                paperId = paper1.id,
-                stage = 0,
-                localPaperId = 1,
-                decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
-            )
-            val projectPaper2 = DataBuilder.createExampleProjectPaper(
-                projectId = project.id,
-                paperId = paper2.id,
-                stage = 1,
-                localPaperId = 2,
-                decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
-            )
-            val projectPaper3 = DataBuilder.createExampleProjectPaper(
-                projectId = project.id,
-                paperId = paper3.id,
-                stage = 0,
-                localPaperId = 3,
-                decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
-            )
-            val review = DataBuilder.createExampleReview(projectPaperId = projectPaper1.id, userId = UUID.randomUUID())
+    fun `When the user requests the next project paper, then the project papers are sorted correctly`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val currentPaper = DataBuilder.createExamplePaper()
+        val paper1 = DataBuilder.createExamplePaper()
+        val paper2 = DataBuilder.createExamplePaper()
+        val paper3 = DataBuilder.createExamplePaper()
+        val currentProjectPaper = DataBuilder.createExampleProjectPaper(
+            projectId = project.id,
+            paperId = currentPaper.id,
+            stage = 0,
+            localPaperId = 0,
+        )
+        val projectPaper1 = DataBuilder.createExampleProjectPaper(
+            projectId = project.id,
+            paperId = paper1.id,
+            stage = 0,
+            localPaperId = 1,
+            decision = PaperDecision.PAPER_DECISION_UNREVIEWED,
+        )
+        val projectPaper2 = DataBuilder.createExampleProjectPaper(
+            projectId = project.id,
+            paperId = paper2.id,
+            stage = 1,
+            localPaperId = 2,
+            decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
+        )
+        val projectPaper3 = DataBuilder.createExampleProjectPaper(
+            projectId = project.id,
+            paperId = paper3.id,
+            stage = 0,
+            localPaperId = 3,
+            decision = PaperDecision.PAPER_DECISION_UNSPECIFIED,
+        )
+        val review = DataBuilder.createExampleReview(projectPaperId = projectPaper1.id, userId = UUID.randomUUID())
 
-            mockCurrentUser(currentUser)
-            coEvery {
-                projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
-            } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-            coEvery {
-                projectPaperRepoMock.getSubsequentProjectPapers(
-                    project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
-                )
-            } returns listOf(projectPaper1, projectPaper2, projectPaper3)
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) } returns listOf(review)
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
-            coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) } returns emptyList()
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
+        } returns Result.success(currentProjectPaper)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery {
+            projectPaperRepoMock.getSubsequentProjectPapers(
+                project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
+            )
+        } returns listOf(projectPaper1, projectPaper2, projectPaper3)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) } returns listOf(review)
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) } returns emptyList()
 
-            coEvery { paperRepoMock.getPaperById(paper3.id) } returns Result.success(paper3)
-            coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper3.id) } returns emptyList()
+        coEvery { paperRepoMock.getPaperById(paper3.id) } returns Result.success(paper3)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper3.id) } returns emptyList()
 
-            assertDoesNotThrow { mainService.getNextPaperToReview(currentProjectPaper.id) }
-            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
-            coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
-            coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) }
-        }
+        assertDoesNotThrow { mainService.getNextPaperToReview(currentProjectPaper.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper1.id) }
+        coVerify(exactly = 1) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper2.id) }
+        coVerify(exactly = 2) { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper3.id) }
+    }
 
     @Test
-    fun `When a project member requests the next project paper, then the already decided paper are correctly filtered`() =
+    fun `When the user requests the next project paper, then the already decided paper are correctly filtered`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
             val currentPaper = DataBuilder.createExamplePaper()
             val paper1 = DataBuilder.createExamplePaper()
@@ -281,8 +256,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,
@@ -300,9 +274,9 @@ class GetNextPaperToReviewTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a project member requests the next project paper and only already decided papers are left, then an already decided paper is returned`() =
+    fun `When the user requests the next project paper and only already decided papers are left, then an already decided paper is returned`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
             val currentPaper = DataBuilder.createExamplePaper()
             val paper1 = DataBuilder.createExamplePaper()
@@ -332,8 +306,7 @@ class GetNextPaperToReviewTest : MainServiceTest() {
             coEvery {
                 projectPaperRepoMock.getProjectPaperById(currentProjectPaper.id)
             } returns Result.success(currentProjectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
             coEvery {
                 projectPaperRepoMock.getSubsequentProjectPapers(
                     project.id, currentProjectPaper.localPaperId, currentProjectPaper.stage,

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
@@ -140,7 +140,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests project papers to review, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests project papers to review, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -10,83 +11,16 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.ProjectPaperWithPaper
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.ProjectOuterClass.PaperDecision
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetPapersToReviewForProjectTest : MainServiceTest() {
-    @Suppress("LongMethod")
-    private fun mockHappyPath(isUserAdmin: Boolean, projectId: UUID) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(id = projectId, authors = listOf(author))
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
-        val review = DataBuilder.createExampleReview()
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !isUserAdmin
-        coEvery {
-            projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
-        } returns listOf(projectPaperWithPaper)
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-    }
-
-    @Test
-    fun `When a server admin requests the project papers to review, then no exception is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-
-        mockHappyPath(true, projectId)
-
-        assertDoesNotThrow { mainService.getPapersToReviewForProject(projectId) }
-    }
-
-    @Test
-    fun `When a project member requests the project papers to review, then no exception is thrown`() = runTest {
-        val projectId = UUID.randomUUID()
-
-        mockHappyPath(false, projectId)
-
-        assertDoesNotThrow { mainService.getPapersToReviewForProject(projectId) }
-    }
-
-    @Test
-    fun `When a non project member requests the project papers to review, then an UnauthorizedException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-
-            mockCurrentUser(currentUser)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-
-            assertThrows<UnauthorizedException> {
-                mainService.getPapersToReviewForProject(project.id)
-            }
-        }
-
     @Test
     fun `When the project papers to review are requested, then only the undecided papers are returned`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val author = DataBuilder.createExampleAuthor()
         val paper = DataBuilder.createExamplePaper(authors = listOf(author))
@@ -105,8 +39,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val review = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
         coEvery {
             projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
         } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
@@ -133,7 +66,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
     @Test
     fun `When the project papers to review are requested, then only undecided papers that were not already reviewed by the current user are returned`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
             val author = DataBuilder.createExampleAuthor()
             val paper = DataBuilder.createExamplePaper(authors = listOf(author))
@@ -153,8 +86,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
             val reviewByOtherUser = DataBuilder.createExampleReview(userId = UUID.randomUUID())
 
             mockCurrentUser(currentUser)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
             coEvery {
                 projectPaperRepoMock.getAllProjectPapersWithPapers(project.id)
             } returns listOf(projectPaperWithPaper1, projectPaperWithPaper2)
@@ -184,21 +116,8 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         }
 
     @Test
-    fun `When a nonexistent project is requested, then a ProjectNotFoundException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject()
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
-
-        assertThrows<ProjectNotFoundException> {
-            mainService.getPapersToReviewForProject(project.id)
-        }
-    }
-
-    @Test
     fun `When a project paper has no reviews yet, then it is returned as paper to review`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val author = DataBuilder.createExampleAuthor()
         val paper = DataBuilder.createExamplePaper(authors = listOf(author))
@@ -210,8 +129,7 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         val projectPaperWithPaper = ProjectPaperWithPaper(projectPaper, paper)
 
         mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
         coEvery { projectPaperRepoMock.getAllProjectPapersWithPapers(project.id) } returns listOf(projectPaperWithPaper)
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
@@ -220,4 +138,18 @@ class GetPapersToReviewForProjectTest : MainServiceTest() {
         assertThat(result.projectPapersList).hasSize(1)
         assertThat(result.projectPapersList.first().id).isEqualTo(projectPaper.id.toString())
     }
+
+    @Test
+    fun `When the user requests project papers to review, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+
+            mockCurrentUser(currentUser)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id)
+            } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { mainService.getPapersToReviewForProject(project.id) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 
 class GetPreviousPaperTest : MainServiceTest() {
     @Test
-    fun `When the user requests the previous project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests the previous project paper and has access, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
@@ -58,7 +58,7 @@ class GetPreviousPaperTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests the previous project paper, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests the previous project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPreviousPaperTest.kt
@@ -1,24 +1,22 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
+import kotlin.test.assertEquals
 
 class GetPreviousPaperTest : MainServiceTest() {
     @Test
-    fun `When a server admin requests the previous project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When the user requests the previous project paper and has access, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(authors = listOf(author))
+        val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
         val previousProjectPaper = DataBuilder.createExampleProjectPaper()
 
@@ -26,11 +24,12 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
         coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(
-                project.id, projectPaper.localPaperId,
+                project.id,
+                projectPaper.localPaperId,
                 PaperNavigationDirection.PREVIOUS,
             )
         } returns Result.success(previousProjectPaper)
@@ -38,55 +37,48 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(previousProjectPaper.id) } returns emptyList()
 
-        assertDoesNotThrow { mainService.getPreviousPaper(projectPaper.id) }
+        val previousPaper = mainService.getPreviousPaper(projectPaper.id)
+
+        assertEquals(previousProjectPaper.id.toString(), previousPaper.id)
     }
 
     @Test
-    fun `When a project member requests the previous project paper, then no exception is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(authors = listOf(author))
+        val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
-        val previousProjectPaper = DataBuilder.createExampleProjectPaper()
 
         mockCurrentUser(currentUser)
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-        } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
-        coEvery {
-            projectPaperRepoMock.getAdjacentPaper(
-                project.id, projectPaper.localPaperId,
-                PaperNavigationDirection.PREVIOUS,
-            )
-        } returns Result.success(previousProjectPaper)
-        coEvery { paperRepoMock.getPaperById(previousProjectPaper.paperId) } returns Result.success(paper)
-        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(previousProjectPaper.id) } returns emptyList()
+        } returns Result.failure(TestSpecificException())
 
-        assertDoesNotThrow { mainService.getPreviousPaper(projectPaper.id) }
+        assertThrows<TestSpecificException> { mainService.getPreviousPaper(projectPaper.id) }
     }
 
     @Test
-    fun `When a non project member requests the previous project paper, then an UnauthorizedException is thrown`() =
+    fun `When the user requests the previous project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+            val currentUser = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
-            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id)
+            val paper = DataBuilder.createExamplePaper()
+            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
 
             mockCurrentUser(currentUser)
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+            coEvery {
+                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+            } returns Result.success(projectPaper)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.getPreviousPaper(projectPaper.id) }
+            assertThrows<TestSpecificException> { mainService.getPreviousPaper(projectPaper.id) }
         }
 
     @Test
-    fun `When no previous paper exists, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
@@ -95,14 +87,61 @@ class GetPreviousPaperTest : MainServiceTest() {
         coEvery {
             projectPaperRepoMock.getProjectPaperById(projectPaper.id)
         } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns true
-        coEvery { projectRepoMock.getProjectById(projectPaper.projectId) } returns Result.success(project)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getPreviousPaper(projectPaper.id) }
+    }
+
+    @Test
+    fun `When retrieving the previous project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
         coEvery {
             projectPaperRepoMock.getAdjacentPaper(
-                project.id, projectPaper.localPaperId,
+                project.id,
+                projectPaper.localPaperId,
                 PaperNavigationDirection.PREVIOUS,
             )
         } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getPreviousPaper(projectPaper.id) }
+    }
+
+    @Test
+    fun `When retrieving the previous paper fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val previousProjectPaper = DataBuilder.createExampleProjectPaper()
+
+        mockCurrentUser(currentUser)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.success(projectPaper)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(currentUser, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery {
+            projectPaperRepoMock.getAdjacentPaper(
+                project.id,
+                projectPaper.localPaperId,
+                PaperNavigationDirection.PREVIOUS,
+            )
+        } returns Result.success(previousProjectPaper)
+        coEvery { paperRepoMock.getPaperById(previousProjectPaper.paperId) } returns Result.failure(
+            TestSpecificException(),
+        )
+
         assertThrows<TestSpecificException> { mainService.getPreviousPaper(projectPaper.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
@@ -1,119 +1,59 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
-import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByIdTest : MainServiceTest() {
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectPaperRepoMock::getProjectPaperById),
-        Arguments.of(paperRepoMock::getPaperById),
-    )
-
-    @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean, projectPaperId: UUID) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val project = DataBuilder.createExampleProject()
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(authors = listOf(author))
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            id = projectPaperId,
-            projectId = project.id,
-            paperId = paper.id,
-        )
-        val review = DataBuilder.createExampleReview()
-
-        mockCurrentUser(currentUser)
-
-        if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery {
-                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-            } returns Result.failure(TestSpecificException())
-            return
-        }
-        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !isUserAdmin
-
-        if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.failure(TestSpecificException())
-            return
-        }
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
-
-        coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-    }
-
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        val projectPaperId = UUID.randomUUID()
-
-        mockHappyPathUntil(failAt, true, projectPaperId)
-
-        assertThrows<TestSpecificException> {
-            mainService.getProjectPaperById(projectPaperId)
-        }
-    }
-
     @Test
-    fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
-        val projectPaperId = UUID.randomUUID()
-
-        mockHappyPathUntil(null, true, projectPaperId)
-
-        assertDoesNotThrow { mainService.getProjectPaperById(projectPaperId) }
-    }
-
-    @Test
-    fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
-        val projectPaperId = UUID.randomUUID()
-
-        mockHappyPathUntil(null, false, projectPaperId)
-
-        assertDoesNotThrow { mainService.getProjectPaperById(projectPaperId) }
-    }
-
-    @Test
-    fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject()
+    fun `When the user requests a project paper and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
         val paper = DataBuilder.createExamplePaper()
-        val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id, paperId = paper.id)
+        val projectPaper = DataBuilder.createExampleProjectPaper(paperId = paper.id)
 
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        mockCurrentUser(user)
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, projectPaper.projectId) }
+        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
 
-        assertThrows<UnauthorizedException> { mainService.getProjectPaperById(projectPaper.id) }
+        assertDoesNotThrow { mainService.getProjectPaperById(projectPaper.id) }
     }
+
+    @Test
+    fun `When retrieving the project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectPaper = DataBuilder.createExampleProjectPaper()
+
+        mockCurrentUser(user)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(projectPaper.id) }
+    }
+
+    @Test
+    fun `When the user requests a project paper, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val projectPaper = DataBuilder.createExampleProjectPaper()
+
+            mockCurrentUser(user)
+            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(user, projectPaper.projectId)
+            } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { mainService.getProjectPaperById(projectPaper.id) }
+        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByIdTest.kt
@@ -14,7 +14,7 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByIdTest : MainServiceTest() {
     @Test
-    fun `When the user requests a project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests a project paper and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(paperId = paper.id)
@@ -43,17 +43,16 @@ class GetProjectPaperByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a project paper, but has no access, then a TestSpecificException is thrown`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val projectPaper = DataBuilder.createExampleProjectPaper()
+    fun `When a user requests a project paper, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectPaper = DataBuilder.createExampleProjectPaper()
 
-            mockCurrentUser(user)
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-            coEvery {
-                projectAccessCheckerMock.isAllowedToReadProject(user, projectPaper.projectId)
-            } throws TestSpecificException()
+        mockCurrentUser(user)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
+        coEvery {
+            projectAccessCheckerMock.isAllowedToReadProject(user, projectPaper.projectId)
+        } throws TestSpecificException()
 
-            assertThrows<TestSpecificException> { mainService.getProjectPaperById(projectPaper.id) }
-        }
+        assertThrows<TestSpecificException> { mainService.getProjectPaperById(projectPaper.id) }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
@@ -1,136 +1,78 @@
 package se.uulm.snowballr.backend.service.projectpaper
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.ProjectOuterClass.Project
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.random.Random
-import kotlin.reflect.KFunction
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByRelativeIdTest : MainServiceTest() {
-    private val projectId = UUID.randomUUID()
-    private val localPaperId = Random.nextLong()
-
-    private fun getExampleRequest() = Project.Paper.Get
+    private fun getRequest(projectId: UUID, relativeId: Long = -1) = GrpcProjectPaper.Get
         .newBuilder()
         .setProjectId(projectId.toString())
-        .setRelativeProjectPaperId(localPaperId.toString())
+        .setRelativeProjectPaperId(relativeId.toString())
         .build()
 
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectPaperRepoMock::getProjectPaperByRelativeId),
-        Arguments.of(paperRepoMock::getPaperById),
-    )
+    @Test
+    fun `When the user request the project paper and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val relativeId = 1L
+        val paper = DataBuilder.createExamplePaper()
+        val projectPaper = DataBuilder.createExampleProjectPaper(paperId = paper.id)
 
-    @Suppress("LongMethod", "ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val project = DataBuilder.createExampleProject(id = projectId)
-        val author = DataBuilder.createExampleAuthor()
-        val paper = DataBuilder.createExamplePaper(authors = listOf(author))
-        val projectPaper = DataBuilder.createExampleProjectPaper(
-            projectId = project.id,
-            paperId = paper.id,
-            localPaperId = localPaperId,
-        )
-        val review = DataBuilder.createExampleReview()
+        val request = getRequest(project.id, relativeId)
 
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !isUserAdmin
-
-        if (failAt == projectPaperRepoMock::getProjectPaperByRelativeId) {
-            coEvery {
-                projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
-            } returns Result.failure(TestSpecificException())
-            return
-        }
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery {
-            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
+            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, relativeId)
         } returns Result.success(projectPaper)
+        coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
+        coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
+        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
 
-        if (failAt == paperRepoMock::getPaperById) {
-            coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.failure(TestSpecificException())
-            return
+        assertDoesNotThrow { mainService.getProjectPaperByRelativeId(request) }
+    }
+
+    @Test
+    fun `When the user request the project paper, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val user = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+
+            val request = getRequest(project.id)
+
+            mockCurrentUser(user)
+            coEvery {
+                projectAccessCheckerMock.isAllowedToReadProject(user, project.id)
+            } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { mainService.getProjectPaperByRelativeId(request) }
         }
-        coEvery { paperRepoMock.getPaperById(projectPaper.paperId) } returns Result.success(paper)
 
+    @Test
+    fun `When retrieving the relative paper fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val relativeId = 2L
+
+        val request = getRequest(project.id, relativeId)
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery {
-            citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
-        } returns listOf(UUID.randomUUID())
-        coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
-        coEvery {
-            reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
-        } returns listOf(UUID.randomUUID())
-    }
+            projectPaperRepoMock.getProjectPaperByRelativeId(project.id, relativeId)
+        } returns Result.failure(TestSpecificException())
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        mockHappyPathUntil(failAt, true)
-
-        assertThrows<TestSpecificException> {
-            mainService.getProjectPaperByRelativeId(getExampleRequest())
-        }
-    }
-
-    @Test
-    fun `When a server admin retrieves the project paper, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, true)
-
-        assertDoesNotThrow { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a project member retrieves the project paper, then no exception is thrown`() = runTest {
-        mockHappyPathUntil(null, false)
-
-        assertDoesNotThrow { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When a non project member retrieves the project paper, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val project = DataBuilder.createExampleProject(projectId)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-
-        assertThrows<UnauthorizedException> {
-            mainService.getProjectPaperByRelativeId(getExampleRequest())
-        }
-    }
-
-    @Test
-    fun `When a nonexistent project is requested, then a NotFoundException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val project = DataBuilder.createExampleProject(id = projectId)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
-
-        assertThrows<NotFoundException> { mainService.getProjectPaperByRelativeId(getExampleRequest()) }
+        assertThrows<TestSpecificException> { mainService.getProjectPaperByRelativeId(request) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
@@ -22,7 +22,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
         .build()
 
     @Test
-    fun `When the user request the project paper and has access, then no exception is thrown`() = runTest {
+    fun `When a user request the project paper and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
         val relativeId = 1L
@@ -44,7 +44,7 @@ class GetProjectPaperByRelativeIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user request the project paper, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user requests the project paper, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 
 class AddPaperToReadingListTest : MainServiceTest() {
     @Test
-    fun `When the user adds a paper to their reading list, then the request is forwarded correctly`() = runTest {
+    fun `When a user adds a paper to their reading list, then the request is forwarded correctly`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
@@ -29,7 +29,7 @@ class AddPaperToReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user adds a non-existent paper to their reading list, then a PaperNotFoundException is thrown`() =
+    fun `When a user adds a non-existent paper to their reading list, then a PaperNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/AddPaperToReadingListTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.readinglist
 
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
@@ -21,7 +22,7 @@ class AddPaperToReadingListTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-        coEvery { readingListRepoMock.createReadingListEntry(user.id, paperId) } returns Unit
+        coJustRun { readingListRepoMock.createReadingListEntry(user.id, paperId) }
 
         assertDoesNotThrow { mainService.addPaperToReadingList(paperId) }
         coVerify(exactly = 1) { readingListRepoMock.createReadingListEntry(user.id, paperId) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/IsPaperOnReadingListTest.kt
@@ -16,27 +16,26 @@ import java.util.UUID
 
 class IsPaperOnReadingListTest : MainServiceTest() {
     @Test
-    fun `When the user checks if a paper is on their reading list, then the request is forwarded correctly`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val paper1 = DataBuilder.createExamplePaper()
-            val paper2 = DataBuilder.createExamplePaper(externalId = "ExternalId2")
+    fun `When a user checks if a paper is on their reading list, then the request is forwarded correctly`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val paper1 = DataBuilder.createExamplePaper()
+        val paper2 = DataBuilder.createExamplePaper(externalId = "ExternalId2")
 
-            mockCurrentUser(user)
-            coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
-            coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
-            coEvery { paperRepoMock.ensurePaperExists(paper1.id) } just Runs
-            coEvery { paperRepoMock.ensurePaperExists(paper2.id) } just Runs
+        mockCurrentUser(user)
+        coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) } returns true
+        coEvery { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) } returns false
+        coEvery { paperRepoMock.ensurePaperExists(paper1.id) } just Runs
+        coEvery { paperRepoMock.ensurePaperExists(paper2.id) } just Runs
 
-            assertTrue(mainService.isPaperOnReadingList(paper1.id))
-            coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) }
+        assertTrue(mainService.isPaperOnReadingList(paper1.id))
+        coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper1.id) }
 
-            assertFalse(mainService.isPaperOnReadingList(paper2.id))
-            coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) }
-        }
+        assertFalse(mainService.isPaperOnReadingList(paper2.id))
+        coVerify(exactly = 1) { readingListRepoMock.isPaperOnReadingList(user.id, paper2.id) }
+    }
 
     @Test
-    fun `When the user checks if a non-existent paper is on their reading list, then a PaperNotFoundException is thrown`() =
+    fun `When a user checks if a non-existent paper is on their reading list, then a PaperNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 
 class RemovePaperFromReadingListTest : MainServiceTest() {
     @Test
-    fun `When the user removes a paper from their reading list, then the request is forwarded correctly`() = runTest {
+    fun `When a user removes a paper from their reading list, then the request is forwarded correctly`() = runTest {
         val user = DataBuilder.createExampleUser()
         val paperId = UUID.randomUUID()
 
@@ -29,7 +29,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user removes a non-existent paper on their reading list, then a PaperNotFoundException is thrown`() =
+    fun `When a user removes a non-existent paper on their reading list, then a PaperNotFoundException is thrown`() =
         runTest {
             val user = DataBuilder.createExampleUser()
             val paperId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/RemovePaperFromReadingListTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.readinglist
 
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
@@ -21,7 +22,7 @@ class RemovePaperFromReadingListTest : MainServiceTest() {
 
         mockCurrentUser(user)
         coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-        coEvery { readingListRepoMock.removeReadingListEntry(user.id, paperId) } returns Unit
+        coJustRun { readingListRepoMock.removeReadingListEntry(user.id, paperId) }
 
         assertDoesNotThrow { mainService.removePaperFromReadingList(paperId) }
         coVerify(exactly = 1) { readingListRepoMock.removeReadingListEntry(user.id, paperId) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -9,7 +10,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.DataBuilder.createExampleReviewDecisionMatrix
@@ -17,18 +17,14 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
-import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.PaperDecision
-import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry
 import snowballr.ReviewOuterClass
 import snowballr.ReviewOuterClass.ReviewDecision
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
@@ -50,11 +46,12 @@ class CreateReviewTest : MainServiceTest() {
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
+        Arguments.of(reviewAccessCheckerMock::isAllowedToCreateReview),
+        Arguments.of(projectRepoMock::getProjectById),
     )
 
     @Suppress("LongParameterList", "ReturnCount", "LongMethod")
     private fun mockCreateReview(
-        useAdminUser: Boolean = true,
         project: Project = this.project,
         initialPaperDecision: PaperDecision = PaperDecision.PAPER_DECISION_UNREVIEWED,
         updatedPaperDecision: PaperDecision = PaperDecision.PAPER_DECISION_IN_REVIEW,
@@ -62,14 +59,7 @@ class CreateReviewTest : MainServiceTest() {
         stopBefore: KFunction<*>? = null,
         failAt: KFunction<*>? = null,
     ) {
-        val currentUser = DataBuilder.createExampleUser(
-            id = userId,
-            role = if (useAdminUser) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
+        val currentUser = DataBuilder.createExampleUser(id = userId)
         val projectPaper = DataBuilder.createExampleProjectPaper(
             id = projectPaperId,
             projectId = project.id,
@@ -80,6 +70,7 @@ class CreateReviewTest : MainServiceTest() {
             decision = decision,
             userId = currentUser.id,
         )
+        val projectResult = Result.success(project)
 
         mockCurrentUser(currentUser)
 
@@ -94,15 +85,22 @@ class CreateReviewTest : MainServiceTest() {
         if (stopBefore == projectRepoMock::getProjectById) {
             return
         } else if (failAt == projectRepoMock::getProjectById) {
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
+            val result = Result.failure<Project>(TestSpecificException())
+            coEvery { projectRepoMock.getProjectById(project.id) } returns result
+            coJustRun { reviewAccessCheckerMock.isAllowedToCreateReview(currentUser, project.id, result) }
             return
         }
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
 
-        if (stopBefore == projectMemberRepoMock::isProjectMember) {
+        if (stopBefore == reviewAccessCheckerMock::isAllowedToCreateReview) {
+            return
+        } else if (failAt == reviewAccessCheckerMock::isAllowedToCreateReview) {
+            coEvery {
+                reviewAccessCheckerMock.isAllowedToCreateReview(currentUser, project.id, projectResult)
+            } throws TestSpecificException()
             return
         }
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !useAdminUser
+        coJustRun { reviewAccessCheckerMock.isAllowedToCreateReview(currentUser, project.id, projectResult) }
 
         if (stopBefore == reviewRepoMock::getAllReviewsForProjectPaper) {
             return
@@ -133,45 +131,10 @@ class CreateReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When a server admin creates a review, then no exception is thrown`() = runTest {
-        mockCreateReview(useAdminUser = true)
+    fun `When the user creates a review and has access, then no exception is thrown`() = runTest {
+        mockCreateReview()
 
         assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
-    }
-
-    @Test
-    fun `When a project member creates a review, then no exception is thrown`() = runTest {
-        mockCreateReview(useAdminUser = false)
-
-        assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
-    }
-
-    @Test
-    fun `When a non project member creates a review, then an UnauthorizedException is thrown`() = runTest {
-        mockCreateReview(useAdminUser = false, stopBefore = projectMemberRepoMock::isProjectMember)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, any()) } returns false
-
-        assertThrows<UnauthorizedException> { mainService.createReview(validCreateReviewRequest.build()) }
-        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            "PROJECT_STATUS_ARCHIVED",
-            "PROJECT_STATUS_DELETED",
-        ],
-    )
-    fun `When the project paper to review is in an inactive project, then a FailedPreconditionException is thrown`(
-        statusName: String,
-    ) = runTest {
-        val project = DataBuilder.createExampleProject(status = ProjectStatus.valueOf(statusName))
-
-        mockCreateReview(project = project, stopBefore = reviewRepoMock::getAllReviewsForProjectPaper)
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-
-        assertThrows<FailedPreconditionException> { mainService.createReview(validCreateReviewRequest.build()) }
-        coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
     @Test
@@ -331,8 +294,9 @@ class CreateReviewTest : MainServiceTest() {
                 stopBefore = reviewRepoMock::createReview,
             )
             coEvery { reviewRepoMock.createReview(createReviewRequest, userId) } returns declineReview
-            coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(declineReview.id) } returns
-                selectedCriteriaIds
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(declineReview.id)
+            } returns selectedCriteriaIds
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns emptyList()
             coEvery {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
@@ -364,8 +328,9 @@ class CreateReviewTest : MainServiceTest() {
 
             mockCreateReview(stopBefore = reviewRepoMock::createReview)
             coEvery { reviewRepoMock.createReview(createReviewRequest, userId) } returns acceptedReview
-            coEvery { reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(acceptedReview.id) } returns
-                listOf(defaultCriterion, hardExclusionCriterion.id)
+            coEvery {
+                reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(acceptedReview.id)
+            } returns listOf(defaultCriterion, hardExclusionCriterion.id)
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(hardExclusionCriterion)
             coEvery {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
@@ -376,13 +341,4 @@ class CreateReviewTest : MainServiceTest() {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
             }
         }
-
-    @Test
-    fun `When a review is created for a non existent project, then a ProjectNotFoundException is thrown`() = runTest {
-        mockCreateReview(stopBefore = projectRepoMock::getProjectById)
-
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
-
-        assertThrows<ProjectNotFoundException> { mainService.createReview(validCreateReviewRequest.build()) }
-    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -129,14 +129,14 @@ class CreateReviewTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user creates a review and has access, then no exception is thrown`() = runTest {
+    fun `When a user creates a review and has access, then no exception is thrown`() = runTest {
         mockCreateReview()
 
         assertDoesNotThrow { mainService.createReview(validCreateReviewRequest.build()) }
     }
 
     @Test
-    fun `When the user already reviewed the project paper, then a DuplicateReviewException is thrown`() = runTest {
+    fun `When a user already reviewed the project paper, then a DuplicateReviewException is thrown`() = runTest {
         val firstReview = DataBuilder.createExampleReview(
             projectPaperId = projectPaperId,
             decision = decision,

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -116,9 +116,7 @@ class CreateReviewTest : MainServiceTest() {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns emptyList()
-        coEvery {
-            projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, updatedPaperDecision)
-        } returns Unit
+        coJustRun { projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, updatedPaperDecision) }
     }
 
     @ParameterizedTest
@@ -254,9 +252,9 @@ class CreateReviewTest : MainServiceTest() {
             coEvery {
                 criterionRepoMock.getAllProjectCriteria(project.id)
             } returns listOf(exclusionCriterion, hardExclusionCriterion)
-            coEvery {
+            coJustRun {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
-            } returns Unit
+            }
 
             assertDoesNotThrow { mainService.createReview(createReviewRequest) }
         }
@@ -298,9 +296,9 @@ class CreateReviewTest : MainServiceTest() {
                 reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(declineReview.id)
             } returns selectedCriteriaIds
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns emptyList()
-            coEvery {
+            coJustRun {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_DECLINED)
-            } returns Unit
+            }
 
             assertDoesNotThrow { mainService.createReview(createReviewRequest) }
             coVerify(exactly = 1) {
@@ -332,9 +330,9 @@ class CreateReviewTest : MainServiceTest() {
                 reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(acceptedReview.id)
             } returns listOf(defaultCriterion, hardExclusionCriterion.id)
             coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns listOf(hardExclusionCriterion)
-            coEvery {
+            coJustRun {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.PAPER_DECISION_IN_REVIEW)
-            } returns Unit
+            }
 
             assertDoesNotThrow { mainService.createReview(createReviewRequest) }
             coVerify(exactly = 1) {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -1,103 +1,67 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
+import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllReviewsForProjectPaperTest : MainServiceTest() {
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(projectPaperRepoMock::getProjectPaperById),
-    )
+    @Test
+    fun `When the user requests all reviews and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectPaper = DataBuilder.createExampleProjectPaper()
+        val review = DataBuilder.createExampleReview()
+        val selectedCriteriaIds = listOf(UUID.randomUUID())
 
-    @Suppress("ReturnCount", "LongMethod")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean, projectPaperId: UUID) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = projectPaperId, projectId = project.id)
-        val review = DataBuilder.createExampleReview(userId = currentUser.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
-
-        mockCurrentUser(currentUser)
-
-        if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery {
-                projectPaperRepoMock.getProjectPaperById(projectPaper.id)
-            } returns Result.failure(TestSpecificException())
-            return
-        }
+        mockCurrentUser(user)
         coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-
-        coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !isUserAdmin
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, projectPaper.projectId) }
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns listOf(review)
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
-    }
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        val projectPaperId = UUID.randomUUID()
+        val reviews = mainService.getAllReviewsForProjectPaper(projectPaper.id).reviewsList
 
-        mockHappyPathUntil(failAt, true, projectPaperId)
-
-        assertThrows<TestSpecificException> {
-            mainService.getAllReviewsForProjectPaper(projectPaperId)
-        }
+        assertEquals(1, reviews.size)
+        assertEquals(review.id.toString(), reviews[0].id)
+        assertEquals(1, reviews[0].selectedCriteriaIdsCount)
+        val selectedCriterionId = reviews[0].selectedCriteriaIdsList[0]
+        assertEquals(selectedCriteriaIds[0].toString(), selectedCriterionId)
     }
 
     @Test
-    fun `When a server admin retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
-        val projectPaperId = UUID.randomUUID()
+    fun `When retrieving the project paper fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectPaper = DataBuilder.createExampleProjectPaper()
 
-        mockHappyPathUntil(null, true, projectPaperId)
+        mockCurrentUser(user)
+        coEvery {
+            projectPaperRepoMock.getProjectPaperById(projectPaper.id)
+        } returns Result.failure(TestSpecificException())
 
-        assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(projectPaperId) }
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(projectPaper.id) }
     }
 
     @Test
-    fun `When a project member retrieves all reviews for a project paper, then no exception is thrown`() = runTest {
-        val projectPaperId = UUID.randomUUID()
+    fun `When the user requests all reviews, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val projectPaper = DataBuilder.createExampleProjectPaper()
 
-        mockHappyPathUntil(null, false, projectPaperId)
+        mockCurrentUser(user)
+        coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
+        coEvery {
+            projectAccessCheckerMock.isAllowedToReadProject(user, projectPaper.projectId)
+        } throws TestSpecificException()
 
-        assertDoesNotThrow { mainService.getAllReviewsForProjectPaper(projectPaperId) }
+        assertThrows<TestSpecificException> { mainService.getAllReviewsForProjectPaper(projectPaper.id) }
     }
-
-    @Test
-    fun `When a non project member retrieves all reviews for a project paper, then an UnauthorizedException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val project = DataBuilder.createExampleProject()
-            val projectPaper = DataBuilder.createExampleProjectPaper(projectId = project.id)
-
-            mockCurrentUser(currentUser)
-            coEvery { projectPaperRepoMock.getProjectPaperById(projectPaper.id) } returns Result.success(projectPaper)
-            coEvery { projectRepoMock.getProjectById(project.id) } returns Result.success(project)
-            coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
-
-            assertThrows<UnauthorizedException> { mainService.getAllReviewsForProjectPaper(projectPaper.id) }
-        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     @Test
-    fun `When the user requests all reviews and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests all reviews and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectPaper = DataBuilder.createExampleProjectPaper()
         val review = DataBuilder.createExampleReview()
@@ -52,7 +52,7 @@ class GetAllReviewsForProjectPaperTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests all reviews, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user requests all reviews, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectPaper = DataBuilder.createExampleProjectPaper()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -1,106 +1,62 @@
 package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
-import java.util.stream.Stream
-import kotlin.reflect.KFunction
+import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetReviewByIdTest : MainServiceTest() {
-    fun failingFunctions(): Stream<Arguments?> = Stream.of(
-        Arguments.of(reviewRepoMock::getReviewById),
-    )
+    @Test
+    fun `When the user requests a review and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview()
+        val selectedCriteriaIds = listOf(UUID.randomUUID())
 
-    @Suppress("ReturnCount")
-    private fun mockHappyPathUntil(failAt: KFunction<*>?, isUserAdmin: Boolean, reviewId: UUID) {
-        val currentUser = DataBuilder.createExampleUser(
-            role = if (isUserAdmin) {
-                UserRole.USER_ROLE_ADMIN
-            } else {
-                UserRole.USER_ROLE_DEFAULT
-            },
-        )
-        val review = DataBuilder.createExampleReview(id = reviewId, userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-        val selectedCriteriaIds = listOf<UUID>(UUID.randomUUID())
-
-        mockCurrentUser(currentUser)
-
-        if (failAt == reviewRepoMock::getReviewById) {
-            coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.failure(TestSpecificException())
-            return
-        }
+        mockCurrentUser(user)
         coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
-
-        if (failAt == projectPaperRepoMock::getProjectPaperById) {
-            coEvery {
-                projectPaperRepoMock.getProjectPaperById(review.projectPaperId)
-            } returns Result.failure(TestSpecificException())
-            return
-        }
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns !isUserAdmin
+        coJustRun { reviewAccessCheckerMock.isAllowedToReadReview(user, review) }
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
-    }
 
-    @ParameterizedTest
-    @MethodSource("failingFunctions")
-    fun `When a step fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
-        val reviewId = UUID.randomUUID()
+        val reviewResult = mainService.getReviewById(review.id)
 
-        mockHappyPathUntil(failAt, true, reviewId)
-
-        assertThrows<TestSpecificException> {
-            mainService.getReviewById(reviewId)
-        }
+        assertEquals(review.id.toString(), reviewResult.id)
+        assertEquals(1, reviewResult.selectedCriteriaIdsCount)
+        val selectedCriterionId = reviewResult.selectedCriteriaIdsList[0]
+        assertEquals(selectedCriteriaIds[0].toString(), selectedCriterionId)
     }
 
     @Test
-    fun `When a server admin retrieves the review, then no exception is thrown`() = runTest {
-        val reviewId = UUID.randomUUID()
+    fun `When retrieving the review fails, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview()
 
-        mockHappyPathUntil(null, true, reviewId)
+        mockCurrentUser(user)
+        coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.failure(TestSpecificException())
 
-        assertDoesNotThrow { mainService.getReviewById(reviewId) }
+        assertThrows<TestSpecificException> { mainService.getReviewById(review.id) }
     }
 
     @Test
-    fun `When a project member retrieves the review, then no exception is thrown`() = runTest {
-        val reviewId = UUID.randomUUID()
+    fun `When the user requests a review, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val review = DataBuilder.createExampleReview()
 
-        mockHappyPathUntil(null, false, reviewId)
-
-        assertDoesNotThrow { mainService.getReviewById(reviewId) }
-    }
-
-    @Test
-    fun `When a non project member retrieves the review, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val review = DataBuilder.createExampleReview(userId = currentUser.id)
-        val project = DataBuilder.createExampleProject()
-        val projectPaper = DataBuilder.createExampleProjectPaper(id = review.projectPaperId, projectId = project.id)
-
-        mockCurrentUser(currentUser)
+        mockCurrentUser(user)
         coEvery { reviewRepoMock.getReviewById(review.id) } returns Result.success(review)
-        coEvery { projectPaperRepoMock.getProjectPaperById(review.projectPaperId) } returns Result.success(projectPaper)
-        coEvery { projectMemberRepoMock.isProjectMember(project.id, currentUser.id) } returns false
+        coEvery {
+            reviewAccessCheckerMock.isAllowedToReadReview(user, review)
+        } throws TestSpecificException()
 
-        assertThrows<UnauthorizedException> { mainService.getReviewById(review.id) }
+        assertThrows<TestSpecificException> { mainService.getReviewById(review.id) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetReviewByIdTest : MainServiceTest() {
     @Test
-    fun `When the user requests a review and has access, then no exception is thrown`() = runTest {
+    fun `When a user requests a review and has access, then no exception is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val review = DataBuilder.createExampleReview()
         val selectedCriteriaIds = listOf(UUID.randomUUID())
@@ -47,7 +47,7 @@ class GetReviewByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a review, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user requests a review, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val review = DataBuilder.createExampleReview()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -12,7 +12,7 @@ import se.uulm.snowballr.backend.service.MainServiceTest
 
 class GetAllUsersTest : MainServiceTest() {
     @Test
-    fun `When the user requests all users and has access, then all users are returned`() = runTest {
+    fun `When a user requests all users and has access, then all users are returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser()
         val users = listOf(currentUser, otherUser)
@@ -29,7 +29,7 @@ class GetAllUsersTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests all users, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user requests all users, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -1,32 +1,40 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 
 class GetAllUsersTest : MainServiceTest() {
     @Test
-    fun `When current user is not admin, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When the user requests all users and has access, then all users are returned`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val otherUser = DataBuilder.createExampleUser()
+        val users = listOf(currentUser, otherUser)
 
         mockCurrentUser(currentUser)
+        coJustRun { userAccessCheckerMock.isAllowedToReadAllUsers(currentUser) }
+        coEvery { userRepoMock.getAllUsers() } returns users
 
-        assertThrows<UnauthorizedException> { mainService.getAllUsers() }
+        val allUsers = mainService.getAllUsers()
+
+        assertEquals(2, allUsers.usersCount)
+        assertEquals(currentUser.id.toString(), allUsers.usersList[0].id)
+        assertEquals(otherUser.id.toString(), allUsers.usersList[1].id)
     }
 
     @Test
-    fun `When user is admin, then all users are returned`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When the user requests all users, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getAllUsers() } returns emptyList()
+        coEvery { userAccessCheckerMock.isAllowedToReadAllUsers(currentUser) } throws TestSpecificException()
 
-        assertDoesNotThrow { mainService.getAllUsers() }
+        assertThrows<TestSpecificException> { mainService.getAllUsers() }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -1,35 +1,18 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.UserIdentifierType
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
-import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
 
 class GetUserByEmailTest : MainServiceTest() {
-    companion object {
-        private fun isActiveStatus(status: UserStatus) = status == UserStatus.USER_STATUS_ACTIVE ||
-            status == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
-
-        @JvmStatic
-        fun inactiveStatuses(): List<UserStatus> =
-            UserStatus.entries.filterNot { isActiveStatus(it) || it == UserStatus.UNRECOGNIZED }
-
-        @JvmStatic
-        fun activeStatuses(): List<UserStatus> = UserStatus.entries.filter { isActiveStatus(it) }
-    }
-
     @Test
     fun `When the current user requests themselves, then user is not requested again`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
@@ -37,62 +20,47 @@ class GetUserByEmailTest : MainServiceTest() {
         mockCurrentUser(currentUser)
 
         val requestedUser = mainService.getUserByEmail(currentUser.email)
+
         assertEquals(currentUser.id.toString(), requestedUser.id)
         coVerify(exactly = 0) { userRepoMock.getUserByEmail(currentUser.email) }
     }
 
     @Test
-    fun `When retrieving requested user by email fails, then a TestSpecificException is thrown`() = runTest {
+    fun `When retrieving the requested user fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val requestedUserEmail = "otherUser@example.com"
+
+        mockCurrentUser(currentUser)
+        coEvery { userRepoMock.getUserByEmail(requestedUserEmail) } returns Result.failure(TestSpecificException())
+
+        assertThrows<TestSpecificException> { mainService.getUserByEmail(requestedUserEmail) }
+    }
+
+    @Test
+    fun `When the user requests a user, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(email = "otherUser@example.com")
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserByEmail(requestedUser.email) } returns Result.failure(TestSpecificException())
+        coEvery { userRepoMock.getUserByEmail(requestedUser.email) } returns Result.success(requestedUser)
+        coEvery {
+            userAccessCheckerMock.isAllowedToReadUser(currentUser, requestedUser, UserIdentifierType.EMAIL)
+        } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { mainService.getUserByEmail(requestedUser.email) }
     }
 
     @Test
-    fun `When verifying user access fails, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
+    fun `When the user requests a user and has access, then the user is returned`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(email = "otherUser@example.com")
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserByEmail(requestedUser.email) } returns Result.success(requestedUser)
-        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns emptyList()
+        coJustRun { userAccessCheckerMock.isAllowedToReadUser(currentUser, requestedUser, UserIdentifierType.EMAIL) }
 
-        assertThrows<UnauthorizedException> { mainService.getUserByEmail(requestedUser.email) }
-    }
+        val result = mainService.getUserByEmail(requestedUser.email)
 
-    @ParameterizedTest
-    @MethodSource("inactiveStatuses")
-    fun `When the requested user is inactive, then a NotFoundException is thrown`(status: UserStatus) = runTest {
-        val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(status = status, email = "otherUser@example.com")
-        val projectMembers = listOf(
-            DataBuilder.createExampleProjectMember(userId = currentUser.id),
-        )
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserByEmail(requestedUser.email) } returns Result.success(requestedUser)
-        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns projectMembers
-
-        assertThrows<NotFoundException>("Should throw NotFoundException for status $status") {
-            mainService.getUserByEmail(requestedUser.email)
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("activeStatuses")
-    fun `When all retrievals succeed and user is active, then user is returned`(status: UserStatus) = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(status = status, email = "otherUser@example.com")
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserByEmail(requestedUser.email) } returns Result.success(requestedUser)
-
-        assertDoesNotThrow("Should succeed for status $status") {
-            mainService.getUserByEmail(requestedUser.email)
-        }
+        assertEquals(requestedUser.email, result.email)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -37,7 +37,7 @@ class GetUserByEmailTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a user, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user requests a user, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(email = "otherUser@example.com")
 
@@ -51,7 +51,7 @@ class GetUserByEmailTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a user and has access, then the user is returned`() = runTest {
+    fun `When a user requests a user and has access, then the user is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser(email = "otherUser@example.com")
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -1,127 +1,70 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.UserIdentifierType
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
-import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
 
 class GetUserByIdTest : MainServiceTest() {
-    companion object {
-        private fun isActiveStatus(status: UserStatus) = status == UserStatus.USER_STATUS_ACTIVE ||
-            status == UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
-
-        @JvmStatic
-        fun inactiveStatuses(): List<UserStatus> =
-            UserStatus.entries.filterNot { isActiveStatus(it) || it == UserStatus.UNRECOGNIZED }
-
-        @JvmStatic
-        fun activeStatuses(): List<UserStatus> = UserStatus.entries.filter { isActiveStatus(it) }
-    }
-
     @Test
-    fun `When current user is admin, then requested user is returned successfully`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-
-        assertDoesNotThrow { mainService.getUserById(requestedUser.id) }
-    }
-
-    @Test
-    fun `When current user requests own user, then user is returned without redundant DB call`() = runTest {
+    fun `When the current user requests themselves, then user is not requested again`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(id = currentUser.id, status = UserStatus.USER_STATUS_ACTIVE)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
 
-        assertDoesNotThrow { mainService.getUserById(requestedUser.id) }
+        val requestedUser = mainService.getUserById(currentUser.id)
+
+        assertEquals(currentUser.id.toString(), requestedUser.id)
 
         // Should not call userRepoMock.getUserById(requestedUserId) again because it's self-request
-        coVerify(exactly = 1) { userRepoMock.getUserById(requestedUser.id) }
+        // First time is for injecting current user into session
+        coVerify(exactly = 1) { userRepoMock.getUserById(currentUser.id) }
     }
 
     @Test
-    fun `When current user is in same project as requested user, then requested user is returned`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val requestedUser = DataBuilder.createExampleUser(status = UserStatus.USER_STATUS_ACTIVE)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery {
-            projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id)
-        } returns listOf(DataBuilder.createExampleProjectMember(userId = currentUser.id))
-
-        assertDoesNotThrow { mainService.getUserById(requestedUser.id) }
-    }
-
-    @Test
-    fun `When current user is not authorized to access requested user, then an UnauthorizedException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val requestedUser = DataBuilder.createExampleUser()
-
-            mockCurrentUser(currentUser)
-            coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-            coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns emptyList()
-
-            assertThrows<UnauthorizedException> { mainService.getUserById(requestedUser.id) }
-        }
-
-    @ParameterizedTest
-    @MethodSource("inactiveStatuses")
-    fun `When requested user is inactive, then a NotFoundException is thrown`(status: UserStatus) = runTest {
+    fun `When retrieving the requested user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
-        val requestedUser = DataBuilder.createExampleUser(status = status)
-        val projectMembers = listOf(
-            DataBuilder.createExampleProjectMember(userId = currentUser.id),
-        )
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-        coEvery { projectMemberRepoMock.getMembersInSameProjectsAsUser(requestedUser.id) } returns projectMembers
-
-        assertThrows<NotFoundException>("Should throw NotFoundException for status $status") {
-            mainService.getUserById(requestedUser.id)
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("activeStatuses")
-    fun `When requested user is active, then user is returned`(status: UserStatus) = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(status = status)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
-
-        assertDoesNotThrow("Should succeed for status $status") {
-            mainService.getUserById(requestedUser.id)
-        }
-    }
-
-    @Test
-    fun `When retrieving requested user fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
         val requestedUserId = UUID.randomUUID()
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.failure(TestSpecificException())
 
         assertThrows<TestSpecificException> { mainService.getUserById(requestedUserId) }
+    }
+
+    @Test
+    fun `When the user requests a user, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val requestedUser = DataBuilder.createExampleUser()
+
+        mockCurrentUser(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+        coEvery {
+            userAccessCheckerMock.isAllowedToReadUser(currentUser, requestedUser, UserIdentifierType.ID)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.getUserById(requestedUser.id) }
+    }
+
+    @Test
+    fun `When the user requests a user and has access, then the user is returned`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val requestedUser = DataBuilder.createExampleUser()
+
+        mockCurrentUser(currentUser)
+        coEvery { userRepoMock.getUserById(requestedUser.id) } returns Result.success(requestedUser)
+        coJustRun { userAccessCheckerMock.isAllowedToReadUser(currentUser, requestedUser, UserIdentifierType.ID) }
+
+        val result = mainService.getUserById(requestedUser.id)
+
+        kotlin.test.assertEquals(requestedUser.id.toString(), result.id)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -41,7 +41,7 @@ class GetUserByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a user, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user requests a user, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser()
 
@@ -55,7 +55,7 @@ class GetUserByIdTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user requests a user and has access, then the user is returned`() = runTest {
+    fun `When a user requests a user and has access, then the user is returned`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val requestedUser = DataBuilder.createExampleUser()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.every
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
@@ -45,7 +46,7 @@ class RegisterTest : MainServiceTest() {
 
         coEvery { userRepoMock.doesUserExistByEmail(user.email) } returns false
         coEvery { userRepoMock.createUser(getExampleRequest(user), any()) } returns user
-        coEvery { verificationTokenRepoMock.saveVerificationToken(user.id, any()) } returns Unit
+        coJustRun { verificationTokenRepoMock.saveVerificationToken(user.id, any()) }
         every { emailManagerMock.createVerificationLink(any()) } returns verificationLink
         coEvery { emailManagerMock.sendVerificationEmail(user.email, userData) } throws TestSpecificException()
 
@@ -63,14 +64,14 @@ class RegisterTest : MainServiceTest() {
 
             coEvery { userRepoMock.doesUserExistByEmail(user.email) } returns false
             coEvery { userRepoMock.createUser(getExampleRequest(user), any()) } returns user
-            coEvery { verificationTokenRepoMock.saveVerificationToken(user.id, capture(tokenSlot)) } returns Unit
+            coJustRun { verificationTokenRepoMock.saveVerificationToken(user.id, capture(tokenSlot)) }
 
             every { emailManagerMock.createVerificationLink(any()) } answers {
                 val token = firstArg<String>()
                 "$testFrontendURL/verifyemail?token=$token"
             }
 
-            coEvery { emailManagerMock.sendVerificationEmail(user.email, capture(emailDataSlot)) } returns Unit
+            coJustRun { emailManagerMock.sendVerificationEmail(user.email, capture(emailDataSlot)) }
 
             assertDoesNotThrow { mainService.register(getExampleRequest(user)) }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -24,22 +24,21 @@ class SoftDeleteUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user soft-deletes another user, but has no access, then a TestSpecificException is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser()
-            val userToDelete = DataBuilder.createExampleUser()
+    fun `When a user soft-deletes another user, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val userToDelete = DataBuilder.createExampleUser()
 
-            mockCurrentUser(currentUser)
-            coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
-            coEvery {
-                userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete)
-            } throws TestSpecificException()
+        mockCurrentUser(currentUser)
+        coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
+        coEvery {
+            userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete)
+        } throws TestSpecificException()
 
-            assertThrows<TestSpecificException> { mainService.softDeleteUser(userToDelete.id) }
-        }
+        assertThrows<TestSpecificException> { mainService.softDeleteUser(userToDelete.id) }
+    }
 
     @Test
-    fun `When the user soft-deletes another user, but they are a last project admin, then TestSpecificException is thrown`() =
+    fun `When a user soft-deletes another user, but they are a last project admin, then TestSpecificException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val userToDelete = DataBuilder.createExampleUser()
@@ -57,7 +56,7 @@ class SoftDeleteUserTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user soft-deletes another user and has access, then no exception is thrown`() = runTest {
+    fun `When a user soft-deletes another user and has access, then no exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val userToDelete = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/SoftDeleteUserTest.kt
@@ -1,16 +1,14 @@
 package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.service.MainServiceTest
-import snowballr.UserOuterClass.UserRole
 import java.util.UUID
 
 class SoftDeleteUserTest : MainServiceTest() {
@@ -26,101 +24,51 @@ class SoftDeleteUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When user is not admin and tries to delete another user, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val userToDelete = DataBuilder.createExampleUser()
+    fun `When the user soft-deletes another user, but has no access, then a TestSpecificException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val userToDelete = DataBuilder.createExampleUser()
 
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
+            coEvery {
+                userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete)
+            } throws TestSpecificException()
 
-        assertThrows<UnauthorizedException> { mainService.softDeleteUser(userToDelete.id) }
-    }
-
-    @Test
-    fun `When trying to delete another admin user, then a FailedPreconditionException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val userToDelete = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
-
-        assertThrows<FailedPreconditionException> { mainService.softDeleteUser(userToDelete.id) }
-    }
+            assertThrows<TestSpecificException> { mainService.softDeleteUser(userToDelete.id) }
+        }
 
     @Test
-    fun `When admin soft-deletes other user, then it succeeds`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When the user soft-deletes another user, but they are a last project admin, then TestSpecificException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val userToDelete = DataBuilder.createExampleUser()
+            val project = DataBuilder.createExampleProject()
+
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
+            coJustRun { userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete) }
+            coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns listOf(project)
+            coEvery {
+                projectAccessCheckerMock.isNotLastProjectAdmin(userToDelete, project.id, any())
+            } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { mainService.softDeleteUser(userToDelete.id) }
+        }
+
+    @Test
+    fun `When the user soft-deletes another user and has access, then no exception is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
         val userToDelete = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
-        coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns emptyList()
-        coEvery { userRepoMock.softDeleteUser(userToDelete.id) } returns Unit
+        coJustRun { userAccessCheckerMock.isAllowedToDeleteUser(currentUser, userToDelete) }
+        coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns listOf(project)
+        coJustRun { userRepoMock.softDeleteUser(userToDelete.id) }
+        coJustRun { projectAccessCheckerMock.isNotLastProjectAdmin(userToDelete, project.id, any()) }
 
         assertDoesNotThrow { mainService.softDeleteUser(userToDelete.id) }
     }
-
-    @Test
-    fun `When user tries to delete own account, then it succeeds`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getUserProjects(currentUser.id, any()) } returns emptyList()
-        coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
-
-        assertDoesNotThrow { mainService.softDeleteUser(currentUser.id) }
-    }
-
-    @Test
-    fun `When admin tries to delete own account, then it succeeds`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-
-        mockCurrentUser(currentUser)
-        coEvery { projectRepoMock.getUserProjects(currentUser.id, any()) } returns emptyList()
-        coEvery { userRepoMock.softDeleteUser(currentUser.id) } returns Unit
-
-        assertDoesNotThrow { mainService.softDeleteUser(currentUser.id) }
-    }
-
-    @Test
-    fun `When trying to delete a user that still is the last project admin in any project, then a FailedPrecondition is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val userToDelete = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject()
-            val projectAdmin = DataBuilder.createExampleProjectMember(projectId = project.id, userId = userToDelete.id)
-
-            mockCurrentUser(currentUser)
-            coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
-            coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns listOf(project)
-            coEvery { projectMemberRepoMock.getAllProjectAdmins(project.id) } returns listOf(projectAdmin)
-
-            assertThrows<FailedPreconditionException> { mainService.softDeleteUser(userToDelete.id) }
-        }
-
-    @Test
-    fun `When trying to delete a user that is not the last project admin in a project, then no exception is thrown`() =
-        runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-            val userToDelete = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject()
-            val projectAdmin = DataBuilder.createExampleProjectMember(
-                projectId = project.id,
-                userId = UUID.randomUUID(),
-            )
-            val secondProjectAdmin = DataBuilder.createExampleProjectMember(
-                projectId = project.id,
-                userId = currentUser.id,
-            )
-
-            mockCurrentUser(currentUser)
-            coEvery { userRepoMock.getUserById(userToDelete.id) } returns Result.success(userToDelete)
-            coEvery { projectRepoMock.getUserProjects(userToDelete.id, any()) } returns listOf(project)
-            coEvery {
-                projectMemberRepoMock.getAllProjectAdmins(project.id)
-            } returns listOf(projectAdmin, secondProjectAdmin)
-            coEvery { userRepoMock.softDeleteUser(userToDelete.id) } returns Unit
-
-            assertDoesNotThrow { mainService.softDeleteUser(userToDelete.id) }
-        }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -37,7 +37,7 @@ class UpdateUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user updates another user, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user updates another user, but has no access, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser()
 
@@ -53,7 +53,7 @@ class UpdateUserTest : MainServiceTest() {
     }
 
     @Test
-    fun `When the user tries to change another user's role, but has no access, then a TestSpecificException is thrown`() =
+    fun `When a user tries to change another user's role, but has no access, then a TestSpecificException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val otherUser = DataBuilder.createExampleUser()
@@ -71,7 +71,7 @@ class UpdateUserTest : MainServiceTest() {
         }
 
     @Test
-    fun `When the user tries to change another user's email to an existent email, then a DuplicateUserException is thrown`() =
+    fun `When a user tries to change another user's email to an existent email, then a DuplicateUserException is thrown`() =
         runTest {
             val currentUser = DataBuilder.createExampleUser()
             val otherUser = DataBuilder.createExampleUser(email = "other@user.com")

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -1,155 +1,129 @@
 package se.uulm.snowballr.backend.service.user
 
-import com.google.protobuf.FieldMask
+import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.dto.User
+import se.uulm.snowballr.backend.model.dto.toGrpcUser
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.service.MainServiceTest
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
-import java.util.UUID
+import kotlin.test.assertEquals
 import snowballr.UserOuterClass.User as GrpcUser
 
 class UpdateUserTest : MainServiceTest() {
-    private val requestedUserId = UUID.randomUUID()
-    private val requestEmail = "newemail@example.com"
-
-    private fun getExampleRequest(changeRole: Boolean = false): GrpcUser.Update {
-        val userBuilder = GrpcUser.newBuilder()
-            .setId(requestedUserId.toString())
-            .setEmail(requestEmail)
-
-        if (changeRole) {
-            userBuilder.setRole(UserRole.USER_ROLE_ADMIN)
-        }
-
-        val mask = FieldMask.newBuilder()
-            .addPaths("email")
-            .addPaths("role")
-            .build()
-
-        return GrpcUser.Update.newBuilder()
-            .setUser(userBuilder.build())
-            .setMask(mask)
-            .build()
-    }
+    private fun getRequest(user: User, paths: List<String> = emptyList()) = GrpcUser.Update.newBuilder()
+        .setUser(user.toGrpcUser())
+        .setMask(FieldMaskUtil.fromStringList(paths))
+        .build()
 
     @Test
-    fun `When requested user retrieval fails, then a TestSpecificException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
+    fun `When retrieving user fails, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val otherUser = DataBuilder.createExampleUser()
+
+        val request = getRequest(otherUser)
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.failure(TestSpecificException())
+        coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { mainService.updateUser(getExampleRequest()) }
+        assertThrows<TestSpecificException> { mainService.updateUser(request) }
     }
 
     @Test
-    fun `When user is not admin and tries to change another user's role, then an UnauthorizedException is thrown`() =
+    fun `When the user updates another user, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val otherUser = DataBuilder.createExampleUser()
+
+        val request = getRequest(otherUser)
+
+        mockCurrentUser(currentUser)
+        coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
+        coEvery {
+            userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { mainService.updateUser(request) }
+    }
+
+    @Test
+    fun `When the user tries to change another user's role, but has no access, then a TestSpecificException is thrown`() =
         runTest {
-            val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-            val requestedUser = DataBuilder.createExampleUser(id = requestedUserId)
+            val currentUser = DataBuilder.createExampleUser()
+            val otherUser = DataBuilder.createExampleUser()
+
+            val request = getRequest(otherUser, listOf("role"))
 
             mockCurrentUser(currentUser)
-            coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
+            coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
+            coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
+            coEvery {
+                userAccessCheckerMock.isAllowedToUpdateUserRole(currentUser, otherUser.id)
+            } throws TestSpecificException()
 
-            assertThrows<UnauthorizedException> { mainService.updateUser(getExampleRequest(true)) }
+            assertThrows<TestSpecificException> { mainService.updateUser(request) }
         }
 
     @Test
-    fun `When user is not admin and tries to update another user, then an UnauthorizedException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_DEFAULT)
-        val otherUser = DataBuilder.createExampleUser(id = requestedUserId)
-        val request = GrpcUser.Update.newBuilder()
-            .setUser(GrpcUser.newBuilder().setId(otherUser.id.toString()).setFirstName("NewFirstName"))
-            .setMask(FieldMask.newBuilder().addPaths("first_name"))
-            .build()
+    fun `When the user tries to change another user's email to an existent email, then a DuplicateUserException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+            val otherUser = DataBuilder.createExampleUser(email = "other@user.com")
+
+            val request = getRequest(otherUser, listOf("email"))
+
+            mockCurrentUser(currentUser)
+            coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
+            coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
+            coEvery { userRepoMock.doesUserExistByEmail(otherUser.email) } returns true
+
+            assertThrows<DuplicateUserException> { mainService.updateUser(request) }
+        }
+
+    @Test
+    fun `When admin updates the email of another user, then it succeeds`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val otherUser = DataBuilder.createExampleUser(email = "other@user.com")
+
+        val request = getRequest(otherUser, listOf("email"))
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
-
-        assertThrows<UnauthorizedException> { mainService.updateUser(request) }
-    }
-
-    @Test
-    fun `When updating email to existent email, then a DuplicateUserException is thrown`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(
-            id = requestedUserId,
-            email = requestEmail,
-            status = UserStatus.USER_STATUS_ACTIVE,
-        )
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
-        coEvery { userRepoMock.doesUserExistByEmail(requestedUser.email) } returns true
-
-        assertThrows<DuplicateUserException> { mainService.updateUser(getExampleRequest()) }
-    }
-
-    @Test
-    fun `When user updates own email, then it succeeds`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(id = requestedUserId, role = UserRole.USER_ROLE_DEFAULT)
-        val request = GrpcUser.Update.newBuilder()
-            .setUser(
-                GrpcUser.newBuilder()
-                    .setId(currentUser.id.toString())
-                    .setEmail("new-and-shiny@example.com"),
-            )
-            .setMask(FieldMask.newBuilder().addPaths("email"))
-            .build()
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.doesUserExistByEmail("new-and-shiny@example.com") } returns false
-        coEvery { userRepoMock.updateUser(request) } returns currentUser
-
-        assertDoesNotThrow { mainService.updateUser(request) }
-    }
-
-    @Test
-    fun `When admin updates another user's role, then it succeeds`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val otherUser = DataBuilder.createExampleUser(
-            id = requestedUserId,
-            role = UserRole.USER_ROLE_DEFAULT,
-            status = UserStatus.USER_STATUS_ACTIVE,
-        )
-        val request = GrpcUser.Update.newBuilder()
-            .setUser(
-                GrpcUser.newBuilder()
-                    .setId(otherUser.id.toString())
-                    .setRole(UserRole.USER_ROLE_ADMIN),
-            )
-            .setMask(FieldMask.newBuilder().addPaths("role"))
-            .build()
-
-        mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
+        coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
+        coEvery { userRepoMock.doesUserExistByEmail(otherUser.email) } returns false
         coEvery { userRepoMock.updateUser(request) } returns otherUser
 
-        assertDoesNotThrow { mainService.updateUser(request) }
+        val updatedUser = mainService.updateUser(request)
+
+        assertEquals(otherUser.id.toString(), updatedUser.id)
+        assertEquals(otherUser.email, updatedUser.email)
     }
 
     @Test
-    fun `When admin updates all fields of another user, then it succeeds`() = runTest {
-        val currentUser = DataBuilder.createExampleUser(role = UserRole.USER_ROLE_ADMIN)
-        val requestedUser = DataBuilder.createExampleUser(
-            id = requestedUserId,
-            email = requestEmail,
-            status = UserStatus.USER_STATUS_ACTIVE,
-        )
+    fun `When admin updates all other fields of another user, then it succeeds`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+        val otherUser = DataBuilder.createExampleUser()
+
+        val request = getRequest(otherUser, listOf("first_name", "last_name", "role", "status"))
 
         mockCurrentUser(currentUser)
-        coEvery { userRepoMock.getUserById(requestedUserId) } returns Result.success(requestedUser)
-        coEvery { userRepoMock.doesUserExistByEmail(requestedUser.email) } returns false
-        coEvery { userRepoMock.updateUser(getExampleRequest()) } returns requestedUser
+        coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
+        coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
+        coJustRun { userAccessCheckerMock.isAllowedToUpdateUserRole(currentUser, otherUser.id) }
+        coEvery { userRepoMock.updateUser(request) } returns otherUser
 
-        assertDoesNotThrow { mainService.updateUser(getExampleRequest()) }
+        val updatedUser = mainService.updateUser(request)
+
+        assertEquals(otherUser.id.toString(), updatedUser.id)
+        assertEquals(otherUser.firstName, updatedUser.firstName)
+        assertEquals(otherUser.lastName, updatedUser.lastName)
+        assertEquals(UserRole.valueOf(otherUser.role.name), updatedUser.role)
+        assertEquals(UserStatus.valueOf(otherUser.status.name), updatedUser.status)
     }
 }


### PR DESCRIPTION
Closes #447 

## What I have made

This was a lot of manual work to mock the access layer.
We removed 65 unnecessary tests with this change (before: 951, after: 886)

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have manually tested my changes~~ (only changes in tests)
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
