### PR TITLE
Add unified python linting formatting and type checking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Either tick or cross out the items that do not apply (using \~\~example text\~\~
 ### Author
 
 - [ ] I have updated the documentation accordingly and commented my code
+  - [ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions
 - [ ] I have manually tested my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -92,6 +92,51 @@ jobs:
                   path: build/integrationTestReportHtml
                   if-no-files-found: error
 
+    changes:
+        name: Detect changed files
+        runs-on: ubuntu-latest
+        outputs:
+            python: ${{ steps.filter.outputs.python }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Check for Python file changes
+              id: filter
+              uses: dorny/paths-filter@v4
+              with:
+                  filters: |
+                      python:
+                        - 'tools/fetcher-cli/**/*.py'
+                        - 'src/main/resources/plugins/fetchers/**/*.py'
+                        - 'pyproject.toml'
+
+    python-code-quality:
+        name: Python code quality
+        runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Setup Python and uv
+              uses: ./.github/workflows/setup-python-uv/
+
+            - name: Create virtual environment
+              run: |
+                  uv venv .venv
+                  uv pip install --python .venv/bin/python3 -r requirements.txt
+
+            - name: Check formatting
+              run: uvx ruff format --check .
+
+            - name: Check linting
+              run: uvx ruff check .
+
+            - name: Type checking
+              run: uvx ty check
+
     teamscale-upload:
         name: Teamscale Upload
         runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ existing docs over restating them here. If you must summarize, keep it short and
 - wiki/Contributing.md — project layout and implementation patterns by layer
 - wiki/Testing.md — unit/integration testing conventions and reports
 - wiki/Fetcher.md — fetcher plugin system, security warning, contract
+- wiki/Tools.md — dev tools, including fetcher CLI reference
 
 ## Structure
 
@@ -36,6 +37,8 @@ existing docs over restating them here. If you must summarize, keep it short and
 │   │   └── resources/           # runtime resources (including fetcher plugin libs)
 │   └── test/
 │       └── kotlin/              # tests mirroring production layout
+├── tools/
+│   └── fetcher-cli/             # CLI tool for directly invoking fetcher plugins
 ├── plugins/
 │   └── fetchers/                # local fetcher plugins and shared libs
 ├── .github/workflows/           # CI, release, and wiki automation
@@ -57,6 +60,7 @@ existing docs over restating them here. If you must summarize, keep it short and
 | Fetcher orchestration progress  | wiki/Contributing.md#fetcher-orchestration-progress                      | Implementation checklist.                        |
 | Testing conventions             | wiki/Testing.md                                                          | Unit/integration tests, reports.                 |
 | Fetcher contract                | wiki/Fetcher.md                                                          | Security warning and invocation protocol.        |
+| Fetcher CLI                     | tools/fetcher-cli/cli.py, wiki/Tools.md                                  | Direct plugin invocation for dev/testing.        |
 | Fetcher orchestrator            | src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt | Job queue logic.                                 |
 | Fetcher orchestrator tests      | src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator           | Unit tests.                                      |
 | Orchestrator wiring/startup     | src/main/kotlin/se/uulm/snowballr/backend/Module.kt, Main.kt             | Koin wiring, start/stop.                         |
@@ -141,6 +145,13 @@ existing docs over restating them here. If you must summarize, keep it short and
 - `uv venv .venv`
 - `uv pip install --python .venv/bin/python3 -r requirements.txt`
   (wiki/Getting-Started.md, wiki/Fetcher.md)
+
+### Fetcher CLI
+
+- Run subcommand: `uv run ./tools/fetcher-cli/cli.py <subcommand> <args>` (wiki/Tools.md)
+- Init config: `uv run ./tools/fetcher-cli/cli.py init-config` — creates `tools/fetcher-cli/config.json` with per-fetcher config stubs
+- Subcommands: `list`, `options`, `search`, `forwards`, `backwards`
+- Output saved to `tools/fetcher-cli/output/`
 
 ## Style, checks, and tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,23 +47,24 @@ existing docs over restating them here. If you must summarize, keep it short and
 
 ## Where to look
 
-| Task                            | Location                                                                 | Notes                                     |
-|---------------------------------|--------------------------------------------------------------------------|-------------------------------------------|
-| Project overview                | README.md                                                                | High-level pointers.                      |
-| Local setup / Docker            | wiki/Getting-Started.md                                                  | Includes compose profiles.                |
-| Configuration                   | wiki/Configuration.md, .env.example                                      | Profiles and env vars.                    |
-| Architecture                    | wiki/Architecture.md                                                     | Request flow and layer responsibilities.  |
-| Project layout / layer patterns | wiki/Contributing.md                                                     | Source of truth.                          |
-| Fetcher orchestration progress  | wiki/Contributing.md#fetcher-orchestration-progress                      | Implementation checklist.                 |
-| Testing conventions             | wiki/Testing.md                                                          | Unit/integration tests, reports.          |
-| Fetcher contract                | wiki/Fetcher.md                                                          | Security warning and invocation protocol. |
-| Fetcher orchestrator            | src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt | Job queue logic.                          |
-| Fetcher orchestrator tests      | src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator           | Unit tests.                               |
-| Orchestrator wiring/startup     | src/main/kotlin/se/uulm/snowballr/backend/Module.kt, Main.kt             | Koin wiring, start/stop.                  |
-| Architecture tests              | src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt  | Layer constraints incl. fetcher.          |
-| Build config                    | build.gradle.kts                                                         | apiVersion, Gradle tasks, fetcher deps.   |
-| Docker images                   | Dockerfile, Dockerfile.proxy                                             | Backend and proxy containers.             |
-| CI workflows                    | .github/workflows                                                        | Lint, tests, docker, wiki publish.        |
+| Task                            | Location                                                                 | Notes                                            |
+|---------------------------------|--------------------------------------------------------------------------|--------------------------------------------------|
+| Project overview                | README.md                                                                | High-level pointers.                             |
+| Local setup / Docker            | wiki/Getting-Started.md                                                  | Includes compose profiles.                       |
+| Configuration                   | wiki/Configuration.md, .env.example                                      | Profiles and env vars.                           |
+| Architecture                    | wiki/Architecture.md                                                     | Request flow and layer responsibilities.         |
+| Project layout / layer patterns | wiki/Contributing.md                                                     | Source of truth.                                 |
+| Fetcher orchestration progress  | wiki/Contributing.md#fetcher-orchestration-progress                      | Implementation checklist.                        |
+| Testing conventions             | wiki/Testing.md                                                          | Unit/integration tests, reports.                 |
+| Fetcher contract                | wiki/Fetcher.md                                                          | Security warning and invocation protocol.        |
+| Fetcher orchestrator            | src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt | Job queue logic.                                 |
+| Fetcher orchestrator tests      | src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator           | Unit tests.                                      |
+| Orchestrator wiring/startup     | src/main/kotlin/se/uulm/snowballr/backend/Module.kt, Main.kt             | Koin wiring, start/stop.                         |
+| Architecture tests              | src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt  | Layer constraints incl. fetcher.                 |
+| Build config                    | build.gradle.kts                                                         | apiVersion, Gradle tasks, fetcher deps.          |
+| Python tool config              | pyproject.toml                                                           | ruff (lint/format) and ty (type-check) settings. |
+| Docker images                   | Dockerfile, Dockerfile.proxy                                             | Backend and proxy containers.                    |
+| CI workflows                    | .github/workflows                                                        | Lint, tests, docker, wiki publish.               |
 
 ## Architecture and patterns
 
@@ -113,8 +114,11 @@ existing docs over restating them here. If you must summarize, keep it short and
 
 ### Lint and format
 
-- Lint: `./gradlew lint` (wiki/Contributing.md)
-- Format: `./gradlew format` (wiki/Contributing.md)
+- Lint (Kotlin): `./gradlew lint` (wiki/Contributing.md)
+- Format (Kotlin): `./gradlew format` (wiki/Contributing.md)
+- Format (Python): `uvx ruff format .` (wiki/Contributing.md)
+- Lint (Python): `uvx ruff check .` (wiki/Contributing.md)
+- Type-check (Python): `uvx ty check` — requires `.venv` with deps synced (wiki/Contributing.md)
 
 ### Tests
 
@@ -140,8 +144,9 @@ existing docs over restating them here. If you must summarize, keep it short and
 
 ## Style, checks, and tests
 
-- **Style:** Follow .editorconfig (4-space indent, max line length 120 for Kotlin).
-- **Checks:** Detekt is the linter; keep code consistent with detekt.yml.
+- **Style:** Follow .editorconfig (4-space indent, max line length 120 for Kotlin). Python line length is 100 (pyproject.toml).
+- **Checks (Kotlin):** Detekt is the linter; keep code consistent with detekt.yml.
+- **Checks (Python):** ruff for formatting and linting; ty for type-checking. Config in pyproject.toml. Covers `tools/fetcher-cli/cli.py`, `src/main/resources/plugins/fetchers/IEEEXplore.py`, and `src/main/resources/plugins/fetchers/lib/snowballr.py`.
 - **Tests:** Follow wiki/Testing.md conventions (when-then naming, nested classes).
 
 Example test naming:
@@ -165,6 +170,7 @@ fun `When input is invalid, then validation fails`() {
 
 - PRs to develop must keep a linear history (see .github/workflows/git_conventions.yml).
 - CI workflows run lint, unit tests, integration tests, and Docker builds (.github/workflows).
+- Python code quality (ruff format/check + ty type-check) runs in CI on changes to Python files or pyproject.toml (.github/workflows/code_quality_checks.yml).
 - Wiki linting and publish are handled in .github/workflows/wiki.yml.
 
 ## Conventional commits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.ruff]
+target-version = "py313"
+line-length = 100
+include = [
+    "tools/fetcher-cli/cli.py",
+    "src/main/resources/plugins/fetchers/IEEEXplore.py",
+    "src/main/resources/plugins/fetchers/lib/snowballr.py",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ty.environment]
+python = ".venv"
+extra-paths = ["src/main/resources/plugins/fetchers/lib"]
+
+[tool.ty.src]
+include = [
+    "tools/fetcher-cli/cli.py",
+    "src/main/resources/plugins/fetchers/IEEEXplore.py",
+    "src/main/resources/plugins/fetchers/lib/snowballr.py",
+]

--- a/src/main/resources/plugins/fetchers/IEEEXplore.py
+++ b/src/main/resources/plugins/fetchers/IEEEXplore.py
@@ -1,14 +1,13 @@
 # THIS FILE IS AUTO-GENERATED. DO NOT MODIFY.
 
-from snowballr import fetcher_plugin, Paper, Author
+
+from snowballr import Author, Paper, fetcher_plugin
 from xploreapi import XPLORE
-from datetime import datetime
 
 metadata_key: str = "IEEEXploreId"
 
-options: dict[str, str] = {
-    "API_KEY": "IEEEXplore API key"
-}
+options: dict[str, str] = {"API_KEY": "IEEEXplore API key"}
+
 
 def search_papers(search_query: str, options: dict[str, str]) -> list[Paper]:
     query = XPLORE(options["API_KEY"])
@@ -19,8 +18,10 @@ def search_papers(search_query: str, options: dict[str, str]) -> list[Paper]:
     articles = results.get("articles", [])
     return list(map(paper_from_response, articles))
 
+
 def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     return []
+
 
 def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     article_number = paper.fetcher_metadata.get(metadata_key)
@@ -49,8 +50,13 @@ def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
 
     return references
 
+
 def paper_from_response(res) -> Paper:
-    authors = [author_from_response(author) for author in res.get("authors", {}).get("authors", []) if "full_name" in author]
+    authors = [
+        author_from_response(author)
+        for author in res.get("authors", {}).get("authors", [])
+        if "full_name" in author
+    ]
     # Prefer publication year over insert year
     date = res.get("publication_year", int(res.get("insert_date", "1970")[:4]))
     return Paper(
@@ -62,15 +68,17 @@ def paper_from_response(res) -> Paper:
         res.get("content_type", ""),
         res.get("publication_title", ""),
         authors,
-        { metadata_key: res["article_number"] },
+        {metadata_key: res["article_number"]},
     )
 
+
 def author_from_response(res) -> Author:
-    first_name, sep, last_name = res.get("full_name", "").rpartition(' ')
+    first_name, sep, last_name = res.get("full_name", "").rpartition(" ")
     return Author(
         first_name,
         last_name,
     )
+
 
 fetcher_plugin(
     options,

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -1,28 +1,30 @@
 # THIS FILE IS AUTO-GENERATED. DO NOT MODIFY.
 
-import sys
-from enum import StrEnum
-from dataclasses import dataclass, field
 import json
-from dataclass_wizard import asdict, fromdict, JSONWizard
+import sys
+from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Callable, Optional
-from datetime import datetime
+
+from dataclass_wizard import JSONWizard, fromdict
+
 
 @dataclass(unsafe_hash=True)
 class Author(JSONWizard):
     class _(JSONWizard.Meta):
-        key_transform_with_load = 'SNAKE'
-        key_transform_with_dump = 'SNAKE'
+        key_transform_with_load = "SNAKE"
+        key_transform_with_dump = "SNAKE"
 
     first_name: str = ""
     last_name: str = ""
 
+
 @dataclass(unsafe_hash=True)
 class Paper(JSONWizard):
     class _(JSONWizard.Meta):
-        marshal_date_time_as = 'Timestamp'
-        key_transform_with_load = 'SNAKE'
-        key_transform_with_dump = 'SNAKE'
+        marshal_date_time_as = "Timestamp"
+        key_transform_with_load = "SNAKE"
+        key_transform_with_dump = "SNAKE"
 
     title: str = ""
     external_id: Optional[str] = None
@@ -34,15 +36,18 @@ class Paper(JSONWizard):
     authors: list[Author] = field(default_factory=list)
     fetcher_metadata: dict[str, str] = field(default_factory=dict)
 
+
 class EventType(StrEnum):
     OPTIONS = "options"
     QUERY = "query"
     FORWARDS = "forwards"
     BACKWARDS = "backwards"
 
+
 type Options = dict[str, str]
 type QueryFn = Callable[[str, Options], list[Paper]]
 type ReferenceFn = Callable[[Paper, Options], list[Paper]]
+
 
 def _read_stdin_payload() -> dict:
     if sys.stdin is None or sys.stdin.closed:
@@ -59,6 +64,7 @@ def _read_stdin_payload() -> dict:
         return {}
 
     return json.loads(payload)
+
 
 def fetcher_plugin(
     options: dict[str, str],
@@ -85,7 +91,8 @@ def fetcher_plugin(
                 query_arg = sys.argv[2]
                 options_arg = json.loads(sys.argv[3])
             else:
-                print("The fetcher was called with an incorrect number of arguments.", file=sys.stderr)
+                msg = "The fetcher was called with an incorrect number of arguments."
+                print(msg, file=sys.stderr)
                 print("python fetcher.py query <SEARCH_QUERY> <OPTIONS>", file=sys.stderr)
                 exit(1)
 
@@ -100,7 +107,8 @@ def fetcher_plugin(
                 paper_arg = Paper.from_json(sys.argv[2])
                 options_arg = json.loads(sys.argv[3])
             else:
-                print("The fetcher was called with an incorrect number of arguments.", file=sys.stderr)
+                msg = "The fetcher was called with an incorrect number of arguments."
+                print(msg, file=sys.stderr)
                 print("python fetcher.py forwards <PAPER> <OPTIONS>", file=sys.stderr)
                 exit(1)
 
@@ -115,7 +123,8 @@ def fetcher_plugin(
                 paper_arg = Paper.from_json(sys.argv[2])
                 options_arg = json.loads(sys.argv[3])
             else:
-                print("The fetcher was called with an incorrect number of arguments.", file=sys.stderr)
+                msg = "The fetcher was called with an incorrect number of arguments."
+                print(msg, file=sys.stderr)
                 print("python fetcher.py backwards <PAPER> <OPTIONS>", file=sys.stderr)
                 exit(1)
 

--- a/tools/fetcher-cli/cli.py
+++ b/tools/fetcher-cli/cli.py
@@ -130,7 +130,10 @@ def print_papers_table(papers: list[dict]) -> None:
     col_authors = 32
     col_id = 22
 
-    header = f"  {'#':<4} {'Title':<{col_title}} {'Year':<{col_year}} {'Authors':<{col_authors}} {'ExternalId':<{col_id}}"
+    header = (
+        f"  {'#':<4} {'Title':<{col_title}} {'Year':<{col_year}}"
+        f" {'Authors':<{col_authors}} {'ExternalId':<{col_id}}"
+    )
     print(header)
     print("  " + "-" * (len(header) - 2))
     for i, paper in enumerate(papers):
@@ -138,10 +141,14 @@ def print_papers_table(papers: list[dict]) -> None:
         year = str(paper.get("year", ""))
         authors = truncate(format_authors(paper.get("authors", [])), col_authors)
         external_id = truncate(paper.get("external_id") or "—", col_id)
-        print(f"  {i:<4} {title:<{col_title}} {year:<{col_year}} {authors:<{col_authors}} {external_id:<{col_id}}")
+        print(
+            f"  {i:<4} {title:<{col_title}} {year:<{col_year}}"
+            f" {authors:<{col_authors}} {external_id:<{col_id}}"
+        )
 
 
 # --- Subcommands ---
+
 
 def cmd_list(_args):
     fetchers = available_fetchers()
@@ -163,7 +170,7 @@ def cmd_options(args):
 
     print(f"Options for '{fetcher}':")
     print(f"  {'Key':<28} {'Description':<42} Configured")
-    print(f"  {'-'*28} {'-'*42} {'-'*10}")
+    print(f"  {'-' * 28} {'-' * 42} {'-' * 10}")
     for key, description in schema.items():
         configured = "yes" if key in fetcher_config else "no"
         print(f"  {key:<28} {description:<42} {configured}")
@@ -171,7 +178,10 @@ def cmd_options(args):
 
 def cmd_init_config(args):
     if CONFIG_FILE.exists() and not args.overwrite:
-        print(f"Error: {CONFIG_FILE} already exists. Use --overwrite to replace it.", file=sys.stderr)
+        print(
+            f"Error: {CONFIG_FILE} already exists. Use --overwrite to replace it.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     fetchers = available_fetchers()
@@ -214,6 +224,7 @@ def cmd_references(args, action: str):
 
 # --- Entry point ---
 
+
 def main():
     parser = argparse.ArgumentParser(
         prog="fetcher-cli",
@@ -238,7 +249,10 @@ def main():
     p_bwd.add_argument("fetcher", help="Fetcher name.")
     p_bwd.add_argument("paper", help="Paper as a JSON string or path to a JSON file.")
 
-    p_init = sub.add_parser("init-config", help="Create config.json pre-populated with all fetcher option keys.")
+    p_init = sub.add_parser(
+        "init-config",
+        help="Create config.json pre-populated with all fetcher option keys.",
+    )
     p_init.add_argument("--overwrite", action="store_true", help="Overwrite existing config.json.")
 
     args = parser.parse_args()

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -19,6 +19,7 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
   * [Miscellaneous Commands](#miscellaneous-commands)
     * [Formatting](#formatting)
     * [Linting](#linting)
+    * [Type Checking](#type-checking)
   * [Release procedure](#release-procedure)
   * [Use another API Version](#use-another-api-version)
   * [Fetcher Orchestration Progress](#fetcher-orchestration-progress)
@@ -310,10 +311,35 @@ For information about our testing setup, see [Testing](https://github.com/SE-UUl
 ./gradlew format
 ```
 
+For Python files:
+
+```bash
+uvx ruff format .
+```
+
 ### Linting
 
 ```bash
 ./gradlew lint
+```
+
+For Python files:
+
+```bash
+uvx ruff check .
+```
+
+### Type Checking
+
+Requires the virtual environment to resolve installed packages. Set it up first if not already done (see [Getting Started](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started)):
+
+```bash
+uv venv .venv
+uv pip install --python .venv/bin/python3 -r requirements.txt
+```
+
+```bash
+uvx ty check
 ```
 
 ## Release procedure

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -331,7 +331,9 @@ uvx ruff check .
 
 ### Type Checking
 
-Requires the virtual environment to resolve installed packages. Set it up first if not already done (see [Getting Started](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started)):
+Requires the virtual environment to resolve installed packages. Set it up first
+if not already done (see
+[Getting Started](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started)):
 
 ```bash
 uv venv .venv

--- a/wiki/Tools.md
+++ b/wiki/Tools.md
@@ -30,7 +30,7 @@ The CLI is located at
 It enables faster development of new fetcher plugins and maintenance of existing
 ones.
 
-Make sure to call it from an active python environment (see
+Make sure to call it from an active Python environment (>= 3.13, see
 [Getting Started](https://github.com/SE-UUlm/snowballr-backend/wiki/Getting-Started)).
 
 ```bash


### PR DESCRIPTION
Closes #511 

## What I have made

- Added `pyproject.toml` with unified `ruff` and `ty` configuration targeting `cli.py`, `IEEEXplore.py`, and `snowballr.py`. `xploreapi.py` excluded as it is an SDK.
- Fixed all resulting `ruff` violations.
- Added a python-code-quality CI job that runs `ruff` and `ty`, gated on Python file changes via `dorny/paths-filter`.
- Added Python linting, formatting, and type checking commands to wiki.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

### Reviewer

- [x] I have checked the changes against the requirements
