### PR TITLE
Add CLI tool to directly interact with fetcher plugins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,7 @@ markdownlint.json
 
 # Scripts and tooling
 scripts/
+tools/
 
 # Plugin volume mount
 plugins/

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ db-data
 ### Plugins ###
 /plugins
 /.venv
+
+### Fetcher CLI ###
+/tools/fetcher-cli/config.json
+/tools/fetcher-cli/output/*
+!/tools/fetcher-cli/output/.gitkeep
+/src/main/resources/plugins/fetchers/lib/__pycache__/

--- a/src/main/resources/plugins/fetchers/lib/xploreapi.py
+++ b/src/main/resources/plugins/fetchers/lib/xploreapi.py
@@ -675,8 +675,13 @@ class XPLORE:
         qry_obj.setopt(qry_obj.WRITEDATA, buffer_obj)
         qry_obj.setopt(qry_obj.CAINFO, certifi.where())
         qry_obj.perform()
+        code = qry_obj.getinfo(pycurl.RESPONSE_CODE)
         qry_obj.close()
         response = buffer_obj.getvalue()
+
+        if code == 500:
+            return "{}"
+
         return response.decode('utf-8')
 
 

--- a/tools/fetcher-cli/cli.py
+++ b/tools/fetcher-cli/cli.py
@@ -159,7 +159,7 @@ def cmd_options(args):
     fetcher_config = get_options_for(fetcher)
 
     if not CONFIG_FILE.exists():
-        print(f"Hint: no config.json found. Run 'init-config' to create one.\n")
+        print("Hint: no config.json found. Run 'init-config' to create one.\n")
 
     print(f"Options for '{fetcher}':")
     print(f"  {'Key':<28} {'Description':<42} Configured")

--- a/tools/fetcher-cli/cli.py
+++ b/tools/fetcher-cli/cli.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+FETCHERS_DIR = (SCRIPT_DIR / "../../src/main/resources/plugins/fetchers").resolve()
+OUTPUT_DIR = SCRIPT_DIR / "output"
+CONFIG_FILE = SCRIPT_DIR / "config.json"
+
+PYTHON_EXECUTABLE = sys.executable
+
+
+def load_config() -> dict:
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE) as f:
+            return json.load(f)
+    return {}
+
+
+def get_options_for(fetcher: str) -> dict:
+    return load_config().get(fetcher, {})
+
+
+def available_fetchers() -> list[str]:
+    return sorted(p.stem for p in FETCHERS_DIR.iterdir() if p.suffix == ".py" and p.is_file())
+
+
+def run_fetcher(fetcher: str, action: str, payload: str = "") -> str:
+    fetcher_path = FETCHERS_DIR / f"{fetcher}.py"
+    if not fetcher_path.exists():
+        print(f"Error: fetcher '{fetcher}' not found in {FETCHERS_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(FETCHERS_DIR / "lib")
+
+    result = subprocess.run(
+        [PYTHON_EXECUTABLE, str(fetcher_path), action],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+    if result.stderr.strip():
+        print(f"[fetcher stderr] {result.stderr.strip()}", file=sys.stderr)
+
+    if result.returncode != 0:
+        print(f"Error: fetcher '{fetcher}' exited with code {result.returncode}.", file=sys.stderr)
+        sys.exit(1)
+
+    output = result.stdout.strip()
+    if not output:
+        print(f"Error: fetcher '{fetcher}' returned no output.", file=sys.stderr)
+        sys.exit(1)
+
+    return output
+
+
+def save_output(action: str, fetcher: str, data: object) -> Path:
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    path = OUTPUT_DIR / f"{action}_{fetcher}_{timestamp}.json"
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    return path
+
+
+def load_paper(paper_arg: str) -> dict:
+    path = Path(paper_arg)
+    if path.exists():
+        with open(path) as f:
+            return json.load(f)
+    return json.loads(paper_arg)
+
+
+def truncate(text: str, width: int) -> str:
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+def format_authors(authors: list) -> str:
+    if not authors:
+        return "—"
+    names = []
+    for a in authors[:3]:
+        first = a.get("first_name", "")
+        last = a.get("last_name", "")
+        names.append(f"{first} {last}".strip() or last)
+    result = ", ".join(names)
+    if len(authors) > 3:
+        result += f" +{len(authors) - 3}"
+    return result
+
+
+def print_papers_table(papers: list[dict]) -> None:
+    if not papers:
+        print("No papers found.")
+        return
+
+    col_title = 52
+    col_year = 6
+    col_authors = 32
+    col_id = 22
+
+    header = f"  {'#':<4} {'Title':<{col_title}} {'Year':<{col_year}} {'Authors':<{col_authors}} {'ExternalId':<{col_id}}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for i, paper in enumerate(papers):
+        title = truncate(paper.get("title", ""), col_title)
+        year = str(paper.get("year", ""))
+        authors = truncate(format_authors(paper.get("authors", [])), col_authors)
+        external_id = truncate(paper.get("external_id") or "—", col_id)
+        print(f"  {i:<4} {title:<{col_title}} {year:<{col_year}} {authors:<{col_authors}} {external_id:<{col_id}}")
+
+
+# --- Subcommands ---
+
+def cmd_list(_args):
+    fetchers = available_fetchers()
+    if not fetchers:
+        print("No fetchers found.")
+        return
+    print(f"Available fetchers ({len(fetchers)}):")
+    for name in fetchers:
+        print(f"  {name}")
+
+
+def cmd_options(args):
+    fetcher = args.fetcher
+    schema: dict[str, str] = json.loads(run_fetcher(fetcher, "options"))
+    fetcher_config = get_options_for(fetcher)
+
+    print(f"Options for '{fetcher}':")
+    print(f"  {'Key':<28} {'Description':<42} Configured")
+    print(f"  {'-'*28} {'-'*42} {'-'*10}")
+    for key, description in schema.items():
+        configured = "yes" if key in fetcher_config else "no"
+        print(f"  {key:<28} {description:<42} {configured}")
+
+
+def cmd_search(args):
+    fetcher = args.fetcher
+    payload = json.dumps({"search_query": args.query, "options": get_options_for(fetcher)})
+    papers: list[dict] = json.loads(run_fetcher(fetcher, "query", payload))
+
+    print_papers_table(papers)
+    saved = save_output("search", fetcher, papers)
+    print(f"\n{len(papers)} paper(s) found. Full results saved to: {saved}")
+
+
+def cmd_references(args, action: str):
+    fetcher = args.fetcher
+    paper = load_paper(args.paper)
+    payload = json.dumps({"paper": paper, "options": get_options_for(fetcher)})
+    papers: list[dict] = json.loads(run_fetcher(fetcher, action, payload))
+
+    print_papers_table(papers)
+    saved = save_output(action, fetcher, papers)
+    print(f"\n{len(papers)} paper(s) found. Full results saved to: {saved}")
+
+
+# --- Entry point ---
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="fetcher-cli",
+        description="CLI for interacting with SnowballR fetcher plugins.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="List all available fetchers.")
+
+    p_opts = sub.add_parser("options", help="Show a fetcher's options and their config status.")
+    p_opts.add_argument("fetcher", help="Fetcher name.")
+
+    p_search = sub.add_parser("search", help="Search for papers.")
+    p_search.add_argument("fetcher", help="Fetcher name.")
+    p_search.add_argument("query", help="Search query string.")
+
+    p_fwd = sub.add_parser("forwards", help="Fetch papers that cite the given paper.")
+    p_fwd.add_argument("fetcher", help="Fetcher name.")
+    p_fwd.add_argument("paper", help="Paper as a JSON string or path to a JSON file.")
+
+    p_bwd = sub.add_parser("backwards", help="Fetch papers cited by the given paper.")
+    p_bwd.add_argument("fetcher", help="Fetcher name.")
+    p_bwd.add_argument("paper", help="Paper as a JSON string or path to a JSON file.")
+
+    args = parser.parse_args()
+    {
+        "list": cmd_list,
+        "options": cmd_options,
+        "search": cmd_search,
+        "forwards": lambda a: cmd_references(a, "forwards"),
+        "backwards": lambda a: cmd_references(a, "backwards"),
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fetcher-cli/cli.py
+++ b/tools/fetcher-cli/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -77,12 +78,28 @@ def save_output(action: str, fetcher: str, data: object) -> Path:
     return path
 
 
+def parse_hstore(value: str) -> dict[str, str]:
+    """Parse a PostgreSQL HSTORE string into a Python dict."""
+    return {
+        m.group(1).replace('\\"', '"'): m.group(2).replace('\\"', '"')
+        for m in re.finditer(r'"((?:[^"\\]|\\.)*)"\s*=>\s*"((?:[^"\\]|\\.)*)"', value)
+    }
+
+
+def normalize_paper(paper: dict) -> dict:
+    """Convert HSTORE-serialized fetcher_metadata to a dict if needed."""
+    metadata = paper.get("fetcher_metadata")
+    if isinstance(metadata, str):
+        paper = {**paper, "fetcher_metadata": parse_hstore(metadata)}
+    return paper
+
+
 def load_paper(paper_arg: str) -> dict:
     path = Path(paper_arg)
     if path.exists():
         with open(path) as f:
-            return json.load(f)
-    return json.loads(paper_arg)
+            return normalize_paper(json.load(f))
+    return normalize_paper(json.loads(paper_arg))
 
 
 def truncate(text: str, width: int) -> str:

--- a/tools/fetcher-cli/cli.py
+++ b/tools/fetcher-cli/cli.py
@@ -17,10 +17,14 @@ PYTHON_EXECUTABLE = sys.executable
 
 
 def load_config() -> dict:
-    if CONFIG_FILE.exists():
+    if not CONFIG_FILE.exists():
+        return {}
+    try:
         with open(CONFIG_FILE) as f:
             return json.load(f)
-    return {}
+    except json.JSONDecodeError:
+        print(f"Warning: {CONFIG_FILE} is not valid JSON — ignoring it.", file=sys.stderr)
+        return {}
 
 
 def get_options_for(fetcher: str) -> dict:
@@ -137,12 +141,37 @@ def cmd_options(args):
     schema: dict[str, str] = json.loads(run_fetcher(fetcher, "options"))
     fetcher_config = get_options_for(fetcher)
 
+    if not CONFIG_FILE.exists():
+        print(f"Hint: no config.json found. Run 'init-config' to create one.\n")
+
     print(f"Options for '{fetcher}':")
     print(f"  {'Key':<28} {'Description':<42} Configured")
     print(f"  {'-'*28} {'-'*42} {'-'*10}")
     for key, description in schema.items():
         configured = "yes" if key in fetcher_config else "no"
         print(f"  {key:<28} {description:<42} {configured}")
+
+
+def cmd_init_config(args):
+    if CONFIG_FILE.exists() and not args.overwrite:
+        print(f"Error: {CONFIG_FILE} already exists. Use --overwrite to replace it.", file=sys.stderr)
+        sys.exit(1)
+
+    fetchers = available_fetchers()
+    if not fetchers:
+        print("No fetchers found — nothing to configure.")
+        return
+
+    config = {}
+    for fetcher in fetchers:
+        schema: dict[str, str] = json.loads(run_fetcher(fetcher, "options"))
+        config[fetcher] = {key: "" for key in schema}
+
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(config, f, indent=2)
+
+    print(f"Created {CONFIG_FILE} with {len(fetchers)} fetcher(s).")
+    print("Fill in the option values before running search or reference commands.")
 
 
 def cmd_search(args):
@@ -192,6 +221,9 @@ def main():
     p_bwd.add_argument("fetcher", help="Fetcher name.")
     p_bwd.add_argument("paper", help="Paper as a JSON string or path to a JSON file.")
 
+    p_init = sub.add_parser("init-config", help="Create config.json pre-populated with all fetcher option keys.")
+    p_init.add_argument("--overwrite", action="store_true", help="Overwrite existing config.json.")
+
     args = parser.parse_args()
     {
         "list": cmd_list,
@@ -199,6 +231,7 @@ def main():
         "search": cmd_search,
         "forwards": lambda a: cmd_references(a, "forwards"),
         "backwards": lambda a: cmd_references(a, "backwards"),
+        "init-config": cmd_init_config,
     }[args.command](args)
 
 

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -27,7 +27,7 @@ being powerful and developer-friendly. Furthermore, it provides a broad set of
 builtin functionality and is very widespread, even in non-computer-science
 degrees. This makes it a very natural and favourable choice.
 
-> [!INFO]
+> [!NOTE]
 > Installing fetchers requires direct access to a running instance of the
 > SnowballR backend. Contact your instance administrator if required.
 
@@ -147,7 +147,7 @@ paper = Paper(
     publication_type,  # str
     publication_name,  # str
     authors,           # list[Author]
-    metadata,          # dict[str, str]
+    fetcher_metadata,  # dict[str, str]
 )
 ```
 
@@ -174,7 +174,7 @@ options = {}
 def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
     return [ Paper(
         "title",
-        None,
+        "external_id",
         "abstract",
         2026,
         "publisher",
@@ -227,7 +227,7 @@ def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
 
     return [ Paper(
         "title",
-        None,
+        "external_id",
         content,
         2026,
         "publisher",
@@ -264,7 +264,7 @@ a plugin.
 
 If the fetcher encounters an error (exit-code != 0), the `stderr` output is
 printed as an error log entry. If the fetcher exits successfully (exit-code ==
-0) and the `stderr` log is not blank, then it is printed as an info log entry.
+0\) and the `stderr` log is not blank, then it is printed as an info log entry.
 
 This can be useful for determining the source of unexpected errors or during
 implementation and debugging.

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -57,9 +57,10 @@ The list of required packages can be also found in the [requirements.txt](https:
 > packages are installed.
 
 To get proper autocomplete and type checking for the SnowballR types, add the
-`plugins/fetchers/lib/` directory to your python path. This can be done by
-adding it to the `PYTHONPATH` environment variable. If the directory does not
-exist yet, start the backend as it should be created automatically.
+[`src/main/resources/plugins/fetchers/lib`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/src/main/resources/plugins/fetchers/lib).
+directory to your python path. This can be done by adding it to the `PYTHONPATH`
+environment variable. If the directory does not exist yet, start the backend as
+it should be created automatically.
 
 ### Plugin Directory
 
@@ -131,11 +132,12 @@ their own set of options.
 
 ### Writing a Fetcher
 
-Equipped with this knowledge, let's get started and write our very
-own fetcher. SnowballR provides a predefined[^1] `Paper`
-dataclass, which is expected as a result. The source is located in
-`plugins/fetchers/lib/snowballr.py` and can be imported with
-`from snowballr import Paper`. It is mutable and can be constructed like this:
+Equipped with this knowledge, let's get started and write our very own fetcher.
+SnowballR provides a predefined[^1] `Paper` dataclass, which is expected as a
+result. The source is located in
+[`src/main/resources/plugins/fetchers/lib/snowballr.py`](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/resources/plugins/fetchers/lib/snowballr.py).
+and can be imported with `from snowballr import Paper`. It is mutable and can be
+constructed like this:
 
 ```py
 paper = Paper(
@@ -272,8 +274,9 @@ implementation and debugging.
 ### Developers
 
 If you want to contribute a fetcher to SnowballR, add it to the resources in
-`src/main/resources/plugins/fetchers/` and adjust the resource builder in
-`src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt`.
+[`src/main/resources/plugins/fetchers/`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/src/main/resources/plugins/fetchers).
+and adjust the resource builder in
+[PythonPluginFetcherManager.kt](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt).
 
 [^1]: There are more definitions provided by SnowballR. Check them out in their
     [definition file](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/resources/plugins/fetchers/lib/snowballr.py).

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -57,7 +57,7 @@ The list of required packages can be also found in the [requirements.txt](https:
 > packages are installed.
 
 To get proper autocomplete and type checking for the SnowballR types, add the
-`./plugins/fetchers/lib/` directory to your python path. This can be done by
+`plugins/fetchers/lib/` directory to your python path. This can be done by
 adding it to the `PYTHONPATH` environment variable. If the directory does not
 exist yet, start the backend as it should be created automatically.
 
@@ -134,7 +134,7 @@ their own set of options.
 Equipped with this knowledge, let's get started and write our very
 own fetcher. SnowballR provides a predefined[^1] `Paper`
 dataclass, which is expected as a result. The source is located in
-`./plugins/fetchers/lib/snowballr.py` and can be imported with
+`plugins/fetchers/lib/snowballr.py` and can be imported with
 `from snowballr import Paper`. It is mutable and can be constructed like this:
 
 ```py

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -30,7 +30,7 @@ The fastest way to get started is to use the provided Docker setup.
 
 > [!INFO]
 > If you encounter a permission-denied error regarding the plugin directory not
-> being writable, make sure to execute `chmod o+wr ./plugins` on the created
+> being writable, make sure to execute `chmod o+wr plugins` on the created
 > directory once. In some cases, Docker's created volumes aren't writable for
 > the user within the container.
 

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -8,8 +8,8 @@ To test the functionality of our app, we employ various tests. To run tests, you
 ./gradlew integrationTest
 ```
 
-The coverage report is located at `./build/coverageHtml/index.html` and the test report at
-`./build/testReportHtml/index.html`.
+The coverage report is located at `build/coverageHtml/index.html` and the test report at
+`build/testReportHtml/index.html`.
 
 On this page, we cover the following topics:
 
@@ -58,8 +58,8 @@ possible to keep it consistent with the already existing tests and to make the a
 If the _JUnit_ assertions are not easily usable, then use the
 [AssertJ](https://github.com/assertj/assertj?tab=readme-ov-file) test assertions.
 
-All test classes must have the same relative path under `./src/test` as the implementation class under
-`./src/main` and the same name with an additional `Test` at the end. This ensures a clear structure and an easy way to
+All test classes must have the same relative path under `src/test` as the implementation class under
+`src/main` and the same name with an additional `Test` at the end. This ensures a clear structure and an easy way to
 find the according test class. The service test classes break this convention as described below.
 
 ### Repository

--- a/wiki/Tools.md
+++ b/wiki/Tools.md
@@ -1,0 +1,140 @@
+This page lists tools that assist the development process of this repository.
+
+<!-- markdownlint-disable MD007 -->
+<!-- @formatter:off -->
+<!-- TOC -->
+  * [Fetcher CLI](#fetcher-cli)
+    * [Configuration](#configuration)
+    * [Subcommands](#subcommands)
+      * [list](#list)
+      * [options](#options)
+      * [search](#search)
+      * [forwards](#forwards)
+      * [backwards](#backwards)
+      * [init-config](#init-config)
+<!-- TOC -->
+<!-- @formatter:on -->
+<!-- markdownlint-enable MD007 -->
+
+## Fetcher CLI
+
+The fetcher plugin system is a core part of the SnowballR application. Ensuring
+correct functionality is a high priority. This is currently not easy because the
+plugins are not easy to access. Especially searching for forward and backward
+references are not called by any API methods, which make them hard to test
+manually. This is where the Fetcher CLI should help out. It offers direct access
+by providing the same implementation as the
+[PythonPluginFetcherManager](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt).
+The CLI is located at
+[`./tools/fetcher-cli`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli).
+It enables faster development of new fetcher plugins and maintenance of existing
+ones.
+
+Make sure to call it from an active python environment (see
+[Getting Started](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started)).
+
+```bash
+uv run ./tools/fetcher-cli/cli.py <subcommand> <args>
+```
+
+### Configuration
+
+Some fetcher plugins may require configuration to work correctly, e.g. an API
+token. To provide this information, create a `config.json` at
+[`./tools/fetcher-cli`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli).
+It should contain a configuration object for each fetcher. This may look like
+this:
+
+```json
+{
+    "ExampleFetcher": {
+        "API_TOKEN": "<your_api_token>"
+    }
+}
+```
+
+If not already existing, a `config.json` can be created using the following
+command:
+
+```bash
+uv run ./tools/fetcher-cli/cli.py init-config
+```
+
+This will create a configuration object for each existing fetcher.
+
+### Subcommands
+
+If call to a fetcher returns data, it will be stored in
+[`./tools/fetcher-cli/output`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli/output).
+The subcommands will also print a short summary of the received data.
+
+#### list
+
+Represents `getAvailableFetchers`.
+
+This will list all existing fetchers. There are no additional arguments.
+
+Example:
+
+```bash
+uv run ./tools/fetcher-cli/cli.py list
+```
+
+#### options
+
+Represents `getAvailableOptions`.
+
+This will return all available options for a specific fetcher.
+
+Example:
+
+```bash
+uv run ./tools/fetcher-cli/cli.py options ExampleFetcher
+```
+
+#### search
+
+Represents `searchPapers`.
+
+This will use the specified fetcher to search papers using the specified query.
+
+Example:
+
+```bash
+uv run ./tools/fetcher-cli/cli.py search ExampleFetcher Snowballing
+```
+
+#### forwards
+
+Represents `fetchForwardReferences`.
+
+This will use the specified fetcher to retrieve all forward references for the
+specified paper.
+
+The paper can be either provided as JSON string or as path to JSON file.
+
+Example:
+
+```bash
+uv run ./tools/fetcher-cli/cli.py forwards ExampleFetcher ./tools/fetcher-cli/paper.json
+```
+
+#### backwards
+
+Represents `fetchBackwardReferences`.
+
+This will use the specified fetcher to retrieve all backward references for the
+specified paper.
+
+The paper can be either provided as JSON string or as path to JSON file.
+
+Example:
+
+```bash
+uv run ./tools/fetcher-cli/cli.py backwards ExampleFetcher ./tools/fetcher-cli/paper.json
+```
+
+#### init-config
+
+See [Configuration](#configuration) for usage examples. To overwrite an existing
+`config.json`, use `--overwrite`. Note that this may delete existing tokens.

--- a/wiki/Tools.md
+++ b/wiki/Tools.md
@@ -26,7 +26,7 @@ manually. This is where the Fetcher CLI should help out. It offers direct access
 by providing the same implementation as the
 [PythonPluginFetcherManager](https://github.com/SE-UUlm/snowballr-backend/blob/develop/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt).
 The CLI is located at
-[`./tools/fetcher-cli`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli).
+[`tools/fetcher-cli`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli).
 It enables faster development of new fetcher plugins and maintenance of existing
 ones.
 
@@ -34,14 +34,14 @@ Make sure to call it from an active python environment (see
 [Getting Started](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started)).
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py <subcommand> <args>
+uv run tools/fetcher-cli/cli.py <subcommand> <args>
 ```
 
 ### Configuration
 
 Some fetcher plugins may require configuration to work correctly, e.g. an API
 token. To provide this information, create a `config.json` at
-[`./tools/fetcher-cli`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli).
+[`tools/fetcher-cli`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli).
 It should contain a configuration object for each fetcher. This may look like
 this:
 
@@ -57,7 +57,7 @@ If not already existing, a `config.json` can be created using the following
 command:
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py init-config
+uv run tools/fetcher-cli/cli.py init-config
 ```
 
 This will create a configuration object for each existing fetcher.
@@ -65,7 +65,7 @@ This will create a configuration object for each existing fetcher.
 ### Subcommands
 
 If call to a fetcher returns data, it will be stored in
-[`./tools/fetcher-cli/output`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli/output).
+[`tools/fetcher-cli/output`](https://github.com/SE-UUlm/snowballr-backend/tree/develop/tools/fetcher-cli/output).
 The subcommands will also print a short summary of the received data.
 
 #### list
@@ -77,7 +77,7 @@ This will list all existing fetchers. There are no additional arguments.
 Example:
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py list
+uv run tools/fetcher-cli/cli.py list
 ```
 
 #### options
@@ -89,7 +89,7 @@ This will return all available options for a specific fetcher.
 Example:
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py options ExampleFetcher
+uv run tools/fetcher-cli/cli.py options ExampleFetcher
 ```
 
 #### search
@@ -101,7 +101,7 @@ This will use the specified fetcher to search papers using the specified query.
 Example:
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py search ExampleFetcher Snowballing
+uv run tools/fetcher-cli/cli.py search ExampleFetcher Snowballing
 ```
 
 #### forwards
@@ -116,7 +116,7 @@ The paper can be either provided as JSON string or as path to JSON file.
 Example:
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py forwards ExampleFetcher ./tools/fetcher-cli/paper.json
+uv run tools/fetcher-cli/cli.py forwards ExampleFetcher tools/fetcher-cli/paper.json
 ```
 
 #### backwards
@@ -131,7 +131,7 @@ The paper can be either provided as JSON string or as path to JSON file.
 Example:
 
 ```bash
-uv run ./tools/fetcher-cli/cli.py backwards ExampleFetcher ./tools/fetcher-cli/paper.json
+uv run tools/fetcher-cli/cli.py backwards ExampleFetcher tools/fetcher-cli/paper.json
 ```
 
 #### init-config

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -6,3 +6,4 @@
 - [Fetcher](https://github.com/SE-UUlm/snowballr-backend/wiki/Fetcher)
 - [Contributing](https://github.com/SE-UUlm/snowballr-backend/wiki/Contributing)
 - [Testing](https://github.com/SE-UUlm/snowballr-backend/wiki/Testing)
+- [Tools](https://github.com/SE-UUlm/snowballr-backend/wiki/Tools)


### PR DESCRIPTION
Closes #505

## What I have made

- this adds a CLI to directly interact with the fetcher plugins
- see the wiki entry for more information
- the bug I found was due to 500 error for specific papers
  - [bug-paper.json](https://github.com/user-attachments/files/28232296/bug-paper.json)
  - [no-bug-paper.json](https://github.com/user-attachments/files/28232300/no-bug-paper.json)

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only CLI tool)

### Reviewer

- [x] I have checked the changes against the requirements
