### PR TITLE
Privilege escalation via field mask key mismatch

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -22,7 +22,7 @@ jobs:
                   markdownlint-config-path: markdownlint.json
                   source-branch: develop
                   ignore-links: "https://stackoverflow.com/questions/6720050/foreign-key-constraints-when-to-use-on-update-and-on-delete/6720458#6720458,https://medium.com/@pererikbergman/repository-design-pattern-e28c0f3e4a30"
-                  ignore-paths: "src/"
+                  ignore-paths: "src/,AGENTS.md,CLAUDE.md"
 
             - name: Calculate implementation progress (dry run)
               run: node scripts/calc-impl-progress.js update-wiki

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+AGENTS.md
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+

--- a/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Main.kt
@@ -69,6 +69,10 @@ private fun initializeFetcherOrchestrator() {
 
 private fun addDbShutdownHook() {
     val db = getKoin().get<IDatabase>()
-    db.close()
-    logger.info { "Closed database connection" }
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            db.close()
+            logger.info { "Closed database connection" }
+        },
+    )
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -160,12 +160,12 @@ class UserService(
         accessChecker.isAllowedToUpdateUser(currentUser, targetUser)
 
         // If the role is changed, the requesting user must be a server admin.
-        if (request.mask.pathsList.contains("role")) {
+        if (request.mask.pathsList.contains("user.role")) {
             accessChecker.isAllowedToUpdateUserRole(currentUser, targetUserId)
         }
 
         // If the email is changed, there must not yet exist an account with that email address.
-        if (request.mask.pathsList.contains("email") && userRepo.doesUserExistByEmail(request.user.email)) {
+        if (request.mask.pathsList.contains("user.email") && userRepo.doesUserExistByEmail(request.user.email)) {
             throw DuplicateUserException(request.user.email)
         }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAllException
+import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
 import se.uulm.snowballr.backend.model.parseUUID
 import snowballr.Authentication
+import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -128,6 +131,36 @@ class UserIntegrationTest : IntegrationTest() {
 
             assertEquals(newFirstName, updatedUser.firstName)
         }
+
+        @Test
+        fun `When a non-admin user tries to escalate their own role, then an UnauthorizedUpdateException is thrown`() =
+            runTest {
+                val nonAdminUser = addUser(DataBuilder.createExampleUser(email = "non.admin@example.com"))
+                val nonAdminUserId = parseUUID(nonAdminUser.id, EntityType.USER)
+
+                val request = GrpcUser.Update.newBuilder()
+                    .setUser(GrpcUser.newBuilder().setId(nonAdminUser.id).setRole(UserRole.USER_ROLE_ADMIN))
+                    .setMask(FieldMask.newBuilder().addPaths("user.role"))
+                    .build()
+
+                actAsUser(nonAdminUserId) {
+                    assertThrows<UnauthorizedUpdateException> { userService.updateUser(request) }
+                }
+            }
+
+        @Test
+        fun `When a user tries to change their email to one already in use, then a DuplicateUserException is thrown`() =
+            runTest {
+                val existingUser = addUser(DataBuilder.createExampleUser(email = "existing@example.com"))
+                val currentUser = userService.getCurrentUser()
+
+                val request = GrpcUser.Update.newBuilder()
+                    .setUser(GrpcUser.newBuilder().setId(currentUser.id).setEmail(existingUser.email))
+                    .setMask(FieldMask.newBuilder().addPaths("user.email"))
+                    .build()
+
+                assertThrows<DuplicateUserException> { userService.updateUser(request) }
+            }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.user
 import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -57,7 +58,7 @@ class UpdateUserTest : UserServiceTest() {
             val currentUser = DataBuilder.createExampleUser()
             val otherUser = DataBuilder.createExampleUser()
 
-            val request = getRequest(otherUser, listOf("role"))
+            val request = getRequest(otherUser, listOf("user.role"))
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
@@ -75,7 +76,7 @@ class UpdateUserTest : UserServiceTest() {
             val currentUser = DataBuilder.createExampleUser()
             val otherUser = DataBuilder.createExampleUser(email = "other@user.com")
 
-            val request = getRequest(otherUser, listOf("email"))
+            val request = getRequest(otherUser, listOf("user.email"))
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
@@ -90,7 +91,7 @@ class UpdateUserTest : UserServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser(email = "other@user.com")
 
-        val request = getRequest(otherUser, listOf("email"))
+        val request = getRequest(otherUser, listOf("user.email"))
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
@@ -109,7 +110,10 @@ class UpdateUserTest : UserServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser()
 
-        val request = getRequest(otherUser, listOf("first_name", "last_name", "role", "status"))
+        val request = getRequest(
+            otherUser,
+            listOf("user.first_name", "user.last_name", "user.role", "user.status"),
+        )
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
@@ -125,4 +129,37 @@ class UpdateUserTest : UserServiceTest() {
         assertEquals(UserRole.valueOf(otherUser.role.name), updatedUser.role)
         assertEquals(UserStatus.valueOf(otherUser.status.name), updatedUser.status)
     }
+
+    @Test
+    fun `When a non-admin user tries to change their own role, then a TestSpecificException is thrown`() = runTest {
+        val currentUser = DataBuilder.createExampleUser()
+
+        val request = getRequest(currentUser, listOf("user.role"))
+
+        mockCurrentUser(currentUser)
+        coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, currentUser) }
+        coEvery {
+            userAccessCheckerMock.isAllowedToUpdateUserRole(currentUser, currentUser.id)
+        } throws TestSpecificException()
+
+        assertThrows<TestSpecificException> { service.updateUser(request) }
+
+        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
+    }
+
+    @Test
+    fun `When a user tries to change their own email to an existent email, then a DuplicateUserException is thrown`() =
+        runTest {
+            val currentUser = DataBuilder.createExampleUser()
+
+            val request = getRequest(currentUser, listOf("user.email"))
+
+            mockCurrentUser(currentUser)
+            coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, currentUser) }
+            coEvery { userRepoMock.doesUserExistByEmail(currentUser.email) } returns true
+
+            assertThrows<DuplicateUserException> { service.updateUser(request) }
+
+            coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
+        }
 }


### PR DESCRIPTION
Closes #527

## What I have made

- Fixed privilege escalation via field mask key mismatch -> changed "role" to "user.role" e.g.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [ ] ~~I have updated the documentation accordingly and commented my code~~
  - [ ] ~~I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [ ] I have checked the changes against the requirements
