### PR TITLE
Implement SearchLocalProjectPaperCandidates call

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,8 @@ version = "0.0.0"
 
 // Snowballr API version to use for the proto files
 val apiVersion = "0.14.0" // can be a tag (e.g., "1.2.3"), commit hash, or branch name like "main"
-val protoDir: Provider<Directory> = layout.buildDirectory.dir("snowballr-api/${apiVersion}")
+val escapedApiVersion = apiVersion.replace('/', '-')
+val protoDir: Provider<Directory> = layout.buildDirectory.dir("snowballr-api/${escapedApiVersion}")
 
 gitVersioning.apply {
     refs {
@@ -326,7 +327,7 @@ tasks.register<Download>("downloadApiFiles") {
         else if (isCommit) "https://github.com/SE-UUlm/snowballr-api/archive/${apiVersion}.zip"
         else "https://github.com/SE-UUlm/snowballr-api/archive/refs/heads/${apiVersion}.zip"
 
-    val zipFile = layout.buildDirectory.file("snowballr-api-${apiVersion}.zip").get().asFile
+    val zipFile = layout.buildDirectory.file("snowballr-api-${escapedApiVersion}.zip").get().asFile
     val protoDirAsFile = protoDir.get().asFile
 
     // Declare inputs & outputs for caching
@@ -349,8 +350,8 @@ tasks.register<Download>("downloadApiFiles") {
 
         fun unzipFile(zip: ZipFile, entry: ZipEntry) {
             // We only want the proto files
-            if (!entry.name.startsWith("snowballr-api-${apiVersion}/proto/")) return
-            val entryName = entry.name.removePrefix("snowballr-api-${apiVersion}/proto/")
+            if (!entry.name.startsWith("snowballr-api-${escapedApiVersion}/proto/")) return
+            val entryName = entry.name.removePrefix("snowballr-api-${escapedApiVersion}/proto/")
 
             val outputFile = protoDirAsFile.resolve(entryName)
             if (entry.isDirectory) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
@@ -6,6 +6,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.context.startKoin
 import org.koin.java.KoinJavaComponent.getKoin
 import org.slf4j.LoggerFactory
+import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.env.DEFAULT_LOG_LEVEL
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.env.EnvService
@@ -28,6 +29,7 @@ fun main() {
     }
 
     initializeFetcherOrchestrator()
+    addDbShutdownHook()
 
     // Create and run the server
     val server = SnowballRServer(env.http.port)
@@ -62,4 +64,10 @@ private fun initializeFetcherOrchestrator() {
             orchestrator.stop()
         },
     )
+}
+
+private fun addDbShutdownHook() {
+    val db = getKoin().get<IDatabase>()
+    db.close()
+    logger.info { "Closed database connection" }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -20,6 +20,7 @@ import se.uulm.snowballr.backend.db.DatabaseHelper.addExtensions
 import se.uulm.snowballr.backend.env.Env
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.table.UserTable
+import java.io.Closeable
 import java.sql.Connection
 import org.jetbrains.exposed.v1.jdbc.Database as JdbcDatabase
 
@@ -47,7 +48,7 @@ private const val DB_USER = "postgres"
  * transactional block. It abstracts the lower-level details of connecting to the database and
  * managing transaction lifecycles, allowing for simpler and more testable database interactions.
  */
-interface IDatabase {
+interface IDatabase : Closeable {
     suspend fun <T> query(
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
         transactionIsolation: Int = Connection.TRANSACTION_SERIALIZABLE,
@@ -113,6 +114,10 @@ class Database(
         suspendTransaction(exposedDatabase, transactionIsolation) {
             block()
         }
+    }
+
+    override fun close() {
+        dataSource.close()
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/db/Database.kt
@@ -65,11 +65,13 @@ class Database(
     private val envReader: EnvReader,
 ) : IDatabase {
     private val dataSource: HikariDataSource
+    private val exposedDatabase: JdbcDatabase
 
     init {
         logger.info { "Connecting to database" }
         dataSource = initDataSource(envReader.env.database)
-        transaction(JdbcDatabase.connect(dataSource)) {
+        exposedDatabase = JdbcDatabase.connect(dataSource)
+        transaction(exposedDatabase) {
             setUpDatabase()
             seedDummyUserIfEnabled()
         }
@@ -108,10 +110,7 @@ class Database(
         transactionIsolation: Int,
         block: suspend JdbcTransaction.() -> T,
     ): T = withContext(dispatcher) {
-        suspendTransaction(
-            JdbcDatabase.connect(dataSource),
-            transactionIsolation,
-        ) {
+        suspendTransaction(exposedDatabase, transactionIsolation) {
             block()
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toFetcherPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.fetcher.FetcherMap
@@ -19,7 +20,6 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherProcessingJob
 import se.uulm.snowballr.backend.model.fetcher.FetchingDirection
 import se.uulm.snowballr.backend.model.fetcher.FetchingResults
 import se.uulm.snowballr.backend.model.fetcher.PaperCreationResults
-import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.isBackwardOrBoth
 import se.uulm.snowballr.backend.model.isForwardOrBoth
 import se.uulm.snowballr.backend.repository.IPaperTableRepo

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -427,7 +427,7 @@ class SnowballRServer(
 
         override suspend fun searchLocalProjectPaperCandidates(
             request: ProjectOuterClass.Project.Paper.SearchQuery,
-        ): PaperOuterClass.Paper.List = super.searchLocalProjectPaperCandidates(request)
+        ): PaperOuterClass.Paper.List = fetcherService.searchLocalProjectPaperCandidates(request)
 
         override suspend fun searchFetcherProjectPaperCandidates(
             request: ProjectOuterClass.Project.Paper.SearchQuery,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -13,41 +13,30 @@ import snowballr.PaperOuterClass.Paper as GrpcPaper
  */
 data class Paper(
     val id: UUID,
-    val title: String,
-    val externalId: String?,
-    val abstract: String,
-    val year: Int,
-    val publisher: String,
-    val publicationType: String,
-    val publicationName: String,
+    override val title: String,
+    override val externalId: String?,
+    override val abstract: String,
+    override val year: Int,
+    override val publisher: String,
+    override val publicationType: String,
+    override val publicationName: String,
     val pdfId: UUID?,
-    val authors: List<Author>,
-    val fetcherMetadata: FetcherMetadata,
+    override val authors: List<Author>,
+    override val fetcherMetadata: FetcherMetadata,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
     val modifiedBy: UUID?,
-)
+) : PaperData
 
 /**
  * Creates a [GrpcPaper] from this [Paper].
  */
-fun Paper.toGrpcPaper(backwardReferencedIdsList: List<String>): GrpcPaper {
-    val paper = this
-    return paper {
-        id = paper.id.toString()
-        title = paper.title
-        if (paper.externalId != null) externalId = paper.externalId
-        abstrakt = paper.abstract
-        year = paper.year
-        publisher = paper.publisher
-        publicationType = paper.publicationType
-        publicationName = paper.publicationName
-        hasPdf = paper.pdfId != null
-        authors.addAll(paper.authors.toGrpcAuthors())
-        backwardReferencedIds.addAll(backwardReferencedIdsList)
-        fetcherMetadata.putAll(fetcherMetadata)
-    }
-}
+fun Paper.toGrpcPaper(backwardReferencedIdsList: List<String>): GrpcPaper = this.toGrpcPaperRequest()
+    .toBuilder()
+    .setId(id.toString())
+    .setHasPdf(pdfId != null)
+    .addAllBackwardReferencedIds(backwardReferencedIdsList)
+    .build()
 
 /**
  * Converts a list of [GrpcPaper] objects into a [GrpcPaper.List].
@@ -69,5 +58,5 @@ fun Paper.toFetcherPaper(): FetcherPaper = FetcherPaper(
     publicationType = publicationType,
     publicationName = publicationName,
     authors = authors,
-    metadata = fetcherMetadata,
+    fetcherMetadata = fetcherMetadata,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/Paper.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.model.dto
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import se.uulm.snowballr.backend.table.PaperTable
-import snowballr.paper
 import java.time.OffsetDateTime
 import java.util.UUID
 import snowballr.PaperOuterClass.Paper as GrpcPaper
@@ -47,7 +46,7 @@ fun List<GrpcPaper>.toGrpcPapers(): GrpcPaper.List = GrpcPaper.List
     .build()
 
 /**
- * Creates a [FetcherPaper] from this [paper]
+ * Creates a [FetcherPaper] from this [Paper].
  */
 fun Paper.toFetcherPaper(): FetcherPaper = FetcherPaper(
     title = title,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/PaperData.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/PaperData.kt
@@ -1,0 +1,36 @@
+package se.uulm.snowballr.backend.model.dto
+
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
+import snowballr.paper
+import snowballr.PaperOuterClass.Paper as GrpcPaper
+
+interface PaperData {
+    val title: String
+    val externalId: String?
+    val abstract: String
+    val year: Int
+    val publisher: String
+    val publicationType: String
+    val publicationName: String
+    val authors: List<Author>
+    val fetcherMetadata: FetcherMetadata
+}
+
+/**
+ * Creates a [GrpcPaper] request from this [PaperData].
+ */
+fun PaperData.toGrpcPaperRequest(): GrpcPaper {
+    val paper = this
+    return paper {
+        title = paper.title
+        val paperExternalId = paper.externalId
+        if (paperExternalId != null) externalId = paperExternalId
+        abstrakt = paper.abstract
+        year = paper.year
+        publisher = paper.publisher
+        publicationType = paper.publicationType
+        publicationName = paper.publicationName
+        authors.addAll(paper.authors.toGrpcAuthors())
+        fetcherMetadata.putAll(paper.fetcherMetadata)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherPaper.kt
@@ -3,12 +3,10 @@ package se.uulm.snowballr.backend.model.fetcher
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import se.uulm.snowballr.backend.model.dto.Author
-import se.uulm.snowballr.backend.model.dto.toGrpcAuthors
-import snowballr.paper
-import snowballr.PaperOuterClass.Paper as GrpcPaper
+import se.uulm.snowballr.backend.model.dto.PaperData
 
 /**
- * Represents a paper fetched from an external source.
+ * Represents a paper fetched from an external source. Also, a serializable implementation of [PaperData].
  *
  * @property title The title of the paper.
  * @property externalId A unique external identifier for the paper, such as a DOI or other unique ID.
@@ -18,38 +16,26 @@ import snowballr.PaperOuterClass.Paper as GrpcPaper
  * @property publicationType The type of publication, such as "journal", "conference", etc. (unconstrained)
  * @property publicationName The name of the publication where the paper appeared.
  * @property authors A list of authors associated with the paper, represented as [Author] objects.
- * @property metadata A map of metadata used by fetchers. For example, API-related unique IDs for later use.
+ * @property fetcherMetadata A map of metadata used by fetchers. For example, API-related unique IDs for later use.
  */
 @Serializable
 data class FetcherPaper(
-    val title: String,
+    @SerialName("title")
+    override val title: String,
     @SerialName("external_id")
-    val externalId: String? = null,
-    val abstract: String,
-    val year: Int,
-    val publisher: String,
+    override val externalId: String?,
+    @SerialName("abstract")
+    override val abstract: String,
+    @SerialName("year")
+    override val year: Int,
+    @SerialName("publisher")
+    override val publisher: String,
     @SerialName("publication_type")
-    val publicationType: String,
+    override val publicationType: String,
     @SerialName("publication_name")
-    val publicationName: String,
-    val authors: List<Author> = emptyList(),
-    val metadata: Map<String, String> = emptyMap(),
-)
-
-/**
- * Creates a [GrpcPaper] request from this [FetcherPaper].
- */
-fun FetcherPaper.toGrpcPaperRequest(): GrpcPaper {
-    val paper = this
-    return paper {
-        title = paper.title
-        if (paper.externalId != null) externalId = paper.externalId
-        abstrakt = paper.abstract
-        year = paper.year
-        publisher = paper.publisher
-        publicationType = paper.publicationType
-        publicationName = paper.publicationName
-        authors.addAll(paper.authors.toGrpcAuthors())
-        fetcherMetadata.putAll(metadata)
-    }
-}
+    override val publicationName: String,
+    @SerialName("authors")
+    override val authors: List<Author>,
+    @SerialName("fetcher_metadata")
+    override val fetcherMetadata: Map<String, String>,
+) : PaperData

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -4,7 +4,9 @@ import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
@@ -80,6 +82,16 @@ interface IPaperTableRepo {
      * @return A list of up to 20 matching papers.
      */
     suspend fun getPapersBySearchQuery(query: String): List<Paper>
+
+    /**
+     * Retrieves all papers that have an external ID that matches at least one external ID in [externalIds].
+     *
+     * This returns the same as for calling [getPaperByExternalId] for each external ID and then filtering out each
+     * [Result.failure].
+     *
+     * Prefer this method when calling [getPaperByExternalId] inside a loop.
+     */
+    suspend fun getPapersByExternalIds(externalIds: List<String>): List<Paper>
 }
 
 /**
@@ -188,6 +200,14 @@ class PaperTableRepo(
         )
 
         matchingPapers.orEmpty()
+    }
+
+    override suspend fun getPapersByExternalIds(externalIds: List<String>): List<Paper> = db.query {
+        if (externalIds.isEmpty()) return@query emptyList()
+
+        PaperTable.selectAll()
+            .where { PaperTable.externalId inList externalIds }
+            .map(ResultRow::toPaper)
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -2,7 +2,10 @@ package se.uulm.snowballr.backend.repository
 
 import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Paper
@@ -66,6 +69,17 @@ interface IPaperTableRepo {
      * - [GrpcPaper.authors_]
      */
     suspend fun updatePaper(request: GrpcPaper.Update): Paper
+
+    /**
+     * Retrieves a list of papers whose title partially or fully match the [query].
+     *
+     * The number of returned papers is limited to a maximum of 20. Furthermore, the matching papers are sorted by their
+     * similarity to the search query.
+     *
+     * @param query The query used to match the paper titles.
+     * @return A list of up to 20 matching papers.
+     */
+    suspend fun getPapersBySearchQuery(query: String): List<Paper>
 }
 
 /**
@@ -80,6 +94,11 @@ interface IPaperTableRepo {
 class PaperTableRepo(
     private val db: IDatabase,
 ) : IPaperTableRepo {
+    companion object {
+        private const val MAXIMUM_NUMBER_OF_PAPER_CANDIDATES = 20
+        private const val MINIMUM_SIMILARITY_SCORE = 0.2
+    }
+
     private fun getPaperByIdOrNull(id: UUID): Paper? = PaperTable.getEntityByIdOrNull(id, ResultRow::toPaper)
 
     private fun getPaperByExternalIdOrNull(externalId: String): Paper? =
@@ -143,4 +162,40 @@ class PaperTableRepo(
             it[modifiedAt] = OffsetDateTime.now()
         }
     }
+
+    override suspend fun getPapersBySearchQuery(query: String): List<Paper> = db.query {
+        val paperTable = "\"${PaperTable.tableName}\""
+        val titleCol = "$paperTable.${PaperTable.title.name}"
+
+        val rawSqlQuery =
+            """
+            WITH papers_with_similarity_scores AS (
+                SELECT *, similarity($titleCol, ?) AS sim_title
+                FROM $paperTable
+            )
+            SELECT *
+            FROM papers_with_similarity_scores
+            WHERE sim_title > $MINIMUM_SIMILARITY_SCORE
+            ORDER BY sim_title DESC
+            LIMIT $MAXIMUM_NUMBER_OF_PAPER_CANDIDATES
+            """.trimIndent()
+
+        val matchingPapers = exec(
+            stmt = rawSqlQuery,
+            args = listOf(TextColumnType() to query),
+            explicitStatementType = StatementType.SELECT,
+            transform = { extractPaperRows(JdbcResult(it)) },
+        )
+
+        matchingPapers.orEmpty()
+    }
+
+    /**
+     * Extracts and converts rows from a [JdbcResult] to a list of [Paper] objects.
+     *
+     * @param result The [JdbcResult] containing paper data.
+     * @return A list of [Paper] objects extracted from the result set.
+     */
+    private fun extractPaperRows(result: JdbcResult): List<Paper> =
+        extractTableRows(result, PaperTable, ResultRow::toPaper)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/RepoResultHelper.kt
@@ -1,5 +1,8 @@
 package se.uulm.snowballr.backend.repository
 
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.IdentifierType
 import se.uulm.snowballr.backend.model.exception.NotFoundException
@@ -57,3 +60,23 @@ fun <T> wrapAsResult(entity: T?, exception: SnowballRException): Result<T> = if 
 } else {
     Result.failure(exception)
 }
+
+/**
+ * Extracts and converts rows from a [JdbcResult] to a list of object of type [T].
+ *
+ * @param T The table entity type.
+ * @param result The [JdbcResult] containing the entity data.
+ * @param table The table from which the result originates.
+ * @param mapper The function that transforms a [ResultRow] to an object of type [T].
+ * @return A list of entity objects of type [T] extracted from the result set.
+ */
+fun <T> extractTableRows(result: JdbcResult, table: Table, mapper: (ResultRow) -> T): List<T> = generateSequence {
+    if (result.next()) {
+        ResultRow.create(
+            result,
+            table.fields.withIndex().associate { it.value to it.index },
+        )
+    } else {
+        null
+    }
+}.map(mapper).toList()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -183,26 +183,8 @@ class UserTableRepo(
     private val db: IDatabase,
 ) : IUserTableRepo {
     companion object {
-        const val MAXIMUM_NUMBER_OF_INVITE_CANDIDATES = 10
-    }
-
-    /**
-     * Extracts and converts rows from a [JdbcResult] to a list of [User] objects.
-     *
-     * @param result The [JdbcResult] containing user data.
-     * @return A list of [User] objects extracted from the result set.
-     */
-    private fun extractUserRows(result: JdbcResult): List<User> {
-        return generateSequence {
-            if (result.next()) {
-                ResultRow.create(
-                    result,
-                    UserTable.fields.withIndex().associate { it.value to it.index },
-                )
-            } else {
-                null
-            }
-        }.map { it.toUser() }.toList()
+        private const val MAXIMUM_NUMBER_OF_INVITE_CANDIDATES = 10
+        private const val MINIMUM_SIMILARITY_SCORE = 0.2
     }
 
     private fun getUserByIdOrNull(id: UUID): User? = UserTable.getEntityByIdOrNull(id, ResultRow::toUser)
@@ -296,7 +278,7 @@ class UserTableRepo(
                 )
                 SELECT *
                 FROM users_with_similarity_scores
-                WHERE GREATEST(sim_first_name, sim_last_name, sim_email) > 0.2
+                WHERE GREATEST(sim_first_name, sim_last_name, sim_email) > $MINIMUM_SIMILARITY_SCORE
                 ORDER BY GREATEST(sim_first_name, sim_last_name, sim_email) DESC
                 LIMIT $MAXIMUM_NUMBER_OF_INVITE_CANDIDATES
                 """.trimIndent()
@@ -416,4 +398,12 @@ class UserTableRepo(
     override suspend fun getUserSettings(id: UUID): Result<UserSettings> = db.query {
         getEntityByKeyAsResult(::getUserSettingsByUserIdOrNull, EntityType.USER, id)
     }
+
+    /**
+     * Extracts and converts rows from a [JdbcResult] to a list of [User] objects.
+     *
+     * @param result The [JdbcResult] containing user data.
+     * @return A list of [User] objects extracted from the result set.
+     */
+    private fun extractUserRows(result: JdbcResult): List<User> = extractTableRows(result, UserTable, ResultRow::toUser)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -36,6 +36,11 @@ interface IFetcherService {
     suspend fun getAvailableFetcherOptions(request: GetAvailableFetcherOptionsRequest): FetcherOptions
 
     /**
+     * Service implementation of [SnowballRService.searchLocalProjectPaperCandidates].
+     */
+    suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List
+
+    /**
      * Service implementation of [SnowballRService.searchFetcherProjectPaperCandidates].
      */
     suspend fun searchFetcherProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List
@@ -69,6 +74,21 @@ class FetcherService(
             .putAllOptions(fetcherManager.getAvailableOptions(request.fetcherName))
             .build()
 
+    override suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List =
+        withUser(userRepo) { currentUser ->
+            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+
+            projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
+
+            val matchingPapers = paperRepo.getPapersBySearchQuery(request.query)
+
+            val filteredPapers = filterPapersNotInProject(projectId, matchingPapers)
+
+            GrpcPaper.List.newBuilder()
+                .addAllPapers(filteredPapers.map { it.toGrpcPaper(emptyList()) })
+                .build()
+        }
+
     override suspend fun searchFetcherProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
@@ -85,7 +105,11 @@ class FetcherService(
                 }
             }
 
-            val filteredPapers = filterExistingPapers(projectId, papers)
+            val filteredPapers = filterExistingFetcherPapers(projectId, papers)
+            logger.debug {
+                val removedPapers = papers.size - filteredPapers.size
+                "Filtered out $removedPapers/${papers.size} papers that already existed in the project."
+            }
 
             GrpcPaper.List.newBuilder()
                 .addAllPapers(filteredPapers)
@@ -97,35 +121,31 @@ class FetcherService(
      *
      * Papers that already exist in the database get their ID assigned, so that they can be associated by the client.
      */
-    private suspend fun filterExistingPapers(projectId: UUID, fetcherPapers: Set<FetcherPaper>): Set<GrpcPaper> {
-        val filteredPapers = mutableSetOf<GrpcPaper>()
+    private suspend fun filterExistingFetcherPapers(projectId: UUID, fetcherPapers: Set<FetcherPaper>): Set<GrpcPaper> {
+        val externalIds = fetcherPapers.mapNotNull { it.externalId }
+        val existingPapers = paperRepo.getPapersByExternalIds(externalIds).associateBy { it.externalId }
+        val notInProjectIds = filterPapersNotInProject(projectId, existingPapers.values).map { it.id }
 
-        for (fetcherPaper in fetcherPapers) {
-            val paper = getPaperIfExists(fetcherPaper)
+        return fetcherPapers.mapNotNull { fetcherPaper ->
+            val existing = existingPapers[fetcherPaper.externalId]
+            when {
+                existing == null -> fetcherPaper.toGrpcPaperRequest()
+                existing.id in notInProjectIds -> existing.toGrpcPaper(emptyList())
+                else -> null
+            }
+        }.toSet()
+    }
 
-            if (paper != null) {
-                val isAlreadyInProject = projectPaperRepo.doesProjectPaperExist(projectId, paper.id)
-                if (!isAlreadyInProject) {
-                    filteredPapers += paper.toGrpcPaper(emptyList())
-                }
-            } else {
-                filteredPapers += fetcherPaper.toGrpcPaperRequest()
+    private suspend fun filterPapersNotInProject(projectId: UUID, papers: Collection<Paper>): List<Paper> {
+        val filteredPapers = mutableSetOf<Paper>()
+
+        for (paper in papers) {
+            val isAlreadyInProject = projectPaperRepo.doesProjectPaperExist(projectId, paper.id)
+            if (!isAlreadyInProject) {
+                filteredPapers += paper
             }
         }
 
-        return filteredPapers
-    }
-
-    /**
-     * Return the database paper if it matches the data from the specified fetched [paper].
-     *
-     * Currently, this check is only done by using the external ID.
-     */
-    private suspend fun getPaperIfExists(paper: FetcherPaper): Paper? {
-        if (paper.externalId == null) {
-            return null
-        }
-
-        return paperRepo.getPaperByExternalId(paper.externalId).getOrNull()
+        return filteredPapers.toList()
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -7,9 +7,9 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toGrpcPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
-import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -81,8 +81,13 @@ class FetcherService(
             projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
             val matchingPapers = paperRepo.getPapersBySearchQuery(request.query)
+            logger.debug { "Found ${matchingPapers.size} papers for query '${request.query}'" }
 
             val filteredPapers = filterPapersNotInProject(projectId, matchingPapers)
+            logger.debug {
+                val removedPapers = matchingPapers.size - filteredPapers.size
+                "Filtered out $removedPapers/${matchingPapers.size} papers that already existed in the project."
+            }
 
             GrpcPaper.List.newBuilder()
                 .addAllPapers(filteredPapers.map { it.toGrpcPaper(emptyList()) })
@@ -104,6 +109,7 @@ class FetcherService(
                     logger.error(e) { "Failed to search fetcher papers for fetcher '$fetcher': ${e.message}" }
                 }
             }
+            logger.debug { "Found ${papers.size} papers for query '${request.query}'" }
 
             val filteredPapers = filterExistingFetcherPapers(projectId, papers)
             logger.debug {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -128,9 +128,9 @@ class FetcherService(
      * Papers that already exist in the database get their ID assigned, so that they can be associated by the client.
      */
     private suspend fun filterExistingFetcherPapers(projectId: UUID, fetcherPapers: Set<FetcherPaper>): Set<GrpcPaper> {
-        val externalIds = fetcherPapers.mapNotNull { it.externalId }
+        val externalIds = fetcherPapers.mapNotNull { it.externalId }.distinct()
         val existingPapers = paperRepo.getPapersByExternalIds(externalIds).associateBy { it.externalId }
-        val notInProjectIds = filterPapersNotInProject(projectId, existingPapers.values).map { it.id }
+        val notInProjectIds = filterPapersNotInProject(projectId, existingPapers.values).map { it.id }.toSet()
 
         return fetcherPapers.mapNotNull { fetcherPaper ->
             val existing = existingPapers[fetcherPaper.externalId]

--- a/src/main/resources/plugins/fetchers/IEEEXplore.py
+++ b/src/main/resources/plugins/fetchers/IEEEXplore.py
@@ -23,7 +23,7 @@ def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     return []
 
 def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
-    article_number = paper.metadata.get(metadata_key)
+    article_number = paper.fetcher_metadata.get(metadata_key)
     if article_number is None:
         return []
 

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -32,7 +32,7 @@ class Paper(JSONWizard):
     publication_type: str = ""
     publication_name: str = ""
     authors: list[Author] = field(default_factory=list)
-    metadata: dict[str, str] = field(default_factory=dict)
+    fetcher_metadata: dict[str, str] = field(default_factory=dict)
 
 class EventType(StrEnum):
     OPTIONS = "options"

--- a/src/main/resources/plugins/fetchers/lib/xploreapi.py
+++ b/src/main/resources/plugins/fetchers/lib/xploreapi.py
@@ -32,13 +32,13 @@ class XPLORE:
 
     def __init__(self, apiKey):
 
-    	# API key
+        # API key
         self.apiKey = apiKey
 
         # auth token
         self.authToken = ''
 
-    	# flag that some search criteria has been provided
+        # flag that some search criteria has been provided
         self.queryProvided = False
 
         # flag that chargeable Full Text request is occurring
@@ -531,7 +531,7 @@ class XPLORE:
                 if self.requestingFullText is True:
                     apiQry = self.buildFullTextRequestQuery(True)
                 elif self.requestingUsage is True:
-                   apiQry = self.buildUsageRequestQuery(True)
+                    apiQry = self.buildUsageRequestQuery(True)
                 data = self.queryAPI(apiQry)
 
             formattedData = self.formatData(data)
@@ -640,7 +640,7 @@ class XPLORE:
         # boolean query
         elif (self.usingBoolean):
 
-             url += '&querytext=(' + urllib.parse.quote_plus(self.parameters['boolean_text']) + ')'
+            url += '&querytext=(' + urllib.parse.quote_plus(self.parameters['boolean_text']) + ')'
 
         else:
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/DataBuilder.kt
@@ -367,6 +367,6 @@ object DataBuilder {
         publicationType = publicationType,
         publicationName = publicationName,
         authors = authors,
-        metadata = fetcherMetadata,
+        fetcherMetadata = fetcherMetadata,
     )
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/TestDatabase.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/TestDatabase.kt
@@ -17,7 +17,6 @@ import se.uulm.snowballr.backend.table.UserTable
 import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import java.util.UUID
-import javax.sql.DataSource
 import org.jetbrains.exposed.v1.jdbc.Database as JdbcDatabase
 
 /**
@@ -30,18 +29,16 @@ import org.jetbrains.exposed.v1.jdbc.Database as JdbcDatabase
  * within a specified coroutine dispatcher, while the [queryBlocking] method provides
  * a blocking interface for executing transactions.
  */
-class TestDatabase(var dataSource: DataSource) : IDatabase {
+class TestDatabase : IDatabase {
     private val postgres = PostgreSQLContainer("postgres:16.1-alpine3.19")
+    private lateinit var exposedDatabase: JdbcDatabase
 
     override suspend fun <T> query(
         dispatcher: CoroutineDispatcher,
         transactionIsolation: Int,
         block: suspend JdbcTransaction.() -> T,
     ): T = withContext(dispatcher) {
-        suspendTransaction(
-            JdbcDatabase.connect(dataSource),
-            transactionIsolation = transactionIsolation,
-        ) {
+        suspendTransaction(exposedDatabase, transactionIsolation = transactionIsolation) {
             block()
         }
     }
@@ -58,7 +55,8 @@ class TestDatabase(var dataSource: DataSource) : IDatabase {
             username = postgres.username
             password = postgres.password
         }
-        dataSource = HikariDataSource(config)
+        val dataSource = HikariDataSource(config)
+        exposedDatabase = JdbcDatabase.connect(dataSource)
     }
 
     /**

--- a/src/test/kotlin/se/uulm/snowballr/backend/TestDatabase.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/TestDatabase.kt
@@ -31,6 +31,7 @@ import org.jetbrains.exposed.v1.jdbc.Database as JdbcDatabase
  */
 class TestDatabase : IDatabase {
     private val postgres = PostgreSQLContainer("postgres:16.1-alpine3.19")
+    private lateinit var dataSource: HikariDataSource
     private lateinit var exposedDatabase: JdbcDatabase
 
     override suspend fun <T> query(
@@ -55,7 +56,7 @@ class TestDatabase : IDatabase {
             username = postgres.username
             password = postgres.password
         }
-        val dataSource = HikariDataSource(config)
+        dataSource = HikariDataSource(config)
         exposedDatabase = JdbcDatabase.connect(dataSource)
     }
 
@@ -135,5 +136,9 @@ class TestDatabase : IDatabase {
         query {
             block()
         }
+    }
+
+    override fun close() {
+        dataSource.close()
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -117,7 +117,7 @@ class PythonPluginFetcherManagerTest {
                 "publication_type": "journal",
                 "publication_name": "Example publication",
                 "authors": [{"first_name": "Ada", "last_name": "Lovelace"}],
-                "metadata": {"id": "meta-1"}
+                "fetcher_metadata": {"id": "meta-1"}
             }]
 
             if sys.argv[1] == "options":
@@ -139,9 +139,9 @@ class PythonPluginFetcherManagerTest {
             publicationType = "journal",
             publicationName = "Example publication",
             authors = listOf(Author("Ada", "Lovelace")),
-            metadata = mapOf("id" to "meta-1"),
+            fetcherMetadata = mapOf("id" to "meta-1"),
         )
-        val requestedPaper = expectedPaper.copy(metadata = mapOf("id" to "meta-request"))
+        val requestedPaper = expectedPaper.copy(fetcherMetadata = mapOf("id" to "meta-request"))
 
         val queryResult = fetcherManager.searchPapers("paper_fetcher", "query", mapOf("api_key" to "123"))
         val forwardResult = fetcherManager.fetchForwardReferences(
@@ -177,7 +177,7 @@ class PythonPluginFetcherManagerTest {
                 "publication_type": "journal",
                 "publication_name": "stdin publication",
                 "authors": [{"first_name": "Grace", "last_name": "Hopper"}],
-                "metadata": {"id": "stdin-meta"}
+                "fetcher_metadata": {"id": "stdin-meta"}
             }]
 
             if sys.argv[1] == "query":
@@ -211,7 +211,7 @@ class PythonPluginFetcherManagerTest {
             publicationType = "journal",
             publicationName = "stdin publication",
             authors = listOf(Author("Grace", "Hopper")),
-            metadata = mapOf("id" to "stdin-meta"),
+            fetcherMetadata = mapOf("id" to "stdin-meta"),
         )
 
         val queryResult = fetcherManager.searchPapers(

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -13,9 +13,9 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
 import se.uulm.snowballr.backend.model.dto.Project
 import se.uulm.snowballr.backend.model.dto.toFetcherPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
-import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.isBackwardOrBoth
 import se.uulm.snowballr.backend.model.isForwardOrBoth
 import se.uulm.snowballr.backend.repository.UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -17,9 +17,9 @@ import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.model.dto.Paper
 import se.uulm.snowballr.backend.model.dto.toFetcherPaper
+import se.uulm.snowballr.backend.model.dto.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
-import se.uulm.snowballr.backend.model.fetcher.toGrpcPaperRequest
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -35,6 +35,7 @@ import se.uulm.snowballr.backend.auth.JwtManager
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.env.Env
 import se.uulm.snowballr.backend.env.EnvReader
+import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.mail.EmailManager
 import se.uulm.snowballr.backend.mail.IEmailManager
@@ -48,6 +49,7 @@ import se.uulm.snowballr.backend.repositoryLayerDeps
 import se.uulm.snowballr.backend.service.IAuthenticationService
 import se.uulm.snowballr.backend.service.ICriterionService
 import se.uulm.snowballr.backend.service.IExportService
+import se.uulm.snowballr.backend.service.IFetcherService
 import se.uulm.snowballr.backend.service.IInvitationService
 import se.uulm.snowballr.backend.service.IPaperService
 import se.uulm.snowballr.backend.service.IProjectMemberService
@@ -61,6 +63,7 @@ import snowballr.Authentication
 import java.util.UUID
 import snowballr.PaperOuterClass.Paper as GrpcPaper
 import snowballr.ProjectOuterClass.Project as GrpcProject
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 import snowballr.UserOuterClass.User as GrpcUser
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
@@ -71,10 +74,12 @@ open class IntegrationTest : KoinTest {
     protected val envReaderMock = mockk<EnvReader>()
     protected val emailManagerMock = mockk<EmailManager>()
     protected val fetcherOrchestratorMock = mockk<IFetcherOrchestrator>()
+    protected val fetcherManagerMock = mockk<IFetcherManager>()
 
     private val allMocks = arrayOf(
         envReaderMock,
         emailManagerMock,
+        fetcherManagerMock,
     )
 
     protected val authenticationService: IAuthenticationService by inject()
@@ -88,6 +93,7 @@ open class IntegrationTest : KoinTest {
     protected val readingListService: IReadingListService by inject()
     protected val reviewService: IReviewService by inject()
     protected val userService: IUserService by inject()
+    protected val fetcherService: IFetcherService by inject()
 
     private val integrationTestModule = module {
         single { envReaderMock }
@@ -103,6 +109,7 @@ open class IntegrationTest : KoinTest {
 
         // Other mocks
         single<IEmailManager> { emailManagerMock }
+        single<IFetcherManager> { fetcherManagerMock }
         single<IFetcherOrchestrator> { fetcherOrchestratorMock }
         // FetcherOrchestrator is not yet part of the integration tests
         coJustRun { fetcherOrchestratorMock.enqueue(any()) }
@@ -274,4 +281,15 @@ open class IntegrationTest : KoinTest {
 
         return invitationToken
     }
+
+    /**
+     * Adds the [paper] to the [project] in stage 0.
+     */
+    protected suspend fun addToProject(project: GrpcProject, paper: GrpcPaper) = projectPaperService.addPaperToProject(
+        GrpcProjectPaper.Add.newBuilder()
+            .setProjectId(project.id)
+            .setPaperId(paper.id)
+            .setStage(0)
+            .build(),
+    )
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -154,6 +154,7 @@ open class IntegrationTest : KoinTest {
         clearAllMocks()
 
         db.tearDown()
+        db.close()
         stopKoin()
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.integration
 
-import com.zaxxer.hikari.HikariDataSource
 import io.mockk.CapturingSlot
 import io.mockk.checkUnnecessaryStub
 import io.mockk.clearAllMocks
@@ -67,8 +66,7 @@ import snowballr.UserOuterClass.User as GrpcUser
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Tag("integration")
 open class IntegrationTest : KoinTest {
-    // Initialize DB with empty dataSource only to set it in the setUp method
-    protected val db = TestDatabase(HikariDataSource())
+    protected val db = TestDatabase()
 
     protected val envReaderMock = mockk<EnvReader>()
     protected val emailManagerMock = mockk<EmailManager>()

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
@@ -1,0 +1,80 @@
+package se.uulm.snowballr.backend.integration.services
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.integration.IntegrationTest
+import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import snowballr.ProjectOuterClass.Project
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+
+class FetcherIntegrationTest : IntegrationTest() {
+    private fun searchQuery(projectId: String, query: String) = GrpcProjectPaper.SearchQuery.newBuilder()
+        .setProjectId(projectId)
+        .setQuery(query)
+        .build()
+
+    @Nested
+    inner class SearchLocalProjectPaperCandidates {
+        @Test
+        fun `When no papers exist, then the result is empty`() = runTest {
+            val project = projectService.createProject(Project.Create.newBuilder().setName("Test Project").build())
+
+            val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+
+            assertTrue(result.papersList.isEmpty())
+        }
+
+        @Test
+        fun `When a matching paper is not in the project, then it is returned`() = runTest {
+            val project = projectService.createProject(Project.Create.newBuilder().setName("Test Project").build())
+            val paper = createPaper("Something about IT")
+
+            val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+
+            assertTrue(result.papersList.any { it.id == paper.id })
+        }
+
+        @Test
+        fun `When a matching paper is already in the project, then it is not returned`() = runTest {
+            val project = projectService.createProject(Project.Create.newBuilder().setName("Test Project").build())
+            val paper = createPaper("Something about IT")
+            addToProject(project, paper)
+
+            val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+
+            assertFalse(result.papersList.any { it.id == paper.id })
+        }
+
+        @Test
+        fun `When one matching paper is in the project and another is not, then only the non-project paper is returned`() =
+            runTest {
+                val project = projectService.createProject(Project.Create.newBuilder().setName("Test Project").build())
+                val inProject = createPaper("Something about IT")
+                val notInProject = createPaper("Something about AI")
+                addToProject(project, inProject)
+
+                val result =
+                    fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about"))
+
+                assertFalse(result.papersList.any { it.id == inProject.id })
+                assertTrue(result.papersList.any { it.id == notInProject.id })
+            }
+
+        @Test
+        fun `When a non-member searches for papers, then access is denied`() = runTest {
+            val project = projectService.createProject(Project.Create.newBuilder().setName("Test Project").build())
+            val outsider = addUser(DataBuilder.createExampleUser(email = "outsider@example.com"))
+
+            actAsUser(outsider.id) {
+                assertThrows<UnauthorizedException> {
+                    fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -13,7 +13,6 @@ import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateP
 import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRangeException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedCreateException
 import se.uulm.snowballr.backend.model.parseUUID
-import snowballr.PaperOuterClass
 import snowballr.ProjectOuterClass.Project
 import snowballr.ReviewOuterClass.ReviewDecision
 import kotlin.test.assertEquals
@@ -23,15 +22,6 @@ import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 import snowballr.ReviewOuterClass.Review as GrpcReview
 
 class ProjectPaperIntegrationTest : IntegrationTest() {
-    private suspend fun addToProject(project: Project, paper: PaperOuterClass.Paper): GrpcProjectPaper =
-        projectPaperService.addPaperToProject(
-            GrpcProjectPaper.Add.newBuilder()
-                .setProjectId(project.id)
-                .setPaperId(paper.id)
-                .setStage(0)
-                .build(),
-        )
-
     private suspend fun reviewPaper(projectPaper: GrpcProjectPaper, decision: ReviewDecision) =
         reviewService.createReview(
             GrpcReview.Create.newBuilder()

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -368,4 +368,53 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
                 assertEquals(20, matchingPapers.size)
             }
     }
+
+    @Nested
+    inner class GetPapersByExternalIds {
+        @Test
+        fun `When papers are found by their external IDs, then the papers are returned`() = runTest {
+            val paper1 = insertPaperAndGetId(externalId = "doi123")
+            val paper2 = insertPaperAndGetId(externalId = "doi456")
+            val paper3 = insertPaperAndGetId(externalId = "doi789")
+
+            val papers = repo.getPapersByExternalIds(listOf("doi123", "doi456", "doi789"))
+
+            assertEquals(3, papers.size)
+            assertThat(papers.map { it.id }).containsExactlyInAnyOrder(paper1, paper2, paper3)
+        }
+
+        @Test
+        fun `When no papers match the external IDs, then no papers are returned`() = runTest {
+            insertPaperAndGetId(externalId = "doi123")
+            insertPaperAndGetId(externalId = "doi456")
+            insertPaperAndGetId(externalId = "doi789")
+
+            val papers = repo.getPapersByExternalIds(listOf("foo", "bar", "cat"))
+
+            assertEquals(0, papers.size)
+        }
+
+        @Test
+        fun `When an empty list is passed, then an empty list is returned`() = runTest {
+            val papers = repo.getPapersByExternalIds(emptyList())
+
+            assertEquals(0, papers.size)
+        }
+
+        @Test
+        fun `When compared to getPaperByExternalId, then the same result is returned`() = runTest {
+            insertPaperAndGetId(externalId = "doi123")
+            insertPaperAndGetId(externalId = "doi456")
+            insertPaperAndGetId(externalId = "doi789")
+
+            val papers1 = repo.getPapersByExternalIds(listOf("doi123", "foo", "doi789"))
+            val papers2 = listOf(
+                repo.getPaperByExternalId("doi123"),
+                repo.getPaperByExternalId("foo"),
+                repo.getPaperByExternalId("doi789"),
+            ).mapNotNull { it.getOrNull() }
+
+            assertEquals(papers1, papers2)
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -332,4 +332,40 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
             assertThat(updatedPaper.modifiedAt).isNull()
         }
     }
+
+    @Nested
+    inner class GetPapersBySearchQuery {
+        @Test
+        fun `When a paper is matching the search query, then the paper is returned`() = runTest {
+            val paper1 = insertPaperAndGetId(title = "Something about IT")
+            val paper2 = insertPaperAndGetId(title = "Something about AI")
+            val paper3 = insertPaperAndGetId(title = "Something about Cats")
+
+            val matchingPapers = repo.getPapersBySearchQuery("Something about")
+
+            assertEquals(3, matchingPapers.size)
+            assertThat(matchingPapers.map { it.id }).containsExactlyInAnyOrder(paper1, paper2, paper3)
+        }
+
+        @Test
+        fun `When no paper is matching the search query, then an empty list is returned`() = runTest {
+            insertPaperAndGetId(title = "Cats are beautiful")
+
+            val matchingPapers = repo.getPapersBySearchQuery("Dogs not that great")
+
+            assertEquals(0, matchingPapers.size)
+        }
+
+        @Test
+        fun `When more than 20 papers match the search query, then only the first 20 matching papers are returned`() =
+            runTest {
+                for (i in 1..25) {
+                    insertPaperAndGetId(title = "Frontend Framework Number $i")
+                }
+
+                val matchingPapers = repo.getPapersBySearchQuery("Frontend Framework")
+
+                assertEquals(20, matchingPapers.size)
+            }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryTest.kt
@@ -81,5 +81,6 @@ open class RepositoryTest(
     @AfterAll
     fun tearDown() {
         db.tearDown()
+        db.close()
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/RepositoryTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import com.zaxxer.hikari.HikariDataSource
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import org.jetbrains.exposed.v1.core.Table
@@ -53,8 +52,7 @@ open class RepositoryTest(
     val tables: Array<Table> = emptyArray(),
     val needsTestUser: Boolean = false,
 ) {
-    // Initialize DB with empty dataSource only to set it in the setUp method
-    protected val db = TestDatabase(HikariDataSource())
+    protected val db = TestDatabase()
 
     protected val envReaderMock = mockk<EnvReader>()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
@@ -42,8 +42,7 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
         coEvery { fetcherManagerMock.searchPapers("bar", request.query, any()) } returns setOf(barFetcherPaper)
-        coEvery { paperRepoMock.getPaperByExternalId("fooId") } returns Result.success(fooPaper)
-        coEvery { paperRepoMock.getPaperByExternalId("barId") } returns Result.success(barPaper)
+        coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId", "barId")) } returns listOf(fooPaper, barPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, barPaper.id) } returns false
 
@@ -55,16 +54,14 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
     }
 
     @Test
-    fun `When a user searches paper, but has no access, then a TestSpecificException is thrown`() = runTest {
+    fun `When a user searches papers, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
         val request = getExampleRequest(project)
 
         mockCurrentUser(user)
-        coEvery {
-            projectAccessCheckerMock.isAllowedToReadProject(user, project.id)
-        } throws TestSpecificException()
+        coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
         assertThrows<TestSpecificException> { service.searchFetcherProjectPaperCandidates(request) }
     }
@@ -106,7 +103,7 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery {
             fetcherManagerMock.searchPapers("bar", request.query, any())
         } throws FetcherException("Failed to search bar papers")
-        coEvery { paperRepoMock.getPaperByExternalId("fooId") } returns Result.success(fooPaper)
+        coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
 
         val papers = service.searchFetcherProjectPaperCandidates(request).papersList
@@ -129,7 +126,7 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
-        coEvery { paperRepoMock.getPaperByExternalId("fooId") } returns Result.success(fooPaper)
+        coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns true
 
         val papers = service.searchFetcherProjectPaperCandidates(request).papersList
@@ -138,29 +135,28 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
     }
 
     @Test
-    fun `When retrieving a paper by its external ID fails, then it is returned without checking for existence`() =
-        runTest {
-            val user = DataBuilder.createExampleUser()
-            val project = DataBuilder.createExampleProject(fetchers = mapOf("foo" to emptyMap()))
-            val projectResult = Result.success(project)
-            val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
-            val fooFetcherPaper = fooPaper.toFetcherPaper()
+    fun `When paper is not found by its external ID, then it is returned without checking for existence`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject(fetchers = mapOf("foo" to emptyMap()))
+        val projectResult = Result.success(project)
+        val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
+        val fooFetcherPaper = fooPaper.toFetcherPaper()
 
-            val request = getExampleRequest(project)
+        val request = getExampleRequest(project)
 
-            mockCurrentUser(user)
-            coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
-            coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-            coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
-            coEvery { paperRepoMock.getPaperByExternalId("fooId") } returns Result.failure(TestSpecificException())
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+        coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
+        coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
+        coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns emptyList()
 
-            val papers = service.searchFetcherProjectPaperCandidates(request).papersList
+        val papers = service.searchFetcherProjectPaperCandidates(request).papersList
 
-            assertEquals(1, papers.size)
-            assertEquals(papers[0].title, fooPaper.title)
-            assertEquals(papers[0].id, "")
-            coVerify(exactly = 0) { projectPaperRepoMock.doesProjectPaperExist(any(), any()) }
-        }
+        assertEquals(1, papers.size)
+        assertEquals(papers[0].title, fooPaper.title)
+        assertEquals(papers[0].id, "")
+        coVerify(exactly = 0) { projectPaperRepoMock.doesProjectPaperExist(any(), any()) }
+    }
 
     @Test
     fun `When a fetched paper doesn't have an external ID, then it is returned without checking for existence`() =
@@ -177,6 +173,7 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
             coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
             coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
             coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
+            coEvery { paperRepoMock.getPapersByExternalIds(emptyList()) } returns emptyList()
 
             val papers = service.searchFetcherProjectPaperCandidates(request).papersList
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
@@ -1,0 +1,72 @@
+package se.uulm.snowballr.backend.service.fetcher
+
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.TestSpecificException
+import se.uulm.snowballr.backend.model.dto.Project
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
+
+class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
+    fun getExampleRequest(project: Project): GrpcProjectPaper.SearchQuery = GrpcProjectPaper.SearchQuery.newBuilder()
+        .setProjectId(project.id.toString())
+        .build()
+
+    @Test
+    fun `When a user searches papers and has access, then no exception is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
+        val barPaper = DataBuilder.createExamplePaper(externalId = "barId")
+
+        val request = getExampleRequest(project)
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+        coEvery { paperRepoMock.getPapersBySearchQuery(request.query) } returns listOf(fooPaper, barPaper)
+        coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
+        coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, barPaper.id) } returns false
+
+        val papers = service.searchLocalProjectPaperCandidates(request).papersList
+
+        assertEquals(2, papers.size)
+        assertTrue(papers.any { p -> p.id == fooPaper.id.toString() })
+        assertTrue(papers.any { p -> p.id == barPaper.id.toString() })
+    }
+
+    @Test
+    fun `When a user searches papers, but has no access, then a TestSpecificException is thrown`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+
+        val request = getExampleRequest(project)
+
+        mockCurrentUser(user)
+        coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { service.searchLocalProjectPaperCandidates(request) }
+    }
+
+    @Test
+    fun `When a matching paper already exists in the project, then it is not returned`() = runTest {
+        val user = DataBuilder.createExampleUser()
+        val project = DataBuilder.createExampleProject()
+        val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
+
+        val request = getExampleRequest(project)
+
+        mockCurrentUser(user)
+        coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
+        coEvery { paperRepoMock.getPapersBySearchQuery(request.query) } returns listOf(fooPaper)
+        coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns true
+
+        val papers = service.searchLocalProjectPaperCandidates(request).papersList
+
+        assertEquals(0, papers.size)
+    }
+}


### PR DESCRIPTION
Closes #504

## What I have made

- fix bug where JdbcTransactionManager can't be found because of multiple connection instances.
- fix bug with unescaped `apiVersion` in gradle task
- implement repo calls for `SearchLocalProjectPaperCandidates`
  - `getPapersByExternalIds` removes calling `getPaperByExternalId` in a loop
- implement service method and improve helper methods

When I tested it against the fetcher search results with the same query, not many papers were returned. Maybe we need to decrease the threshold or add more fields to the similarity query.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
