### PR TITLE
Create necessary repo calls for Fetcher Orchestration

### DIFF
--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -62,7 +62,6 @@ jobs:
 
             - name: Upload coverage report
               uses: actions/upload-artifact@v7
-              if: ${{ !cancelled() }}
               with:
                   name: coverage-report
                   path: ${{ github.workspace }}/build/coverageXml/report.xml

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.model.dto
 
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.table.PaperTable
 import snowballr.paper
 import java.time.OffsetDateTime
@@ -20,7 +21,7 @@ data class Paper(
     val publicationName: String,
     val pdfId: UUID?,
     val authors: List<Author>,
-    val fetcherMetadata: Map<String, String>,
+    val fetcherMetadata: FetcherMetadata,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
     val modifiedBy: UUID?,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherMetadata.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherMetadata.kt
@@ -1,0 +1,6 @@
+package se.uulm.snowballr.backend.model.fetcher
+
+/**
+ * A map of metadata used by fetchers. For example, API-related unique IDs for later use.
+ */
+typealias FetcherMetadata = Map<String, String>

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -9,6 +9,7 @@ import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toAuthor
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.toPaper
@@ -50,8 +51,10 @@ interface IPaperTableRepo {
 
     /**
      * Creates a new paper in the database with the provided values.
+     *
+     * Optionally, a map of [FetcherMetadata] can be passed.
      */
-    suspend fun createPaper(request: GrpcPaper): Paper
+    suspend fun createPaper(request: GrpcPaper, metadata: FetcherMetadata = emptyMap()): Paper
 
     /**
      * Updates an existing paper in the database with the provided new values.
@@ -103,7 +106,7 @@ class PaperTableRepo(
         PaperTable.doesEntityExist { PaperTable.externalId eq externalId }
     }
 
-    override suspend fun createPaper(request: GrpcPaper): Paper = db.query {
+    override suspend fun createPaper(request: GrpcPaper, metadata: FetcherMetadata): Paper = db.query {
         PaperTable.insertAndGet(ResultRow::toPaper) {
             it[title] = request.title
             it[externalId] = request.externalId.ifBlank { null }
@@ -113,6 +116,7 @@ class PaperTableRepo(
             it[publicationName] = request.publicationName
             it[publicationType] = request.publicationType
             it[authors] = request.authorsList.map(GrpcAuthor::toAuthor)
+            it[fetcherMetadata] = metadata
             it[createdAt] = OffsetDateTime.now()
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepo.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.statements.UpdateStatement
@@ -143,6 +144,14 @@ interface IProjectTableRepo {
      * entity.
      */
     suspend fun hardDeleteClearedProjects()
+
+    /**
+     * Ensures that the max stage of the project is greater than or equal to the passed [stage].
+     *
+     * If the max stage of the project is lower than [stage] then the project value is updated; otherwise nothing
+     * happens.
+     */
+    suspend fun updateMaxStageIfExceeded(projectId: UUID, stage: Long)
 }
 
 /**
@@ -282,6 +291,14 @@ class ProjectTableRepo(
 
         logger.info {
             "Hard-deleted ${successfulDeletedIds.size} projects, failed to delete ${failedToDeleteIds.size} projects."
+        }
+    }
+
+    override suspend fun updateMaxStageIfExceeded(projectId: UUID, stage: Long) {
+        db.query {
+            ProjectTable.update({ (ProjectTable.id eq projectId) and (ProjectTable.maxStage less stage) }) {
+                it[ProjectTable.maxStage] = stage
+            }
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/SqlStateHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/SqlStateHelper.kt
@@ -1,0 +1,8 @@
+package se.uulm.snowballr.backend.repository
+
+import java.sql.SQLException
+
+/**
+ * Checks whether this [SQLException] is thrown due to a unique constraint violation.
+ */
+fun SQLException.isUniqueConstraintViolation() = this.sqlState == "23505"

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepo.kt
@@ -1,6 +1,7 @@
 package se.uulm.snowballr.backend.repository.association
 
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.table.association.CitationTable
@@ -23,6 +24,16 @@ interface ICitationTableRepo {
      * Returns the forward references of a paper by its ID.
      */
     suspend fun getForwardReferencedPaperIdsOfPaperById(id: UUID): List<UUID>
+
+    /**
+     * Adds a backward reference: records that paper [id] cites [referencedPaperId].
+     */
+    suspend fun addBackwardReferencedPaper(id: UUID, referencedPaperId: UUID)
+
+    /**
+     * Adds a forward reference: records that paper [citingPaperId] cites paper [id].
+     */
+    suspend fun addForwardReferencedPaper(id: UUID, citingPaperId: UUID)
 }
 
 /**
@@ -51,5 +62,20 @@ class CitationTableRepo(
             .where { CitationTable.citedPaperId eq id }
             .map { it[CitationTable.paperId].value }
             .toList()
+    }
+
+    override suspend fun addBackwardReferencedPaper(id: UUID, referencedPaperId: UUID) =
+        addReferencedPaper(id, referencedPaperId)
+
+    override suspend fun addForwardReferencedPaper(id: UUID, citingPaperId: UUID) =
+        addReferencedPaper(citingPaperId, id)
+
+    private suspend fun addReferencedPaper(citingPaperId: UUID, citedPaperId: UUID) {
+        db.query {
+            CitationTable.insert {
+                it[CitationTable.paperId] = citingPaperId
+                it[CitationTable.citedPaperId] = citedPaperId
+            }
+        }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
-import org.postgresql.util.HStoreConverter
 import se.uulm.snowballr.backend.table.columntypes.HStoreColumnType
 import se.uulm.snowballr.backend.table.columntypes.ObfuscatedTextColumnType
 import se.uulm.snowballr.backend.table.columntypes.RedactedBinaryColumnType
@@ -66,19 +65,3 @@ fun Table.redactedBinary(name: String) = registerColumn(name, RedactedBinaryColu
  * The order of the key-value pairs is not guaranteed.
  */
 fun Table.stringMap(name: String): Column<Map<String, String>> = registerColumn(name, HStoreColumnType())
-    .transform(
-        wrap = {
-            // HStore -> Map
-            it.trim('{', '}')
-                .split(", ")
-                .filter(String::isNotEmpty)
-                .associate { pair ->
-                    val (left, right) = pair.split('=')
-                    left to right
-                }
-        },
-        unwrap = {
-            // Map -> HStore
-            HStoreConverter.toString(it)
-        },
-    )

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.table
 
-import arrow.core.mapValuesNotNull
 import org.jetbrains.exposed.v1.core.BasicBinaryColumnType
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ReferenceOption
@@ -60,17 +59,23 @@ fun Table.redactedBinary(name: String) = registerColumn(name, RedactedBinaryColu
 
 /**
  * Stores a Map<String, String> inside an [HStoreColumnType]. Unallowed characters are automatically escaped.
+ *
+ * The order of the key-value pairs is not guaranteed.
  */
-fun Table.stringMap(name: String): Column<Map<String, String>> = registerColumn(
-    name,
-    HStoreColumnType(),
-).transform(
-    wrap = {
-        HStoreConverter
-            .fromString(it.trim('{', '}'))
-            .mapValuesNotNull { entry -> entry.value }
-    },
-    unwrap = {
-        HStoreConverter.toString(it)
-    },
-)
+fun Table.stringMap(name: String): Column<Map<String, String>> = registerColumn(name, HStoreColumnType())
+    .transform(
+        wrap = {
+            // HStore -> Map
+            it.trim('{', '}')
+                .split(", ")
+                .filter(String::isNotEmpty)
+                .associate { pair ->
+                    val (left, right) = pair.split('=')
+                    left to right
+                }
+        },
+        unwrap = {
+            // Map -> HStore
+            HStoreConverter.toString(it)
+        },
+    )

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/ColumnHelper.kt
@@ -7,6 +7,9 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
 import org.postgresql.util.HStoreConverter
+import se.uulm.snowballr.backend.table.columntypes.HStoreColumnType
+import se.uulm.snowballr.backend.table.columntypes.ObfuscatedTextColumnType
+import se.uulm.snowballr.backend.table.columntypes.RedactedBinaryColumnType
 import java.time.OffsetDateTime
 
 /** Common column definition for a user reference */
@@ -30,7 +33,7 @@ fun Table.modifiedAt() = timestampWithTimeZone("modified_at").nullable()
 /**
  * Nullable reference to the user who modified the entity.
  *
- * - `onDelete=RESTRICT` so that no user can be deleted who is referenced by a entity
+ * - `onDelete=RESTRICT` so that no user can be deleted who is referenced by an entity
  * - `onUpdate=CASCADE` so that when the user ID is updated, the foreign key ID is updated too
  */
 fun Table.modifiedBy() = userReference("modified_by", ReferenceOption.RESTRICT, ReferenceOption.CASCADE).nullable()

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/HStoreColumnType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/HStoreColumnType.kt
@@ -19,4 +19,6 @@ class HStoreColumnType : TextColumnType() {
         }
         super.setParameter(stmt, index, parameterValue)
     }
+
+    override fun valueToString(value: String?) = "'${super.valueToString(value)}'"
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/PaperTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/PaperTable.kt
@@ -20,7 +20,9 @@ import java.time.OffsetDateTime
  * - [publisher]: Represents the publisher of the paper as a nullable [String].
  * - [publicationType]: Represents the type of publication as a nullable [String].
  * - [publicationName]: Represents the name of the publication where the paper is published, as a nullable [String].
+ * - [authors]: Represents the authors of the paper as list of [Author].
  * - [pdfId]: Represents a reference to the [PdfTable] where the PDF data for the paper is stored.
+ * - [fetcherMetadata]: Represents metadata used by fetchers as a [Map].
  * - [createdAt]: Represents the timestamp of when the paper was created as an [OffsetDateTime].
  * - [modifiedAt]: Represents the timestamp of when the paper was last modified as an [OffsetDateTime].
  * - [modifiedBy]: A foreign key referencing the user table, representing the user who last modified the paper.

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/HStoreColumnType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/HStoreColumnType.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.table
+package se.uulm.snowballr.backend.table.columntypes
 
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.statements.api.PreparedStatementApi

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/HStoreColumnType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/HStoreColumnType.kt
@@ -1,24 +1,26 @@
 package se.uulm.snowballr.backend.table.columntypes
 
-import org.jetbrains.exposed.v1.core.TextColumnType
-import org.jetbrains.exposed.v1.core.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.v1.core.ColumnType
+import org.postgresql.util.HStoreConverter
 import org.postgresql.util.PGobject
 
 /**
  * Uses PostgreSQL's HSTORE extension to store key-value pairs in a single column.
  */
-class HStoreColumnType : TextColumnType() {
+class HStoreColumnType : ColumnType<Map<String, String>>() {
     override fun sqlType(): String = "HSTORE"
 
-    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
-        val parameterValue: PGobject? = value?.let {
-            PGobject().apply {
-                type = sqlType()
-                this.value = value as? String
-            }
-        }
-        super.setParameter(stmt, index, parameterValue)
+    @Suppress("UNCHECKED_CAST", "NullableToStringCall")
+    override fun valueFromDB(value: Any): Map<String, String> = if (value is Map<*, *>) {
+        value as Map<String, String>
+    } else {
+        error("Unexpected value type for HSTORE column: ${value::class.simpleName}")
     }
 
-    override fun valueToString(value: String?) = "'${super.valueToString(value)}'"
+    override fun notNullValueToDB(value: Map<String, String>): PGobject = PGobject().apply {
+        type = sqlType()
+        this.value = HStoreConverter.toString(value)
+    }
+
+    override fun valueToString(value: Map<String, String>?): String = "'${super.valueToString(value)}'"
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/ObfuscatedTextColumnType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/ObfuscatedTextColumnType.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.table
+package se.uulm.snowballr.backend.table.columntypes
 
 import org.jetbrains.exposed.v1.core.TextColumnType
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/RedactedBinaryColumnType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/columntypes/RedactedBinaryColumnType.kt
@@ -1,4 +1,4 @@
-package se.uulm.snowballr.backend.table
+package se.uulm.snowballr.backend.table.columntypes
 
 import org.jetbrains.exposed.v1.core.BasicBinaryColumnType
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -207,6 +207,7 @@ private class NamingConventions {
             .haveNameMatching(".*TableRepo.*")
             .orShould(haveNameMatching(".*RepoHelperKt.*")) // exception
             .orShould(haveNameMatching(".*RepoResultHelperKt.*")) // exception
+            .orShould(haveSimpleName("SqlStateHelperKt")) // exception
             .because("All repositories should have the 'TableRepo' suffix")
             .check(classes)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -209,6 +209,23 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
 
                 assertNull(createdPaper.externalId)
             }
+
+        @Test
+        fun `When a paper is created with fetcher metadata, then the metadata is persisted`() = runTest {
+            val request = getExamplePaperRequest()
+            val metadata = mapOf(
+                "id" to UUID.randomUUID().toString(),
+                "foo" to "bar",
+            )
+
+            val createdPaper = repo.createPaper(request, metadata)
+
+            assertEquals(metadata.size, createdPaper.fetcherMetadata.size)
+            for ((key, value) in metadata) {
+                val actual = createdPaper.fetcherMetadata[key]
+                assertEquals(value, actual)
+            }
+        }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ProjectTableRepoTest.kt
@@ -720,4 +720,37 @@ class ProjectTableRepoTest :
                 assertEquals(ProjectStatus.PROJECT_STATUS_UNSPECIFIED, project.status)
             }
     }
+
+    @Nested
+    inner class UpdateMaxStageIfExceeded {
+        @Test
+        fun `When the max stage is updated to a lower value, then the max stage stays the same`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 12)
+
+            repo.updateMaxStageIfExceeded(projectId, 9)
+            val project = repo.getProjectById(projectId).getOrThrow()
+
+            assertEquals(12, project.maxStage)
+        }
+
+        @Test
+        fun `When the max stage is updated to a greater value, then the value is updated`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 42)
+
+            repo.updateMaxStageIfExceeded(projectId, 43)
+            val project = repo.getProjectById(projectId).getOrThrow()
+
+            assertEquals(43, project.maxStage)
+        }
+
+        @Test
+        fun `When the max stage is updated to the equal value, then the max stage stays the same`() = runTest {
+            val projectId = insertProjectAndGetId(createdBy = testUserId, maxStage = 3)
+
+            repo.updateMaxStageIfExceeded(projectId, 3)
+            val project = repo.getProjectById(projectId).getOrThrow()
+
+            assertEquals(3, project.maxStage)
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryTest
+import se.uulm.snowballr.backend.repository.isUniqueConstraintViolation
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.CitationTable
 import java.sql.SQLException
 import java.util.UUID
+import kotlin.test.assertTrue
 
 class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable), false) {
     private val repo = CitationTableRepo(db)
@@ -119,7 +121,8 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
 
             repo.addBackwardReferencedPaper(paperId, referencedPaperId)
 
-            assertThrows<SQLException> { repo.addBackwardReferencedPaper(paperId, referencedPaperId) }
+            val ex = assertThrows<SQLException> { repo.addBackwardReferencedPaper(paperId, referencedPaperId) }
+            assertTrue(ex.isUniqueConstraintViolation())
         }
     }
 
@@ -143,7 +146,8 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
 
             repo.addForwardReferencedPaper(paperId, citingPaperId)
 
-            assertThrows<SQLException> { repo.addForwardReferencedPaper(paperId, citingPaperId) }
+            val ex = assertThrows<SQLException> { repo.addForwardReferencedPaper(paperId, citingPaperId) }
+            assertTrue(ex.isUniqueConstraintViolation())
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
@@ -5,10 +5,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryTest
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.CitationTable
+import java.sql.SQLException
 import java.util.UUID
 
 class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable), false) {
@@ -26,7 +28,10 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
         @Test
         fun `When a paper has no backward references, then none are returned`() = runTest {
             val paperId = insertPaperAndGetId()
-            assertThat(repo.getBackwardsReferencedPaperIdsOfPaperById(paperId)).isEmpty()
+
+            val backwardReferencedPaperIds = repo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
+
+            assertThat(backwardReferencedPaperIds).isEmpty()
         }
 
         @Test
@@ -34,7 +39,9 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
             val paperId = insertPaperAndGetId()
             val paperId2 = insertPaperAndGetId(externalId = "ExternalId2")
             addCitation(paperId, paperId2)
+
             val actualReferences = repo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
+
             assertThat(actualReferences).hasSize(1)
             assertThat(actualReferences).containsExactly(paperId2)
         }
@@ -46,7 +53,9 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
             val paperId3 = insertPaperAndGetId(externalId = "ExternalId3")
             addCitation(paperId, paperId2)
             addCitation(paperId, paperId3)
+
             val actualReferences = repo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
+
             assertThat(actualReferences).hasSize(2)
             assertThat(actualReferences).containsExactlyInAnyOrder(paperId2, paperId3)
         }
@@ -57,7 +66,10 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
         @Test
         fun `When a paper has no forward references, then none are returned`() = runTest {
             val paperId = insertPaperAndGetId()
-            assertThat(repo.getForwardReferencedPaperIdsOfPaperById(paperId)).isEmpty()
+
+            val forwardReferencedPaperIds = repo.getForwardReferencedPaperIdsOfPaperById(paperId)
+
+            assertThat(forwardReferencedPaperIds).isEmpty()
         }
 
         @Test
@@ -65,7 +77,9 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
             val paperId = insertPaperAndGetId()
             val citedPaperId = insertPaperAndGetId(externalId = "ExternalId2")
             addCitation(paperId, citedPaperId)
+
             val actualReferences = repo.getForwardReferencedPaperIdsOfPaperById(citedPaperId)
+
             assertThat(actualReferences).hasSize(1)
             assertThat(actualReferences).containsExactly(paperId)
         }
@@ -77,9 +91,59 @@ class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable),
             val citedPaperId = insertPaperAndGetId(externalId = "ExternalId3")
             addCitation(paperId, citedPaperId)
             addCitation(paperId2, citedPaperId)
+
             val actualReferences = repo.getForwardReferencedPaperIdsOfPaperById(citedPaperId)
+
             assertThat(actualReferences).hasSize(2)
             assertThat(actualReferences).containsExactlyInAnyOrder(paperId, paperId2)
+        }
+    }
+
+    @Nested
+    inner class AddBackwardReferencedPaper {
+        @Test
+        fun `When adding a backward reference, then it appears in the backward references`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val referencedPaperId = insertPaperAndGetId(externalId = "ExternalId2")
+
+            repo.addBackwardReferencedPaper(paperId, referencedPaperId)
+
+            val actualReferences = repo.getBackwardsReferencedPaperIdsOfPaperById(paperId)
+            assertThat(actualReferences).containsExactly(referencedPaperId)
+        }
+
+        @Test
+        fun `When adding the same backward reference twice, then an SQLException is thrown`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val referencedPaperId = insertPaperAndGetId(externalId = "ExternalId2")
+
+            repo.addBackwardReferencedPaper(paperId, referencedPaperId)
+
+            assertThrows<SQLException> { repo.addBackwardReferencedPaper(paperId, referencedPaperId) }
+        }
+    }
+
+    @Nested
+    inner class AddForwardReferencedPaper {
+        @Test
+        fun `When adding a forward reference, then it appears in the forward references`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val citingPaperId = insertPaperAndGetId(externalId = "ExternalId2")
+
+            repo.addForwardReferencedPaper(paperId, citingPaperId)
+
+            val actualReferences = repo.getForwardReferencedPaperIdsOfPaperById(paperId)
+            assertThat(actualReferences).containsExactly(citingPaperId)
+        }
+
+        @Test
+        fun `When adding the same forward reference twice, then an SQLException is thrown`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val citingPaperId = insertPaperAndGetId(externalId = "ExternalId2")
+
+            repo.addForwardReferencedPaper(paperId, citingPaperId)
+
+            assertThrows<SQLException> { repo.addForwardReferencedPaper(paperId, citingPaperId) }
         }
     }
 }


### PR DESCRIPTION
Closes #493

## What I have made

Added calls:
- `updateMaxStageIfExceeded` -> bump max stage if necessary
- `addBackwardsReferencedPaper` -> add reference for newly fetched papers
- `addForwardReferencedPaper` -> add reference for newly fetched papers

Changed calls:
- `createPaper` -> now accepts `metadata` parameter

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [ ] I have checked the changes against the requirements
