### PR TITLE
Orchestrate fetchers

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -3,5 +3,8 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>Deprecation:SnowballRServer.kt$SnowballRServer$newInstance</ID>
+    <ID>ForbiddenComment:FetcherOrchestrator.kt$FetcherOrchestrator$// TODO: merge data</ID>
+    <ID>ForbiddenComment:FetcherOrchestrator.kt$FetcherOrchestrator$// TODO: paper filtering/merging</ID>
+    <ID>ForbiddenComment:FetcherOrchestrator.kt$FetcherOrchestrator$// TODO: replace with check for whole paper data by similarity not only external ID</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
@@ -4,10 +4,13 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.LoggerContext
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.context.startKoin
+import org.koin.java.KoinJavaComponent.getKoin
 import org.slf4j.LoggerFactory
 import se.uulm.snowballr.backend.env.DEFAULT_LOG_LEVEL
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.env.EnvService
+import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
+import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.grpc.SnowballRServer
 
 private val logger = KotlinLogging.logger {}
@@ -24,6 +27,8 @@ fun main() {
         modules(snowballRModule)
     }
 
+    initializeFetcherOrchestrator()
+
     // Create and run the server
     val server = SnowballRServer(env.http.port)
     server.start()
@@ -38,10 +43,23 @@ fun main() {
  * [io.github.oshai.kotlinlogging.Level] as string such as `DEBUG` or `INFO`.
  * If an invalid log level is provided, the default log level [DEFAULT_LOG_LEVEL] will be used.
  */
-fun configureRootLogger(logLevel: String) {
+private fun configureRootLogger(logLevel: String) {
     val context = (LoggerFactory.getILoggerFactory() ?: error("unable to get logger context")) as LoggerContext
     val rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
 
     rootLogger.level = Level.toLevel(logLevel, Level.toLevel(DEFAULT_LOG_LEVEL))
     logger.info { "Set log level to $logLevel" }
+}
+
+/**
+ * Starts the [FetcherOrchestrator] and adds a shutdown hook to stop it on shutdown.
+ */
+private fun initializeFetcherOrchestrator() {
+    val orchestrator = getKoin().get<IFetcherOrchestrator>()
+    orchestrator.start()
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            orchestrator.stop()
+        },
+    )
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -32,7 +32,9 @@ import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.env.EnvService
 import se.uulm.snowballr.backend.env.IEnvService
+import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
+import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.fetcher.PythonPluginFetcherManager
 import se.uulm.snowballr.backend.mail.EmailManager
 import se.uulm.snowballr.backend.mail.EmailTemplateManager
@@ -199,6 +201,7 @@ private fun Module.customServicesDeps() {
     singleOf(::CookieManager) { bind<ICookieManager>() }
     singleOf(::EmailManager) { bind<IEmailManager>() }
     singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
+    single<IFetcherOrchestrator> { FetcherOrchestrator(get(), get(), get(), get(), get()) }
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.auth
 
-import se.uulm.snowballr.backend.fetcher.FetcherMap
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import snowballr.ProjectOuterClass
 import snowballr.UserOuterClass
 import java.util.UUID

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherMap.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherMap.kt
@@ -1,7 +1,0 @@
-package se.uulm.snowballr.backend.fetcher
-
-/**
- * Map of a fetcher name to its option map.
- * The option map maps the key to its value.
- */
-typealias FetcherMap = Map<String, Map<String, String>>

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -104,7 +104,7 @@ class FetcherOrchestrator(
             return
         }
 
-        paperRepo.ensurePaperExists(job.projectPaper.projectId)
+        paperRepo.ensurePaperExists(job.projectPaper.paperId)
 
         val processingJob = FetcherProcessingJob(
             projectId = project.id,

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -19,6 +19,8 @@ import se.uulm.snowballr.backend.model.fetcher.FetchingDirection
 import se.uulm.snowballr.backend.model.fetcher.FetchingResults
 import se.uulm.snowballr.backend.model.fetcher.PaperCreationResults
 import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
+import se.uulm.snowballr.backend.model.isBackwardOrBoth
+import se.uulm.snowballr.backend.model.isForwardOrBoth
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
@@ -151,13 +153,13 @@ class FetcherOrchestrator(
      * fetched by calling the [fetcherManager].
      */
     private suspend fun runFetching(job: FetcherProcessingJob, paper: Paper): FetchingResults {
-        val backwardReferences = if (shouldFetchBackward(job.snowballingType)) {
+        val backwardReferences = if (job.snowballingType.isBackwardOrBoth()) {
             fetch(job.fetchers, paper, FetchingDirection.BACKWARD)
         } else {
             emptySet()
         }
 
-        val forwardReferences = if (shouldFetchForward(job.snowballingType)) {
+        val forwardReferences = if (job.snowballingType.isForwardOrBoth()) {
             fetch(job.fetchers, paper, FetchingDirection.FORWARD)
         } else {
             emptySet()
@@ -165,14 +167,6 @@ class FetcherOrchestrator(
 
         return FetchingResults(backwardReferences, forwardReferences)
     }
-
-    private fun shouldFetchBackward(snowballingType: SnowballingType) =
-        snowballingType == SnowballingType.SNOWBALLING_TYPE_BOTH ||
-            snowballingType == SnowballingType.SNOWBALLING_TYPE_BACKWARD
-
-    private fun shouldFetchForward(snowballingType: SnowballingType) =
-        snowballingType == SnowballingType.SNOWBALLING_TYPE_BOTH ||
-            snowballingType == SnowballingType.SNOWBALLING_TYPE_FORWARD
 
     /**
      * Calls the [fetcherManager] to fetch papers according to the passed [direction] for each fetcher in [fetchers].

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -87,6 +87,7 @@ class FetcherOrchestrator(
 
     override fun stop() {
         scope.cancel()
+        isStarted = false
     }
 
     override suspend fun enqueue(job: FetcherEnqueueJob) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -134,7 +134,7 @@ class FetcherOrchestrator(
 
         val fetchingResults = runFetching(job, paper)
 
-        // do paper filtering/merging
+        // TODO: paper filtering/merging
         // fetching from multiple fetchers will probably return the same papers from different fetchers
         // first merge fetched papers then merge with existing paper in DB (if existent)
 
@@ -225,10 +225,10 @@ class FetcherOrchestrator(
 
         for (ref in refs) {
             if (ref.externalId != null) {
-                // replace with check for whole paper data by similarity not only external ID
+                // TODO: replace with check for whole paper data by similarity not only external ID
                 val result = paperRepo.getPaperByExternalId(ref.externalId)
                 if (result.isSuccess) {
-                    // merge data
+                    // TODO: merge data
                     createdPaperRefs += result.getOrThrow()
                     continue
                 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -144,6 +144,12 @@ class FetcherOrchestrator(
         logger.info { "Finished fetcher processing job for paper ${job.paperId}" }
     }
 
+    /**
+     * Runs the fetching part of the job processing.
+     *
+     * Based on the snowballing type papers that are referenced either forward, backward, or from both directions are
+     * fetched by calling the [fetcherManager].
+     */
     private suspend fun runFetching(job: FetcherProcessingJob, paper: Paper): FetchingResults {
         val backwardReferences = if (shouldFetchBackward(job.snowballingType)) {
             fetch(job.fetchers, paper, FetchingDirection.BACKWARD)
@@ -168,6 +174,11 @@ class FetcherOrchestrator(
         snowballingType == SnowballingType.SNOWBALLING_TYPE_BOTH ||
             snowballingType == SnowballingType.SNOWBALLING_TYPE_FORWARD
 
+    /**
+     * Calls the [fetcherManager] to fetch papers according to the passed [direction] for each fetcher in [fetchers].
+     *
+     * If a [FetcherException] is thrown by one of the fetchers, the exception is caught and logged.
+     */
     private suspend fun fetch(fetchers: FetcherMap, paper: Paper, direction: FetchingDirection): Set<FetcherPaper> {
         val fetchCall = when (direction) {
             FetchingDirection.BACKWARD -> fetcherManager::fetchBackwardReferences
@@ -194,6 +205,11 @@ class FetcherOrchestrator(
         return set
     }
 
+    /**
+     * Runs the paper creation part of the job processing.
+     *
+     * For both sets in [results] the paper data is stored in the DB if not already existent.
+     */
     private suspend fun runPaperCreation(results: FetchingResults): PaperCreationResults {
         val createdBackwardRefs = createRefs(results.backwardRefs)
         logger.info { "Created ${createdBackwardRefs.size} backward referenced papers" }
@@ -203,6 +219,12 @@ class FetcherOrchestrator(
         return PaperCreationResults(createdBackwardRefs, createdForwardRefs)
     }
 
+    /**
+     * Creates a DB paper for each of the [FetcherPaper]s in [refs].
+     *
+     * If a paper already exists in the DB, no paper is added and the existent paper is retrieved and added to the
+     * result set.
+     */
     private suspend fun createRefs(refs: Set<FetcherPaper>): Set<Paper> {
         val createdPaperRefs = mutableSetOf<Paper>()
 
@@ -227,11 +249,24 @@ class FetcherOrchestrator(
         return createdPaperRefs
     }
 
+    /**
+     * Runs the citation part of the job processing.
+     *
+     * For both sets in [creationResults] citation entries are added for the origin paper with the passed [paperId] and
+     * the reference in one of the sets.
+     */
     private suspend fun runPaperCitation(paperId: UUID, creationResults: PaperCreationResults) {
         createCitation(paperId, creationResults.backwardRefs, FetchingDirection.BACKWARD)
         createCitation(paperId, creationResults.forwardRefs, FetchingDirection.FORWARD)
     }
 
+    /**
+     * Creates a citation entry for the paper with the passed [paperId] and each reference in [refs] according to the
+     * [direction].
+     *
+     * If a citation entry already exists for a combination, nothing happens as this means the connection between both
+     * papers already exists (no-op).
+     */
     private suspend fun createCitation(paperId: UUID, refs: Set<Paper>, direction: FetchingDirection) {
         val citeCall = when (direction) {
             FetchingDirection.BACKWARD -> citationRepo::addBackwardReferencedPaper
@@ -257,6 +292,13 @@ class FetcherOrchestrator(
         logger.info { "Added $addedCitations ${refName}s for paper $paperId" }
     }
 
+    /**
+     * Runs the part of the job processing in which the created papers are added to the project.
+     *
+     * All papers in [creationResults] are added to the target stage in the project, if not already added. If the
+     * maximum stage of the project is below the target stage, it will be increased. A paper that has already been added
+     * to the project is a reference of a paper in an earlier stage.
+     */
     private suspend fun runAddingPapersToProject(job: FetcherProcessingJob, creationResults: PaperCreationResults) {
         val baseRequest = GrpcProjectPaper.Add.newBuilder()
             .setProjectId(job.projectId.toString())

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.fetcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -37,7 +38,9 @@ interface IFetcherOrchestrator {
     /**
      * Start the fetcher orchestrator.
      *
-     * @throws IllegalStateException if the fetcher orchestrator already is running.
+     * An instance of [IFetcherOrchestrator] can only be started once and cannot be restarted again.
+     *
+     * @throws IllegalStateException if the fetcher orchestrator already is running or has been stopped before.
      */
     fun start()
 
@@ -69,8 +72,10 @@ class FetcherOrchestrator(
 
     private var isStarted = false
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun start() {
         check(!isStarted) { "Orchestrator is already running" }
+        check(!queue.isClosedForSend) { "Orchestrator has been closed" }
 
         isStarted = true
         scope.launch {
@@ -79,15 +84,20 @@ class FetcherOrchestrator(
                 try {
                     processJob(job)
                 } catch (e: Exception) {
-                    logger.error(e) { "Failed to process job" }
+                    logger.error(e) { "Failed to process job: ${e.message}" }
                 }
             }
         }
+
+        logger.info { "Fetcher Orchestrator started" }
     }
 
     override fun stop() {
         scope.cancel()
+        queue.close()
         isStarted = false
+
+        logger.info { "Fetcher Orchestrator stopped" }
     }
 
     override suspend fun enqueue(job: FetcherEnqueueJob) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -1,0 +1,298 @@
+package se.uulm.snowballr.backend.fetcher
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.toFetcherPaper
+import se.uulm.snowballr.backend.model.exception.FetcherException
+import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import se.uulm.snowballr.backend.model.fetcher.FetcherProcessingJob
+import se.uulm.snowballr.backend.model.fetcher.FetchingDirection
+import se.uulm.snowballr.backend.model.fetcher.FetchingResults
+import se.uulm.snowballr.backend.model.fetcher.PaperCreationResults
+import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
+import se.uulm.snowballr.backend.repository.IPaperTableRepo
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+import se.uulm.snowballr.backend.repository.isUniqueConstraintViolation
+import snowballr.ProjectOuterClass.SnowballingType
+import java.sql.SQLException
+import java.util.UUID
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+
+private val logger = KotlinLogging.logger { }
+
+interface IFetcherOrchestrator {
+    /**
+     * Start the fetcher orchestrator.
+     *
+     * @throws IllegalStateException if the fetcher orchestrator already is running.
+     */
+    fun start()
+
+    /**
+     * Stop the fetcher orchestrator.
+     */
+    fun stop()
+
+    /**
+     * Enqueue a job to the fetcher orchestrator.
+     *
+     * @throws IllegalStateException if the fetcher orchestrator is not running.
+     */
+    suspend fun enqueue(job: FetcherEnqueueJob)
+}
+
+class FetcherOrchestrator(
+    private val fetcherManager: IFetcherManager,
+    private val projectRepo: IProjectTableRepo,
+    private val paperRepo: IPaperTableRepo,
+    private val citationRepo: ICitationTableRepo,
+    private val projectPaperRepo: IProjectPaperTableRepo,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : IFetcherOrchestrator {
+    private val queue = Channel<FetcherProcessingJob>(Channel.UNLIMITED)
+
+    // Use supervisor job so that jobs can fail without cancelling the entire scope
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    private var isStarted = false
+
+    override fun start() {
+        check(!isStarted) { "Orchestrator is already running" }
+
+        isStarted = true
+        scope.launch {
+            for (job in queue) {
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    processJob(job)
+                } catch (e: Exception) {
+                    logger.error(e) { "Failed to process job" }
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        scope.cancel()
+    }
+
+    override suspend fun enqueue(job: FetcherEnqueueJob) {
+        check(isStarted) { "Orchestrator has not been started yet" }
+
+        val project = projectRepo.getProjectById(job.projectPaper.projectId).getOrThrow()
+
+        if (project.snowballingType == SnowballingType.SNOWBALLING_TYPE_UNSPECIFIED) {
+            logger.warn { "Snowballing type is unspecified for project '${job.projectPaper.projectId}'." }
+            return
+        }
+
+        if (project.fetchers.isEmpty()) {
+            logger.warn { "No fetchers configured for project '${job.projectPaper.projectId}'." }
+            return
+        }
+
+        paperRepo.ensurePaperExists(job.projectPaper.projectId)
+
+        val processingJob = FetcherProcessingJob(
+            projectId = project.id,
+            fetchers = project.fetchers,
+            snowballingType = project.snowballingType,
+            targetStage = job.projectPaper.stage + 1,
+            paperId = job.projectPaper.paperId,
+            triggeringUserId = job.triggeringUserId,
+        )
+
+        val result = queue.trySend(processingJob)
+
+        if (result.isSuccess) {
+            logger.info {
+                "Successfully enqueued job for paper ${job.projectPaper.id} in stage ${job.projectPaper.stage}"
+            }
+        } else {
+            logger.error { "Failed to enqueue job for paper ${job.projectPaper.id} in stage ${job.projectPaper.stage}" }
+        }
+    }
+
+    private suspend fun processJob(job: FetcherProcessingJob) {
+        logger.info { "Starting fetcher processing job for paper ${job.paperId}" }
+
+        val paper = paperRepo.getPaperById(job.paperId).getOrThrow()
+
+        val fetchingResults = runFetching(job, paper)
+
+        // do paper filtering/merging
+        // fetching from multiple fetchers will probably return the same papers from different fetchers
+        // first merge fetched papers then merge with existing paper in DB (if existent)
+
+        val creationResults = runPaperCreation(fetchingResults)
+
+        runPaperCitation(job.paperId, creationResults)
+
+        runAddingPapersToProject(job, creationResults)
+
+        logger.info { "Finished fetcher processing job for paper ${job.paperId}" }
+    }
+
+    private suspend fun runFetching(job: FetcherProcessingJob, paper: Paper): FetchingResults {
+        val backwardReferences = if (shouldFetchBackward(job.snowballingType)) {
+            fetch(job.fetchers, paper, FetchingDirection.BACKWARD)
+        } else {
+            emptySet()
+        }
+
+        val forwardReferences = if (shouldFetchForward(job.snowballingType)) {
+            fetch(job.fetchers, paper, FetchingDirection.FORWARD)
+        } else {
+            emptySet()
+        }
+
+        return FetchingResults(backwardReferences, forwardReferences)
+    }
+
+    private fun shouldFetchBackward(snowballingType: SnowballingType) =
+        snowballingType == SnowballingType.SNOWBALLING_TYPE_BOTH ||
+            snowballingType == SnowballingType.SNOWBALLING_TYPE_BACKWARD
+
+    private fun shouldFetchForward(snowballingType: SnowballingType) =
+        snowballingType == SnowballingType.SNOWBALLING_TYPE_BOTH ||
+            snowballingType == SnowballingType.SNOWBALLING_TYPE_FORWARD
+
+    private suspend fun fetch(fetchers: FetcherMap, paper: Paper, direction: FetchingDirection): Set<FetcherPaper> {
+        val fetchCall = when (direction) {
+            FetchingDirection.BACKWARD -> fetcherManager::fetchBackwardReferences
+            FetchingDirection.FORWARD -> fetcherManager::fetchForwardReferences
+        }
+
+        val set = mutableSetOf<FetcherPaper>()
+
+        for ((fetcher, options) in fetchers) {
+            try {
+                val fetchedPapers = fetchCall(fetcher, paper.toFetcherPaper(), options)
+                set += fetchedPapers
+            } catch (ex: FetcherException) {
+                logger.error(ex) {
+                    "Failed to fetch ${direction.displayName} with fetcher '$fetcher': ${ex.message}"
+                }
+            }
+        }
+        logger.info {
+            "Fetched ${set.size} ${direction.displayName} referenced papers from ${fetchers.size} fetcher(s) for " +
+                "paper ${paper.id}"
+        }
+
+        return set
+    }
+
+    private suspend fun runPaperCreation(results: FetchingResults): PaperCreationResults {
+        val createdBackwardRefs = createRefs(results.backwardRefs)
+        logger.info { "Created ${createdBackwardRefs.size} backward referenced papers" }
+        val createdForwardRefs = createRefs(results.forwardRefs)
+        logger.info { "Created ${createdForwardRefs.size} forward referenced papers" }
+
+        return PaperCreationResults(createdBackwardRefs, createdForwardRefs)
+    }
+
+    private suspend fun createRefs(refs: Set<FetcherPaper>): Set<Paper> {
+        val createdPaperRefs = mutableSetOf<Paper>()
+
+        for (ref in refs) {
+            if (ref.externalId != null) {
+                // replace with check for whole paper data by similarity not only external ID
+                val result = paperRepo.getPaperByExternalId(ref.externalId)
+                if (result.isSuccess) {
+                    // merge data
+                    createdPaperRefs += result.getOrThrow()
+                    continue
+                }
+            }
+
+            try {
+                createdPaperRefs += paperRepo.createPaper(ref.toGrpcPaperRequest(), ref.metadata)
+            } catch (ex: SQLException) {
+                logger.error(ex) { "Failed to create paper for fetched paper: ${ex.message}" }
+            }
+        }
+
+        return createdPaperRefs
+    }
+
+    private suspend fun runPaperCitation(paperId: UUID, creationResults: PaperCreationResults) {
+        createCitation(paperId, creationResults.backwardRefs, FetchingDirection.BACKWARD)
+        createCitation(paperId, creationResults.forwardRefs, FetchingDirection.FORWARD)
+    }
+
+    private suspend fun createCitation(paperId: UUID, refs: Set<Paper>, direction: FetchingDirection) {
+        val citeCall = when (direction) {
+            FetchingDirection.BACKWARD -> citationRepo::addBackwardReferencedPaper
+            FetchingDirection.FORWARD -> citationRepo::addForwardReferencedPaper
+        }
+        val refName = "${direction.displayName} reference"
+
+        var addedCitations = 0
+        for (ref in refs) {
+            try {
+                citeCall(paperId, ref.id)
+                addedCitations++
+            } catch (ex: SQLException) {
+                // A unique constraint violation is okay (no-op)
+                if (!ex.isUniqueConstraintViolation()) {
+                    logger.error(ex) {
+                        "Failed to create $refName between paper $paperId and reference ${ref.id}: ${ex.message}"
+                    }
+                }
+            }
+        }
+
+        logger.info { "Added $addedCitations ${refName}s for paper $paperId" }
+    }
+
+    private suspend fun runAddingPapersToProject(job: FetcherProcessingJob, creationResults: PaperCreationResults) {
+        val baseRequest = GrpcProjectPaper.Add.newBuilder()
+            .setProjectId(job.projectId.toString())
+            .setStage(job.targetStage)
+
+        val filteredRefs = mutableListOf<Paper>()
+        for (createdRef in creationResults.allRefs) {
+            val doesAlreadyExist = projectPaperRepo.doesProjectPaperExist(job.projectId, createdRef.id)
+            if (doesAlreadyExist) {
+                logger.debug {
+                    "Skipping paper ${createdRef.id} because it is already added to the project"
+                }
+                continue
+            }
+
+            filteredRefs += createdRef
+        }
+
+        logger.debug {
+            "Adding ${filteredRefs.size}/${creationResults.allRefs.size} papers to project ${job.projectId}"
+        }
+
+        if (filteredRefs.isNotEmpty()) {
+            projectRepo.updateMaxStageIfExceeded(job.projectId, job.targetStage)
+        }
+
+        for (ref in filteredRefs) {
+            try {
+                val request = baseRequest.setPaperId(ref.id.toString()).build()
+                projectPaperRepo.addPaperToProject(request, job.triggeringUserId)
+            } catch (ex: SQLException) {
+                logger.error(ex) {
+                    "Failed to add paper ${ref.id} to project ${job.projectId} in stage ${job.targetStage}:" +
+                        " ${ex.message}"
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/GrpcTypeExtensions.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/GrpcTypeExtensions.kt
@@ -1,0 +1,15 @@
+package se.uulm.snowballr.backend.model
+
+import snowballr.ProjectOuterClass.SnowballingType
+
+/**
+ * Returns true if this [SnowballingType] is BACKWARD or BOTH; otherwise false.
+ */
+fun SnowballingType.isBackwardOrBoth() = this == SnowballingType.SNOWBALLING_TYPE_BACKWARD ||
+    this == SnowballingType.SNOWBALLING_TYPE_BOTH
+
+/**
+ * Returns true if this [SnowballingType] is FORWARD or BOTH; otherwise false.
+ */
+fun SnowballingType.isForwardOrBoth() = this == SnowballingType.SNOWBALLING_TYPE_FORWARD ||
+    this == SnowballingType.SNOWBALLING_TYPE_BOTH

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.model.dto
 
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import se.uulm.snowballr.backend.table.PaperTable
 import snowballr.paper
 import java.time.OffsetDateTime
@@ -54,3 +55,18 @@ fun List<GrpcPaper>.toGrpcPapers(): GrpcPaper.List = GrpcPaper.List
     .newBuilder()
     .addAllPapers(this)
     .build()
+
+/**
+ * Creates a [FetcherPaper] from this [paper]
+ */
+fun Paper.toFetcherPaper(): FetcherPaper = FetcherPaper(
+    title = title,
+    externalId = externalId,
+    abstract = abstract,
+    year = year,
+    publisher = publisher,
+    publicationType = publicationType,
+    publicationName = publicationName,
+    authors = authors,
+    metadata = fetcherMetadata,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Project.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
-import se.uulm.snowballr.backend.fetcher.FetcherMap
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import se.uulm.snowballr.backend.table.ProjectTable
 import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/UserSettings.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
-import se.uulm.snowballr.backend.fetcher.FetcherMap
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import snowballr.CriterionOuterClass
 import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherEnqueueJob.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherEnqueueJob.kt
@@ -1,0 +1,12 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+import se.uulm.snowballr.backend.model.dto.ProjectPaper
+import java.util.UUID
+
+/**
+ * Enqueuing job for fetching referenced papers from a passed origin paper.
+ */
+data class FetcherEnqueueJob(
+    val projectPaper: ProjectPaper,
+    val triggeringUserId: UUID,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherMap.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherMap.kt
@@ -1,0 +1,13 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+/**
+ * Map of a fetcher name to its options map.
+ *
+ * The option map maps the key to its value.
+ */
+typealias FetcherMap = Map<String, FetcherOptions>
+
+/**
+ * Options of a single fetcher.
+ */
+typealias FetcherOptions = Map<String, String>

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherPaper.kt
@@ -4,8 +4,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.toGrpcAuthors
+import snowballr.paper
 import java.time.OffsetDateTime
 import java.util.UUID
+import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 /**
  * Represents a paper fetched from an external source.
@@ -58,3 +61,20 @@ fun FetcherPaper.toPaper(): Paper = Paper(
     modifiedAt = null,
     modifiedBy = null,
 )
+
+/**
+ * Creates a [GrpcPaper] request from this [FetcherPaper].
+ */
+fun FetcherPaper.toGrpcPaperRequest(): GrpcPaper {
+    val paper = this
+    return paper {
+        title = paper.title
+        if (paper.externalId != null) externalId = paper.externalId
+        abstrakt = paper.abstract
+        year = paper.year
+        publisher = paper.publisher
+        publicationType = paper.publicationType
+        publicationName = paper.publicationName
+        authors.addAll(paper.authors.toGrpcAuthors())
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherProcessingJob.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherProcessingJob.kt
@@ -1,0 +1,16 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+import snowballr.ProjectOuterClass.SnowballingType
+import java.util.UUID
+
+/**
+ * Processing job for fetching referenced papers.
+ */
+data class FetcherProcessingJob(
+    val projectId: UUID,
+    val fetchers: FetcherMap,
+    val snowballingType: SnowballingType,
+    val targetStage: Long,
+    val paperId: UUID,
+    val triggeringUserId: UUID,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetchingDirection.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetchingDirection.kt
@@ -1,0 +1,9 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+/**
+ * Direction into which the fetcher should fetch referenced papers.
+ */
+enum class FetchingDirection(val displayName: String) {
+    FORWARD("forward"),
+    BACKWARD("backward"),
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/PaperReferencesPair.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/PaperReferencesPair.kt
@@ -10,7 +10,6 @@ data class PaperReferencesPair<T>(
     val forwardRefs: Set<T>,
 ) {
     val allRefs get() = backwardRefs + forwardRefs
-    val totalSize get() = allRefs.size
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/PaperReferencesPair.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/PaperReferencesPair.kt
@@ -1,0 +1,24 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+import se.uulm.snowballr.backend.model.dto.Paper
+
+/**
+ * Represents a pair of backward and forward references of type [T].
+ */
+data class PaperReferencesPair<T>(
+    val backwardRefs: Set<T>,
+    val forwardRefs: Set<T>,
+) {
+    val allRefs get() = backwardRefs + forwardRefs
+    val totalSize get() = allRefs.size
+}
+
+/**
+ * Pair of refs as [FetcherPaper]s.
+ */
+typealias FetchingResults = PaperReferencesPair<FetcherPaper>
+
+/**
+ * Pair of refs as [Paper]s.
+ */
+typealias PaperCreationResults = PaperReferencesPair<Paper>

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/SqlStateHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/SqlStateHelper.kt
@@ -2,7 +2,9 @@ package se.uulm.snowballr.backend.repository
 
 import java.sql.SQLException
 
+const val UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE = "23505"
+
 /**
  * Checks whether this [SQLException] is thrown due to a unique constraint violation.
  */
-fun SQLException.isUniqueConstraintViolation() = this.sqlState == "23505"
+fun SQLException.isUniqueConstraintViolation() = this.sqlState == UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IReviewAccessChecker
+import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Review
@@ -12,6 +13,7 @@ import se.uulm.snowballr.backend.model.dto.toGrpcReview
 import se.uulm.snowballr.backend.model.dto.toGrpcReviews
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
+import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -61,6 +63,7 @@ interface IReviewService {
  * @param reviewHasCriterionRepo Interface for persistence and retrieval operations related to review-criteria relation.
  * @param accessChecker Interface for checking access permissions for reviews based on defined rules.
  * @param projectAccessChecker Interface for checking access permissions for projects based on defined rules.
+ * @param fetcherOrchestrator Interface for enqueuing fetcher jobs for fetching referenced papers.
  */
 @Suppress("LongParameterList")
 class ReviewService(
@@ -72,6 +75,7 @@ class ReviewService(
     private val reviewHasCriterionRepo: IReviewHasCriterionTableRepo,
     private val accessChecker: IReviewAccessChecker,
     private val projectAccessChecker: IProjectAccessChecker,
+    private val fetcherOrchestrator: IFetcherOrchestrator,
 ) : IReviewService {
     override suspend fun getReviewById(reviewId: UUID): GrpcReview = withUser(userRepo) { currentUser ->
         val review = repo.getReviewById(reviewId).getOrThrow()
@@ -131,6 +135,10 @@ class ReviewService(
         } else {
             val updatedDecision = determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
             projectPaperRepo.updateProjectPaperDecision(projectPaperId, updatedDecision)
+
+            if (updatedDecision === PaperDecision.PAPER_DECISION_ACCEPTED) {
+                fetcherOrchestrator.enqueue(FetcherEnqueueJob(projectPaper, currentUser.id))
+            }
         }
 
         review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ProjectTable.kt
@@ -6,8 +6,8 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
 import org.jetbrains.exposed.v1.json.json
-import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ProjectStatus
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -5,9 +5,9 @@ import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.json.json
-import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -15,7 +15,9 @@ import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
+import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.fetcher.FetcherMap
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import se.uulm.snowballr.backend.table.patternOf
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole
@@ -186,20 +188,20 @@ object DataBuilder {
         modifiedAt: OffsetDateTime? = null,
         modifiedBy: UUID? = null,
     ) = Paper(
-        id,
-        title,
-        externalId,
-        abstract,
-        year,
-        publisher,
-        publicationType,
-        publicationName,
-        pdfId,
-        authors,
-        fetcherMetadata,
-        createdAt,
-        modifiedAt,
-        modifiedBy,
+        id = id,
+        title = title,
+        externalId = externalId,
+        abstract = abstract,
+        year = year,
+        publisher = publisher,
+        publicationType = publicationType,
+        publicationName = publicationName,
+        pdfId = pdfId,
+        authors = authors,
+        fetcherMetadata = fetcherMetadata,
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
+        modifiedBy = modifiedBy,
     )
 
     fun createExampleProjectPaper(
@@ -214,21 +216,21 @@ object DataBuilder {
         modifiedAt: OffsetDateTime? = null,
         modifiedBy: UUID? = null,
     ) = ProjectPaper(
-        id,
-        paperId,
-        projectId,
-        localPaperId,
-        stage,
-        decision,
-        createdAt,
-        createdBy,
-        modifiedAt,
-        modifiedBy,
+        id = id,
+        paperId = paperId,
+        projectId = projectId,
+        localPaperId = localPaperId,
+        stage = stage,
+        decision = decision,
+        createdAt = createdAt,
+        createdBy = createdBy,
+        modifiedAt = modifiedAt,
+        modifiedBy = modifiedBy,
     )
 
     fun createExampleAuthor(firstName: String = "FirstName", lastName: String = "LastName") = Author(
-        firstName,
-        lastName,
+        firstName = firstName,
+        lastName = lastName,
     )
 
     fun createExampleReview(
@@ -239,12 +241,12 @@ object DataBuilder {
         createdAt: OffsetDateTime = OffsetDateTime.now(),
         modifiedAt: OffsetDateTime? = null,
     ) = Review(
-        id,
-        projectPaperId,
-        userId,
-        decision,
-        createdAt,
-        modifiedAt,
+        id = id,
+        projectPaperId = projectPaperId,
+        userId = userId,
+        decision = decision,
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
     )
 
     fun createExampleVerificationToken(
@@ -336,5 +338,35 @@ object DataBuilder {
     ) = ReviewWithSelectedCriteriaIds(
         review = review,
         selectedCriteriaIds = selectedCriteriaIds,
+    )
+
+    fun createExampleFetcherEnqueueJob(
+        projectPaper: ProjectPaper = createExampleProjectPaper(),
+        triggeringUserId: UUID = UUID.randomUUID(),
+    ) = FetcherEnqueueJob(
+        projectPaper = projectPaper,
+        triggeringUserId = triggeringUserId,
+    )
+
+    fun createExampleFetcherPaper(
+        title: String = "Title",
+        externalId: String? = "ExternalId",
+        abstract: String = "Abstract",
+        year: Int = 2025,
+        publisher: String = "Publisher",
+        publicationType: String = "PublicationType",
+        publicationName: String = "PublicationName",
+        fetcherMetadata: Map<String, String> = emptyMap(),
+        authors: List<Author> = emptyList(),
+    ) = FetcherPaper(
+        title = title,
+        externalId = externalId,
+        abstract = abstract,
+        year = year,
+        publisher = publisher,
+        publicationType = publicationType,
+        publicationName = publicationName,
+        authors = authors,
+        metadata = fetcherMetadata,
     )
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend
 
-import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.Author
 import se.uulm.snowballr.backend.model.dto.Criterion
 import se.uulm.snowballr.backend.model.dto.InvitationToken
@@ -16,6 +15,7 @@ import se.uulm.snowballr.backend.model.dto.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.model.dto.UserSettings
 import se.uulm.snowballr.backend.model.dto.VerificationToken
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import se.uulm.snowballr.backend.table.patternOf
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.MemberRole

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -65,6 +65,9 @@ private class StructureRules {
             // Scheduler / Cron Jobs
             .layer("Scheduler")
             .definedBy("$BASE_PACKAGE.scheduler..")
+            // Fetcher
+            .layer("Fetcher")
+            .definedBy("$BASE_PACKAGE.fetcher..")
             // Checks
             .whereLayer("Input Validation")
             .mayOnlyBeAccessedByLayers("gRPC Server")
@@ -75,13 +78,15 @@ private class StructureRules {
             .whereLayer("Access")
             .mayOnlyBeAccessedByLayers("Service", "Main")
             .whereLayer("Repository")
-            .mayOnlyBeAccessedByLayers("Service", "Access", "Scheduler", "Main")
+            .mayOnlyBeAccessedByLayers("Service", "Access", "Scheduler", "Main", "Fetcher")
             .whereLayer("Table")
             .mayOnlyBeAccessedByLayers("Repository", "DB")
             .whereLayer("DB")
             .mayOnlyBeAccessedByLayers("Main", "Repository")
             .whereLayer("Scheduler")
             .mayOnlyBeAccessedByLayers("gRPC Server", "Main")
+            .whereLayer("Fetcher")
+            .mayOnlyBeAccessedByLayers("Main", "Service")
             .check(classes)
     }
 
@@ -116,17 +121,20 @@ private class StructureRules {
             // Scheduler / Cron Jobs
             .layer("Scheduler")
             .definedBy("$BASE_PACKAGE.scheduler..")
+            // Fetcher
+            .layer("Fetcher")
+            .definedBy("$BASE_PACKAGE.fetcher..")
             // Checks
             .whereLayer("Main")
             .mayNotBeAccessedByAnyLayer()
             .whereLayer("Main")
-            .mayOnlyAccessLayers("gRPC Server", "Service", "Access", "Repository", "DB", "Scheduler")
+            .mayOnlyAccessLayers("gRPC Server", "Service", "Access", "Repository", "DB", "Scheduler", "Fetcher")
             .whereLayer("Input Validation")
             .mayNotAccessAnyLayer()
             .whereLayer("gRPC Server")
             .mayOnlyAccessLayers("Service", "Input Validation", "Scheduler")
             .whereLayer("Service")
-            .mayOnlyAccessLayers("Repository", "Access")
+            .mayOnlyAccessLayers("Repository", "Access", "Fetcher")
             .whereLayer("Access")
             .mayOnlyAccessLayers("Repository")
             .whereLayer("Repository")
@@ -136,6 +144,8 @@ private class StructureRules {
             .whereLayer("DB")
             .mayOnlyAccessLayers("Table")
             .whereLayer("Scheduler")
+            .mayOnlyAccessLayers("Repository")
+            .whereLayer("Fetcher")
             .mayOnlyAccessLayers("Repository")
             .check(classes)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorEnqueueTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorEnqueueTest.kt
@@ -1,0 +1,92 @@
+package se.uulm.snowballr.backend.fetcher.orchestrator
+
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import snowballr.ProjectOuterClass.SnowballingType
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetcherOrchestratorEnqueueTest : FetcherOrchestratorTest() {
+    @Test
+    fun `When a job is enqueued without the orchestrator being started, then an IllegalStateException is thrown`() =
+        runTest {
+            val orchestrator = orchestrator(testScheduler)
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+
+            assertThrows<IllegalStateException> { orchestrator.enqueue(job) }
+        }
+
+    @Test
+    fun `When retrieving the project fails, then a TestSpecificException is thrown`() =
+        runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+
+            coEvery {
+                projectRepoMock.getProjectById(job.projectPaper.projectId)
+            } returns Result.failure(TestSpecificException())
+
+            assertThrows<TestSpecificException> { orchestrator.enqueue(job) }
+        }
+
+    @Test
+    fun `When the project's snowballing type is UNSPECIFIED, then the job is not enqueued`() =
+        runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project =
+                DataBuilder.createExampleProject(snowballingType = SnowballingType.SNOWBALLING_TYPE_UNSPECIFIED)
+
+            coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
+
+            orchestrator.enqueue(job)
+
+            // Method returns before paper existence can be checked
+            coVerify(exactly = 0) { paperRepoMock.ensurePaperExists(any()) }
+        }
+
+    @Test
+    fun `When the project's list of fetchers is empty, then the job is not enqueued`() =
+        runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project = DataBuilder.createExampleProject(fetchers = emptyMap())
+
+            coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
+
+            orchestrator.enqueue(job)
+
+            // Method returns before paper existence can be checked
+            coVerify(exactly = 0) { paperRepoMock.ensurePaperExists(any()) }
+        }
+
+    @Test
+    fun `When the origin paper doesn't exist, then a TestSpecificException is thrown`() =
+        runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project = DataBuilder.createExampleProject(fetchers = mapOf(Pair("foo", emptyMap())))
+
+            coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
+            coEvery { paperRepoMock.ensurePaperExists(job.projectPaper.projectId) } throws TestSpecificException()
+
+            assertThrows<TestSpecificException> { orchestrator.enqueue(job) }
+        }
+
+    @Test
+    fun `When the enqueue job data is valid, then the job is enqueued`() = runOrchestratorTest { orchestrator ->
+        val job = DataBuilder.createExampleFetcherEnqueueJob()
+        val project = DataBuilder.createExampleProject(fetchers = mapOf(Pair("foo", emptyMap())))
+
+        coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
+        coJustRun { paperRepoMock.ensurePaperExists(job.projectPaper.projectId) }
+        // We let this fail in the processJob method to verify that enqueuing was successful
+        coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.failure(TestSpecificException())
+
+        orchestrator.enqueue(job)
+
+        coVerify(exactly = 1) { paperRepoMock.getPaperById(job.projectPaper.paperId) }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorEnqueueTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorEnqueueTest.kt
@@ -70,7 +70,7 @@ class FetcherOrchestratorEnqueueTest : FetcherOrchestratorTest() {
             val project = DataBuilder.createExampleProject(fetchers = mapOf(Pair("foo", emptyMap())))
 
             coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
-            coEvery { paperRepoMock.ensurePaperExists(job.projectPaper.projectId) } throws TestSpecificException()
+            coEvery { paperRepoMock.ensurePaperExists(job.projectPaper.paperId) } throws TestSpecificException()
 
             assertThrows<TestSpecificException> { orchestrator.enqueue(job) }
         }
@@ -81,7 +81,7 @@ class FetcherOrchestratorEnqueueTest : FetcherOrchestratorTest() {
         val project = DataBuilder.createExampleProject(fetchers = mapOf(Pair("foo", emptyMap())))
 
         coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
-        coJustRun { paperRepoMock.ensurePaperExists(job.projectPaper.projectId) }
+        coJustRun { paperRepoMock.ensurePaperExists(job.projectPaper.paperId) }
         // We let this fail in the processJob method to verify that enqueuing was successful
         coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.failure(TestSpecificException())
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -1,0 +1,471 @@
+package se.uulm.snowballr.backend.fetcher.orchestrator
+
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
+import se.uulm.snowballr.backend.model.dto.Project
+import se.uulm.snowballr.backend.model.dto.toFetcherPaper
+import se.uulm.snowballr.backend.model.exception.FetcherException
+import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
+import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
+import se.uulm.snowballr.backend.model.isBackwardOrBoth
+import se.uulm.snowballr.backend.model.isForwardOrBoth
+import se.uulm.snowballr.backend.repository.UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE
+import se.uulm.snowballr.backend.utils.GrpcEnumSourceTest
+import snowballr.ProjectOuterClass.SnowballingType
+import java.sql.SQLException
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
+    private val exampleFetchers = mapOf(
+        "foo" to mapOf(
+            "fooOp1" to "true",
+            "fooOp2" to "10",
+        ),
+        "bar" to mapOf(
+            "barOp1" to "xyz",
+        ),
+    )
+
+    /**
+     * Calls [FetcherOrchestrator.enqueue] with mocked values.
+     */
+    private suspend fun FetcherOrchestrator.enqueueTestJob(job: FetcherEnqueueJob, project: Project) {
+        coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
+        coJustRun { paperRepoMock.ensurePaperExists(job.projectPaper.projectId) }
+
+        this.enqueue(job)
+    }
+
+    @Test
+    fun `When retrieving the origin paper fails, then no fetching is attempted`() =
+        runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+
+            coEvery {
+                paperRepoMock.getPaperById(job.projectPaper.paperId)
+            } returns Result.failure(TestSpecificException())
+
+            orchestrator.enqueueTestJob(job, project)
+
+            assertFetchingFailure()
+        }
+
+    @Test
+    fun `When a job fails, then the next job is still processed`() = runOrchestratorTest { orchestrator ->
+        val failingJob = DataBuilder.createExampleFetcherEnqueueJob()
+        val succeedingJob = DataBuilder.createExampleFetcherEnqueueJob()
+        val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+
+        coEvery {
+            paperRepoMock.getPaperById(failingJob.projectPaper.paperId)
+        } returns Result.failure(TestSpecificException())
+
+        // succeeding job proceeds at least to fetching
+        val paper = DataBuilder.createExamplePaper(id = succeedingJob.projectPaper.paperId)
+        coEvery { paperRepoMock.getPaperById(succeedingJob.projectPaper.paperId) } returns Result.success(paper)
+        coEvery { fetcherManagerMock.fetchBackwardReferences(any(), any(), any()) } returns emptySet()
+        coEvery { fetcherManagerMock.fetchForwardReferences(any(), any(), any()) } returns emptySet()
+
+        orchestrator.enqueueTestJob(failingJob, project)
+        orchestrator.enqueueTestJob(succeedingJob, project)
+
+        coVerify(atLeast = 1) { paperRepoMock.getPaperById(succeedingJob.projectPaper.paperId) }
+    }
+
+    @Nested
+    inner class RunFetching {
+        @ParameterizedTest
+        @GrpcEnumSourceTest(SnowballingType::class, excludes = ["SNOWBALLING_TYPE_UNSPECIFIED"])
+        fun `When fetching fails for all fetchers, then no papers are created or added`(type: SnowballingType) =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val fetcherName = "test"
+                val project = DataBuilder.createExampleProject(
+                    snowballingType = type,
+                    fetchers = mapOf(fetcherName to emptyMap()),
+                )
+                val paper = DataBuilder.createExamplePaper()
+                val fetcherPaper = paper.toFetcherPaper()
+
+                coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.success(paper)
+                if (type.isBackwardOrBoth()) {
+                    coEvery {
+                        fetcherManagerMock.fetchBackwardReferences(fetcherName, fetcherPaper, emptyMap())
+                    } throws FetcherException("backward fetching failed")
+                }
+                if (type.isForwardOrBoth()) {
+                    coEvery {
+                        fetcherManagerMock.fetchForwardReferences(fetcherName, fetcherPaper, emptyMap())
+                    } throws FetcherException("forward fetching failed")
+                }
+
+                orchestrator.enqueueTestJob(job, project)
+
+                if (type == SnowballingType.SNOWBALLING_TYPE_FORWARD) {
+                    coVerify(exactly = 0) { fetcherManagerMock.fetchBackwardReferences(any(), any(), any()) }
+                }
+                if (type == SnowballingType.SNOWBALLING_TYPE_BACKWARD) {
+                    coVerify(exactly = 0) { fetcherManagerMock.fetchForwardReferences(any(), any(), any()) }
+                }
+                assertPaperCreationFailure()
+            }
+
+        @ParameterizedTest
+        @GrpcEnumSourceTest(SnowballingType::class, excludes = ["SNOWBALLING_TYPE_UNSPECIFIED"])
+        fun `When fetching fails for one fetcher, then other fetchers still produce results`(type: SnowballingType) =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val fetcher1Name = "test1"
+                val fetcher2Name = "test2"
+                val project = DataBuilder.createExampleProject(
+                    snowballingType = type,
+                    fetchers = mapOf(
+                        fetcher1Name to emptyMap(),
+                        fetcher2Name to emptyMap(),
+                    ),
+                )
+                val paper = DataBuilder.createExamplePaper()
+                val fetcherPaper = paper.toFetcherPaper()
+                val fetchedPaper = DataBuilder.createExampleFetcherPaper()
+
+                coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.success(paper)
+                if (type.isBackwardOrBoth()) {
+                    coEvery {
+                        fetcherManagerMock.fetchBackwardReferences(fetcher1Name, fetcherPaper, emptyMap())
+                    } throws FetcherException("backward fetching failed")
+                    coEvery {
+                        fetcherManagerMock.fetchBackwardReferences(fetcher2Name, fetcherPaper, emptyMap())
+                    } returns setOf(fetchedPaper)
+                }
+                if (type.isForwardOrBoth()) {
+                    coEvery {
+                        fetcherManagerMock.fetchForwardReferences(fetcher1Name, fetcherPaper, emptyMap())
+                    } throws FetcherException("forward fetching failed")
+                    coEvery {
+                        fetcherManagerMock.fetchForwardReferences(fetcher2Name, fetcherPaper, emptyMap())
+                    } returns setOf(fetchedPaper)
+                }
+
+                // Stop at paper creation
+                coEvery {
+                    paperRepoMock.getPaperByExternalId(fetchedPaper.externalId.toString())
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                if (type == SnowballingType.SNOWBALLING_TYPE_FORWARD) {
+                    coVerify(exactly = 0) { fetcherManagerMock.fetchBackwardReferences(any(), any(), any()) }
+                }
+                if (type == SnowballingType.SNOWBALLING_TYPE_BACKWARD) {
+                    coVerify(exactly = 0) { fetcherManagerMock.fetchForwardReferences(any(), any(), any()) }
+                }
+                assertPaperCreationFailure()
+            }
+    }
+
+    @Nested
+    inner class RunPaperCreation {
+        @Test
+        fun `When fetched papers already exist, then they are not created again`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(externalId = "BackwardId")
+                val forwardRef = DataBuilder.createExamplePaper(externalId = "ForwardId")
+
+                mockRunFetching(job, setOf(backwardRef.toFetcherPaper()), setOf(forwardRef.toFetcherPaper()))
+                coEvery {
+                    paperRepoMock.getPaperByExternalId(backwardRef.externalId.toString())
+                } returns Result.success(backwardRef)
+                coEvery {
+                    paperRepoMock.getPaperByExternalId(forwardRef.externalId.toString())
+                } returns Result.success(forwardRef)
+
+                // Stop at paper citation
+                coEvery {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                } throws SQLException("Citing backwards failed")
+                coEvery {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                } throws SQLException("Citing forwards failed")
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                coVerify(exactly = 0) { paperRepoMock.createPaper(any(), any()) }
+                assertAddingPapersToProjectFailure()
+            }
+
+        @ParameterizedTest
+        @CsvSource("externalId", "NULL", nullValues = ["NULL"])
+        fun `When fetched papers don't already exist, then they are created`(externalId: String?) =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = externalId)
+                val backwardFetcherRef = backwardRef.toFetcherPaper()
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = externalId)
+                val forwardFetcherRef = forwardRef.toFetcherPaper()
+
+                mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+                if (externalId != null) {
+                    coEvery {
+                        paperRepoMock.getPaperByExternalId(backwardRef.externalId.toString())
+                    } returns Result.failure(TestSpecificException())
+                    coEvery {
+                        paperRepoMock.getPaperByExternalId(forwardRef.externalId.toString())
+                    } returns Result.failure(TestSpecificException())
+                }
+                coEvery {
+                    paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest(), backwardFetcherRef.metadata)
+                } returns backwardRef
+                coEvery {
+                    paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest(), forwardFetcherRef.metadata)
+                } returns forwardRef
+
+                // Stop at adding papers to project
+                coEvery {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                } throws SQLException("Citing backwards failed")
+                coEvery {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                } throws SQLException("Citing forwards failed")
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+                coVerify(exactly = 1) {
+                    paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest(), backwardFetcherRef.metadata)
+                }
+                coVerify(exactly = 1) {
+                    paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest(), forwardFetcherRef.metadata)
+                }
+            }
+
+        @Test
+        fun `When creating the DB papers fails, then no citations are created`() = runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+            val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+            val backwardFetcherRef = backwardRef.toFetcherPaper()
+            val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+            val forwardFetcherRef = forwardRef.toFetcherPaper()
+
+            mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+            coEvery {
+                paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest(), backwardFetcherRef.metadata)
+            } throws SQLException("Creating backward paper failed")
+            coEvery {
+                paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest(), forwardFetcherRef.metadata)
+            } throws SQLException("Creating forward paper failed")
+
+            orchestrator.enqueueTestJob(job, project)
+
+            assertPaperCitationFailure()
+        }
+    }
+
+    @Nested
+    inner class RunPaperCitation {
+        @Test
+        fun `When citation creation fails with a non-duplicate error, then processing continues`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+
+                mockRunPaperCreation(job, setOf(backwardRef), setOf(forwardRef))
+                coEvery {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                } throws SQLException("Citing backwards failed")
+                coEvery {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                } throws SQLException("Citing forwards failed")
+
+                // Stop at adding papers to project
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+                coVerify(exactly = 1) {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                }
+                coVerify(exactly = 1) {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                }
+            }
+
+        @Test
+        fun `When citation creation fails because of duplication, then processing continues`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+
+                mockRunPaperCreation(job, setOf(backwardRef), setOf(forwardRef))
+                coEvery {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                } throws SQLException("Citing backwards failed", UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE)
+                coEvery {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                } throws SQLException("Citing forwards failed", UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE)
+
+                // Stop at adding papers to project
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+                coVerify(exactly = 1) {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                }
+                coVerify(exactly = 1) {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                }
+            }
+
+        @Test
+        fun `When creating the citation succeeds, then the processing proceeds`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+
+                mockRunPaperCreation(job, setOf(backwardRef), setOf(forwardRef))
+                coJustRun { citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id) }
+                coJustRun { citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id) }
+
+                // Stop at adding papers to project
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+            }
+    }
+
+    @Nested
+    inner class RunAddingPapersToProject {
+        @Test
+        fun `When all papers already exist in the project, then no new papers are added to it`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+
+                mockRunPaperCitation(job, setOf(backwardRef), setOf(forwardRef))
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id) } returns true
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, forwardRef.id) } returns true
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+                coVerify(exactly = 0) { projectRepoMock.updateMaxStageIfExceeded(any(), any()) }
+            }
+
+        @Test
+        fun `When bumping the max stage fails, then no papers are added to the project`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+
+                mockRunPaperCitation(job, setOf(backwardRef), setOf(forwardRef))
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id) } returns false
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, forwardRef.id) } returns false
+                coEvery {
+                    projectRepoMock.updateMaxStageIfExceeded(project.id, job.projectPaper.stage + 1)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+            }
+
+        @Test
+        fun `When adding papers to the project fails, then then no papers are added to the project`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+                val targetStage = job.projectPaper.stage + 1
+                val baseRequest = GrpcProjectPaper.Add.newBuilder()
+                    .setProjectId(project.id.toString())
+                    .setStage(targetStage)
+                val backwardRequest = baseRequest.setPaperId(backwardRef.id.toString()).build()
+                val forwardRequest = baseRequest.setPaperId(forwardRef.id.toString()).build()
+
+                mockRunPaperCitation(job, setOf(backwardRef), setOf(forwardRef))
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id) } returns false
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, forwardRef.id) } returns false
+                coJustRun { projectRepoMock.updateMaxStageIfExceeded(project.id, targetStage) }
+                coEvery {
+                    projectPaperRepoMock.addPaperToProject(backwardRequest, job.triggeringUserId)
+                } throws SQLException("Adding backward paper to project failed")
+                coEvery {
+                    projectPaperRepoMock.addPaperToProject(forwardRequest, job.triggeringUserId)
+                } throws SQLException("Adding forward paper to project failed")
+
+                orchestrator.enqueueTestJob(job, project)
+
+                // Only the two failure calls were made
+                coVerify(exactly = 2) { projectPaperRepoMock.addPaperToProject(any(), any()) }
+            }
+
+        @Test
+        fun `When papers are not already in the project, then they are added to it`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
+                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
+                val targetStage = job.projectPaper.stage + 1
+                val baseRequest = GrpcProjectPaper.Add.newBuilder()
+                    .setProjectId(project.id.toString())
+                    .setStage(targetStage)
+                val backwardRequest = baseRequest.setPaperId(backwardRef.id.toString()).build()
+                val forwardRequest = baseRequest.setPaperId(forwardRef.id.toString()).build()
+
+                mockRunPaperCitation(job, setOf(backwardRef), setOf(forwardRef))
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id) } returns false
+                coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, forwardRef.id) } returns false
+                coJustRun { projectRepoMock.updateMaxStageIfExceeded(project.id, targetStage) }
+                coJustRun { projectPaperRepoMock.addPaperToProject(backwardRequest, job.triggeringUserId) }
+                coJustRun { projectPaperRepoMock.addPaperToProject(forwardRequest, job.triggeringUserId) }
+
+                orchestrator.enqueueTestJob(job, project)
+
+                // Two successful calls were made
+                coVerify(exactly = 2) { projectPaperRepoMock.addPaperToProject(any(), any()) }
+            }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -41,7 +41,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
      */
     private suspend fun FetcherOrchestrator.enqueueTestJob(job: FetcherEnqueueJob, project: Project) {
         coEvery { projectRepoMock.getProjectById(job.projectPaper.projectId) } returns Result.success(project)
-        coJustRun { paperRepoMock.ensurePaperExists(job.projectPaper.projectId) }
+        coJustRun { paperRepoMock.ensurePaperExists(job.projectPaper.paperId) }
 
         this.enqueue(job)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
@@ -1,0 +1,33 @@
+package se.uulm.snowballr.backend.fetcher.orchestrator
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetcherOrchestratorStartStopTest : FetcherOrchestratorTest() {
+    @Test
+    fun `When the orchestrator is started and stopped, then no exception is thrown`() = runTest {
+        val orchestrator = orchestrator(testScheduler)
+
+        assertDoesNotThrow { orchestrator.start() }
+        assertDoesNotThrow { orchestrator.stop() }
+    }
+
+    @Test
+    fun `When the orchestrator is started twice, then an IllegalStateException is thrown`() = runTest {
+        val orchestrator = orchestrator(testScheduler)
+
+        orchestrator.start()
+        assertThrows<IllegalStateException> { orchestrator.start() }
+    }
+
+    @Test
+    fun `When the orchestrator is stopped without being started, then no exception is thrown`() = runTest {
+        val orchestrator = orchestrator(testScheduler)
+
+        assertDoesNotThrow { orchestrator.stop() }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
@@ -32,15 +32,13 @@ class FetcherOrchestratorStartStopTest : FetcherOrchestratorTest() {
     }
 
     @Test
-    fun `When the orchestrator is restarted after being stopped, then no exception is thrown`() = runTest {
+    fun `When the orchestrator is started after being stopped, then an IllegalStateException is thrown`() = runTest {
         val orchestrator = orchestrator(testScheduler)
 
-        orchestrator.start()
         orchestrator.stop()
 
-        assertDoesNotThrow {
+        assertThrows<IllegalStateException> {
             orchestrator.start()
-            orchestrator.stop()
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
@@ -30,4 +30,17 @@ class FetcherOrchestratorStartStopTest : FetcherOrchestratorTest() {
 
         assertDoesNotThrow { orchestrator.stop() }
     }
+
+    @Test
+    fun `When the orchestrator is restarted after being stopped, then no exception is thrown`() = runTest {
+        val orchestrator = orchestrator(testScheduler)
+
+        orchestrator.start()
+        orchestrator.stop()
+
+        assertDoesNotThrow {
+            orchestrator.start()
+            orchestrator.stop()
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -47,11 +47,11 @@ sealed class FetcherOrchestratorTest {
     }
 
     /**
-     * Creates a [se.uulm.snowballr.backend.fetcher.FetcherOrchestrator] with the mocked dependencies and an [UnconfinedTestDispatcher] with the passed
+     * Creates a [FetcherOrchestrator] with the mocked dependencies and an [UnconfinedTestDispatcher] with the passed
      * [scheduler].
      *
-     * We use an [UnconfinedTestDispatcher] so that after [se.uulm.snowballr.backend.fetcher.FetcherOrchestrator.enqueue] returns,
-     * [se.uulm.snowballr.backend.fetcher.FetcherOrchestrator.processJob] has already processed the job, and we can verify the internal mocks.
+     * We use an [UnconfinedTestDispatcher] so that after [FetcherOrchestrator.enqueue] returns,
+     * [FetcherOrchestrator.processJob] has already processed the job, and we can verify the internal mocks.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun orchestrator(scheduler: TestCoroutineScheduler) = FetcherOrchestrator(

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -1,0 +1,148 @@
+package se.uulm.snowballr.backend.fetcher.orchestrator
+
+import io.mockk.checkUnnecessaryStub
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
+import se.uulm.snowballr.backend.fetcher.IFetcherManager
+import se.uulm.snowballr.backend.model.dto.Paper
+import se.uulm.snowballr.backend.model.dto.toFetcherPaper
+import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
+import se.uulm.snowballr.backend.repository.IPaperTableRepo
+import se.uulm.snowballr.backend.repository.IProjectTableRepo
+import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
+import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
+
+sealed class FetcherOrchestratorTest {
+    val fetcherManagerMock = mockk<IFetcherManager>()
+    val projectRepoMock = mockk<IProjectTableRepo>()
+    val paperRepoMock = mockk<IPaperTableRepo>()
+    val citationRepoMock = mockk<ICitationTableRepo>()
+    val projectPaperRepoMock = mockk<IProjectPaperTableRepo>()
+
+    private val allMocks = arrayOf(
+        fetcherManagerMock,
+        projectRepoMock,
+        paperRepoMock,
+        citationRepoMock,
+        projectPaperRepoMock,
+    )
+
+    @AfterEach
+    fun tearDownTest() {
+        checkUnnecessaryStub(*allMocks)
+        clearAllMocks()
+    }
+
+    /**
+     * Creates a [se.uulm.snowballr.backend.fetcher.FetcherOrchestrator] with the mocked dependencies and an [UnconfinedTestDispatcher] with the passed
+     * [scheduler].
+     *
+     * We use an [UnconfinedTestDispatcher] so that after [se.uulm.snowballr.backend.fetcher.FetcherOrchestrator.enqueue] returns,
+     * [se.uulm.snowballr.backend.fetcher.FetcherOrchestrator.processJob] has already processed the job, and we can verify the internal mocks.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun orchestrator(scheduler: TestCoroutineScheduler) = FetcherOrchestrator(
+        fetcherManager = fetcherManagerMock,
+        projectRepo = projectRepoMock,
+        paperRepo = paperRepoMock,
+        citationRepo = citationRepoMock,
+        projectPaperRepo = projectPaperRepoMock,
+        dispatcher = UnconfinedTestDispatcher(scheduler),
+    )
+
+    /**
+     * Wrapper for [runTest] that creates and starts a [FetcherOrchestrator], passes it to [testBody] and stops the
+     * orchestrator afterward.
+     */
+    protected fun runOrchestratorTest(testBody: suspend TestScope.(FetcherOrchestrator) -> Unit) = runTest {
+        val orchestrator = orchestrator(testScheduler)
+        orchestrator.start()
+
+        testBody(orchestrator)
+
+        orchestrator.stop()
+    }
+
+    protected fun assertFetchingFailure() {
+        coVerify(exactly = 0) { fetcherManagerMock.fetchForwardReferences(any(), any(), any()) }
+        coVerify(exactly = 0) { fetcherManagerMock.fetchBackwardReferences(any(), any(), any()) }
+
+        assertPaperCreationFailure()
+    }
+
+    protected fun assertPaperCreationFailure() {
+        coVerify(exactly = 0) { paperRepoMock.createPaper(any(), any()) }
+
+        assertPaperCitationFailure()
+    }
+
+    protected fun assertPaperCitationFailure() {
+        coVerify(exactly = 0) { citationRepoMock.addBackwardReferencedPaper(any(), any()) }
+        coVerify(exactly = 0) { citationRepoMock.addForwardReferencedPaper(any(), any()) }
+
+        assertAddingPapersToProjectFailure()
+    }
+
+    protected fun assertAddingPapersToProjectFailure() {
+        coVerify(exactly = 0) { projectPaperRepoMock.addPaperToProject(any(), any()) }
+    }
+
+    protected fun mockRunFetching(
+        job: FetcherEnqueueJob,
+        backwardRefs: Set<FetcherPaper>,
+        forwardRefs: Set<FetcherPaper>,
+    ) {
+        val paper = DataBuilder.createExamplePaper(id = job.projectPaper.paperId)
+        val fetcherPaper = paper.toFetcherPaper()
+
+        coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.success(paper)
+        coEvery {
+            fetcherManagerMock.fetchBackwardReferences(any(), fetcherPaper, any())
+        } returns backwardRefs
+        coEvery {
+            fetcherManagerMock.fetchForwardReferences(any(), fetcherPaper, any())
+        } returns forwardRefs
+    }
+
+    protected fun mockRunPaperCreation(job: FetcherEnqueueJob, backwardRefs: Set<Paper>, forwardRefs: Set<Paper>) {
+        val backwardFetcherRefs = backwardRefs.map(Paper::toFetcherPaper).toSet()
+        val forwardFetcherRefs = forwardRefs.map(Paper::toFetcherPaper).toSet()
+
+        mockRunFetching(job, backwardFetcherRefs, forwardFetcherRefs)
+        for (backwardRef in backwardRefs) {
+            val backwardFetcherRef = backwardRef.toFetcherPaper()
+            coEvery {
+                paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest(), backwardFetcherRef.metadata)
+            } returns backwardRef
+        }
+        for (forwardRef in forwardRefs) {
+            val forwardFetcherRef = forwardRef.toFetcherPaper()
+            coEvery {
+                paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest(), forwardFetcherRef.metadata)
+            } returns forwardRef
+        }
+    }
+
+    protected fun mockRunPaperCitation(job: FetcherEnqueueJob, backwardRefs: Set<Paper>, forwardRefs: Set<Paper>) {
+        mockRunPaperCreation(job, backwardRefs, forwardRefs)
+        for (backwardRef in backwardRefs) {
+            coJustRun { citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id) }
+        }
+        for (forwardRef in forwardRefs) {
+            coJustRun { citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id) }
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -36,8 +36,7 @@ import se.uulm.snowballr.backend.auth.JwtManager
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.env.Env
 import se.uulm.snowballr.backend.env.EnvReader
-import se.uulm.snowballr.backend.fetcher.IFetcherManager
-import se.uulm.snowballr.backend.fetcher.PythonPluginFetcherManager
+import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.mail.EmailManager
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.mailServiceDeps
@@ -50,7 +49,6 @@ import se.uulm.snowballr.backend.repositoryLayerDeps
 import se.uulm.snowballr.backend.service.IAuthenticationService
 import se.uulm.snowballr.backend.service.ICriterionService
 import se.uulm.snowballr.backend.service.IExportService
-import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IInvitationService
 import se.uulm.snowballr.backend.service.IPaperService
 import se.uulm.snowballr.backend.service.IProjectMemberService
@@ -74,6 +72,7 @@ open class IntegrationTest : KoinTest {
 
     protected val envReaderMock = mockk<EnvReader>()
     protected val emailManagerMock = mockk<EmailManager>()
+    protected val fetcherOrchestratorMock = mockk<IFetcherOrchestrator>()
 
     private val allMocks = arrayOf(
         envReaderMock,
@@ -83,7 +82,6 @@ open class IntegrationTest : KoinTest {
     protected val authenticationService: IAuthenticationService by inject()
     protected val criterionService: ICriterionService by inject()
     protected val exportService: IExportService by inject()
-    protected val fetcherService: IFetcherService by inject()
     protected val invitationService: IInvitationService by inject()
     protected val paperService: IPaperService by inject()
     protected val projectMemberService: IProjectMemberService by inject()
@@ -107,6 +105,9 @@ open class IntegrationTest : KoinTest {
 
         // Other mocks
         single<IEmailManager> { emailManagerMock }
+        single<IFetcherOrchestrator> { fetcherOrchestratorMock }
+        // FetcherOrchestrator is not yet part of the integration tests
+        coJustRun { fetcherOrchestratorMock.enqueue(any()) }
 
         // The other layers are the same as in production
         repositoryLayerDeps()
@@ -124,7 +125,6 @@ open class IntegrationTest : KoinTest {
             createdAtStart()
             bind<IJwtManager>()
         }
-        single<IFetcherManager> { PythonPluginFetcherManager(get()) }
         singleOf(::CookieManager) { bind<ICookieManager>() }
         singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryHelper.kt
@@ -6,8 +6,8 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import se.uulm.snowballr.backend.db.IDatabase
-import se.uulm.snowballr.backend.fetcher.FetcherMap
 import se.uulm.snowballr.backend.model.dto.Author
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import se.uulm.snowballr.backend.table.CriterionTable
 import se.uulm.snowballr.backend.table.InvitationTokenTable
 import se.uulm.snowballr.backend.table.PaperTable

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -18,6 +18,7 @@ import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.Review
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
+import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import snowballr.CriterionOuterClass.CriterionCategory
 import snowballr.ProjectOuterClass.PaperDecision
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix.Pattern
@@ -116,6 +117,9 @@ class CreateReviewTest : ReviewServiceTest() {
         } returns selectedCriteriaIds
         coEvery { criterionRepoMock.getAllProjectCriteria(project.id) } returns emptyList()
         coJustRun { projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, updatedPaperDecision) }
+        if (updatedPaperDecision == PaperDecision.PAPER_DECISION_ACCEPTED) {
+            coJustRun { fetcherOrchestratorMock.enqueue(FetcherEnqueueJob(projectPaper, currentUser.id)) }
+        }
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IReviewAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
+import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.model.dto.User
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -29,6 +30,7 @@ sealed class ReviewServiceTest : BaseServiceTest() {
     val reviewHasCriterionRepoMock = mockk<IReviewHasCriterionTableRepo>()
     val reviewAccessCheckerMock = mockk<IReviewAccessChecker>()
     val projectAccessCheckerMock = mockk<IProjectAccessChecker>()
+    val fetcherOrchestratorMock = mockk<IFetcherOrchestrator>()
 
     private val allMocks = arrayOf(
         reviewRepoMock,
@@ -39,6 +41,7 @@ sealed class ReviewServiceTest : BaseServiceTest() {
         reviewHasCriterionRepoMock,
         reviewAccessCheckerMock,
         projectAccessCheckerMock,
+        fetcherOrchestratorMock,
     )
 
     val service = ReviewService(
@@ -50,6 +53,7 @@ sealed class ReviewServiceTest : BaseServiceTest() {
         reviewHasCriterionRepo = reviewHasCriterionRepoMock,
         accessChecker = reviewAccessCheckerMock,
         projectAccessChecker = projectAccessCheckerMock,
+        fetcherOrchestrator = fetcherOrchestratorMock,
     )
 
     override fun getAllMocks(): Array<Any> = allMocks

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -21,6 +21,7 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
     * [Linting](#linting)
   * [Release procedure](#release-procedure)
   * [Use another API Version](#use-another-api-version)
+  * [Fetcher Orchestration Progress](#fetcher-orchestration-progress)
 <!-- TOC -->
 <!-- @formatter:on -->
 <!-- markdownlint-enable MD007 -->
@@ -327,3 +328,17 @@ To use another API version than the currently used one, go to the `build.gradle.
 `apiVersion` variable to the desired version. Make sure that the version exists in the
 [API repository](https://github.com/SE-UUlm/snowballr-api). After changing the version, recompile the code using
 `./gradlew compileKotlin`.
+
+## Fetcher Orchestration Progress
+
+* [x] Jobs for fetching references can be enqueued
+* [x] Jobs are processed sequentially
+* [x] References are fetched for each fetcher configured in the project
+* [ ] Fetching results are merged and filtered (no duplicated data)
+* [ ] If fetched paper matches DB paper, paper in DB is updated and no new one is created (only checks externalId yet)
+* [x] Non-existent papers are added to the DB
+* [x] Citation references are stored in DB
+* [x] Papers that are not already in another stage are added to the target stage
+* [x] `maxStage` of the project is bumped if necessary
+* [ ] Logging in job processing contains unique job ID (MDC)
+* [x] Failed jobs are caught and discarded so the consumer loop continues


### PR DESCRIPTION
Closes #441 

## What I have made

This adds the initial version of the fetcher orchestrator as planned.
This implementation will be subject to future changes. For now, manual testing is not quite possible. First, https://github.com/SE-UUlm/snowballr-frontend/pull/516 needs to be finished to initially add some papers to the project, which then can trigger the orchestrator.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have manually tested my changes~~ (not possible yet, as mentioned above)
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
