### PR TITLE
Improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Build output
+build/
+.gradle/
+
+# Git internals
+.git/
+
+# DB data volume
+db-data/
+
+# Test sources (Dockerfile only copies src/main)
+src/test/
+
+# Gradle wrapper (not used in Docker build)
+gradlew
+gradlew.bat
+
+# Docker files
+docker-compose.yml
+Dockerfile
+Dockerfile.proxy
+
+# CI/CD
+.github/
+
+# Documentation
+README.md
+CHANGELOG.md
+LICENSE
+wiki/
+images/
+
+# Dev tooling config
+detekt-baseline.xml
+detekt.yml
+markdownlint.json
+
+# Scripts and tooling
+scripts/
+
+# Plugin volume mount
+plugins/
+
+# IDE
+.idea/
+
+# AI
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# Stage 1: Build the application
-FROM gradle:9.3.1-jdk21-alpine AS build
-
 # Asset IDs of v0.4.38 release of grpc-health-probe
 # https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.38
 ARG AMD64_ID=251600596
 ARG ARM64_ID=251600609
 
+# Stage 1: Build the application
+FROM gradle:9.3.1-jdk21-alpine AS build
+
 WORKDIR /app
 
-RUN apk add libc6-compat curl
+RUN apk add libc6-compat
 
 # Copy build files only — dependency resolution re-runs only when these change
 COPY build.gradle.kts settings.gradle.kts gradle.properties ./
@@ -23,8 +23,14 @@ COPY src/main src/main
 RUN --mount=type=cache,target=/root/.gradle \
     gradle shadowJar --no-daemon --stacktrace
 
-# Download binaries of grpc-health-probe based on the architecture and make them executable
-RUN ARCH=$(uname -m) && \
+# Stage 2: Download grpc-health-probe (runs in parallel with build)
+FROM alpine:3.21 AS grpc-health-probe
+
+ARG AMD64_ID
+ARG ARM64_ID
+
+RUN apk add --no-cache curl && \
+    ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
       export ASSET_ID=${AMD64_ID}; \
     elif [ "$ARCH" = "aarch64" ]; then \
@@ -37,13 +43,13 @@ RUN ARCH=$(uname -m) && \
       -H "Accept:application/octet-stream" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       https://api.github.com/repos/grpc-ecosystem/grpc-health-probe/releases/assets/${ASSET_ID} \
-      -o grpc_health_probe \
-    && chmod +x grpc_health_probe
+      -o /grpc_health_probe \
+    && chmod +x /grpc_health_probe
 
-# Stage 2: Provide uv binary
+# Stage 3: Provide uv binary
 FROM ghcr.io/astral-sh/uv:0.11.7 AS uv
 
-# Stage 3: Run the application
+# Stage 4: Run the application
 FROM eclipse-temurin:21-jre-alpine-3.21 AS final
 
 WORKDIR /app
@@ -53,7 +59,7 @@ RUN adduser -D backend-user
 # Copy built jar file
 COPY --chown=backend-user:backend-user --from=build /app/build/libs/snowballr-backend-*.jar app.jar
 # Copy grpc_health_probe
-COPY --chown=backend-user:backend-user --from=build /app/grpc_health_probe grpc_health_probe
+COPY --chown=backend-user:backend-user --from=grpc-health-probe /grpc_health_probe grpc_health_probe
 COPY --from=uv /uv /bin/uv
 
 ENV PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=uv /uv /bin/uv
 
 ENV PORT=8080
 ENV PLUGIN_DIRECTORY=/app/plugins/
-ENV PYTHON_EXECUTABLE=/app/venv/bin/python3
+ENV PYTHON_EXECUTABLE=/app/.venv/bin/python3
 
 VOLUME /app/plugins/
 
@@ -66,11 +66,12 @@ HEALTHCHECK CMD ./grpc_health_probe -addr=localhost:${PORT} -service "snowballr.
 # Install python and fetcher dependencies using uv
 COPY requirements.txt .
 RUN apk add --no-cache python3 libcurl
-RUN uv venv /app/venv
+RUN uv venv /app/.venv
 # Needed for pycurl
 ENV PYCURL_SSL_LIBRARY=openssl
 RUN apk add --no-cache --virtual .py-build-deps python3-dev build-base curl-dev
-RUN uv pip sync --python /app/venv/bin/python3 requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip sync --python /app/.venv/bin/python requirements.txt
 RUN apk del .py-build-deps
 
 # Run the application as a non-root user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM gradle:9.3.1-jdk21-alpine AS build
 
 WORKDIR /app
 
+# libc6-compat: provide glibc compatibility for prebuilt binaries
 RUN apk add libc6-compat
 
 # Copy build files only — dependency resolution re-runs only when these change
@@ -29,6 +30,7 @@ FROM alpine:3.21 AS grpc-health-probe
 ARG AMD64_ID
 ARG ARM64_ID
 
+# Download binaries of grpc-health-probe based on the architecture and make them executable
 RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,20 @@ ARG ARM64_ID=251600609
 
 WORKDIR /app
 
-# Copy the Gradle wrapper files
-COPY gradlew .
+RUN apk add libc6-compat curl
+
+# Copy build files only — dependency resolution re-runs only when these change
+COPY build.gradle.kts settings.gradle.kts ./
 COPY gradle gradle
-COPY build.gradle.kts .
-COPY settings.gradle.kts .
 
-# Copy the project's source code and proto files
+# Resolve and cache all dependencies before copying source
+RUN --mount=type=cache,target=/root/.gradle \
+    gradle dependencies --no-daemon
+
+# Copy the project's source code and proto files and build
 COPY src/main src/main
-
-# Grant execution rights to the Gradle wrapper script and build the jar file
-RUN apk add libc6-compat \
-    && chmod +x gradlew \
-    && ./gradlew shadowJar --no-daemon --stacktrace
-
-# Install curl utility
-RUN apk add curl
+RUN --mount=type=cache,target=/root/.gradle \
+    gradle shadowJar --no-daemon --stacktrace
 
 # Download binaries of grpc-health-probe based on the architecture and make them executable
 RUN ARCH=$(uname -m) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,12 @@ FROM eclipse-temurin:21-jre-alpine-3.21 AS final
 
 WORKDIR /app
 
+RUN adduser -D backend-user
+
 # Copy built jar file
-COPY --from=build /app/build/libs/snowballr-backend-*.jar app.jar
+COPY --chown=backend-user:backend-user --from=build /app/build/libs/snowballr-backend-*.jar app.jar
 # Copy grpc_health_probe
-COPY --from=build /app/grpc_health_probe grpc_health_probe
+COPY --chown=backend-user:backend-user --from=build /app/grpc_health_probe grpc_health_probe
 COPY --from=uv /uv /bin/uv
 
 ENV PORT=8080
@@ -64,7 +66,7 @@ VOLUME /app/plugins/
 HEALTHCHECK CMD ./grpc_health_probe -addr=localhost:${PORT} -service "snowballr.SnowballR"
 
 # Install python and fetcher dependencies using uv
-COPY requirements.txt .
+COPY --chown=backend-user:backend-user requirements.txt .
 RUN apk add --no-cache python3 libcurl
 RUN uv venv /app/.venv
 # Needed for pycurl
@@ -72,10 +74,8 @@ ENV PYCURL_SSL_LIBRARY=openssl
 RUN apk add --no-cache --virtual .py-build-deps python3-dev build-base curl-dev
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip sync --python /app/.venv/bin/python requirements.txt
-RUN apk del .py-build-deps
+RUN apk del .py-build-deps && chown -R backend-user /app/.venv
 
-# Run the application as a non-root user.
-RUN adduser -D backend-user && chown -R backend-user /app
 USER backend-user
 
 # Start execute the jar file when starting the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 RUN apk add libc6-compat curl
 
 # Copy build files only — dependency resolution re-runs only when these change
-COPY build.gradle.kts settings.gradle.kts ./
+COPY build.gradle.kts settings.gradle.kts gradle.properties ./
 COPY gradle gradle
 
 # Resolve and cache all dependencies before copying source

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,20 +58,11 @@ WORKDIR /app
 
 RUN adduser -D backend-user
 
-# Copy built jar file
-COPY --chown=backend-user:backend-user --from=build /app/build/libs/snowballr-backend-*.jar app.jar
-# Copy grpc_health_probe
-COPY --chown=backend-user:backend-user --from=grpc-health-probe /grpc_health_probe grpc_health_probe
 COPY --from=uv /uv /bin/uv
 
 ENV PORT=8080
 ENV PLUGIN_DIRECTORY=/app/plugins/
 ENV PYTHON_EXECUTABLE=/app/.venv/bin/python3
-
-VOLUME /app/plugins/
-
-# Healthcheck uses grpc-health-probe
-HEALTHCHECK CMD ./grpc_health_probe -addr=localhost:${PORT} -service "snowballr.SnowballR"
 
 # Install python and fetcher dependencies using uv
 COPY --chown=backend-user:backend-user requirements.txt .
@@ -83,6 +74,15 @@ RUN apk add --no-cache --virtual .py-build-deps python3-dev build-base curl-dev
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip sync --python /app/.venv/bin/python requirements.txt
 RUN apk del .py-build-deps && chown -R backend-user /app/.venv
+
+VOLUME /app/plugins/
+
+# Healthcheck uses grpc-health-probe
+HEALTHCHECK CMD ./grpc_health_probe -addr=localhost:${PORT} -service "snowballr.SnowballR"
+
+# Copy build artifacts last — source changes only invalidate layers below this point
+COPY --chown=backend-user:backend-user --from=build /app/build/libs/snowballr-backend-*.jar app.jar
+COPY --chown=backend-user:backend-user --from=grpc-health-probe /grpc_health_probe grpc_health_probe
 
 USER backend-user
 


### PR DESCRIPTION
Closes #495

## What I have made

Consider reviewing this commit by commit.

There were major flaws in our Dockerfile, this should fix the worst:
- using gradle instead of gradle wrapper and not downloading it every time (use already existing binaries)
- adding proper .dockerignore
- also copying gradle.properties (not essential now, but if there were required properties, this would lead to issues)
- using cache mount for uv
- instead of adding rights to the non-root user at the end, we can just add them while copying the files into the image
- grpc health probe is downloaded in parallel

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only Docker image changes)

### Reviewer

- [x] I have checked the changes against the requirements
