### PR TITLE
Use non grpc request types for review domain

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -32,6 +32,7 @@ import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.dto.project.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.project.toGrpcProjects
+import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
@@ -43,6 +44,7 @@ import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.model.outgoing.project.toGrpc
@@ -509,7 +511,13 @@ class SnowballRServer(
             reviewService.getAllReviewsForProjectPaper(parseProjectPaperId(request)).toGrpcReviews()
 
         override suspend fun createReview(request: ReviewOuterClass.Review.Create): ReviewOuterClass.Review =
-            reviewService.createReview(request).toGrpc()
+            reviewService.createReview(
+                CreateReviewRequest(
+                    projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER),
+                    decision = ReviewDecision.fromGrpc(request.decision),
+                    selectedCriteriaIds = request.selectedCriteriaIdsList.map { parseUUID(it, EntityType.CRITERION) },
+                ),
+            ).toGrpc()
 
         override suspend fun updateReview(request: ReviewOuterClass.Review.Update): ReviewOuterClass.Review =
             super.updateReview(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -46,6 +46,8 @@ import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequ
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.model.outgoing.project.toGrpc
+import se.uulm.snowballr.backend.model.outgoing.review.toGrpc
+import se.uulm.snowballr.backend.model.outgoing.review.toGrpcReviews
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.scheduler.SchedulerManager
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -501,13 +503,13 @@ class SnowballRServer(
             super.removePaperFromProject(request)
 
         override suspend fun getReviewById(request: Base.Id): ReviewOuterClass.Review =
-            reviewService.getReviewById(parseReviewId(request))
+            reviewService.getReviewById(parseReviewId(request)).toGrpc()
 
         override suspend fun getAllReviewsForProjectPaper(request: Base.Id): ReviewOuterClass.Review.List =
-            reviewService.getAllReviewsForProjectPaper(parseProjectPaperId(request))
+            reviewService.getAllReviewsForProjectPaper(parseProjectPaperId(request)).toGrpcReviews()
 
         override suspend fun createReview(request: ReviewOuterClass.Review.Create): ReviewOuterClass.Review =
-            reviewService.createReview(request)
+            reviewService.createReview(request).toGrpc()
 
         override suspend fun updateReview(request: ReviewOuterClass.Review.Update): ReviewOuterClass.Review =
             super.updateReview(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/Review.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/Review.kt
@@ -25,20 +25,6 @@ fun Review.toGrpcReview(selectedCriteriaIds: List<String>): ReviewOuterClass.Rev
     .addAllSelectedCriteriaIds(selectedCriteriaIds)
     .build()
 
-fun List<Review>.toGrpcReviews(reviewSelectedCriteriaMap: Map<Review, List<String>>): ReviewOuterClass.Review.List =
-    ReviewOuterClass.Review.List
-        .newBuilder()
-        .addAllReviews(
-            this.map { review ->
-                val selectedCriteria = reviewSelectedCriteriaMap[review].orEmpty()
-
-                review.toGrpcReview(
-                    selectedCriteria,
-                )
-            },
-        )
-        .build()
-
 /**
  * Checks whether the review accepts the paper.
  *

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/review/CreateReviewRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/review/CreateReviewRequest.kt
@@ -1,0 +1,10 @@
+package se.uulm.snowballr.backend.model.incoming.review
+
+import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
+import java.util.UUID
+
+data class CreateReviewRequest(
+    val projectPaperId: UUID,
+    val decision: ReviewDecision,
+    val selectedCriteriaIds: List<UUID>,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/review/ReviewResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/review/ReviewResponse.kt
@@ -1,0 +1,42 @@
+package se.uulm.snowballr.backend.model.outgoing.review
+
+import se.uulm.snowballr.backend.model.dto.review.Review
+import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
+import snowballr.ReviewOuterClass
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class ReviewResponse(
+    val id: UUID,
+    val projectPaperId: UUID,
+    val userId: UUID,
+    val decision: ReviewDecision,
+    val createdAt: OffsetDateTime,
+    val modifiedAt: OffsetDateTime?,
+    val selectedCriteriaIds: List<UUID>,
+) {
+    companion object {
+        fun fromReviewAndIds(review: Review, selectedCriteriaIds: List<UUID>) = ReviewResponse(
+            id = review.id,
+            projectPaperId = review.projectPaperId,
+            userId = review.userId,
+            decision = review.decision,
+            createdAt = review.createdAt,
+            modifiedAt = review.modifiedAt,
+            selectedCriteriaIds = selectedCriteriaIds,
+        )
+    }
+}
+
+fun ReviewResponse.toGrpc(): ReviewOuterClass.Review = ReviewOuterClass.Review
+    .newBuilder()
+    .setId(id.toString())
+    .setUserId(userId.toString())
+    .setDecision(decision.toGrpc())
+    .addAllSelectedCriteriaIds(selectedCriteriaIds.map { it.toString() })
+    .build()
+
+fun List<ReviewResponse>.toGrpcReviews(): ReviewOuterClass.Review.List = ReviewOuterClass.Review.List
+    .newBuilder()
+    .addAllReviews(this.map { it.toGrpc() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepo.kt
@@ -3,20 +3,18 @@ package se.uulm.snowballr.backend.repository
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.review.Review
-import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.review.ReviewWithSelectedCriteriaIds
 import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.table.ReviewTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import se.uulm.snowballr.backend.table.toReview
 import java.util.UUID
-import snowballr.ReviewOuterClass.Review as GrpcReview
 
 /**
  * Defines an interface for repository operations related to the [Review].
@@ -59,7 +57,7 @@ interface IReviewTableRepo {
      * @param userId The ID of the user who created the review.
      * @return The created [Review] object representing the newly created review.
      */
-    suspend fun createReview(request: GrpcReview.Create, userId: UUID): Review
+    suspend fun createReview(request: CreateReviewRequest, userId: UUID): Review
 }
 
 /**
@@ -104,20 +102,16 @@ class ReviewTableRepo(
             }
     }
 
-    override suspend fun createReview(request: GrpcReview.Create, userId: UUID): Review = db.query {
-        val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
-
+    override suspend fun createReview(request: CreateReviewRequest, userId: UUID): Review = db.query {
         val review = ReviewTable.insertAndGet(ResultRow::toReview) {
-            it[ReviewTable.projectPaperId] = projectPaperId
+            it[projectPaperId] = request.projectPaperId
             it[ReviewTable.userId] = userId
-            it[decision] = ReviewDecision.fromGrpc(request.decision)
+            it[decision] = request.decision
         }
 
-        request.selectedCriteriaIdsList.forEach { criterionId ->
-            ReviewHasCriterionTable.insert {
-                it[this.reviewId] = review.id
-                it[this.criterionId] = parseUUID(criterionId, EntityType.CRITERION)
-            }
+        ReviewHasCriterionTable.batchInsert(request.selectedCriteriaIds) { criterionId ->
+            this[ReviewHasCriterionTable.reviewId] = review.id
+            this[ReviewHasCriterionTable.criterionId] = criterionId
         }
 
         review

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -15,13 +15,12 @@ import se.uulm.snowballr.backend.model.dto.review.Review
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.review.doesAcceptPaper
 import se.uulm.snowballr.backend.model.dto.review.doesDeclinePaper
-import se.uulm.snowballr.backend.model.dto.review.toGrpcReview
-import se.uulm.snowballr.backend.model.dto.review.toGrpcReviews
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
+import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -36,17 +35,17 @@ interface IReviewService {
     /**
      * Service implementation of [SnowballRService.getReviewById].
      */
-    suspend fun getReviewById(reviewId: UUID): GrpcReview
+    suspend fun getReviewById(reviewId: UUID): ReviewResponse
 
     /**
      * Service implementation of [SnowballRService.getAllReviewsForProjectPaper].
      */
-    suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): GrpcReview.List
+    suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<ReviewResponse>
 
     /**
      * Service implementation of [SnowballRService.createReview].
      */
-    suspend fun createReview(request: GrpcReview.Create): GrpcReview
+    suspend fun createReview(request: GrpcReview.Create): ReviewResponse
 }
 
 /**
@@ -81,32 +80,33 @@ class ReviewService(
     private val projectAccessChecker: IProjectAccessChecker,
     private val fetcherOrchestrator: IFetcherOrchestrator,
 ) : IReviewService {
-    override suspend fun getReviewById(reviewId: UUID): GrpcReview = withUser(userRepo) { currentUser ->
+    override suspend fun getReviewById(reviewId: UUID): ReviewResponse = withUser(userRepo) { currentUser ->
         val review = repo.getReviewById(reviewId).getOrThrow()
 
         accessChecker.isAllowedToReadReview(currentUser, review)
 
         val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(reviewId)
-        review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+
+        ReviewResponse.fromReviewAndIds(review, selectedCriteriaIds)
     }
 
-    override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): GrpcReview.List =
+    override suspend fun getAllReviewsForProjectPaper(projectPaperId: UUID): List<ReviewResponse> =
         withUser(userRepo) { currentUser ->
             val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
 
             projectAccessChecker.isAllowedToReadProject(currentUser, projectPaper.projectId)
 
             val reviews = repo.getAllReviewsForProjectPaper(projectPaperId)
-            val reviewSelectedCriteriaMap = mutableMapOf<Review, List<String>>()
+            val reviewSelectedCriteriaMap = mutableMapOf<Review, List<UUID>>()
             for (review in reviews) {
                 reviewSelectedCriteriaMap[review] = reviewHasCriterionRepo
-                    .getSelectedCriteriaIdsForReviewById(review.id).map(UUID::toString)
+                    .getSelectedCriteriaIdsForReviewById(review.id)
             }
 
-            reviews.toGrpcReviews(reviewSelectedCriteriaMap)
+            reviews.map { ReviewResponse.fromReviewAndIds(it, reviewSelectedCriteriaMap[it].orEmpty()) }
         }
 
-    override suspend fun createReview(request: GrpcReview.Create): GrpcReview = withUser(userRepo) { currentUser ->
+    override suspend fun createReview(request: GrpcReview.Create): ReviewResponse = withUser(userRepo) { currentUser ->
         val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
         val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
 
@@ -146,7 +146,7 @@ class ReviewService(
             fetcherOrchestrator.enqueue(FetcherEnqueueJob(projectPaper, currentUser.id))
         }
 
-        review.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+        ReviewResponse.fromReviewAndIds(review, selectedCriteriaIds)
     }
 
     private suspend fun hasSelectedHardExclusionCriterion(projectId: UUID, selectedCriteriaIds: List<UUID>): Boolean {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -4,7 +4,6 @@ import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IReviewAccessChecker
 import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
@@ -20,8 +19,8 @@ import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewEx
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
@@ -29,7 +28,6 @@ import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
 import java.util.UUID
-import snowballr.ReviewOuterClass.Review as GrpcReview
 
 interface IReviewService {
     /**
@@ -45,7 +43,7 @@ interface IReviewService {
     /**
      * Service implementation of [SnowballRService.createReview].
      */
-    suspend fun createReview(request: GrpcReview.Create): ReviewResponse
+    suspend fun createReview(request: CreateReviewRequest): ReviewResponse
 }
 
 /**
@@ -106,48 +104,48 @@ class ReviewService(
             reviews.map { ReviewResponse.fromReviewAndIds(it, reviewSelectedCriteriaMap[it].orEmpty()) }
         }
 
-    override suspend fun createReview(request: GrpcReview.Create): ReviewResponse = withUser(userRepo) { currentUser ->
-        val projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER)
-        val projectPaper = projectPaperRepo.getProjectPaperById(projectPaperId).getOrThrow()
+    override suspend fun createReview(request: CreateReviewRequest): ReviewResponse =
+        withUser(userRepo) { currentUser ->
+            val projectPaper = projectPaperRepo.getProjectPaperById(request.projectPaperId).getOrThrow()
 
-        val projectResult = projectRepo.getProjectById(projectPaper.projectId)
-        accessChecker.isAllowedToCreateReview(currentUser, projectPaper.projectId, projectResult)
-        val project = projectResult.getOrThrow()
+            val projectResult = projectRepo.getProjectById(projectPaper.projectId)
+            accessChecker.isAllowedToCreateReview(currentUser, projectPaper.projectId, projectResult)
+            val project = projectResult.getOrThrow()
 
-        val reviewsForProjectPaper = repo.getAllReviewsForProjectPaper(projectPaperId)
-        val hasUserAlreadyReviewed = reviewsForProjectPaper.any { review -> review.userId == currentUser.id }
-        if (hasUserAlreadyReviewed) {
-            throw DuplicateReviewException(projectPaperId, currentUser.id)
+            val reviewsForProjectPaper = repo.getAllReviewsForProjectPaper(request.projectPaperId)
+            val hasUserAlreadyReviewed = reviewsForProjectPaper.any { review -> review.userId == currentUser.id }
+            if (hasUserAlreadyReviewed) {
+                throw DuplicateReviewException(request.projectPaperId, currentUser.id)
+            }
+
+            if (projectPaper.hasFinalDecision()) {
+                throw FailedPreconditionException(
+                    "The project paper must be either unreviewed or still in review. " +
+                        "Finally decided project papers cannot be reviewed anymore.",
+                )
+            }
+
+            val review = repo.createReview(request, currentUser.id)
+            val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
+
+            val hasSelectedExclusionCriterion = hasSelectedHardExclusionCriterion(project.id, selectedCriteriaIds)
+
+            val decision = if (hasSelectedExclusionCriterion && review.doesDeclinePaper()) {
+                PaperDecision.DECLINED
+            } else {
+                determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
+            }
+            projectPaperRepo.updateProjectPaperDecision(request.projectPaperId, decision)
+
+            if (project.status != ProjectStatus.ACTIVE_LOCKED) {
+                setProjectStatusActiveLocked(project.id)
+            }
+            if (decision === PaperDecision.ACCEPTED) {
+                fetcherOrchestrator.enqueue(FetcherEnqueueJob(projectPaper, currentUser.id))
+            }
+
+            ReviewResponse.fromReviewAndIds(review, selectedCriteriaIds)
         }
-
-        if (projectPaper.hasFinalDecision()) {
-            throw FailedPreconditionException(
-                "The project paper must be either unreviewed or still in review. " +
-                    "Finally decided project papers cannot be reviewed anymore.",
-            )
-        }
-
-        val review = repo.createReview(request, currentUser.id)
-        val selectedCriteriaIds = reviewHasCriterionRepo.getSelectedCriteriaIdsForReviewById(review.id)
-
-        val hasSelectedExclusionCriterion = hasSelectedHardExclusionCriterion(project.id, selectedCriteriaIds)
-
-        val decision = if (hasSelectedExclusionCriterion && review.doesDeclinePaper()) {
-            PaperDecision.DECLINED
-        } else {
-            determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
-        }
-        projectPaperRepo.updateProjectPaperDecision(projectPaperId, decision)
-
-        if (project.status != ProjectStatus.ACTIVE_LOCKED) {
-            setProjectStatusActiveLocked(project.id)
-        }
-        if (decision === PaperDecision.ACCEPTED) {
-            fetcherOrchestrator.enqueue(FetcherEnqueueJob(projectPaper, currentUser.id))
-        }
-
-        ReviewResponse.fromReviewAndIds(review, selectedCriteriaIds)
-    }
 
     private suspend fun hasSelectedHardExclusionCriterion(projectId: UUID, selectedCriteriaIds: List<UUID>): Boolean {
         val hardExclusionCriteria = criterionRepo.getAllProjectCriteria(projectId)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -15,20 +15,21 @@ import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRange
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedCreateException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
-import snowballr.ReviewOuterClass.Review as GrpcReview
 
 class ProjectPaperIntegrationTest : IntegrationTest() {
     private suspend fun reviewPaper(projectPaper: GrpcProjectPaper, decision: ReviewDecision) =
         reviewService.createReview(
-            GrpcReview.Create.newBuilder()
-                .setProjectPaperId(projectPaper.id)
-                .setDecision(decision.toGrpc())
-                .build(),
+            CreateReviewRequest(
+                projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                decision = decision,
+                selectedCriteriaIds = emptyList(),
+            ),
         )
 
     private suspend fun setNumberOfRequiredReviewers(project: Project, numberOfReviewers: Int): Project {

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.project.Project
+import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import snowballr.ProjectOuterClass.PaperDecision
-import snowballr.ReviewOuterClass.ReviewDecision
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
@@ -55,12 +55,12 @@ class ReviewIntegrationTest : IntegrationTest() {
             reviewService.createReview(
                 GrpcReview.Create.newBuilder()
                     .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+                    .setDecision(ReviewDecision.ACCEPTED.toGrpc())
                     .build(),
             )
 
             val reviews = reviewService.getAllReviewsForProjectPaper(projectPaperId)
-            assertTrue(reviews.reviewsList.isNotEmpty())
+            assertTrue(reviews.isNotEmpty())
         }
 
         @Test
@@ -70,15 +70,14 @@ class ReviewIntegrationTest : IntegrationTest() {
             val review = reviewService.createReview(
                 GrpcReview.Create.newBuilder()
                     .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.REVIEW_DECISION_DECLINED)
+                    .setDecision(ReviewDecision.DECLINED.toGrpc())
                     .build(),
             )
-            val reviewId = parseUUID(review.id, EntityType.REVIEW)
 
-            val fetched = reviewService.getReviewById(reviewId)
+            val fetched = reviewService.getReviewById(review.id)
 
             assertEquals(review.id, fetched.id)
-            assertEquals(ReviewDecision.REVIEW_DECISION_DECLINED, fetched.decision)
+            assertEquals(ReviewDecision.DECLINED, fetched.decision)
         }
 
         @Test
@@ -89,7 +88,7 @@ class ReviewIntegrationTest : IntegrationTest() {
             reviewService.createReview(
                 GrpcReview.Create.newBuilder()
                     .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+                    .setDecision(ReviewDecision.ACCEPTED.toGrpc())
                     .build(),
             )
 
@@ -105,7 +104,7 @@ class ReviewIntegrationTest : IntegrationTest() {
             reviewService.createReview(
                 GrpcReview.Create.newBuilder()
                     .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.REVIEW_DECISION_DECLINED)
+                    .setDecision(ReviewDecision.DECLINED.toGrpc())
                     .build(),
             )
 
@@ -129,7 +128,7 @@ class ReviewIntegrationTest : IntegrationTest() {
             reviewService.createReview(
                 GrpcReview.Create.newBuilder()
                     .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.REVIEW_DECISION_ACCEPTED)
+                    .setDecision(ReviewDecision.ACCEPTED.toGrpc())
                     .build(),
             )
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -11,12 +11,12 @@ import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import snowballr.ProjectOuterClass.PaperDecision
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
-import snowballr.ReviewOuterClass.Review as GrpcReview
 
 class ReviewIntegrationTest : IntegrationTest() {
     private suspend fun setupProjectAndPaper(): Pair<Project, GrpcProjectPaper> {
@@ -53,10 +53,11 @@ class ReviewIntegrationTest : IntegrationTest() {
             val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
             reviewService.createReview(
-                GrpcReview.Create.newBuilder()
-                    .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.ACCEPTED.toGrpc())
-                    .build(),
+                CreateReviewRequest(
+                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    decision = ReviewDecision.ACCEPTED,
+                    selectedCriteriaIds = emptyList(),
+                ),
             )
 
             val reviews = reviewService.getAllReviewsForProjectPaper(projectPaperId)
@@ -68,10 +69,11 @@ class ReviewIntegrationTest : IntegrationTest() {
             val (_, projectPaper) = setupProjectAndPaper()
 
             val review = reviewService.createReview(
-                GrpcReview.Create.newBuilder()
-                    .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.DECLINED.toGrpc())
-                    .build(),
+                CreateReviewRequest(
+                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    decision = ReviewDecision.DECLINED,
+                    selectedCriteriaIds = emptyList(),
+                ),
             )
 
             val fetched = reviewService.getReviewById(review.id)
@@ -86,10 +88,11 @@ class ReviewIntegrationTest : IntegrationTest() {
             val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
             reviewService.createReview(
-                GrpcReview.Create.newBuilder()
-                    .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.ACCEPTED.toGrpc())
-                    .build(),
+                CreateReviewRequest(
+                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    decision = ReviewDecision.ACCEPTED,
+                    selectedCriteriaIds = emptyList(),
+                ),
             )
 
             val updatedProjectPaper = projectPaperService.getProjectPaperById(projectPaperId)
@@ -102,10 +105,11 @@ class ReviewIntegrationTest : IntegrationTest() {
             val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
             reviewService.createReview(
-                GrpcReview.Create.newBuilder()
-                    .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.DECLINED.toGrpc())
-                    .build(),
+                CreateReviewRequest(
+                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    decision = ReviewDecision.DECLINED,
+                    selectedCriteriaIds = emptyList(),
+                ),
             )
 
             val updatedProjectPaper = projectPaperService.getProjectPaperById(projectPaperId)
@@ -126,10 +130,11 @@ class ReviewIntegrationTest : IntegrationTest() {
             val (project, projectPaper) = setupProjectAndPaper()
 
             reviewService.createReview(
-                GrpcReview.Create.newBuilder()
-                    .setProjectPaperId(projectPaper.id)
-                    .setDecision(ReviewDecision.ACCEPTED.toGrpc())
-                    .build(),
+                CreateReviewRequest(
+                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    decision = ReviewDecision.ACCEPTED,
+                    selectedCriteriaIds = emptyList(),
+                ),
             )
 
             val updatedProject = project.copy(reviewMaybeAllowed = true)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/ReviewTableRepoTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.repository.RepositoryHelper.assignCriterionToReview
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertCriterionAndGetId
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
@@ -24,7 +25,6 @@ import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.table.association.ReviewHasCriterionTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.ReviewOuterClass.Review
 import java.sql.SQLException
 import java.util.UUID
 import kotlin.test.assertContains
@@ -214,9 +214,12 @@ class ReviewTableRepoTest : RepositoryTest(
 
     @Nested
     inner class CreateReview {
-        private fun createReviewRequest(projectPaperId: UUID) = Review.Create.newBuilder()
-            .setProjectPaperId(projectPaperId.toString())
-            .setDecision(ReviewDecision.ACCEPTED.toGrpc())
+        private fun createReviewRequest(projectPaperId: UUID, selectedCriteriaIds: List<UUID> = emptyList()) =
+            CreateReviewRequest(
+                projectPaperId = projectPaperId,
+                decision = ReviewDecision.ACCEPTED,
+                selectedCriteriaIds = selectedCriteriaIds,
+            )
 
         @Test
         fun `When a review is created, then the correct review is returned`() = runTest {
@@ -226,7 +229,7 @@ class ReviewTableRepoTest : RepositoryTest(
                 insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
             val userId = insertUserAndGetId(email = "existing.reviewer@example.com")
 
-            val review = repo.createReview(createReviewRequest(projectPaperId).build(), userId)
+            val review = repo.createReview(createReviewRequest(projectPaperId), userId)
 
             assertEquals(projectPaperId, review.projectPaperId)
             assertEquals(ReviewDecision.ACCEPTED, review.decision)
@@ -242,7 +245,7 @@ class ReviewTableRepoTest : RepositoryTest(
                     insertProjectPaperAndGetId(paperId = paperId, projectId = projectId, createdBy = testUserId)
 
                 assertThrows<SQLException> {
-                    repo.createReview(createReviewRequest(projectPaperId).build(), UUID.randomUUID())
+                    repo.createReview(createReviewRequest(projectPaperId), UUID.randomUUID())
                 }
             }
 
@@ -256,7 +259,7 @@ class ReviewTableRepoTest : RepositoryTest(
                 val userId = insertUserAndGetId(email = "double.reviewing.user@example.com")
                 insertReviewAndGetId(projectPaperId, userId)
 
-                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId).build(), userId) }
+                assertThrows<SQLException> { repo.createReview(createReviewRequest(projectPaperId), userId) }
             }
 
         @Test
@@ -269,9 +272,7 @@ class ReviewTableRepoTest : RepositoryTest(
                 val userId = insertUserAndGetId(email = "reviewing.user.with.criteria@example.com")
                 val selectedCriterion = insertCriterionAndGetId(projectId = projectId, createdBy = testUserId)
 
-                val createReviewWithCriteriaRequest = createReviewRequest(projectPaperId)
-                    .addSelectedCriteriaIds(selectedCriterion.toString())
-                    .build()
+                val createReviewWithCriteriaRequest = createReviewRequest(projectPaperId, listOf(selectedCriterion))
 
                 val review = repo.createReview(createReviewWithCriteriaRequest, userId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -163,9 +163,9 @@ class CreateReviewTest : ReviewServiceTest() {
 
         val review = service.createReview(validCreateReviewRequest.build())
 
-        assertEquals(userId.toString(), review.userId)
-        assertEquals(decision.toGrpc(), review.decision)
-        assertEquals(selectedCriteriaIds.map { it.toString() }, review.selectedCriteriaIdsList)
+        assertEquals(userId, review.userId)
+        assertEquals(decision, review.decision)
+        assertEquals(selectedCriteriaIds, review.selectedCriteriaIds)
 
         coVerify(exactly = 1) {
             projectRepoMock.updateProject(getUpdateProjectStatusRequest(project.id), setOf("project.status"))

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -28,7 +28,7 @@ import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewEx
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
-import snowballr.ReviewOuterClass
+import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
@@ -43,11 +43,11 @@ class CreateReviewTest : ReviewServiceTest() {
     private val defaultCriterion = UUID.randomUUID()
     private val selectedCriteriaIds = listOf<UUID>(defaultCriterion)
 
-    private val validCreateReviewRequest: ReviewOuterClass.Review.Create.Builder =
-        ReviewOuterClass.Review.Create.newBuilder()
-            .setProjectPaperId(projectPaperId.toString())
-            .setDecision(decision.toGrpc())
-            .addAllSelectedCriteriaIds(selectedCriteriaIds.map(UUID::toString))
+    private val validCreateReviewRequest = CreateReviewRequest(
+        projectPaperId = projectPaperId,
+        decision = decision,
+        selectedCriteriaIds = selectedCriteriaIds,
+    )
 
     fun failingFunctions(): Stream<Arguments?> = Stream.of(
         Arguments.of(projectPaperRepoMock::getProjectPaperById),
@@ -131,7 +131,7 @@ class CreateReviewTest : ReviewServiceTest() {
             return
         }
         coEvery {
-            reviewRepoMock.createReview(validCreateReviewRequest.build(), currentUser.id)
+            reviewRepoMock.createReview(validCreateReviewRequest, currentUser.id)
         } returns review
         coEvery {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
@@ -153,7 +153,7 @@ class CreateReviewTest : ReviewServiceTest() {
     fun `When a repo call fails, then a TestSpecificException is thrown`(failAt: KFunction<*>) = runTest {
         mockCreateReview(failAt = failAt)
 
-        assertThrows<TestSpecificException> { service.createReview(validCreateReviewRequest.build()) }
+        assertThrows<TestSpecificException> { service.createReview(validCreateReviewRequest) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
@@ -161,7 +161,7 @@ class CreateReviewTest : ReviewServiceTest() {
     fun `When a user creates a review and has access, then the created review has the correct values`() = runTest {
         mockCreateReview()
 
-        val review = service.createReview(validCreateReviewRequest.build())
+        val review = service.createReview(validCreateReviewRequest)
 
         assertEquals(userId, review.userId)
         assertEquals(decision, review.decision)
@@ -182,7 +182,7 @@ class CreateReviewTest : ReviewServiceTest() {
         mockCreateReview(stopBefore = reviewRepoMock::getAllReviewsForProjectPaper)
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaperId) } returns listOf(firstReview)
 
-        assertThrows<DuplicateReviewException> { service.createReview(validCreateReviewRequest.build()) }
+        assertThrows<DuplicateReviewException> { service.createReview(validCreateReviewRequest) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
@@ -193,7 +193,7 @@ class CreateReviewTest : ReviewServiceTest() {
             stopBefore = reviewRepoMock::createReview,
         )
 
-        assertThrows<FailedPreconditionException> { service.createReview(validCreateReviewRequest.build()) }
+        assertThrows<FailedPreconditionException> { service.createReview(validCreateReviewRequest) }
         coVerify(exactly = 0) { reviewRepoMock.createReview(any(), any()) }
     }
 
@@ -211,7 +211,7 @@ class CreateReviewTest : ReviewServiceTest() {
                 updatedPaperDecision = PaperDecision.ACCEPTED,
             )
 
-            service.createReview(validCreateReviewRequest.build())
+            service.createReview(validCreateReviewRequest)
 
             coVerify(exactly = 1) {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.ACCEPTED)
@@ -237,7 +237,7 @@ class CreateReviewTest : ReviewServiceTest() {
                 updatedPaperDecision = PaperDecision.ACCEPTED,
             )
 
-            service.createReview(validCreateReviewRequest.build())
+            service.createReview(validCreateReviewRequest)
 
             coVerify(exactly = 1) {
                 projectPaperRepoMock.updateProjectPaperDecision(projectPaperId, PaperDecision.ACCEPTED)
@@ -264,7 +264,7 @@ class CreateReviewTest : ReviewServiceTest() {
             )
             mockCreateReview(project = project)
 
-            service.createReview(validCreateReviewRequest.build())
+            service.createReview(validCreateReviewRequest)
             coVerify(exactly = 1) {
                 projectPaperRepoMock.updateProjectPaperDecision(
                     projectPaperId,
@@ -287,12 +287,10 @@ class CreateReviewTest : ReviewServiceTest() {
                 decision = ReviewDecision.DECLINED,
                 userId = userId,
             )
-            val createReviewRequest = validCreateReviewRequest
-                .setDecision(ReviewDecision.DECLINED.toGrpc())
-                .addAllSelectedCriteriaIds(
-                    listOf(exclusionCriterion.id.toString(), hardExclusionCriterion.id.toString()),
-                )
-                .build()
+            val createReviewRequest = validCreateReviewRequest.copy(
+                decision = ReviewDecision.DECLINED,
+                selectedCriteriaIds = listOf(exclusionCriterion.id, hardExclusionCriterion.id),
+            )
 
             mockCreateReview(stopBefore = reviewRepoMock::createReview)
             coEvery { reviewRepoMock.createReview(createReviewRequest, userId) } returns review
@@ -337,11 +335,7 @@ class CreateReviewTest : ReviewServiceTest() {
                 decision = ReviewDecision.DECLINED,
                 userId = userId,
             )
-            val createReviewRequest = ReviewOuterClass.Review.Create.newBuilder()
-                .setProjectPaperId(projectPaperId.toString())
-                .setDecision(ReviewDecision.DECLINED.toGrpc())
-                .addAllSelectedCriteriaIds(selectedCriteriaIds.map(UUID::toString))
-                .build()
+            val createReviewRequest = validCreateReviewRequest.copy(decision = ReviewDecision.DECLINED)
 
             mockCreateReview(
                 project = project,
@@ -377,12 +371,10 @@ class CreateReviewTest : ReviewServiceTest() {
                 decision = ReviewDecision.ACCEPTED,
                 userId = userId,
             )
-            val createReviewRequest = ReviewOuterClass.Review.Create.newBuilder()
-                .setProjectPaperId(projectPaperId.toString())
-                .setDecision(ReviewDecision.ACCEPTED.toGrpc())
-                .addAllSelectedCriteriaIds(selectedCriteriaIds.map(UUID::toString))
-                .addSelectedCriteriaIds(hardExclusionCriterion.id.toString())
-                .build()
+            val createReviewRequest = validCreateReviewRequest.copy(
+                decision = ReviewDecision.ACCEPTED,
+                selectedCriteriaIds = selectedCriteriaIds + listOf(hardExclusionCriterion.id),
+            )
 
             mockCreateReview(stopBefore = reviewRepoMock::createReview)
             coEvery { reviewRepoMock.createReview(createReviewRequest, userId) } returns acceptedReview
@@ -406,11 +398,7 @@ class CreateReviewTest : ReviewServiceTest() {
     @Test
     fun `When the project has already status ACTIVE_LOCKED, then the status is not updated again`() = runTest {
         val project = project.copy(status = ProjectStatus.ACTIVE_LOCKED)
-        val createReviewRequest = ReviewOuterClass.Review.Create.newBuilder()
-            .setProjectPaperId(projectPaperId.toString())
-            .setDecision(ReviewDecision.ACCEPTED.toGrpc())
-            .addAllSelectedCriteriaIds(selectedCriteriaIds.map(UUID::toString))
-            .build()
+        val createReviewRequest = validCreateReviewRequest.copy(decision = ReviewDecision.ACCEPTED)
 
         mockCreateReview(project)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -28,13 +28,13 @@ class GetAllReviewsForProjectPaperTest : ReviewServiceTest() {
             reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(review.id)
         } returns selectedCriteriaIds
 
-        val reviews = service.getAllReviewsForProjectPaper(projectPaper.id).reviewsList
+        val reviews = service.getAllReviewsForProjectPaper(projectPaper.id)
 
         assertEquals(1, reviews.size)
-        assertEquals(review.id.toString(), reviews[0].id)
-        assertEquals(1, reviews[0].selectedCriteriaIdsCount)
-        val selectedCriterionId = reviews[0].selectedCriteriaIdsList[0]
-        assertEquals(selectedCriteriaIds[0].toString(), selectedCriterionId)
+        assertEquals(review.id, reviews[0].id)
+        assertEquals(1, reviews[0].selectedCriteriaIds.size)
+        val selectedCriterionId = reviews[0].selectedCriteriaIds[0]
+        assertEquals(selectedCriteriaIds[0], selectedCriterionId)
         assertReviewEquality(review, reviews[0])
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -28,10 +28,10 @@ class GetReviewByIdTest : ReviewServiceTest() {
 
         val reviewResult = service.getReviewById(review.id)
 
-        assertEquals(review.id.toString(), reviewResult.id)
-        assertEquals(1, reviewResult.selectedCriteriaIdsCount)
-        val selectedCriterionId = reviewResult.selectedCriteriaIdsList[0]
-        assertEquals(selectedCriteriaIds[0].toString(), selectedCriterionId)
+        assertEquals(review.id, reviewResult.id)
+        assertEquals(1, reviewResult.selectedCriteriaIds.size)
+        val selectedCriterionId = reviewResult.selectedCriteriaIds[0]
+        assertEquals(selectedCriteriaIds[0], selectedCriterionId)
         assertReviewEquality(review, reviewResult)
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
@@ -9,6 +9,7 @@ import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.model.dto.review.Review
 import se.uulm.snowballr.backend.model.dto.user.User
+import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
@@ -18,7 +19,6 @@ import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTable
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ReviewService
 import se.uulm.snowballr.backend.service.withUser
-import snowballr.ReviewOuterClass
 import kotlin.test.assertEquals
 
 /**
@@ -69,8 +69,8 @@ sealed class ReviewServiceTest : BaseServiceTest {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
     }
 
-    protected fun assertReviewEquality(expected: Review, actual: ReviewOuterClass.Review) {
-        assertEquals(expected.userId.toString(), actual.userId)
-        assertEquals(expected.decision.toGrpc(), actual.decision)
+    protected fun assertReviewEquality(expected: Review, actual: ReviewResponse) {
+        assertEquals(expected.userId, actual.userId)
+        assertEquals(expected.decision, actual.decision)
     }
 }


### PR DESCRIPTION
Closes #546

## What I have made

Waits for #544

This removes any grpc related types from the service and repo layer for the review domain.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
