### PR TITLE
Editing fetcher options fails due to missing typing extensions in plugin environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,5 @@ SMTP_SENDER_NAME=Example
 SMTP_SENDER_EMAIL=noreply@example.com
 
 # Plugins
-PLUGIN_DIRECTORY=./plugins
+PLUGIN_DIRECTORY=plugins
 PYTHON_EXECUTABLE=.venv/bin/python3

--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,4 @@ SMTP_SENDER_EMAIL=noreply@example.com
 
 # Plugins
 PLUGIN_DIRECTORY=./plugins
-PYTHON_EXECUTABLE=python3
+PYTHON_EXECUTABLE=.venv/bin/python3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
             SMTP_SENDER_NAME: ${SMTP_SENDER_NAME:-}
             SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
             SENSITIVE_INFORMATION_RETENTION_DAYS: ${SENSITIVE_INFORMATION_RETENTION_DAYS:-}
+            PLUGIN_DIRECTORY: /app/plugins/
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
             SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
             SENSITIVE_INFORMATION_RETENTION_DAYS: ${SENSITIVE_INFORMATION_RETENTION_DAYS:-}
             PLUGIN_DIRECTORY: /app/plugins/
+            PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE:-.venv/bin/python3}
         volumes:
             - ./plugins:/app/plugins
         ports:
@@ -92,6 +93,7 @@ services:
             SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
             SENSITIVE_INFORMATION_RETENTION_DAYS: ${SENSITIVE_INFORMATION_RETENTION_DAYS:-}
             PLUGIN_DIRECTORY: /app/plugins/
+            PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE:-.venv/bin/python3}
         volumes:
             - ./plugins:/app/plugins
         ports:
@@ -145,6 +147,7 @@ services:
             SMTP_SENDER_EMAIL: ${SMTP_SENDER_EMAIL:-}
             SENSITIVE_INFORMATION_RETENTION_DAYS: ${SENSITIVE_INFORMATION_RETENTION_DAYS:-}
             PLUGIN_DIRECTORY: /app/plugins/
+            PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE:-.venv/bin/python3}
         ports:
             - ${PORT:-8080}:${PORT:-8080}
         healthcheck:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2026.4.22
 charset-normalizer==3.4.7
 dataclass-wizard==0.39.1
+typing-extensions==4.15.0
 idna==3.13
 pycurl==7.46.0
 requests==2.33.1

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -50,7 +50,7 @@ private const val DEFAULT_DATABASE_HOST = "localhost"
 private const val DEFAULT_INVITATION_TOKEN_LIFETIME_IN_DAYS = 7
 private const val DEFAULT_VERIFICATION_TOKEN_LIFETIME_IN_DAYS = 1
 private val DEFAULT_PLUGIN_DIRECTORY = Path.of("./plugins")
-private const val DEFAULT_PYTHON_EXECUTABLE = "python3"
+private const val DEFAULT_PYTHON_EXECUTABLE = ".venv/bin/python3"
 
 private val logger = KotlinLogging.logger {}
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/env/EnvReader.kt
@@ -49,7 +49,7 @@ private const val DEFAULT_SENSITIVE_INFORMATION_RETENTION_DAYS = 30
 private const val DEFAULT_DATABASE_HOST = "localhost"
 private const val DEFAULT_INVITATION_TOKEN_LIFETIME_IN_DAYS = 7
 private const val DEFAULT_VERIFICATION_TOKEN_LIFETIME_IN_DAYS = 1
-private val DEFAULT_PLUGIN_DIRECTORY = Path.of("./plugins")
+private val DEFAULT_PLUGIN_DIRECTORY = Path.of("plugins")
 private const val DEFAULT_PYTHON_EXECUTABLE = ".venv/bin/python3"
 
 private val logger = KotlinLogging.logger {}
@@ -206,7 +206,7 @@ class EnvReader(
      */
     private fun buildPlugins(): Env.Plugins {
         return Env.Plugins(
-            pluginDirectory = envService.getPathOrDefault(PLUGIN_DIRECTORY, DEFAULT_PLUGIN_DIRECTORY),
+            pluginDirectory = envService.getPathOrDefault(PLUGIN_DIRECTORY, DEFAULT_PLUGIN_DIRECTORY).normalize(),
             pythonExecutable = envService.getStringOrDefault(PYTHON_EXECUTABLE, DEFAULT_PYTHON_EXECUTABLE),
         )
     }

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -20,33 +20,33 @@ The `PROFILE` variable determines the default behavior of the application.
 
 ### Environment Variables Table
 
-| Variable                               |               Required               |    Default    | Description                                                                                                |
-|----------------------------------------|:------------------------------------:|:-------------:|------------------------------------------------------------------------------------------------------------|
-| `PROFILE`                              |                 :x:                  | `PRODUCTION`  | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).                                   |
-| `PORT`                                 | :white_check_mark: (in `PRODUCTION`) |     8080      | The port where the backend is served.                                                                      |
-| `DATABASE_HOST`                        | :white_check_mark: (in `PRODUCTION`) |  `localhost`  | Hostname of the database connection.                                                                       |
-| `LOG_LEVEL`                            |                 :x:                  | Profile-based | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`.                          |
-| `AUTH_BYPASS_ENABLED`                  |                 :x:                  | Profile-based | Bypasses authentication and uses the dummy user for all whitelisted requests.                              |
-| `FRONTEND_BASE_URL`                    | :white_check_mark: (in `PRODUCTION`) | Profile-based | Base URL of the frontend application, used for generating URLs in emails.                                  |
-| `DATABASE_SEED_USER_ENABLED`           |                 :x:                  | Profile-based | Inserts a dummy user into the database on startup.                                                         |
-| `DATABASE_PASSWORD`                    |          :white_check_mark:          |       -       | Password for the database e.g. `postgres_password`.                                                        |
-| `JWT_PRIVATE_KEY_BASE64`               |          :white_check_mark:          |       -       | Base64 encoded private key for JWT authentication.                                                         |
-| `JWT_PUBLIC_KEY_BASE64`                |          :white_check_mark:          |       -       | Base64 encoded public key for JWT authentication.                                                          |
-| `SMTP_HOST`                            |          :white_check_mark:          |       -       | SMTP host for sending emails.                                                                              |
-| `SMTP_PORT`                            |          :white_check_mark:          |       -       | SMTP port for sending emails.                                                                              |
-| `SMTP_USER`                            |                 :x:                  |       -       | SMTP user for sending emails.                                                                              |
-| `SMTP_PASSWORD`                        |                 :x:                  |       -       | SMTP password for sending emails.                                                                          |
-| `SMTP_TRANSPORT_LOGGING_ONLY_ENABLED`  |                 :x:                  | Profile-based | SMTP transport logging to only log emails instead of actually sending them.                                |
-| `SMTP_SENDER_NAME`                     |          :white_check_mark:          |       -       | Name of the sender for emails.                                                                             |
-| `SMTP_SENDER_EMAIL`                    |          :white_check_mark:          |       -       | Email address of the sender for emails.                                                                    |
-| `SENSITIVE_INFORMATION_RETENTION_DAYS` |                 :x:                  |      30       | Number of days sensitive information will be kept after an entity got deleted.                             |
-| `WEB_PORT`                             |                 :x:*                 |     8081      | The port where the proxy is served (used for gRPC-Web).                                                    |
-| `BACKEND_TAG`                          |                 :x:*                 | `latest-dev`  | Tag of registry backend image to use for `registry` docker compose profile.                                |
-| `SENSITIVE_INFORMATION_RETENTION_DAYS` |                 :x:                  | Profile-based | Number of days sensitive information will be kept after an entity got deleted.                             |
-| `INVITATION_TOKEN_LIFETIME_IN_DAYS`    |                 :x:                  |       7       | Lifetime of invitation tokens in days.                                                                     |
-| `VERIFICATION_TOKEN_LIFETIME_IN_DAYS`  |                 :x:                  |       1       | Lifetime of verification tokens in days.                                                                   |
-| `PLUGIN_DIRECTORY`                     |                 :x:                  |  `./plugins`  | The directory in which the plugins reside. The directory is relative to the root directory of the project. |
-| `PYTHON_EXECUTABLE`                    |                 :x:                  |   `python3`   | Python executable used to run fetchers (for example `.venv/bin/python3`).                                  |
+| Variable                               |               Required               |       Default       | Description                                                                                                |
+|----------------------------------------|:------------------------------------:|:-------------------:|------------------------------------------------------------------------------------------------------------|
+| `PROFILE`                              |                 :x:                  |    `PRODUCTION`     | Sets the configuration profile (`PRODUCTION`, `DEVELOPMENT`, `TESTING`).                                   |
+| `PORT`                                 | :white_check_mark: (in `PRODUCTION`) |        8080         | The port where the backend is served.                                                                      |
+| `DATABASE_HOST`                        | :white_check_mark: (in `PRODUCTION`) |     `localhost`     | Hostname of the database connection.                                                                       |
+| `LOG_LEVEL`                            |                 :x:                  |    Profile-based    | The log level to use. One of `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `OFF`.                          |
+| `AUTH_BYPASS_ENABLED`                  |                 :x:                  |    Profile-based    | Bypasses authentication and uses the dummy user for all whitelisted requests.                              |
+| `FRONTEND_BASE_URL`                    | :white_check_mark: (in `PRODUCTION`) |    Profile-based    | Base URL of the frontend application, used for generating URLs in emails.                                  |
+| `DATABASE_SEED_USER_ENABLED`           |                 :x:                  |    Profile-based    | Inserts a dummy user into the database on startup.                                                         |
+| `DATABASE_PASSWORD`                    |          :white_check_mark:          |          -          | Password for the database e.g. `postgres_password`.                                                        |
+| `JWT_PRIVATE_KEY_BASE64`               |          :white_check_mark:          |          -          | Base64 encoded private key for JWT authentication.                                                         |
+| `JWT_PUBLIC_KEY_BASE64`                |          :white_check_mark:          |          -          | Base64 encoded public key for JWT authentication.                                                          |
+| `SMTP_HOST`                            |          :white_check_mark:          |          -          | SMTP host for sending emails.                                                                              |
+| `SMTP_PORT`                            |          :white_check_mark:          |          -          | SMTP port for sending emails.                                                                              |
+| `SMTP_USER`                            |                 :x:                  |          -          | SMTP user for sending emails.                                                                              |
+| `SMTP_PASSWORD`                        |                 :x:                  |          -          | SMTP password for sending emails.                                                                          |
+| `SMTP_TRANSPORT_LOGGING_ONLY_ENABLED`  |                 :x:                  |    Profile-based    | SMTP transport logging to only log emails instead of actually sending them.                                |
+| `SMTP_SENDER_NAME`                     |          :white_check_mark:          |          -          | Name of the sender for emails.                                                                             |
+| `SMTP_SENDER_EMAIL`                    |          :white_check_mark:          |          -          | Email address of the sender for emails.                                                                    |
+| `SENSITIVE_INFORMATION_RETENTION_DAYS` |                 :x:                  |         30          | Number of days sensitive information will be kept after an entity got deleted.                             |
+| `WEB_PORT`                             |                 :x:*                 |        8081         | The port where the proxy is served (used for gRPC-Web).                                                    |
+| `BACKEND_TAG`                          |                 :x:*                 |    `latest-dev`     | Tag of registry backend image to use for `registry` docker compose profile.                                |
+| `SENSITIVE_INFORMATION_RETENTION_DAYS` |                 :x:                  |    Profile-based    | Number of days sensitive information will be kept after an entity got deleted.                             |
+| `INVITATION_TOKEN_LIFETIME_IN_DAYS`    |                 :x:                  |          7          | Lifetime of invitation tokens in days.                                                                     |
+| `VERIFICATION_TOKEN_LIFETIME_IN_DAYS`  |                 :x:                  |          1          | Lifetime of verification tokens in days.                                                                   |
+| `PLUGIN_DIRECTORY`                     |                 :x:                  |     `./plugins`     | The directory in which the plugins reside. The directory is relative to the root directory of the project. |
+| `PYTHON_EXECUTABLE`                    |                 :x:                  | `.venv/bin/python3` | Python executable used to run fetchers.                                                                    |
 
 \* only used when using the docker compose profiles.
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -45,7 +45,7 @@ The `PROFILE` variable determines the default behavior of the application.
 | `SENSITIVE_INFORMATION_RETENTION_DAYS` |                 :x:                  |    Profile-based    | Number of days sensitive information will be kept after an entity got deleted.                             |
 | `INVITATION_TOKEN_LIFETIME_IN_DAYS`    |                 :x:                  |          7          | Lifetime of invitation tokens in days.                                                                     |
 | `VERIFICATION_TOKEN_LIFETIME_IN_DAYS`  |                 :x:                  |          1          | Lifetime of verification tokens in days.                                                                   |
-| `PLUGIN_DIRECTORY`                     |                 :x:                  |     `./plugins`     | The directory in which the plugins reside. The directory is relative to the root directory of the project. |
+| `PLUGIN_DIRECTORY`                     |                 :x:                  |      `plugins`      | The directory in which the plugins reside. The directory is relative to the root directory of the project. |
 | `PYTHON_EXECUTABLE`                    |                 :x:                  | `.venv/bin/python3` | Python executable used to run fetchers.                                                                    |
 
 \* only used when using the docker compose profiles.

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -65,7 +65,7 @@ exist yet, start the backend as it should be created automatically.
 
 Fetcher plugins are loaded during runtime from the `fetchers` subdirectory
 of the plugin directory. This directory can be configured using the
-`PLUGIN_DIRECTORY` environment variable and defaults to `./plugins/`. This
+`PLUGIN_DIRECTORY` environment variable and defaults to `plugins/`. This
 directory is relative to the working directory of the backend and should
 already be present if you have previously started the backend. Every `.py`
 file directly contained within the `fetchers` directory will be treated as a

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -53,7 +53,7 @@ The list of required packages can be also found in the [requirements.txt](https:
 
 > [!IMPORTANT]
 > The plugin system uses the configured python executable (`PYTHON_EXECUTABLE`,
-> default `python3`). Make sure it points to the environment where the required
+> default `.venv/bin/python3`). Make sure it points to the environment where the required
 > packages are installed.
 
 To get proper autocomplete and type checking for the SnowballR types, add the


### PR DESCRIPTION
Closes #497

## What I have made

- Added missing `typing-extensions` dependency
- Updated python executable path (default) to use the python executable from virtual environment
- Normalized plugin directory resolution so the logs don't show (`/./plugins`) and updated defaults
- Added missing `PLUGIN_DIRECTORY` env var to backend-only profile

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [ ] I have checked the changes against the requirements
