### PR TITLE
Create fetcher for semantic scholar

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
     <dictionary name="project">
         <words>
+            <w>snowballr</w>
             <w>uulm</w>
         </words>
     </dictionary>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ existing docs over restating them here. If you must summarize, keep it short and
 
 - **Style:** Follow .editorconfig (4-space indent, max line length 120 for Kotlin). Python line length is 100 (pyproject.toml).
 - **Checks (Kotlin):** Detekt is the linter; keep code consistent with detekt.yml.
-- **Checks (Python):** ruff for formatting and linting; ty for type-checking. Config in pyproject.toml. Covers `tools/fetcher-cli/cli.py`, `src/main/resources/plugins/fetchers/IEEEXplore.py`, `src/main/resources/plugins/fetchers/SemanticScholar.py`, and `src/main/resources/plugins/fetchers/lib/snowballr.py`.
+- **Checks (Python):** ruff for formatting and linting; ty for type-checking. Config in pyproject.toml.
 - **Tests:** Follow wiki/Testing.md conventions (when-then naming, nested classes).
 
 Example test naming:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ existing docs over restating them here. If you must summarize, keep it short and
 
 - **Style:** Follow .editorconfig (4-space indent, max line length 120 for Kotlin). Python line length is 100 (pyproject.toml).
 - **Checks (Kotlin):** Detekt is the linter; keep code consistent with detekt.yml.
-- **Checks (Python):** ruff for formatting and linting; ty for type-checking. Config in pyproject.toml. Covers `tools/fetcher-cli/cli.py`, `src/main/resources/plugins/fetchers/IEEEXplore.py`, and `src/main/resources/plugins/fetchers/lib/snowballr.py`.
+- **Checks (Python):** ruff for formatting and linting; ty for type-checking. Config in pyproject.toml. Covers `tools/fetcher-cli/cli.py`, `src/main/resources/plugins/fetchers/IEEEXplore.py`, `src/main/resources/plugins/fetchers/SemanticScholar.py`, and `src/main/resources/plugins/fetchers/lib/snowballr.py`.
 - **Tests:** Follow wiki/Testing.md conventions (when-then naming, nested classes).
 
 Example test naming:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ kotlin {
 }
 
 val fetcherVenvDir = layout.projectDirectory.dir(".venv").asFile
-val fetcherVenvPython = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+val fetcherVenvPython: String = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
     fetcherVenvDir.resolve("Scripts/python.exe").absolutePath
 } else {
     fetcherVenvDir.resolve("bin/python3").absolutePath
@@ -164,6 +164,8 @@ tasks.register<Test>("integrationTest") {
     useJUnitPlatform {
         includeTags("integration")
     }
+    description = "Runs all integration tests"
+    group = "verification"
     testClassesDirs = sourceSets["test"].output.classesDirs
     classpath = sourceSets["test"].runtimeClasspath
     reports.html.required.set(true)

--- a/justfile
+++ b/justfile
@@ -1,0 +1,8 @@
+set positional-arguments
+
+default:
+    @just --list
+
+# Run fetcher CLI
+fetcher-cli *args='':
+    uv run --no-project tools/fetcher-cli/cli.py "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ line-length = 100
 include = [
     "tools/fetcher-cli/cli.py",
     "src/main/resources/plugins/fetchers/IEEEXplore.py",
+    "src/main/resources/plugins/fetchers/SemanticScholar.py",
     "src/main/resources/plugins/fetchers/lib/snowballr.py",
 ]
 
@@ -18,5 +19,6 @@ extra-paths = ["src/main/resources/plugins/fetchers/lib"]
 include = [
     "tools/fetcher-cli/cli.py",
     "src/main/resources/plugins/fetchers/IEEEXplore.py",
+    "src/main/resources/plugins/fetchers/SemanticScholar.py",
     "src/main/resources/plugins/fetchers/lib/snowballr.py",
 ]

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManager.kt
@@ -33,11 +33,12 @@ private const val FETCHER_RESOURCES_PREFIX = "$FETCHER_RESOURCES_ROOT/"
 
 // Bundled python scripts and libraries to bootstrap python fetcher infrastructure.
 private val resources = buildResources(FETCHER_RESOURCES_ROOT) {
-    file("IEEEXplore.py")
     dir("lib") {
         file("xploreapi.py")
         file("snowballr.py")
     }
+    file("IEEEXplore.py")
+    file("SemanticScholar.py")
 }
 
 class PythonPluginFetcherManager(

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/AuthorValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/AuthorValidator.kt
@@ -1,8 +1,11 @@
 package se.uulm.snowballr.backend.validation
 
 import arrow.core.EitherNel
+import arrow.core.raise.Raise
 import arrow.core.raise.either
+import arrow.core.raise.ensure
 import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.ValidationIssue
 import snowballr.PaperOuterClass.Author
 
@@ -12,8 +15,20 @@ object AuthorValidator {
 
     fun validateAuthor(author: Author): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
-            { ensureTextFieldValidity("first_name", author.firstName, FIRST_NAME_MAX_LENGTH) },
-            { ensureTextFieldValidity("last_name", author.lastName, LAST_NAME_MAX_LENGTH) },
-        ) { _, _ -> }
+            { ensureFieldLength("first_name", author.firstName, FIRST_NAME_MAX_LENGTH) },
+            { ensureFieldLength("last_name", author.lastName, LAST_NAME_MAX_LENGTH) },
+            { ensureOnlyOneBlankField(author) },
+        ) { _, _, _ -> }
+    }
+
+    /**
+     * Ensures that the given author has at least one non-blank name field.
+     *
+     * @param author The author to validate.
+     */
+    private fun Raise<ValidationIssue>.ensureOnlyOneBlankField(author: Author) {
+        ensure(
+            author.firstName.isNotBlank() || author.lastName.isNotBlank(),
+        ) { BlankField("first_name' and 'last_name") }
     }
 }

--- a/src/main/resources/plugins/fetchers/IEEEXplore.py
+++ b/src/main/resources/plugins/fetchers/IEEEXplore.py
@@ -70,7 +70,7 @@ def paper_from_response(res) -> Paper:
 
 
 def author_from_response(res) -> Author:
-    first_name, sep, last_name = res.get("full_name", "").rpartition(" ")
+    first_name, _, last_name = res.get("full_name", "").rpartition(" ")
     return Author(
         first_name,
         last_name,

--- a/src/main/resources/plugins/fetchers/IEEEXplore.py
+++ b/src/main/resources/plugins/fetchers/IEEEXplore.py
@@ -1,6 +1,3 @@
-# THIS FILE IS AUTO-GENERATED. DO NOT MODIFY.
-
-
 from snowballr import Author, Paper, fetcher_plugin
 from xploreapi import XPLORE
 

--- a/src/main/resources/plugins/fetchers/IEEEXplore.py
+++ b/src/main/resources/plugins/fetchers/IEEEXplore.py
@@ -55,17 +55,17 @@ def paper_from_response(res) -> Paper:
         if "full_name" in author
     ]
     # Prefer publication year over insert year
-    date = res.get("publication_year", int(res.get("insert_date", "1970")[:4]))
+    date = res.get("publication_year", int(res.get("insert_date", "0000")[:4]))
     return Paper(
-        res.get("title", ""),
-        res.get("doi", None),
-        res.get("abstract", ""),
-        date,
-        res.get("publisher", ""),
-        res.get("content_type", ""),
-        res.get("publication_title", ""),
-        authors,
-        {metadata_key: res["article_number"]},
+        title=res.get("title", ""),
+        external_id=res.get("doi", None),
+        abstract=res.get("abstract", ""),
+        year=date,
+        publisher=res.get("publisher", ""),
+        publication_type=res.get("content_type", ""),
+        publication_name=res.get("publication_title", ""),
+        authors=authors,
+        fetcher_metadata={metadata_key: res["article_number"]},
     )
 
 

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -74,7 +74,9 @@ def get_references(
 def request_with_retry(url: str, options: dict[str, str]) -> dict[str, Any]:
     """
     Requests without API Key might be blocked because of the public rate limiting.
-    A request is retried if a "Too Many Requests" status code is returned.
+    A request is retried if a "Too Many Requests" status code is returned or if the
+    connection is dropped mid-transfer (IncompleteRead / ChunkedEncodingError), which
+    can happen for large citation responses when the server closes the socket early.
 
     This method expects that the caller terminates the call if a time limit is reached.
     """
@@ -84,14 +86,14 @@ def request_with_retry(url: str, options: dict[str, str]) -> dict[str, Any]:
         headers["x-api-key"] = options["API_KEY"]
 
     while True:
-        response = requests.get(
-            url,
-            headers=headers,
-        )
-        if response.status_code == 429:
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            if response.status_code == 429:
+                continue
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.ChunkedEncodingError:
             continue
-        response.raise_for_status()
-        return response.json()
 
 
 def paper_from_response(res) -> Paper:

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -1,0 +1,130 @@
+from snowballr import fetcher_plugin, Paper, Author, safe_get
+import requests
+import urllib.parse
+import sys
+from typing import Optional, Any
+
+id_metadata_key: str = "SemanticScholarId"
+corpus_id_metadata_key: str = "SemanticScholarCorpusId"
+
+options = {
+    "API_KEY": "SemanticScholar API key"
+}
+
+base_url = "https://api.semanticscholar.org/graph/v1/"
+fields = "corpusId,title,externalIds,abstract,publicationDate,year,venue,publicationTypes,authors"
+
+def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
+    """
+    API reference:
+    https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_paper_relevance_search
+    """
+    query = urllib.parse.quote_plus(searchQuery)
+    url = f"{base_url}paper/search?query={query}&fields={fields}&limit=25"
+
+    data = request_with_retry(url, options)
+    papers = safe_get(data, "data", [])
+
+    return list(map(paper_from_response, papers))
+
+def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
+    """
+    API reference:
+    https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_get_paper_citations
+    """
+    return get_references(paper, options, "citations", "citingPaper")
+
+def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
+    """
+    API reference:
+    https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_get_paper_references
+    """
+    return get_references(paper, options, "references", "citedPaper")
+
+def get_references(paper: Paper, options: dict[str, str], url_suffix: str, obj_key: str) -> list[Paper]:
+    paper_id = paper.fetcher_metadata.get(id_metadata_key)
+    # TODO: try other IDs (external IDs)
+    if paper_id is None:
+        return []
+
+    url = f"{base_url}paper/{paper_id}/{url_suffix}?fields={fields}&limit=1000"
+    paper_objects = []
+    offset = 0
+
+    # Use pagination to request all references
+    while True:
+        offset_url = f"{url}&offset={offset}"
+        data = request_with_retry(offset_url, options)
+        paper_objects += safe_get(data, "data", [])
+
+        # 'next' is None if last page is reached
+        if data.get("next") is None:
+            break
+
+        offset += 1000
+
+    return list(map(lambda obj: paper_from_response(safe_get(obj, obj_key, {})), paper_objects))
+
+def request_with_retry(url: str, options: dict[str, str]) -> dict[str, Any]:
+    """
+    Requests without API Key might be blocked because of the public rate limiting.
+    A request is retried if a "Too Many Requests" status code is returned.
+
+    This method expects that the caller terminates the call if a time limit is reached.
+    """
+    headers = {}
+
+    if "API_KEY" in options:
+        headers["x-api-key"] = options["API_KEY"]
+
+    while True:
+        response = requests.get(
+            url,
+            headers=headers,
+        )
+        if response.status_code == 429:
+            continue
+        response.raise_for_status()
+        return response.json()
+
+def paper_from_response(res) -> Paper:
+    authors = [author_from_response(author) for author in safe_get(res, "authors", []) if "name" in author]
+    external_id = external_id_from_response(safe_get(res, "externalIds", {}))
+    year = int(safe_get(res, "publicationDate", str(safe_get(res, "year", "0000")))[:4])
+    publication_type=next(iter(safe_get(res, "publicationTypes", [])), "")
+    return Paper(
+        title=safe_get(res, "title", ""),
+        external_id=external_id,
+        abstract=safe_get(res, "abstract", ""),
+        year=year,
+        publisher="",
+        publication_type=publication_type,
+        publication_name=safe_get(res, "venue", ""),
+        authors=authors,
+        fetcher_metadata={
+            id_metadata_key: res["paperId"],
+            corpus_id_metadata_key: str(res["corpusId"]),
+        },
+    )
+
+def author_from_response(res) -> Author:
+    first_name, sep, last_name = safe_get(res, "name", "").rpartition(' ')
+    return Author(
+        first_name,
+        last_name,
+    )
+
+def external_id_from_response(res) -> Optional[str]:
+    # Order of external IDs to retrieve (first match is returned)
+    order = ["DOI", "DBLP", "PubMed", "PubMedCentral", "Medline", "MAG", "ArXiv"]
+    for key in order:
+        if key in res:
+            return res.get(key, None)
+    return None
+
+fetcher_plugin(
+    options,
+    search_papers,
+    forward_references,
+    backward_references,
+)

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -13,13 +13,13 @@ from snowballr import (
 id_metadata_key: str = "SemanticScholarId"
 corpus_id_metadata_key: str = "SemanticScholarCorpusId"
 
-options = {"API_KEY": "SemanticScholar API key"}
+fetcher_options = {"API_KEY": "SemanticScholar API key"}
 
 base_url = "https://api.semanticscholar.org/graph/v1"
 fields = "corpusId,title,externalIds,abstract,publicationDate,year,venue,publicationTypes,authors"
 
 
-def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
+def search_papers(search_query: str, options: dict[str, str]) -> list[Paper]:
     """
     API reference:
     https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_paper_relevance_search
@@ -28,7 +28,7 @@ def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
     """
     url = f"{base_url}/paper/search"
     params = {
-        "query": urllib.parse.quote_plus(searchQuery),
+        "query": urllib.parse.quote_plus(search_query),
         "fields": fields,
         "limit": 25,
     }
@@ -144,7 +144,7 @@ def external_id_from_response(res) -> Optional[str]:
 
 
 fetcher_plugin(
-    options,
+    fetcher_options,
     search_papers,
     forward_references,
     backward_references,

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -15,7 +15,7 @@ corpus_id_metadata_key: str = "SemanticScholarCorpusId"
 
 options = {"API_KEY": "SemanticScholar API key"}
 
-base_url = "https://api.semanticscholar.org/graph/v1/"
+base_url = "https://api.semanticscholar.org/graph/v1"
 fields = "corpusId,title,externalIds,abstract,publicationDate,year,venue,publicationTypes,authors"
 
 
@@ -26,11 +26,15 @@ def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
 
     This returns at most 25 papers.
     """
-    query = urllib.parse.quote_plus(searchQuery)
-    url = f"{base_url}paper/search?query={query}&fields={fields}&limit=25"
-
+    url = f"{base_url}/paper/search"
+    params = {
+        "query": urllib.parse.quote_plus(searchQuery),
+        "fields": fields,
+        "limit": 25,
+    }
     headers, timeout_seconds = _s2_params(options)
-    data = request_with_retry(url, headers, timeout_seconds)
+
+    data = request_with_retry(url, headers, params, timeout_seconds)
     papers = safe_get(data, "data", [])
 
     return list(map(paper_from_response, papers))
@@ -61,15 +65,19 @@ def get_references(
     if paper_id is None:
         return []
 
-    url = f"{base_url}paper/{paper_id}/{url_suffix}?fields={fields}&limit=1000"
+    url = f"{base_url}/paper/{paper_id}/{url_suffix}"
+    params = {
+        "fields": fields,
+        "limit": 1000,
+    }
     headers, timeout_seconds = _s2_params(options)
 
     def next_url(data: dict[str, Any]) -> Optional[str]:
         next_offset = data.get("next")
-        return f"{url}&offset={next_offset}" if next_offset is not None else None
+        return f"{url}?offset={next_offset}" if next_offset is not None else None
 
     paper_objects = []
-    for page in paginate_with_retry(url, headers, next_url, timeout_seconds):
+    for page in paginate_with_retry(url, next_url, headers, params, timeout_seconds):
         paper_objects += safe_get(page, "data", [])
 
     return list(map(lambda obj: paper_from_response(safe_get(obj, obj_key, {})), paper_objects))

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -42,7 +42,8 @@ def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     return get_references(paper, options, "references", "citedPaper")
 
 def get_references(paper: Paper, options: dict[str, str], url_suffix: str, obj_key: str) -> list[Paper]:
-    paper_id = paper.fetcher_metadata.get(id_metadata_key)
+    metadata = paper.fetcher_metadata
+    paper_id = safe_get(metadata, id_metadata_key, metadata.get(corpus_id_metadata_key, None))
     # TODO: try other IDs (external IDs)
     if paper_id is None:
         return []
@@ -92,6 +93,15 @@ def paper_from_response(res) -> Paper:
     external_id = external_id_from_response(safe_get(res, "externalIds", {}))
     year = int(safe_get(res, "publicationDate", str(safe_get(res, "year", "0000")))[:4])
     publication_type=next(iter(safe_get(res, "publicationTypes", [])), "")
+
+    metadata = {}
+    paper_id = res.get("paperId", None)
+    if paper_id is not None:
+        metadata[id_metadata_key] = paper_id
+    corpus_id = res.get("corpusId", None)
+    if corpus_id is not None:
+        metadata[corpus_id_metadata_key] = str(corpus_id)
+
     return Paper(
         title=safe_get(res, "title", ""),
         external_id=external_id,
@@ -101,10 +111,7 @@ def paper_from_response(res) -> Paper:
         publication_type=publication_type,
         publication_name=safe_get(res, "venue", ""),
         authors=authors,
-        fetcher_metadata={
-            id_metadata_key: res["paperId"],
-            corpus_id_metadata_key: str(res["corpusId"]),
-        },
+        fetcher_metadata=metadata,
     )
 
 def author_from_response(res) -> Author:

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -1,18 +1,17 @@
-from snowballr import fetcher_plugin, Paper, Author, safe_get
-import requests
 import urllib.parse
-import sys
-from typing import Optional, Any
+from typing import Any, Optional
+
+import requests
+from snowballr import Author, Paper, fetcher_plugin, safe_get
 
 id_metadata_key: str = "SemanticScholarId"
 corpus_id_metadata_key: str = "SemanticScholarCorpusId"
 
-options = {
-    "API_KEY": "SemanticScholar API key"
-}
+options = {"API_KEY": "SemanticScholar API key"}
 
 base_url = "https://api.semanticscholar.org/graph/v1/"
 fields = "corpusId,title,externalIds,abstract,publicationDate,year,venue,publicationTypes,authors"
+
 
 def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
     """
@@ -27,12 +26,14 @@ def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
 
     return list(map(paper_from_response, papers))
 
+
 def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     """
     API reference:
     https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_get_paper_citations
     """
     return get_references(paper, options, "citations", "citingPaper")
+
 
 def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     """
@@ -41,7 +42,10 @@ def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     """
     return get_references(paper, options, "references", "citedPaper")
 
-def get_references(paper: Paper, options: dict[str, str], url_suffix: str, obj_key: str) -> list[Paper]:
+
+def get_references(
+    paper: Paper, options: dict[str, str], url_suffix: str, obj_key: str
+) -> list[Paper]:
     metadata = paper.fetcher_metadata
     paper_id = safe_get(metadata, id_metadata_key, metadata.get(corpus_id_metadata_key, None))
     # TODO: try other IDs (external IDs)
@@ -66,6 +70,7 @@ def get_references(paper: Paper, options: dict[str, str], url_suffix: str, obj_k
 
     return list(map(lambda obj: paper_from_response(safe_get(obj, obj_key, {})), paper_objects))
 
+
 def request_with_retry(url: str, options: dict[str, str]) -> dict[str, Any]:
     """
     Requests without API Key might be blocked because of the public rate limiting.
@@ -88,11 +93,14 @@ def request_with_retry(url: str, options: dict[str, str]) -> dict[str, Any]:
         response.raise_for_status()
         return response.json()
 
+
 def paper_from_response(res) -> Paper:
-    authors = [author_from_response(author) for author in safe_get(res, "authors", []) if "name" in author]
+    authors = [
+        author_from_response(author) for author in safe_get(res, "authors", []) if "name" in author
+    ]
     external_id = external_id_from_response(safe_get(res, "externalIds", {}))
     year = int(safe_get(res, "publicationDate", str(safe_get(res, "year", "0000")))[:4])
-    publication_type=next(iter(safe_get(res, "publicationTypes", [])), "")
+    publication_type = next(iter(safe_get(res, "publicationTypes", [])), "")
 
     metadata = {}
     paper_id = res.get("paperId", None)
@@ -114,12 +122,14 @@ def paper_from_response(res) -> Paper:
         fetcher_metadata=metadata,
     )
 
+
 def author_from_response(res) -> Author:
-    first_name, sep, last_name = safe_get(res, "name", "").rpartition(' ')
+    first_name, sep, last_name = safe_get(res, "name", "").rpartition(" ")
     return Author(
         first_name,
         last_name,
     )
+
 
 def external_id_from_response(res) -> Optional[str]:
     # Order of external IDs to retrieve (first match is returned)
@@ -128,6 +138,7 @@ def external_id_from_response(res) -> Optional[str]:
         if key in res:
             return res.get(key, None)
     return None
+
 
 fetcher_plugin(
     options,

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -1,8 +1,14 @@
 import urllib.parse
 from typing import Any, Optional
 
-import requests
-from snowballr import Author, Paper, fetcher_plugin, safe_get
+from snowballr import (
+    Author,
+    Paper,
+    fetcher_plugin,
+    paginate_with_retry,
+    request_with_retry,
+    safe_get,
+)
 
 id_metadata_key: str = "SemanticScholarId"
 corpus_id_metadata_key: str = "SemanticScholarCorpusId"
@@ -17,11 +23,14 @@ def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
     """
     API reference:
     https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_paper_relevance_search
+
+    This returns at most 25 papers.
     """
     query = urllib.parse.quote_plus(searchQuery)
     url = f"{base_url}paper/search?query={query}&fields={fields}&limit=25"
 
-    data = request_with_retry(url, options)
+    headers, timeout_seconds = _s2_params(options)
+    data = request_with_retry(url, headers, timeout_seconds)
     papers = safe_get(data, "data", [])
 
     return list(map(paper_from_response, papers))
@@ -47,53 +56,34 @@ def get_references(
     paper: Paper, options: dict[str, str], url_suffix: str, obj_key: str
 ) -> list[Paper]:
     metadata = paper.fetcher_metadata
-    paper_id = safe_get(metadata, id_metadata_key, metadata.get(corpus_id_metadata_key, None))
+    paper_id = safe_get(metadata, id_metadata_key, metadata[corpus_id_metadata_key])
     # TODO: try other IDs (external IDs)
     if paper_id is None:
         return []
 
     url = f"{base_url}paper/{paper_id}/{url_suffix}?fields={fields}&limit=1000"
+    headers, timeout_seconds = _s2_params(options)
+
+    def next_url(data: dict[str, Any]) -> Optional[str]:
+        next_offset = data.get("next")
+        return f"{url}&offset={next_offset}" if next_offset is not None else None
+
     paper_objects = []
-    offset = 0
-
-    # Use pagination to request all references
-    while True:
-        offset_url = f"{url}&offset={offset}"
-        data = request_with_retry(offset_url, options)
-        paper_objects += safe_get(data, "data", [])
-
-        # 'next' is None if last page is reached
-        if data.get("next") is None:
-            break
-
-        offset += 1000
+    for page in paginate_with_retry(url, headers, next_url, timeout_seconds):
+        paper_objects += safe_get(page, "data", [])
 
     return list(map(lambda obj: paper_from_response(safe_get(obj, obj_key, {})), paper_objects))
 
 
-def request_with_retry(url: str, options: dict[str, str]) -> dict[str, Any]:
-    """
-    Requests without API Key might be blocked because of the public rate limiting.
-    A request is retried if a "Too Many Requests" status code is returned or if the
-    connection is dropped mid-transfer (IncompleteRead / ChunkedEncodingError), which
-    can happen for large citation responses when the server closes the socket early.
-
-    This method expects that the caller terminates the call if a time limit is reached.
-    """
+def _s2_params(options: dict[str, str]) -> tuple[dict[str, str], float]:
     headers = {}
+    timeout_seconds = 0.0
 
     if "API_KEY" in options:
         headers["x-api-key"] = options["API_KEY"]
+        timeout_seconds = 1.0  # 1 RPS for calls with API key
 
-    while True:
-        try:
-            response = requests.get(url, headers=headers, timeout=10)
-            if response.status_code == 429:
-                continue
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.ChunkedEncodingError:
-            continue
+    return headers, timeout_seconds
 
 
 def paper_from_response(res) -> Paper:
@@ -101,14 +91,17 @@ def paper_from_response(res) -> Paper:
         author_from_response(author) for author in safe_get(res, "authors", []) if "name" in author
     ]
     external_id = external_id_from_response(safe_get(res, "externalIds", {}))
-    year = int(safe_get(res, "publicationDate", str(safe_get(res, "year", "0000")))[:4])
+
+    date_str = safe_get(res, "publicationDate", "") or str(safe_get(res, "year", "0"))
+    year = int(str(date_str)[:4] or "0")
+
     publication_type = next(iter(safe_get(res, "publicationTypes", [])), "")
 
     metadata = {}
-    paper_id = res.get("paperId", None)
+    paper_id = res["paperId"]
     if paper_id is not None:
         metadata[id_metadata_key] = paper_id
-    corpus_id = res.get("corpusId", None)
+    corpus_id = res["corpusId"]
     if corpus_id is not None:
         metadata[corpus_id_metadata_key] = str(corpus_id)
 
@@ -126,7 +119,7 @@ def paper_from_response(res) -> Paper:
 
 
 def author_from_response(res) -> Author:
-    first_name, sep, last_name = safe_get(res, "name", "").rpartition(" ")
+    first_name, _, last_name = safe_get(res, "name", "").rpartition(" ")
     return Author(
         first_name,
         last_name,
@@ -138,7 +131,7 @@ def external_id_from_response(res) -> Optional[str]:
     order = ["DOI", "DBLP", "PubMed", "PubMedCentral", "Medline", "MAG", "ArXiv"]
     for key in order:
         if key in res:
-            return res.get(key, None)
+            return res[key]
     return None
 
 

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -151,7 +151,10 @@ def safe_get(res: dict, key: str, default: Any):
 
 
 def request_with_retry(
-    url: str, headers: dict[str, Any], timeout_seconds: float = 0.0
+    url: str,
+    headers: dict[str, Any] = {},
+    params: dict[str, Any] = {},
+    timeout_seconds: float = 0.0,
 ) -> dict[str, Any]:
     """
     Requests the specified url with automated retries.
@@ -176,7 +179,7 @@ def request_with_retry(
 
     for n in range(max_attempts):
         try:
-            response = requests.get(url, headers=headers, timeout=10)
+            response = requests.get(url, headers=headers, params=params, timeout=10)
 
             if response.status_code == 429:
                 if n == max_attempts - 1:
@@ -209,8 +212,9 @@ def _exp_backoff(timeout_seconds: float, max_timeout: float, attempt: int) -> fl
 
 def paginate_with_retry(
     first_url: str,
-    headers: dict[str, Any],
     next_url: Callable[[dict[str, Any]], Optional[str]],
+    headers: dict[str, Any] = {},
+    params: dict[str, Any] = {},
     timeout_seconds: float = 0.0,
 ) -> Iterator[dict[str, Any]]:
     """
@@ -231,6 +235,6 @@ def paginate_with_retry(
             time.sleep(timeout_seconds - elapsed)
 
         last_call = time.monotonic()
-        response = request_with_retry(url, headers, timeout_seconds)
+        response = request_with_retry(url, headers, params, timeout_seconds)
         yield response
         url = next_url(response)

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -2,7 +2,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from dataclass_wizard import JSONWizard, fromdict
 
@@ -132,3 +132,16 @@ def fetcher_plugin(
         case _:
             print("Unknown fetcher action.", file=sys.stderr)
             exit(1)
+
+
+def safe_get(res: dict, key: str, default: Any):
+    """
+    Retrieves a value from the passed dictionary using the specified key.
+    If the key doesn't exist or the value of the entry is None, the provided default value is
+    returned.
+    """
+    val = res.get(key)
+    if val is None:
+        return default
+    else:
+        return val

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -1,5 +1,3 @@
-# THIS FILE IS AUTO-GENERATED. DO NOT MODIFY.
-
 import json
 import sys
 from dataclasses import dataclass, field

--- a/src/main/resources/plugins/fetchers/lib/snowballr.py
+++ b/src/main/resources/plugins/fetchers/lib/snowballr.py
@@ -1,9 +1,12 @@
 import json
+import random
 import sys
+import time
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
 
+import requests
 from dataclass_wizard import JSONWizard, fromdict
 
 
@@ -27,7 +30,7 @@ class Paper(JSONWizard):
     title: str = ""
     external_id: Optional[str] = None
     abstract: str = ""
-    year: int = 1970
+    year: int = 0
     publisher: str = ""
     publication_type: str = ""
     publication_name: str = ""
@@ -145,3 +148,89 @@ def safe_get(res: dict, key: str, default: Any):
         return default
     else:
         return val
+
+
+def request_with_retry(
+    url: str, headers: dict[str, Any], timeout_seconds: float = 0.0
+) -> dict[str, Any]:
+    """
+    Requests the specified url with automated retries.
+
+    If a "Too Many Requests" status code is returned, the request is retried after a certain
+    timeout. The timeout is defined in the following order:
+    - by the "Retry-After" header
+    - by the "timeout_seconds" parameter with exponential backoff and jitter
+
+    If timeout_seconds is set to 0, no backoff is applied and the requests are fired constantly.
+    Use this with caution.
+
+    A request is also retried if the connection is dropped mid-transfer (ChunkedEncodingError),
+    which can happen for large responses when the server closes the socket early.
+
+    The request has a timeout of 10 seconds.
+
+    The maximum number of attempts is 5 and the maximum timeout between requests is 60 seconds.
+    """
+    max_attempts = 5
+    max_timeout = 60
+
+    for n in range(max_attempts):
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+
+            if response.status_code == 429:
+                if n == max_attempts - 1:
+                    response.raise_for_status()
+
+                retry_after = response.headers.get("Retry-After")
+                wait = int(retry_after) if retry_after is not None else None
+
+                if wait is None:
+                    wait = _exp_backoff(timeout_seconds, max_timeout, n)
+
+                if wait > 0:
+                    time.sleep(wait)
+                continue
+
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.ChunkedEncodingError:
+            time.sleep(_exp_backoff(timeout_seconds, max_timeout, n))
+            continue
+
+    raise RuntimeError(
+        f"Failed to fetch the requested resource '{url}' after {max_attempts} attempts"
+    )
+
+
+def _exp_backoff(timeout_seconds: float, max_timeout: float, attempt: int) -> float:
+    return random.uniform(0, min(max_timeout, timeout_seconds * 2**attempt))
+
+
+def paginate_with_retry(
+    first_url: str,
+    headers: dict[str, Any],
+    next_url: Callable[[dict[str, Any]], Optional[str]],
+    timeout_seconds: float = 0.0,
+) -> Iterator[dict[str, Any]]:
+    """
+    Paginates through a resource by repeatedly calling request_with_retry.
+
+    Before each request, sleeps the remaining time since the last call to respect the
+    timeout_seconds interval, avoiding 429s proactively. request_with_retry still handles any 429s
+    reactively as a safety net.
+
+    Pagination stops when next_url returns None.
+    """
+    url: Optional[str] = first_url
+    last_call = 0.0
+
+    while url is not None:
+        elapsed = time.monotonic() - last_call
+        if elapsed < timeout_seconds:
+            time.sleep(timeout_seconds - elapsed)
+
+        last_call = time.monotonic()
+        response = request_with_retry(url, headers, timeout_seconds)
+        yield response
+        url = next_url(response)

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -51,6 +51,7 @@ class PythonPluginFetcherManagerTest {
     @Test
     fun `When the manager is initialized, then bundled plugin resources are copied`() {
         assertThat(fetcherDirectory.resolve("IEEEXplore.py").exists()).isTrue()
+        assertThat(fetcherDirectory.resolve("SemanticScholar.py").exists()).isTrue()
         assertThat(fetcherDirectory.resolve("lib").resolve("snowballr.py").exists()).isTrue()
         assertThat(fetcherDirectory.resolve("lib").resolve("xploreapi.py").exists()).isTrue()
     }
@@ -71,6 +72,7 @@ class PythonPluginFetcherManagerTest {
         val availableFetchers = fetcherManager.getAvailableFetchers()
 
         assertThat(availableFetchers).contains("IEEEXplore", "custom_fetcher")
+        assertThat(availableFetchers).contains("SemanticScholar", "custom_fetcher")
         assertThat(availableFetchers).doesNotContain("README", "nested_fetcher")
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/AuthorValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/AuthorValidatorTest.kt
@@ -4,30 +4,49 @@ import `in`.rcard.assertj.arrowcore.EitherAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.TooLongField
 import se.uulm.snowballr.backend.validation.AuthorValidator.validateAuthor
 import snowballr.author
-import snowballr.copy
+import snowballr.PaperOuterClass.Author as GrpcAuthor
 
 class AuthorValidatorTest {
-    private val validAuthor = author {
-        firstName = "John"
-        lastName = "Doe"
+    companion object {
+        @JvmStatic
+        fun validAuthors() = listOf(
+            author { firstName = "John"; lastName = "Doe" },
+            author { firstName = ""; lastName = "Doe" },
+            author { firstName = "John"; lastName = "" },
+        ).map { Arguments.of(it) }
+
+        @JvmStatic
+        fun invalidAuthorsTooLongName() = listOf(
+            Pair(author { firstName = "a".repeat(AuthorValidator.FIRST_NAME_MAX_LENGTH + 1); lastName = "Doe" }, 1),
+            Pair(author { firstName = "John"; lastName = "a".repeat(AuthorValidator.LAST_NAME_MAX_LENGTH + 1) }, 1),
+            Pair(
+                author {
+                    firstName = "a".repeat(AuthorValidator.FIRST_NAME_MAX_LENGTH + 1)
+                    lastName = "a".repeat(AuthorValidator.LAST_NAME_MAX_LENGTH + 1)
+                },
+                2,
+            ),
+        )
     }
 
-    @Test
-    fun `When an author is valid, then no issues are returned`() {
-        val author = validAuthor
-
+    @ParameterizedTest
+    @MethodSource("se.uulm.snowballr.backend.validation.AuthorValidatorTest#validAuthors")
+    fun `When an author is valid, then no issues are returned`(author: GrpcAuthor) {
         val result = validateAuthor(author)
 
         EitherAssert.assertThat(result).isRight()
     }
 
     @Test
-    fun `When an author has a blank name, then 'BlankField' issues are returned`() {
-        val author = validAuthor.copy {
+    fun `When an author has a completely blank name, then 'BlankField' issues are returned`() {
+        val author = author {
             firstName = ""
             lastName = ""
         }
@@ -38,22 +57,19 @@ class AuthorValidatorTest {
         EitherAssert.assertThat(result).isLeft()
         val issues = result.leftOrNull()
         assertNotNull(issues)
-        assertThat(issues).hasSize(2)
+        assertThat(issues).hasSize(1)
     }
 
-    @Test
-    fun `When an author has a too long name, then 'TooLongField' issues are returned`() {
-        val author = validAuthor.copy {
-            firstName = "a".repeat(AuthorValidator.FIRST_NAME_MAX_LENGTH + 1)
-            lastName = "a".repeat(AuthorValidator.LAST_NAME_MAX_LENGTH + 1)
-        }
-
+    @ParameterizedTest
+    @MethodSource("se.uulm.snowballr.backend.validation.AuthorValidatorTest#invalidAuthorsTooLongName")
+    fun `When an author has a too long name, then 'TooLongField' issues are returned`(data: Pair<GrpcAuthor, Int>) {
+        val (author, expectedIssues) = data
         val result = validateAuthor(author)
 
         assertInvalidResult<TooLongField>(result)
         EitherAssert.assertThat(result).isLeft()
         val issues = result.leftOrNull()
         assertNotNull(issues)
-        assertThat(issues).hasSize(2)
+        assertThat(issues).hasSize(expectedIssues)
     }
 }

--- a/tools/fetcher-cli/cli.py
+++ b/tools/fetcher-cli/cli.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -204,22 +205,26 @@ def cmd_init_config(args):
 def cmd_search(args):
     fetcher = args.fetcher
     payload = json.dumps({"search_query": args.query, "options": get_options_for(fetcher)})
+    start = time.monotonic()
     papers: list[dict] = json.loads(run_fetcher(fetcher, "query", payload))
+    elapsed = time.monotonic() - start
 
     print_papers_table(papers)
     saved = save_output("search", fetcher, papers)
-    print(f"\n{len(papers)} paper(s) found. Full results saved to: {saved}")
+    print(f"\n{len(papers)} paper(s) found in {elapsed:.2f}s. Full results saved to: {saved}")
 
 
 def cmd_references(args, action: str):
     fetcher = args.fetcher
     paper = load_paper(args.paper)
     payload = json.dumps({"paper": paper, "options": get_options_for(fetcher)})
+    start = time.monotonic()
     papers: list[dict] = json.loads(run_fetcher(fetcher, action, payload))
+    elapsed = time.monotonic() - start
 
     print_papers_table(papers)
     saved = save_output(action, fetcher, papers)
-    print(f"\n{len(papers)} paper(s) found. Full results saved to: {saved}")
+    print(f"\n{len(papers)} paper(s) found in {elapsed:.2f}s. Full results saved to: {saved}")
 
 
 # --- Entry point ---

--- a/wiki/Fetcher.md
+++ b/wiki/Fetcher.md
@@ -86,13 +86,13 @@ SnowballR library:
 
 from snowballr import fetcher_plugin, Paper
 
-options: dict[str, str] = ...
+fetcher_options: dict[str, str] = ...
 def search_papers(search_query: str, options: dict[str, str]) -> list[Paper]: ...
 def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]: ...
 def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]: ...
 
 fetcher_plugin(
-    options,
+    fetcher_options,
     search_papers,
     forward_references,
     backward_references,
@@ -171,9 +171,9 @@ Let's put all the pieces together:
 
 from snowballr import fetcher_plugin, Paper, Author
 
-options = {}
+fetcher_options = {}
 
-def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
+def search_papers(search_query: str, options: dict[str, str]) -> list[Paper]:
     return [ Paper(
         "title",
         "external_id",
@@ -193,7 +193,7 @@ def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
     return []
 
 fetcher_plugin(
-    options,
+    fetcher_options,
     search_papers,
     forward_references,
     backward_references,
@@ -212,45 +212,11 @@ We'll make use of the installed `requests` package (which is already a
 dependency) to acquire external resources.
 
 ```py
-# ./plugins/fetchers/http.py
-
-from snowballr import fetcher_plugin, Paper, Author
-import requests
-
-options = {
-    "API_KEY": "The API key"
-}
-
-def search_papers(searchQuery: str, options: dict[str, str]) -> list[Paper]:
-    content = requests.get(
-        "https://example.com",
-        auth=("user", options["API_KEY"])
-    ).text
-
-    return [ Paper(
-        "title",
-        "external_id",
-        content,
-        2026,
-        "publisher",
-        "publication_type",
-        "publication_name",
-        [Author("first_name", "last_name")],
-        {}
-    ) ]
-
-def forward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
-    return []
-
-def backward_references(paper: Paper, options: dict[str, str]) -> list[Paper]:
-    return []
-
-fetcher_plugin(
-    options,
-    search_papers,
-    forward_references,
-    backward_references,
-)
+content = requests.get(
+    "https://example.com",
+    headers={"API_KEY": options["API_KEY"]},
+    auth=("user", options["API_KEY"])
+).text
 ```
 
 This fetcher accepts an `API_KEY` option, displaying the hint `The API key`


### PR DESCRIPTION
Closes #513

## What I have made

This adds the fetcher for SemanticScholar. The fetcher can be used in two modes:
- without API key: shared pool, continuously tries to connect to the server
- with API key: 1 request per second, with exponential backoff + jitter

As discussed, I will change the validation logic so that we can accept data that we receive from SemanticScholar. So ignore the validator call in the FetcherService for now.

I recommend using the Fetcher CLI or using the frontend paper searching branch (still WIP).

The following file can be used for requesting forward and backward references:
[example.json](https://github.com/user-attachments/files/28361752/example.json)

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - [x] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions
- [x] I have manually tested my changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (currently no tests for fetchers)

### Reviewer

- [ ] I have checked the changes against the requirements
