### PR TITLE
Use non grpc request types for user domain

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -28,6 +28,7 @@ import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriterion
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.scheduler.SchedulerManager
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -213,7 +214,14 @@ class SnowballRServer(
             fetcherService.getAvailableFetchers()
 
         override suspend fun register(request: Authentication.RegisterRequest) = returnNothing {
-            userService.register(request)
+            userService.register(
+                RegisterRequest(
+                    firstName = request.firstName,
+                    lastName = request.lastName,
+                    email = request.email,
+                    password = request.password,
+                ),
+            )
         }
 
         override suspend fun verifyEmail(request: Authentication.VerifyEmailRequest) = returnNothing {

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -26,9 +26,12 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriterion
+import se.uulm.snowballr.backend.model.dto.user.UserRole
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.scheduler.SchedulerManager
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -265,7 +268,17 @@ class SnowballRServer(
             userService.getUserByEmail(request.email)
 
         override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User =
-            userService.updateUser(request)
+            userService.updateUser(
+                UpdateUserRequest(
+                    userId = parseUUID(request.user.id, EntityType.USER),
+                    firstName = request.user.firstName,
+                    lastName = request.user.lastName,
+                    email = request.user.email,
+                    role = UserRole.fromGrpc(request.user.role),
+                    status = UserStatus.fromGrpc(request.user.status),
+                ),
+                FieldMaskUtil.normalize(request.mask).pathsList,
+            )
 
         override suspend fun softDeleteUser(request: Base.Id) = returnNothing {
             userService.softDeleteUser(parseUserId(request))

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -28,6 +28,8 @@ import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriterion
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
+import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
+import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
@@ -257,15 +259,17 @@ class SnowballRServer(
             authenticationService.changePassword(request)
         }
 
-        override suspend fun getAllUsers(request: Base.Nothing): UserOuterClass.User.List = userService.getAllUsers()
+        override suspend fun getAllUsers(request: Base.Nothing): UserOuterClass.User.List =
+            userService.getAllUsers().toGrpcUsers()
 
-        override suspend fun getCurrentUser(request: Base.Nothing): UserOuterClass.User = userService.getCurrentUser()
+        override suspend fun getCurrentUser(request: Base.Nothing): UserOuterClass.User =
+            userService.getCurrentUser().toGrpcUser()
 
         override suspend fun getUserById(request: Base.Id): UserOuterClass.User =
-            userService.getUserById(parseUserId(request))
+            userService.getUserById(parseUserId(request)).toGrpcUser()
 
         override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User =
-            userService.getUserByEmail(request.email)
+            userService.getUserByEmail(request.email).toGrpcUser()
 
         override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User =
             userService.updateUser(
@@ -278,7 +282,7 @@ class SnowballRServer(
                     status = UserStatus.fromGrpc(request.user.status),
                 ),
                 FieldMaskUtil.normalize(request.mask).pathsList,
-            )
+            ).toGrpcUser()
 
         override suspend fun softDeleteUser(request: Base.Id) = returnNothing {
             userService.softDeleteUser(parseUserId(request))

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -29,6 +29,7 @@ import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriterion
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
+import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
@@ -306,7 +307,7 @@ class SnowballRServer(
             projectPaperService.getPreviousPaper(parseProjectPaperId(request))
 
         override suspend fun getUserSettings(request: Base.Nothing): UserSettingsOuterClass.UserSettings =
-            userService.getUserSettings()
+            userService.getUserSettings().toGrpcUserSettings()
 
         override suspend fun updateUserSettings(
             request: UserSettingsOuterClass.UserSettings.Update,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettings.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettings.kt
@@ -3,10 +3,6 @@ package se.uulm.snowballr.backend.model.dto.user
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.fetcher.FetcherMap
-import snowballr.CriterionOuterClass
-import snowballr.Fetcher.FetcherOptions
-import snowballr.ProjectOuterClass
-import snowballr.UserSettingsOuterClass
 import java.util.UUID
 
 data class UserSettings(
@@ -19,31 +15,3 @@ data class UserSettings(
     val snowballingType: SnowballingType,
     val reviewMaybeAllowed: Boolean,
 )
-
-/**
- * Creates a [UserSettingsOuterClass.UserSettings] from this [UserSettings].
- */
-fun UserSettings.toGrpcUserSettings(
-    criteria: CriterionOuterClass.Criterion.List,
-): UserSettingsOuterClass.UserSettings = UserSettingsOuterClass.UserSettings
-    .newBuilder()
-    .setShowHotkeys(this.areHotkeysShown)
-    .setReviewMode(this.isReviewModeEnabled)
-    .setDefaultCriteria(criteria)
-    .setDefaultProjectSettings(
-        ProjectOuterClass.Project.Settings.newBuilder()
-            .setSimilarityThreshold(this.similarityThreshold)
-            .setDecisionMatrix(this.decisionMatrix.toGrpc())
-            .putAllFetchers(
-                this.fetchers.mapValues {
-                    FetcherOptions
-                        .newBuilder()
-                        .putAllOptions(it.value)
-                        .build()
-                },
-            )
-            .setSnowballingType(this.snowballingType.toGrpc())
-            .setReviewMaybeAllowed(this.reviewMaybeAllowed)
-            .build(),
-    )
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettingsWithCriteria.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettingsWithCriteria.kt
@@ -1,0 +1,35 @@
+package se.uulm.snowballr.backend.model.dto.user
+
+import se.uulm.snowballr.backend.model.dto.criterion.Criterion
+import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
+import snowballr.Fetcher.FetcherOptions
+import snowballr.ProjectOuterClass
+import snowballr.UserSettingsOuterClass
+
+data class UserSettingsWithCriteria(
+    val settings: UserSettings,
+    val criteria: List<Criterion>,
+)
+
+fun UserSettingsWithCriteria.toGrpcUserSettings(): UserSettingsOuterClass.UserSettings =
+    UserSettingsOuterClass.UserSettings.newBuilder()
+        .setShowHotkeys(settings.areHotkeysShown)
+        .setReviewMode(settings.isReviewModeEnabled)
+        .setDefaultCriteria(criteria.toGrpcCriteria())
+        .setDefaultProjectSettings(
+            ProjectOuterClass.Project.Settings.newBuilder()
+                .setSimilarityThreshold(settings.similarityThreshold)
+                .setDecisionMatrix(settings.decisionMatrix.toGrpc())
+                .putAllFetchers(
+                    settings.fetchers.mapValues {
+                        FetcherOptions
+                            .newBuilder()
+                            .putAllOptions(it.value)
+                            .build()
+                    },
+                )
+                .setSnowballingType(settings.snowballingType.toGrpc())
+                .setReviewMaybeAllowed(settings.reviewMaybeAllowed)
+                .build(),
+        )
+        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/user/RegisterRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/user/RegisterRequest.kt
@@ -1,0 +1,8 @@
+package se.uulm.snowballr.backend.model.incoming.user
+
+data class RegisterRequest(
+    val firstName: String,
+    val lastName: String,
+    val email: String,
+    val password: String,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/user/UpdateUserRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/user/UpdateUserRequest.kt
@@ -1,0 +1,14 @@
+package se.uulm.snowballr.backend.model.incoming.user
+
+import se.uulm.snowballr.backend.model.dto.user.UserRole
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
+import java.util.UUID
+
+data class UpdateUserRequest(
+    val userId: UUID,
+    val firstName: String,
+    val lastName: String,
+    val email: String,
+    val role: UserRole,
+    val status: UserStatus,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -25,11 +25,11 @@ import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserSettings
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.toUser
 import se.uulm.snowballr.backend.table.toUserSettings
-import snowballr.Authentication
 import java.time.OffsetDateTime
 import java.util.UUID
 import snowballr.UserOuterClass.User as GrpcUser
@@ -100,7 +100,7 @@ interface IUserTableRepo {
      * @param passwordHash The hashed password for the user.
      * @return The created [User] object representing the newly registered user.
      */
-    suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User
+    suspend fun createUser(request: RegisterRequest, passwordHash: String): User
 
     /**
      * Updates an existent user in the database with the provided new information.
@@ -290,7 +290,7 @@ class UserTableRepo(
             matchingUsers.orEmpty()
         }
 
-    override suspend fun createUser(request: Authentication.RegisterRequest, passwordHash: String): User = db.query {
+    override suspend fun createUser(request: RegisterRequest, passwordHash: String): User = db.query {
         UserTable.insertAndGet(ResultRow::toUser) {
             it[email] = request.email
             it[firstName] = request.firstName

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/UserTableRepo.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import com.google.protobuf.util.FieldMaskUtil
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.TextColumnType
@@ -26,13 +25,12 @@ import se.uulm.snowballr.backend.model.dto.user.UserSettings
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.table.toUser
 import se.uulm.snowballr.backend.table.toUserSettings
 import java.time.OffsetDateTime
 import java.util.UUID
-import snowballr.UserOuterClass.User as GrpcUser
 
 private val logger = KotlinLogging.logger { }
 
@@ -104,16 +102,12 @@ interface IUserTableRepo {
 
     /**
      * Updates an existent user in the database with the provided new information.
-     * The following fields can be updated:
-     * - first name
-     * - last name
-     * - email
-     * - role
      *
      * @param request The update request containing the new user details, such as the new first name.
+     * @param paths The field mask paths that should be updated.
      * @return The updated [User] object reflecting the changes from the [request].
      */
-    suspend fun updateUser(request: GrpcUser.Update): User
+    suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): User
 
     /**
      * Performs a soft-delete meaning the user with the given [id] is not removed from the database, but only the
@@ -301,18 +295,15 @@ class UserTableRepo(
         }
     }
 
-    override suspend fun updateUser(request: GrpcUser.Update): User = db.query {
-        val userId = parseUUID(request.user.id, EntityType.USER)
-        val fieldMask = FieldMaskUtil.normalize(request.mask)
-
-        UserTable.updateByIdAndGet(userId, ResultRow::toUser) {
-            for (field in fieldMask.pathsList) {
+    override suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): User = db.query {
+        UserTable.updateByIdAndGet(request.userId, ResultRow::toUser) {
+            for (field in paths) {
                 when (field) {
-                    "user.email" -> it[email] = request.user.email
-                    "user.first_name" -> it[firstName] = request.user.firstName
-                    "user.last_name" -> it[lastName] = request.user.lastName
-                    "user.role" -> it[role] = UserRole.fromGrpc(request.user.role)
-                    "user.status" -> it[status] = UserStatus.fromGrpc(request.user.status)
+                    "user.email" -> it[email] = request.email
+                    "user.first_name" -> it[firstName] = request.firstName
+                    "user.last_name" -> it[lastName] = request.lastName
+                    "user.role" -> it[role] = request.role
+                    "user.status" -> it[status] = request.status
                 }
             }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import com.google.protobuf.FieldMask
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.auth.IJwtManager
 import se.uulm.snowballr.backend.auth.PasswordUtils
@@ -8,17 +7,16 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.dto.user.isActiveAndConfirmed
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.failedprecondition.EntityNotActiveException
 import se.uulm.snowballr.backend.model.exception.invalidargument.IncorrectOldPasswordException
 import se.uulm.snowballr.backend.model.exception.notfound.VerificationTokenNotFoundException
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import snowballr.Authentication
 import java.time.OffsetDateTime
-import snowballr.UserOuterClass.User as GrpcUser
 
 interface IAuthenticationService {
     /**
@@ -73,11 +71,15 @@ class AuthenticationService(
 
         // Update the user's status to active
         val updatedUser = user.copy(status = UserStatus.ACTIVE)
-        val userUpdate = GrpcUser.Update.newBuilder()
-            .setUser(updatedUser.toGrpcUser())
-            .setMask(FieldMask.newBuilder().addPaths("user.status").build())
-            .build()
-        repo.updateUser(userUpdate)
+        val userUpdate = UpdateUserRequest(
+            userId = updatedUser.id,
+            firstName = updatedUser.firstName,
+            lastName = updatedUser.lastName,
+            email = updatedUser.email,
+            role = updatedUser.role,
+            status = updatedUser.status,
+        )
+        repo.updateUser(userUpdate, listOf("user.status"))
 
         // Remove the verification token after successful verification
         verificationTokenRepo.deleteVerificationToken(request.token)

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -9,10 +9,9 @@ import se.uulm.snowballr.backend.formatting.daysToHumanReadable
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.UserIdentifierType
-import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
+import se.uulm.snowballr.backend.model.dto.user.UserSettingsWithCriteria
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
@@ -22,7 +21,6 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import java.util.UUID
-import snowballr.UserSettingsOuterClass.UserSettings as GrpcUserSettings
 
 interface IUserService {
     /**
@@ -58,7 +56,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.getUserSettings].
      */
-    suspend fun getUserSettings(): GrpcUserSettings
+    suspend fun getUserSettings(): UserSettingsWithCriteria
 
     /**
      * Service implementation of [SnowballRService.getCurrentUser].
@@ -191,10 +189,10 @@ class UserService(
 
     override suspend fun getCurrentUser(): User = withUser(userRepo) { it }
 
-    override suspend fun getUserSettings(): GrpcUserSettings = withUser(userRepo) { currentUser ->
+    override suspend fun getUserSettings(): UserSettingsWithCriteria = withUser(userRepo) { currentUser ->
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
         val defaultUserCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        userSettings.toGrpcUserSettings(defaultUserCriteria.toGrpcCriteria())
+        UserSettingsWithCriteria(userSettings, defaultUserCriteria)
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -8,7 +8,6 @@ import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.formatting.daysToHumanReadable
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.UserIdentifierType
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
@@ -19,7 +18,7 @@ import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
@@ -52,7 +51,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.updateUser].
      */
-    suspend fun updateUser(request: GrpcUser.Update): GrpcUser
+    suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): GrpcUser
 
     /**
      * Service implementation of [SnowballRService.softDeleteUser].
@@ -153,24 +152,24 @@ class UserService(
         emailManager.sendVerificationEmail(user.email, data)
     }
 
-    override suspend fun updateUser(request: GrpcUser.Update): GrpcUser = withUser(userRepo) { currentUser ->
-        val targetUserId = parseUUID(request.user.id, EntityType.USER)
-        val targetUser = userRepo.getUserById(targetUserId).getOrThrow()
+    override suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): GrpcUser =
+        withUser(userRepo) { currentUser ->
+            val targetUser = userRepo.getUserById(request.userId).getOrThrow()
 
-        accessChecker.isAllowedToUpdateUser(currentUser, targetUser)
+            accessChecker.isAllowedToUpdateUser(currentUser, targetUser)
 
-        // If the role is changed, the requesting user must be a server admin.
-        if (request.mask.pathsList.contains("user.role")) {
-            accessChecker.isAllowedToUpdateUserRole(currentUser, targetUserId)
+            // If the role is changed, the requesting user must be a server admin.
+            if (paths.contains("user.role")) {
+                accessChecker.isAllowedToUpdateUserRole(currentUser, request.userId)
+            }
+
+            // If the email is changed, there must not yet exist an account with that email address.
+            if (paths.contains("user.email") && userRepo.doesUserExistByEmail(request.email)) {
+                throw DuplicateUserException(request.email)
+            }
+
+            userRepo.updateUser(request, paths).toGrpcUser()
         }
-
-        // If the email is changed, there must not yet exist an account with that email address.
-        if (request.mask.pathsList.contains("user.email") && userRepo.doesUserExistByEmail(request.user.email)) {
-            throw DuplicateUserException(request.user.email)
-        }
-
-        userRepo.updateUser(request).toGrpcUser()
-    }
 
     override suspend fun softDeleteUser(userId: UUID) = withUser(userRepo) { currentUser ->
         val targetUser = userRepo.getUserById(userId).getOrThrow()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -12,9 +12,7 @@ import se.uulm.snowballr.backend.model.UserIdentifierType
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
@@ -24,24 +22,23 @@ import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import java.util.UUID
-import snowballr.UserOuterClass.User as GrpcUser
 import snowballr.UserSettingsOuterClass.UserSettings as GrpcUserSettings
 
 interface IUserService {
     /**
      * Service implementation of [SnowballRService.getUserById].
      */
-    suspend fun getUserById(userId: UUID): GrpcUser
+    suspend fun getUserById(userId: UUID): User
 
     /**
      * Service implementation of [SnowballRService.getUserByEmail].
      */
-    suspend fun getUserByEmail(email: String): GrpcUser
+    suspend fun getUserByEmail(email: String): User
 
     /**
      * Service implementation of [SnowballRService.getAllUsers].
      */
-    suspend fun getAllUsers(): GrpcUser.List
+    suspend fun getAllUsers(): List<User>
 
     /**
      * Service implementation of [SnowballRService.register].
@@ -51,7 +48,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.updateUser].
      */
-    suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): GrpcUser
+    suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): User
 
     /**
      * Service implementation of [SnowballRService.softDeleteUser].
@@ -66,7 +63,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.getCurrentUser].
      */
-    suspend fun getCurrentUser(): GrpcUser
+    suspend fun getCurrentUser(): User
 }
 
 /**
@@ -100,31 +97,31 @@ class UserService(
         private const val VERIFICATION_TOKEN_LENGTH = 48
     }
 
-    override suspend fun getUserById(userId: UUID): GrpcUser = withUser(userRepo) { currentUser ->
-        if (currentUser.id == userId) return@withUser currentUser.toGrpcUser()
+    override suspend fun getUserById(userId: UUID): User = withUser(userRepo) { currentUser ->
+        if (currentUser.id == userId) return@withUser currentUser
 
         val targetUser = userRepo.getUserById(userId).getOrThrow()
 
         accessChecker.isAllowedToReadUser(currentUser, targetUser, UserIdentifierType.ID)
 
-        targetUser.toGrpcUser()
+        targetUser
     }
 
-    override suspend fun getUserByEmail(email: String): GrpcUser = withUser(userRepo) { currentUser ->
-        if (currentUser.email == email) return@withUser currentUser.toGrpcUser()
+    override suspend fun getUserByEmail(email: String): User = withUser(userRepo) { currentUser ->
+        if (currentUser.email == email) return@withUser currentUser
 
         // We have to request the user first to get the ID for the access checks
         val targetUser = userRepo.getUserByEmail(email).getOrThrow()
 
         accessChecker.isAllowedToReadUser(currentUser, targetUser, UserIdentifierType.EMAIL)
 
-        targetUser.toGrpcUser()
+        targetUser
     }
 
-    override suspend fun getAllUsers(): GrpcUser.List = withUser(userRepo) { currentUser ->
+    override suspend fun getAllUsers(): List<User> = withUser(userRepo) { currentUser ->
         accessChecker.isAllowedToReadAllUsers(currentUser)
 
-        userRepo.getAllUsers().toGrpcUsers()
+        userRepo.getAllUsers()
     }
 
     override suspend fun register(request: RegisterRequest) {
@@ -152,7 +149,7 @@ class UserService(
         emailManager.sendVerificationEmail(user.email, data)
     }
 
-    override suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): GrpcUser =
+    override suspend fun updateUser(request: UpdateUserRequest, paths: List<String>): User =
         withUser(userRepo) { currentUser ->
             val targetUser = userRepo.getUserById(request.userId).getOrThrow()
 
@@ -168,7 +165,7 @@ class UserService(
                 throw DuplicateUserException(request.email)
             }
 
-            userRepo.updateUser(request, paths).toGrpcUser()
+            userRepo.updateUser(request, paths)
         }
 
     override suspend fun softDeleteUser(userId: UUID) = withUser(userRepo) { currentUser ->
@@ -192,7 +189,7 @@ class UserService(
         userRepo.softDeleteUser(targetUser.id)
     }
 
-    override suspend fun getCurrentUser(): GrpcUser = withUser(userRepo, User::toGrpcUser)
+    override suspend fun getCurrentUser(): User = withUser(userRepo) { it }
 
     override suspend fun getUserSettings(): GrpcUserSettings = withUser(userRepo) { currentUser ->
         val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/UserService.kt
@@ -18,12 +18,12 @@ import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
-import snowballr.Authentication
 import java.util.UUID
 import snowballr.UserOuterClass.User as GrpcUser
 import snowballr.UserSettingsOuterClass.UserSettings as GrpcUserSettings
@@ -47,7 +47,7 @@ interface IUserService {
     /**
      * Service implementation of [SnowballRService.register].
      */
-    suspend fun register(request: Authentication.RegisterRequest)
+    suspend fun register(request: RegisterRequest)
 
     /**
      * Service implementation of [SnowballRService.updateUser].
@@ -128,7 +128,7 @@ class UserService(
         userRepo.getAllUsers().toGrpcUsers()
     }
 
-    override suspend fun register(request: Authentication.RegisterRequest) {
+    override suspend fun register(request: RegisterRequest) {
         // Check whether a user with the given email already exists
         if (userRepo.doesUserExistByEmail(request.email)) {
             throw DuplicateUserException(request.email)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/BaseIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/BaseIntegrationTest.kt
@@ -3,8 +3,6 @@ package se.uulm.snowballr.backend.integration
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.parseUUID
 import kotlin.test.assertEquals
 
 class BaseIntegrationTest : IntegrationTest() {
@@ -18,9 +16,8 @@ class BaseIntegrationTest : IntegrationTest() {
             email = "john.doe@example.com",
         )
         val otherUser = addUser(otherUserData)
-        val otherUserId = parseUUID(otherUser.id, EntityType.USER)
 
-        actAsUser(otherUserId) {
+        actAsUser(otherUser.id) {
             val otherCurrentUser = userService.getCurrentUser()
             assertEquals(otherUser.id, otherCurrentUser.id)
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -43,6 +43,7 @@ import se.uulm.snowballr.backend.mailServiceDeps
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.email.EmailData
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.RepositoryHelper
 import se.uulm.snowballr.backend.repositoryLayerDeps
@@ -191,12 +192,12 @@ open class IntegrationTest : KoinTest {
         coJustRun { emailManagerMock.sendVerificationEmail(any(), verificationData) }
 
         // Register user
-        val registerUserRequest = Authentication.RegisterRequest.newBuilder()
-            .setFirstName(user.firstName)
-            .setLastName(user.lastName)
-            .setEmail(user.email)
-            .setPassword("SecureP@ssw0rd!")
-            .build()
+        val registerUserRequest = RegisterRequest(
+            firstName = user.firstName,
+            lastName = user.lastName,
+            email = user.email,
+            password = "SecureP@ssw0rd!",
+        )
         userService.register(registerUserRequest)
 
         // Verify the user's email

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -40,11 +40,9 @@ import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.mail.EmailManager
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.mailServiceDeps
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.RepositoryHelper
 import se.uulm.snowballr.backend.repositoryLayerDeps
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -65,7 +63,6 @@ import java.util.UUID
 import snowballr.PaperOuterClass.Paper as GrpcPaper
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
-import snowballr.UserOuterClass.User as GrpcUser
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Tag("integration")
@@ -183,7 +180,7 @@ open class IntegrationTest : KoinTest {
      * @param user The user data to register with. The email must be unique, otherwise the registration will fail.
      * @return The registered user.
      */
-    protected suspend fun addUser(user: User): GrpcUser {
+    protected suspend fun addUser(user: User): User {
         val verificationToken = slot<String>()
         val link = "https://example.com/verify"
         coEvery { emailManagerMock.createVerificationLink(capture(verificationToken)) } returns link
@@ -218,7 +215,7 @@ open class IntegrationTest : KoinTest {
      * @param acceptInvitation Whether the invitation should be accepted after being sent. If true, the user will be
      * added to the project.
      */
-    protected suspend fun inviteUserToProject(project: GrpcProject, user: GrpcUser, acceptInvitation: Boolean = false) {
+    protected suspend fun inviteUserToProject(project: GrpcProject, user: User, acceptInvitation: Boolean = false) {
         val invitationToken = inviteHelper(project, user.firstName, user.email)
 
         if (acceptInvitation) {
@@ -251,16 +248,6 @@ open class IntegrationTest : KoinTest {
         block()
         every { GrpcContext.getUserIdFromContext() } returns testUserId
     }
-
-    /**
-     * Runs code as another user. This enables making requests as another user to test external events.
-     *
-     * @param userId The ID of the user that should execute the requests in [block].
-     * @param block The code that is executed on behalf of the user with the passed [userId].
-     */
-    @Suppress("RedundantSuspendModifier", "RedundantSuppression")
-    protected suspend fun actAsUser(userId: String, block: suspend () -> Unit) =
-        actAsUser(parseUUID(userId, EntityType.USER), block)
 
     private suspend fun inviteHelper(
         project: GrpcProject,

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -9,6 +9,7 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
+import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
@@ -17,10 +18,9 @@ import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.Project
 import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
-import snowballr.UserOuterClass.User as GrpcUser
 
 class AccessControlIntegrationTest : IntegrationTest() {
-    private suspend fun setupProjectWithMember(): Pair<Project, GrpcUser> {
+    private suspend fun setupProjectWithMember(): Pair<Project, User> {
         val project = projectService.createProject(Project.Create.newBuilder().setName("Test Project").build())
         val member = addUser(DataBuilder.createExampleUser(email = "member@example.com"))
         inviteUserToProject(project, member, acceptInvitation = true)
@@ -160,7 +160,7 @@ class AccessControlIntegrationTest : IntegrationTest() {
 
             val request = GrpcProjectMember.Update.newBuilder()
                 .setProjectId(project.id)
-                .setUserId(secondMember.id)
+                .setUserId(secondMember.id.toString())
                 .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
                 .build()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
@@ -15,6 +15,7 @@ import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.invalidargument.IncorrectOldPasswordException
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import snowballr.Authentication
 import java.util.UUID
 
@@ -70,12 +71,12 @@ class AuthenticationIntegrationTest : IntegrationTest() {
 
             val newUser = DataBuilder.createExampleUser(email = "unverified.user@example.com")
             userService.register(
-                Authentication.RegisterRequest.newBuilder()
-                    .setFirstName(newUser.firstName)
-                    .setLastName(newUser.lastName)
-                    .setEmail(newUser.email)
-                    .setPassword("SecureP@ssw0rd!")
-                    .build(),
+                RegisterRequest(
+                    firstName = newUser.firstName,
+                    lastName = newUser.lastName,
+                    email = newUser.email,
+                    password = "SecureP@ssw0rd!",
+                ),
             )
 
             assertThrows<UnauthenticatedException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
@@ -17,7 +17,6 @@ import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.invalidargument.IncorrectOldPasswordException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import snowballr.Authentication
-import java.util.UUID
 
 @ExtendWith(GrpcTestContextExtension::class)
 class AuthenticationIntegrationTest : IntegrationTest() {
@@ -146,7 +145,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
         @Test
         fun `When a non-active user tries to change the password, then changing fails`() = runTest {
             val user = addUser(DataBuilder.createExampleUser(email = "change.password.deleted@example.com"))
-            userService.softDeleteUser(UUID.fromString(user.id))
+            userService.softDeleteUser(user.id)
 
             actAsUser(user.id) {
                 assertThrows<FailedPreconditionException> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
@@ -101,7 +101,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertTrue(candidates.usersList.any { it.id == otherUser.id })
+            assertTrue(candidates.usersList.any { it.id == otherUser.id.toString() })
         }
 
         @Test
@@ -118,7 +118,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertFalse(candidates.usersList.any { it.id == otherUser.id })
+            assertFalse(candidates.usersList.any { it.id == otherUser.id.toString() })
         }
 
         @Test
@@ -135,7 +135,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertFalse(candidates.usersList.any { it.id == otherUser.id })
+            assertFalse(candidates.usersList.any { it.id == otherUser.id.toString() })
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
@@ -26,7 +26,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             inviteUserToProject(project, otherUser, acceptInvitation = true)
 
             val members = projectMemberService.getProjectMembers(projectId)
-            assertTrue(members.membersList.any { it.user.id == otherUser.id })
+            assertTrue(members.membersList.any { it.user.id == otherUser.id.toString() })
         }
 
         @Test
@@ -69,7 +69,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             )
 
             val members = projectMemberService.getProjectMembers(projectId)
-            assertFalse(members.membersList.any { it.user.id == otherUser.id })
+            assertFalse(members.membersList.any { it.user.id == otherUser.id.toString() })
         }
 
         @Test
@@ -91,7 +91,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 }
 
                 val members = projectMemberService.getProjectMembers(projectId)
-                assertFalse(members.membersList.any { it.user.id == otherUser.id })
+                assertFalse(members.membersList.any { it.user.id == otherUser.id.toString() })
             }
     }
 
@@ -108,13 +108,13 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             projectMemberService.updateProjectMemberRole(
                 GrpcProjectMember.Update.newBuilder()
                     .setProjectId(project.id)
-                    .setUserId(otherUser.id)
+                    .setUserId(otherUser.id.toString())
                     .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
                     .build(),
             )
 
             val members = projectMemberService.getProjectMembers(projectId)
-            val updatedMember = members.membersList.find { it.user.id == otherUser.id }
+            val updatedMember = members.membersList.find { it.user.id == otherUser.id.toString() }
             assertEquals(MemberRole.MEMBER_ROLE_ADMIN, updatedMember?.role)
         }
 
@@ -130,7 +130,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             projectMemberService.updateProjectMemberRole(
                 GrpcProjectMember.Update.newBuilder()
                     .setProjectId(project.id)
-                    .setUserId(otherUser.id)
+                    .setUserId(otherUser.id.toString())
                     .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
                     .build(),
             )
@@ -139,13 +139,13 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             projectMemberService.updateProjectMemberRole(
                 GrpcProjectMember.Update.newBuilder()
                     .setProjectId(project.id)
-                    .setUserId(otherUser.id)
+                    .setUserId(otherUser.id.toString())
                     .setNewRole(MemberRole.MEMBER_ROLE_DEFAULT)
                     .build(),
             )
 
             val members = projectMemberService.getProjectMembers(projectId)
-            val demotedMember = members.membersList.find { it.user.id == otherUser.id }
+            val demotedMember = members.membersList.find { it.user.id == otherUser.id.toString() }
             assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, demotedMember?.role)
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReadingListIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReadingListIntegrationTest.kt
@@ -106,13 +106,12 @@ class ReadingListIntegrationTest : IntegrationTest() {
         fun `When a paper is added to one user's reading list, then it does not appear in another user's reading list`() =
             runTest {
                 val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
-                val otherUserId = parseUUID(otherUser.id, EntityType.USER)
                 val paper = createPaper()
                 val paperId = parseUUID(paper.id, EntityType.PAPER)
 
                 readingListService.addPaperToReadingList(paperId)
 
-                actAsUser(otherUserId) {
+                actAsUser(otherUser.id) {
                     val otherReadingList = readingListService.getReadingList()
                     assertFalse(otherReadingList.papersList.any { it.id == paper.id })
                 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.integration.services
 
-import com.google.protobuf.FieldMask
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.slot
@@ -12,17 +11,18 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.dto.user.UserRole
+import se.uulm.snowballr.backend.model.dto.user.UserStatus.Companion.fromGrpc
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAllException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import snowballr.Authentication
-import snowballr.UserOuterClass.UserRole
 import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import snowballr.UserOuterClass.User as GrpcUser
 
 class UserIntegrationTest : IntegrationTest() {
     @Nested
@@ -108,12 +108,16 @@ class UserIntegrationTest : IntegrationTest() {
             val currentUser = userService.getCurrentUser()
             val newFirstName = "UpdatedFirstName"
 
-            val request = GrpcUser.Update.newBuilder()
-                .setUser(GrpcUser.newBuilder().setId(currentUser.id).setFirstName(newFirstName))
-                .setMask(FieldMask.newBuilder().addPaths("user.first_name"))
-                .build()
+            val request = UpdateUserRequest(
+                userId = parseUUID(currentUser.id, EntityType.USER),
+                firstName = newFirstName,
+                lastName = currentUser.lastName,
+                email = currentUser.email,
+                role = UserRole.fromGrpc(currentUser.role),
+                status = fromGrpc(currentUser.status),
+            )
 
-            val updatedUser = userService.updateUser(request)
+            val updatedUser = userService.updateUser(request, listOf("user.first_name"))
 
             assertEquals(newFirstName, updatedUser.firstName)
         }
@@ -123,12 +127,16 @@ class UserIntegrationTest : IntegrationTest() {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
             val newFirstName = "AdminUpdatedName"
 
-            val request = GrpcUser.Update.newBuilder()
-                .setUser(GrpcUser.newBuilder().setId(otherUser.id).setFirstName(newFirstName))
-                .setMask(FieldMask.newBuilder().addPaths("user.first_name"))
-                .build()
+            val request = UpdateUserRequest(
+                userId = parseUUID(otherUser.id, EntityType.USER),
+                firstName = newFirstName,
+                lastName = otherUser.lastName,
+                email = otherUser.email,
+                role = UserRole.fromGrpc(otherUser.role),
+                status = fromGrpc(otherUser.status),
+            )
 
-            val updatedUser = userService.updateUser(request)
+            val updatedUser = userService.updateUser(request, listOf("user.first_name"))
 
             assertEquals(newFirstName, updatedUser.firstName)
         }
@@ -139,13 +147,17 @@ class UserIntegrationTest : IntegrationTest() {
                 val nonAdminUser = addUser(DataBuilder.createExampleUser(email = "non.admin@example.com"))
                 val nonAdminUserId = parseUUID(nonAdminUser.id, EntityType.USER)
 
-                val request = GrpcUser.Update.newBuilder()
-                    .setUser(GrpcUser.newBuilder().setId(nonAdminUser.id).setRole(UserRole.USER_ROLE_ADMIN))
-                    .setMask(FieldMask.newBuilder().addPaths("user.role"))
-                    .build()
+                val request = UpdateUserRequest(
+                    userId = parseUUID(nonAdminUser.id, EntityType.USER),
+                    firstName = nonAdminUser.firstName,
+                    lastName = nonAdminUser.lastName,
+                    email = nonAdminUser.email,
+                    role = UserRole.ADMIN,
+                    status = fromGrpc(nonAdminUser.status),
+                )
 
                 actAsUser(nonAdminUserId) {
-                    assertThrows<UnauthorizedUpdateException> { userService.updateUser(request) }
+                    assertThrows<UnauthorizedUpdateException> { userService.updateUser(request, listOf("user.role")) }
                 }
             }
 
@@ -155,12 +167,16 @@ class UserIntegrationTest : IntegrationTest() {
                 val existingUser = addUser(DataBuilder.createExampleUser(email = "existing@example.com"))
                 val currentUser = userService.getCurrentUser()
 
-                val request = GrpcUser.Update.newBuilder()
-                    .setUser(GrpcUser.newBuilder().setId(currentUser.id).setEmail(existingUser.email))
-                    .setMask(FieldMask.newBuilder().addPaths("user.email"))
-                    .build()
+                val request = UpdateUserRequest(
+                    userId = parseUUID(currentUser.id, EntityType.USER),
+                    firstName = existingUser.firstName,
+                    lastName = existingUser.lastName,
+                    email = existingUser.email,
+                    role = UserRole.fromGrpc(existingUser.role),
+                    status = fromGrpc(existingUser.status),
+                )
 
-                assertThrows<DuplicateUserException> { userService.updateUser(request) }
+                assertThrows<DuplicateUserException> { userService.updateUser(request, listOf("user.email")) }
             }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -15,6 +15,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAllException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import snowballr.Authentication
 import snowballr.UserOuterClass.UserRole
@@ -35,12 +36,12 @@ class UserIntegrationTest : IntegrationTest() {
             coJustRun { emailManagerMock.sendVerificationEmail(any(), any()) }
 
             userService.register(
-                Authentication.RegisterRequest.newBuilder()
-                    .setFirstName(newUser.firstName)
-                    .setLastName(newUser.lastName)
-                    .setEmail(newUser.email)
-                    .setPassword("SecureP@ssw0rd!")
-                    .build(),
+                RegisterRequest(
+                    firstName = newUser.firstName,
+                    lastName = newUser.lastName,
+                    email = newUser.email,
+                    password = "SecureP@ssw0rd!",
+                ),
             )
 
             val unverifiedUser = userService.getUserByEmail(newUser.email)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -10,17 +10,14 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.user.UserRole
-import se.uulm.snowballr.backend.model.dto.user.UserStatus.Companion.fromGrpc
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAllException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
-import se.uulm.snowballr.backend.model.parseUUID
 import snowballr.Authentication
-import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -45,7 +42,7 @@ class UserIntegrationTest : IntegrationTest() {
             )
 
             val unverifiedUser = userService.getUserByEmail(newUser.email)
-            assertEquals(UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED, unverifiedUser.status)
+            assertEquals(UserStatus.ACTIVE_UNCONFIRMED, unverifiedUser.status)
 
             authenticationService.verifyEmail(
                 Authentication.VerifyEmailRequest.newBuilder()
@@ -54,7 +51,7 @@ class UserIntegrationTest : IntegrationTest() {
             )
 
             val verifiedUser = userService.getUserByEmail(newUser.email)
-            assertEquals(UserStatus.USER_STATUS_ACTIVE, verifiedUser.status)
+            assertEquals(UserStatus.ACTIVE, verifiedUser.status)
         }
     }
 
@@ -64,15 +61,14 @@ class UserIntegrationTest : IntegrationTest() {
         fun `When the current user requests their own data, then their data is returned`() = runTest {
             val currentUser = userService.getCurrentUser()
 
-            assertEquals(testUserId.toString(), currentUser.id)
+            assertEquals(testUserId, currentUser.id)
         }
 
         @Test
         fun `When an admin requests another user by ID, then the user's data is returned`() = runTest {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
-            val otherUserId = parseUUID(otherUser.id, EntityType.USER)
 
-            val fetchedUser = userService.getUserById(otherUserId)
+            val fetchedUser = userService.getUserById(otherUser.id)
 
             assertEquals(otherUser.id, fetchedUser.id)
             assertEquals(otherUser.email, fetchedUser.email)
@@ -83,19 +79,18 @@ class UserIntegrationTest : IntegrationTest() {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
 
             val allUsers = userService.getAllUsers()
-            val userIds = allUsers.usersList.map { it.id }
+            val userIds = allUsers.map { it.id }
 
-            assertEquals(2, allUsers.usersList.size)
-            assertTrue(userIds.contains(testUserId.toString()))
+            assertEquals(2, allUsers.size)
+            assertTrue(userIds.contains(testUserId))
             assertTrue(userIds.contains(otherUser.id))
         }
 
         @Test
         fun `When a non-admin requests all users, then access is denied`() = runTest {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
-            val otherUserId = parseUUID(otherUser.id, EntityType.USER)
 
-            actAsUser(otherUserId) {
+            actAsUser(otherUser.id) {
                 assertThrows<UnauthorizedReadAllException> { userService.getAllUsers() }
             }
         }
@@ -109,12 +104,12 @@ class UserIntegrationTest : IntegrationTest() {
             val newFirstName = "UpdatedFirstName"
 
             val request = UpdateUserRequest(
-                userId = parseUUID(currentUser.id, EntityType.USER),
+                userId = currentUser.id,
                 firstName = newFirstName,
                 lastName = currentUser.lastName,
                 email = currentUser.email,
-                role = UserRole.fromGrpc(currentUser.role),
-                status = fromGrpc(currentUser.status),
+                role = currentUser.role,
+                status = currentUser.status,
             )
 
             val updatedUser = userService.updateUser(request, listOf("user.first_name"))
@@ -128,12 +123,12 @@ class UserIntegrationTest : IntegrationTest() {
             val newFirstName = "AdminUpdatedName"
 
             val request = UpdateUserRequest(
-                userId = parseUUID(otherUser.id, EntityType.USER),
+                userId = otherUser.id,
                 firstName = newFirstName,
                 lastName = otherUser.lastName,
                 email = otherUser.email,
-                role = UserRole.fromGrpc(otherUser.role),
-                status = fromGrpc(otherUser.status),
+                role = otherUser.role,
+                status = otherUser.status,
             )
 
             val updatedUser = userService.updateUser(request, listOf("user.first_name"))
@@ -145,18 +140,17 @@ class UserIntegrationTest : IntegrationTest() {
         fun `When a non-admin user tries to escalate their own role, then an UnauthorizedUpdateException is thrown`() =
             runTest {
                 val nonAdminUser = addUser(DataBuilder.createExampleUser(email = "non.admin@example.com"))
-                val nonAdminUserId = parseUUID(nonAdminUser.id, EntityType.USER)
 
                 val request = UpdateUserRequest(
-                    userId = parseUUID(nonAdminUser.id, EntityType.USER),
+                    userId = nonAdminUser.id,
                     firstName = nonAdminUser.firstName,
                     lastName = nonAdminUser.lastName,
                     email = nonAdminUser.email,
                     role = UserRole.ADMIN,
-                    status = fromGrpc(nonAdminUser.status),
+                    status = nonAdminUser.status,
                 )
 
-                actAsUser(nonAdminUserId) {
+                actAsUser(nonAdminUser.id) {
                     assertThrows<UnauthorizedUpdateException> { userService.updateUser(request, listOf("user.role")) }
                 }
             }
@@ -168,12 +162,12 @@ class UserIntegrationTest : IntegrationTest() {
                 val currentUser = userService.getCurrentUser()
 
                 val request = UpdateUserRequest(
-                    userId = parseUUID(currentUser.id, EntityType.USER),
+                    userId = currentUser.id,
                     firstName = existingUser.firstName,
                     lastName = existingUser.lastName,
                     email = existingUser.email,
-                    role = UserRole.fromGrpc(existingUser.role),
-                    status = fromGrpc(existingUser.status),
+                    role = existingUser.role,
+                    status = existingUser.status,
                 )
 
                 assertThrows<DuplicateUserException> { userService.updateUser(request, listOf("user.email")) }
@@ -185,18 +179,16 @@ class UserIntegrationTest : IntegrationTest() {
         @Test
         fun `When an admin soft-deletes a non-admin user, then the operation succeeds`() = runTest {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
-            val otherUserId = parseUUID(otherUser.id, EntityType.USER)
 
-            assertDoesNotThrow { userService.softDeleteUser(otherUserId) }
+            assertDoesNotThrow { userService.softDeleteUser(otherUser.id) }
         }
 
         @Test
         fun `When a user soft-deletes themselves, then the operation succeeds`() = runTest {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
-            val otherUserId = parseUUID(otherUser.id, EntityType.USER)
 
-            actAsUser(otherUserId) {
-                assertDoesNotThrow { userService.softDeleteUser(otherUserId) }
+            actAsUser(otherUser.id) {
+                assertDoesNotThrow { userService.softDeleteUser(otherUser.id) }
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -22,6 +22,7 @@ import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertUserAndGetId
 import se.uulm.snowballr.backend.table.CriterionTable
@@ -29,7 +30,6 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.Authentication
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import snowballr.UserOuterClass.User
 import java.sql.SQLException
@@ -169,14 +169,12 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
     inner class CreateUser {
         @Test
         fun `When a user is created, then the user is returned`() = runTest {
-            val request =
-                Authentication.RegisterRequest
-                    .newBuilder()
-                    .setEmail("alice.smith@example.com")
-                    .setFirstName("Alice")
-                    .setLastName("Smith")
-                    .setPassword("AAbb__00")
-                    .build()
+            val request = RegisterRequest(
+                firstName = "Alice",
+                lastName = "Smith",
+                email = "alice.smith@example.com",
+                password = "AAbb__00",
+            )
 
             val user = repo.createUser(request, "hashedPassword")
 
@@ -189,14 +187,12 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
 
         @Test
         fun `When a user with an existent email is created, then an SQLException is thrown`() = runTest {
-            val request =
-                Authentication.RegisterRequest
-                    .newBuilder()
-                    .setEmail("alice.smith@example.com")
-                    .setFirstName("Alice")
-                    .setLastName("Smith")
-                    .setPassword("AAbb__00")
-                    .build()
+            val request = RegisterRequest(
+                firstName = "Alice",
+                lastName = "Smith",
+                email = "alice.smith@example.com",
+                password = "AAbb__00",
+            )
 
             repo.createUser(request, "hashedPassword")
 
@@ -207,25 +203,21 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
 
         @Test
         fun `When two users with different emails are created, then they have different IDs`() = runTest {
-            val request1 =
-                Authentication.RegisterRequest
-                    .newBuilder()
-                    .setEmail("alice.smith@example.com")
-                    .setFirstName("Alice")
-                    .setLastName("Smith")
-                    .setPassword("AAbb__00")
-                    .build()
+            val request1 = RegisterRequest(
+                firstName = "Alice",
+                lastName = "Smith",
+                email = "alice.smith@example.com",
+                password = "AAbb__00",
+            )
 
             val user1 = repo.createUser(request1, "hashedPassword1")
 
-            val request2 =
-                Authentication.RegisterRequest
-                    .newBuilder()
-                    .setEmail("john.smith@example.com")
-                    .setFirstName("John")
-                    .setLastName("Smith")
-                    .setPassword("BBaa__00")
-                    .build()
+            val request2 = RegisterRequest(
+                firstName = "John",
+                lastName = "Smith",
+                email = "john.smith@example.com",
+                password = "BBaa__00",
+            )
 
             val user2 = repo.createUser(request2, "hashedPassword2")
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -20,9 +19,9 @@ import se.uulm.snowballr.backend.isBetweenWithDelta
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertProjectAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertUserAndGetId
 import se.uulm.snowballr.backend.table.CriterionTable
@@ -31,7 +30,6 @@ import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import snowballr.ProjectOuterClass.ReviewDecisionMatrix
-import snowballr.UserOuterClass.User
 import java.sql.SQLException
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -234,21 +232,16 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
         ) = runTest {
             val userId = insertUserAndGetId(email = "test.user@example.com")
             val originalUser = repo.getUserById(userId).getOrThrow()
+            val request = UpdateUserRequest(
+                userId = originalUser.id,
+                firstName = "John",
+                lastName = "Doe",
+                email = "updated.user@example.com",
+                role = UserRole.ADMIN,
+                status = UserStatus.DELETED,
+            )
 
-            val updatedUserDetails = originalUser.toGrpcUser().toBuilder()
-                .setEmail("updated.user@example.com")
-                .setFirstName("John")
-                .setLastName("Doe")
-                .setRole(UserRole.ADMIN.toGrpc())
-                .setStatus(UserStatus.DELETED.toGrpc())
-                .build()
-
-            val request = User.Update.newBuilder()
-                .setUser(updatedUserDetails)
-                .setMask(FieldMaskUtil.fromStringList(fieldMask))
-                .build()
-
-            val updatedUser = repo.updateUser(request)
+            val updatedUser = repo.updateUser(request, fieldMask)
 
             if ("user.email" in fieldMask) {
                 assertEquals("updated.user@example.com", updatedUser.email)
@@ -282,17 +275,19 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             insertUserAndGetId(email = "alice.smith@example.com")
 
             val user2Id = insertUserAndGetId(email = "bob.smith@example.com")
-            val user2Builder = repo.getUserById(user2Id).getOrThrow().toGrpcUser().toBuilder()
+            val user2 = repo.getUserById(user2Id).getOrThrow()
 
-            val updateRequest =
-                User.Update
-                    .newBuilder()
-                    .setUser(user2Builder.setEmail("alice.smith@example.com").build())
-                    .setMask(FieldMaskUtil.fromString("user.email"))
-                    .build()
+            val updateRequest = UpdateUserRequest(
+                userId = user2.id,
+                firstName = user2.firstName,
+                lastName = user2.lastName,
+                email = "alice.smith@example.com",
+                role = user2.role,
+                status = user2.status,
+            )
 
             assertThrows<SQLException> {
-                repo.updateUser(updateRequest)
+                repo.updateUser(updateRequest, listOf("user.email"))
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
@@ -11,9 +11,9 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.notfound.VerificationTokenNotFoundException
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import snowballr.Authentication
 import java.time.OffsetDateTime
-import snowballr.UserOuterClass.User as GrpcUser
 
 class VerifyEmailTest : AuthenticationServiceTest() {
     @Test
@@ -60,11 +60,11 @@ class VerifyEmailTest : AuthenticationServiceTest() {
             val user = DataBuilder.createExampleUser(status = UserStatus.ACTIVE_UNCONFIRMED)
             val token = DataBuilder.createExampleVerificationToken(userId = user.id)
             val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
-            val userUpdateSlot = slot<GrpcUser.Update>()
+            val userUpdateSlot = slot<UpdateUserRequest>()
 
             coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns Result.success(token)
             coEvery { userRepoMock.getUserById(user.id) } returns Result.success(user)
-            coEvery { userRepoMock.updateUser(capture(userUpdateSlot)) } returns user
+            coEvery { userRepoMock.updateUser(capture(userUpdateSlot), any()) } returns user
             coJustRun { verificationTokenRepoMock.deleteVerificationToken(token.token) }
 
             service.verifyEmail(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetAllUsersTest.kt
@@ -22,9 +22,9 @@ class GetAllUsersTest : UserServiceTest() {
 
         val allUsers = service.getAllUsers()
 
-        assertEquals(2, allUsers.usersCount)
-        assertEquals(currentUser.id.toString(), allUsers.usersList[0].id)
-        assertEquals(otherUser.id.toString(), allUsers.usersList[1].id)
+        assertEquals(2, allUsers.size)
+        assertEquals(currentUser.id, allUsers[0].id)
+        assertEquals(otherUser.id, allUsers[1].id)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -14,6 +14,6 @@ class GetCurrentUserTest : UserServiceTest() {
 
         val result = service.getCurrentUser()
 
-        assertEquals(user.id.toString(), result.id)
+        assertEquals(user.id, result.id)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -20,7 +20,7 @@ class GetUserByEmailTest : UserServiceTest() {
 
         val requestedUser = service.getUserByEmail(currentUser.email)
 
-        assertEquals(currentUser.id.toString(), requestedUser.id)
+        assertEquals(currentUser.id, requestedUser.id)
         coVerify(exactly = 0) { userRepoMock.getUserByEmail(currentUser.email) }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByIdTest.kt
@@ -21,7 +21,7 @@ class GetUserByIdTest : UserServiceTest() {
 
         val requestedUser = service.getUserById(currentUser.id)
 
-        assertEquals(currentUser.id.toString(), requestedUser.id)
+        assertEquals(currentUser.id, requestedUser.id)
 
         // Should not call userRepoMock.getUserById(requestedUserId) again because it's self-request
         // First time is for injecting current user into session
@@ -64,6 +64,6 @@ class GetUserByIdTest : UserServiceTest() {
 
         val result = service.getUserById(requestedUser.id)
 
-        kotlin.test.assertEquals(requestedUser.id.toString(), result.id)
+        assertEquals(requestedUser.id, result.id)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
+import kotlin.test.assertEquals
 
 class GetUserSettingsTest : UserServiceTest() {
     @Test
@@ -30,7 +31,8 @@ class GetUserSettingsTest : UserServiceTest() {
 
             val result = service.getUserSettings()
 
-            assertUserSettingsEquality(userSettings, result)
+            assertUserSettingsEquality(userSettings, result.settings)
+            assertEquals(emptyList(), result.criteria)
         }
 
     @Test
@@ -46,6 +48,7 @@ class GetUserSettingsTest : UserServiceTest() {
 
             val result = service.getUserSettings()
 
-            assertUserSettingsEquality(userSettings, result)
+            assertUserSettingsEquality(userSettings, result.settings)
+            assertEquals(listOf(criterion), result.criteria)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/RegisterTest.kt
@@ -14,22 +14,20 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
-import snowballr.Authentication
+import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 
 class RegisterTest : UserServiceTest() {
-    private fun getExampleRequest(user: User) = Authentication.RegisterRequest.newBuilder()
-        .setEmail(user.email)
-        .setFirstName(user.firstName)
-        .setLastName(user.lastName)
-        .setPassword("VALIDPassword__1234")
-        .build()
+    private fun getExampleRequest(user: User) = RegisterRequest(
+        firstName = user.firstName,
+        lastName = user.lastName,
+        email = user.email,
+        password = "VALIDPassword__1234",
+    )
 
     @Test
     fun `When a user with the given email already exists, then a DuplicateUserException is thrown`() = runTest {
         val existentEmail = "existent-email"
-        val request = Authentication.RegisterRequest.newBuilder()
-            .setEmail(existentEmail)
-            .build()
+        val request = getExampleRequest(DataBuilder.createExampleUser()).copy(email = existentEmail)
 
         coEvery { userRepoMock.doesUserExistByEmail(existentEmail) } returns true
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -101,7 +101,7 @@ class UpdateUserTest : UserServiceTest() {
 
         val updatedUser = service.updateUser(request, listOf("user.email"))
 
-        assertEquals(otherUser.id.toString(), updatedUser.id)
+        assertEquals(otherUser.id, updatedUser.id)
         assertEquals(otherUser.email, updatedUser.email)
     }
 
@@ -121,11 +121,11 @@ class UpdateUserTest : UserServiceTest() {
 
         val updatedUser = service.updateUser(request, paths)
 
-        assertEquals(otherUser.id.toString(), updatedUser.id)
+        assertEquals(otherUser.id, updatedUser.id)
         assertEquals(otherUser.firstName, updatedUser.firstName)
         assertEquals(otherUser.lastName, updatedUser.lastName)
-        assertEquals(otherUser.role.toGrpc(), updatedUser.role)
-        assertEquals(otherUser.status.toGrpc(), updatedUser.status)
+        assertEquals(otherUser.role, updatedUser.role)
+        assertEquals(otherUser.status, updatedUser.status)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service.user
 
-import com.google.protobuf.util.FieldMaskUtil
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -10,28 +9,31 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
+import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import kotlin.test.assertEquals
-import snowballr.UserOuterClass.User as GrpcUser
 
 class UpdateUserTest : UserServiceTest() {
-    private fun getRequest(user: User, paths: List<String> = emptyList()) = GrpcUser.Update.newBuilder()
-        .setUser(user.toGrpcUser())
-        .setMask(FieldMaskUtil.fromStringList(paths))
-        .build()
+    private fun getExampleRequest(user: User) = UpdateUserRequest(
+        userId = user.id,
+        firstName = user.firstName,
+        lastName = user.lastName,
+        email = user.email,
+        role = user.role,
+        status = user.status,
+    )
 
     @Test
     fun `When retrieving user fails, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser()
 
-        val request = getRequest(otherUser)
+        val request = getExampleRequest(otherUser)
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { service.updateUser(request) }
+        assertThrows<TestSpecificException> { service.updateUser(request, emptyList()) }
     }
 
     @Test
@@ -39,7 +41,7 @@ class UpdateUserTest : UserServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser()
 
-        val request = getRequest(otherUser)
+        val request = getExampleRequest(otherUser)
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
@@ -47,7 +49,7 @@ class UpdateUserTest : UserServiceTest() {
             userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser)
         } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.updateUser(request) }
+        assertThrows<TestSpecificException> { service.updateUser(request, emptyList()) }
     }
 
     @Test
@@ -56,7 +58,7 @@ class UpdateUserTest : UserServiceTest() {
             val currentUser = DataBuilder.createExampleUser()
             val otherUser = DataBuilder.createExampleUser()
 
-            val request = getRequest(otherUser, listOf("user.role"))
+            val request = getExampleRequest(otherUser)
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
@@ -65,7 +67,7 @@ class UpdateUserTest : UserServiceTest() {
                 userAccessCheckerMock.isAllowedToUpdateUserRole(currentUser, otherUser.id)
             } throws TestSpecificException()
 
-            assertThrows<TestSpecificException> { service.updateUser(request) }
+            assertThrows<TestSpecificException> { service.updateUser(request, listOf("user.role")) }
         }
 
     @Test
@@ -74,14 +76,14 @@ class UpdateUserTest : UserServiceTest() {
             val currentUser = DataBuilder.createExampleUser()
             val otherUser = DataBuilder.createExampleUser(email = "other@user.com")
 
-            val request = getRequest(otherUser, listOf("user.email"))
+            val request = getExampleRequest(otherUser)
 
             mockCurrentUser(currentUser)
             coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
             coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
             coEvery { userRepoMock.doesUserExistByEmail(otherUser.email) } returns true
 
-            assertThrows<DuplicateUserException> { service.updateUser(request) }
+            assertThrows<DuplicateUserException> { service.updateUser(request, listOf("user.email")) }
         }
 
     @Test
@@ -89,15 +91,15 @@ class UpdateUserTest : UserServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser(email = "other@user.com")
 
-        val request = getRequest(otherUser, listOf("user.email"))
+        val request = getExampleRequest(otherUser)
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
         coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
         coEvery { userRepoMock.doesUserExistByEmail(otherUser.email) } returns false
-        coEvery { userRepoMock.updateUser(request) } returns otherUser
+        coEvery { userRepoMock.updateUser(request, listOf("user.email")) } returns otherUser
 
-        val updatedUser = service.updateUser(request)
+        val updatedUser = service.updateUser(request, listOf("user.email"))
 
         assertEquals(otherUser.id.toString(), updatedUser.id)
         assertEquals(otherUser.email, updatedUser.email)
@@ -108,18 +110,16 @@ class UpdateUserTest : UserServiceTest() {
         val currentUser = DataBuilder.createExampleUser()
         val otherUser = DataBuilder.createExampleUser()
 
-        val request = getRequest(
-            otherUser,
-            listOf("user.first_name", "user.last_name", "user.role", "user.status"),
-        )
+        val request = getExampleRequest(otherUser)
+        val paths = listOf("user.first_name", "user.last_name", "user.role", "user.status")
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getUserById(otherUser.id) } returns Result.success(otherUser)
         coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, otherUser) }
         coJustRun { userAccessCheckerMock.isAllowedToUpdateUserRole(currentUser, otherUser.id) }
-        coEvery { userRepoMock.updateUser(request) } returns otherUser
+        coEvery { userRepoMock.updateUser(request, paths) } returns otherUser
 
-        val updatedUser = service.updateUser(request)
+        val updatedUser = service.updateUser(request, paths)
 
         assertEquals(otherUser.id.toString(), updatedUser.id)
         assertEquals(otherUser.firstName, updatedUser.firstName)
@@ -132,7 +132,7 @@ class UpdateUserTest : UserServiceTest() {
     fun `When a non-admin user tries to change their own role, then a TestSpecificException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser()
 
-        val request = getRequest(currentUser, listOf("user.role"))
+        val request = getExampleRequest(currentUser)
 
         mockCurrentUser(currentUser)
         coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, currentUser) }
@@ -140,9 +140,9 @@ class UpdateUserTest : UserServiceTest() {
             userAccessCheckerMock.isAllowedToUpdateUserRole(currentUser, currentUser.id)
         } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.updateUser(request) }
+        assertThrows<TestSpecificException> { service.updateUser(request, listOf("user.role")) }
 
-        coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
+        coVerify(exactly = 0) { userRepoMock.updateUser(any(), any()) }
     }
 
     @Test
@@ -150,14 +150,14 @@ class UpdateUserTest : UserServiceTest() {
         runTest {
             val currentUser = DataBuilder.createExampleUser()
 
-            val request = getRequest(currentUser, listOf("user.email"))
+            val request = getExampleRequest(currentUser)
 
             mockCurrentUser(currentUser)
             coJustRun { userAccessCheckerMock.isAllowedToUpdateUser(currentUser, currentUser) }
             coEvery { userRepoMock.doesUserExistByEmail(currentUser.email) } returns true
 
-            assertThrows<DuplicateUserException> { service.updateUser(request) }
+            assertThrows<DuplicateUserException> { service.updateUser(request, listOf("user.email")) }
 
-            coVerify(exactly = 0) { userRepoMock.updateUser(any()) }
+            coVerify(exactly = 0) { userRepoMock.updateUser(any(), any()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UserServiceTest.kt
@@ -17,7 +17,6 @@ import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.UserService
 import se.uulm.snowballr.backend.service.withUser
-import snowballr.UserSettingsOuterClass
 import kotlin.test.assertEquals
 
 /**
@@ -65,17 +64,14 @@ sealed class UserServiceTest : BaseServiceTest {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
     }
 
-    protected fun assertUserSettingsEquality(expected: UserSettings, actual: UserSettingsOuterClass.UserSettings) {
-        assertEquals(expected.areHotkeysShown, actual.showHotkeys)
-        assertEquals(expected.isReviewModeEnabled, actual.reviewMode)
-        assertEquals(expected.criteriaIds.map { it.toString() }, actual.defaultCriteria.criteriaList.map { it.id })
-        assertEquals(expected.similarityThreshold, actual.defaultProjectSettings.similarityThreshold)
-        assertEquals(expected.decisionMatrix.toGrpc(), actual.defaultProjectSettings.decisionMatrix)
-        assertEquals(
-            expected.fetchers,
-            actual.defaultProjectSettings.fetchersMap.mapValues { options -> options.value.optionsMap },
-        )
-        assertEquals(expected.snowballingType.toGrpc(), actual.defaultProjectSettings.snowballingType)
-        assertEquals(expected.reviewMaybeAllowed, actual.defaultProjectSettings.reviewMaybeAllowed)
+    protected fun assertUserSettingsEquality(expected: UserSettings, actual: UserSettings) {
+        assertEquals(expected.areHotkeysShown, actual.areHotkeysShown)
+        assertEquals(expected.isReviewModeEnabled, actual.isReviewModeEnabled)
+        assertEquals(expected.criteriaIds, actual.criteriaIds)
+        assertEquals(expected.similarityThreshold, actual.similarityThreshold)
+        assertEquals(expected.decisionMatrix, actual.decisionMatrix)
+        assertEquals(expected.fetchers, actual.fetchers)
+        assertEquals(expected.snowballingType, actual.snowballingType)
+        assertEquals(expected.reviewMaybeAllowed, actual.reviewMaybeAllowed)
     }
 }


### PR DESCRIPTION
Closes #541

## What I have made

Waits for #539

This removes any grpc related types from the service and repo layer for the user domain.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
