### PR TITLE
Use non grpc request types for paper domain

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.fetcher.FetcherMap
@@ -20,6 +19,7 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherProcessingJob
 import se.uulm.snowballr.backend.model.fetcher.FetchingDirection
 import se.uulm.snowballr.backend.model.fetcher.FetchingResults
 import se.uulm.snowballr.backend.model.fetcher.PaperCreationResults
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
@@ -237,7 +237,7 @@ class FetcherOrchestrator(
             }
 
             try {
-                createdPaperRefs += paperRepo.createPaper(ref.toGrpcPaperRequest())
+                createdPaperRefs += paperRepo.createPaper(CreatePaperRequest.fromFetcherPaper(ref))
             } catch (ex: SQLException) {
                 logger.error(ex) { "Failed to create paper for fetched paper: ${ex.message ?: "<empty>"}" }
             }

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -43,6 +43,7 @@ import se.uulm.snowballr.backend.model.fetcher.toGrpc
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
+import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
@@ -554,7 +555,20 @@ class SnowballRServer(
             ).toGrpc()
 
         override suspend fun updatePaper(request: PaperOuterClass.Paper.Update): PaperOuterClass.Paper =
-            paperService.updatePaper(request).toGrpc()
+            paperService.updatePaper(
+                UpdatePaperRequest(
+                    paperId = parseUUID(request.paper.id, EntityType.PAPER),
+                    title = request.paper.title,
+                    externalId = request.paper.externalId,
+                    abstract = request.paper.abstrakt,
+                    year = request.paper.year,
+                    publisher = request.paper.publisher,
+                    publicationName = request.paper.publicationName,
+                    publicationType = request.paper.publicationType,
+                    authors = request.paper.authorsList.map { Author(it.firstName, it.lastName) },
+                ),
+                FieldMaskUtil.normalize(request.mask).pathsList,
+            ).toGrpc()
 
         override suspend fun getForwardReferencedPapers(request: Base.Id): PaperOuterClass.Paper.List =
             paperService.getForwardReferencedPapers(parsePaperId(request)).toGrpc()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -26,6 +26,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
 import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriterion
+import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
@@ -41,6 +42,7 @@ import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.fetcher.toGrpc
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
@@ -537,7 +539,19 @@ class SnowballRServer(
         ): PaperOuterClass.Paper.List = fetcherService.searchFetcherProjectPaperCandidates(request).toGrpc()
 
         override suspend fun createPaper(request: PaperOuterClass.Paper): PaperOuterClass.Paper =
-            paperService.createPaper(request).toGrpc()
+            paperService.createPaper(
+                CreatePaperRequest(
+                    title = request.title,
+                    externalId = request.externalId,
+                    abstract = request.abstrakt,
+                    year = request.year,
+                    publisher = request.publisher,
+                    publicationName = request.publicationName,
+                    publicationType = request.publicationType,
+                    authors = request.authorsList.map { Author(it.firstName, it.lastName) },
+                    fetcherMetadata = request.fetcherMetadataMap,
+                ),
+            ).toGrpc()
 
         override suspend fun updatePaper(request: PaperOuterClass.Paper.Update): PaperOuterClass.Paper =
             paperService.updatePaper(request).toGrpc()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -47,6 +47,7 @@ import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequ
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
+import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.project.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.review.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.review.toGrpcReviews
@@ -331,7 +332,7 @@ class SnowballRServer(
         ): UserSettingsOuterClass.UserSettings = super.updateUserSettings(request)
 
         override suspend fun getReadingList(request: Base.Nothing): PaperOuterClass.Paper.List =
-            readingListService.getReadingList()
+            readingListService.getReadingList().toGrpc()
 
         override suspend fun isPaperOnReadingList(request: Base.Id) = returnBoolValue {
             readingListService.isPaperOnReadingList(parsePaperId(request))
@@ -525,27 +526,27 @@ class SnowballRServer(
         override suspend fun deleteReview(request: Base.Id): Base.Nothing = super.deleteReview(request)
 
         override suspend fun getPaperById(request: Base.Id): PaperOuterClass.Paper =
-            paperService.getPaperById(parsePaperId(request))
+            paperService.getPaperById(parsePaperId(request)).toGrpc()
 
         override suspend fun searchLocalProjectPaperCandidates(
             request: ProjectOuterClass.Project.Paper.SearchQuery,
-        ): PaperOuterClass.Paper.List = fetcherService.searchLocalProjectPaperCandidates(request)
+        ): PaperOuterClass.Paper.List = fetcherService.searchLocalProjectPaperCandidates(request).toGrpc()
 
         override suspend fun searchFetcherProjectPaperCandidates(
             request: ProjectOuterClass.Project.Paper.SearchQuery,
-        ): PaperOuterClass.Paper.List = fetcherService.searchFetcherProjectPaperCandidates(request)
+        ): PaperOuterClass.Paper.List = fetcherService.searchFetcherProjectPaperCandidates(request).toGrpc()
 
         override suspend fun createPaper(request: PaperOuterClass.Paper): PaperOuterClass.Paper =
-            paperService.createPaper(request)
+            paperService.createPaper(request).toGrpc()
 
         override suspend fun updatePaper(request: PaperOuterClass.Paper.Update): PaperOuterClass.Paper =
-            paperService.updatePaper(request)
+            paperService.updatePaper(request).toGrpc()
 
         override suspend fun getForwardReferencedPapers(request: Base.Id): PaperOuterClass.Paper.List =
-            paperService.getForwardReferencedPapers(parsePaperId(request))
+            paperService.getForwardReferencedPapers(parsePaperId(request)).toGrpc()
 
         override suspend fun getBackwardReferencedPapers(request: Base.Id): PaperOuterClass.Paper.List =
-            paperService.getBackwardReferencedPapers(parsePaperId(request))
+            paperService.getBackwardReferencedPapers(parsePaperId(request)).toGrpc()
 
         override suspend fun getPaperPdf(request: Base.Id): Base.Blob = super.getPaperPdf(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Author.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Author.kt
@@ -25,11 +25,6 @@ fun Author.toGrpcAuthor(): GrpcAuthor = GrpcAuthor.newBuilder()
     .build()
 
 /**
- * Creates an [Author] from this [GrpcAuthor].
- */
-fun GrpcAuthor.toAuthor(): Author = Author(firstName, lastName)
-
-/**
  * Creates a list of [GrpcAuthor] from this list of [Author].
  */
 fun List<Author>.toGrpcAuthors(): List<GrpcAuthor> = this.map(Author::toGrpcAuthor)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Paper.kt
@@ -38,14 +38,6 @@ fun Paper.toGrpcPaper(backwardReferencedIdsList: List<String>): GrpcPaper = this
     .build()
 
 /**
- * Converts a list of [GrpcPaper] objects into a [GrpcPaper.List].
- */
-fun List<GrpcPaper>.toGrpcPapers(): GrpcPaper.List = GrpcPaper.List
-    .newBuilder()
-    .addAllPapers(this)
-    .build()
-
-/**
  * Creates a [FetcherPaper] from this [Paper].
  */
 fun Paper.toFetcherPaper(): FetcherPaper = FetcherPaper(

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/paper/CreatePaperRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/paper/CreatePaperRequest.kt
@@ -1,0 +1,37 @@
+package se.uulm.snowballr.backend.model.incoming.paper
+
+import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.paper.Paper
+import se.uulm.snowballr.backend.model.dto.paper.PaperData
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+
+data class CreatePaperRequest(
+    val title: String,
+    val externalId: String?,
+    val abstract: String,
+    val year: Int,
+    val publisher: String,
+    val publicationName: String,
+    val publicationType: String,
+    val authors: List<Author>,
+    val fetcherMetadata: FetcherMetadata,
+) {
+    companion object {
+        fun fromPaper(paper: Paper) = fromPaperData(paper)
+
+        fun fromFetcherPaper(paper: FetcherPaper) = fromPaperData(paper)
+
+        private fun fromPaperData(paper: PaperData) = CreatePaperRequest(
+            title = paper.title,
+            externalId = paper.externalId,
+            abstract = paper.abstract,
+            year = paper.year,
+            publisher = paper.publisher,
+            publicationName = paper.publicationName,
+            publicationType = paper.publicationType,
+            authors = paper.authors,
+            fetcherMetadata = paper.fetcherMetadata,
+        )
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/paper/UpdatePaperRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/paper/UpdatePaperRequest.kt
@@ -1,0 +1,44 @@
+package se.uulm.snowballr.backend.model.incoming.paper
+
+import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.paper.Paper
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
+import java.util.UUID
+
+data class UpdatePaperRequest(
+    val paperId: UUID,
+    val title: String,
+    val externalId: String?,
+    val abstract: String,
+    val year: Int,
+    val publisher: String,
+    val publicationName: String,
+    val publicationType: String,
+    val authors: List<Author>,
+) {
+    companion object {
+        fun fromPaper(paper: Paper) = UpdatePaperRequest(
+            paperId = paper.id,
+            title = paper.title,
+            externalId = paper.externalId,
+            abstract = paper.abstract,
+            year = paper.year,
+            publisher = paper.publisher,
+            publicationName = paper.publicationName,
+            publicationType = paper.publicationType,
+            authors = paper.authors,
+        )
+
+        fun fromPaperResponse(paper: PaperResponse) = UpdatePaperRequest(
+            paperId = paper.id,
+            title = paper.title,
+            externalId = paper.externalId,
+            abstract = paper.abstract,
+            year = paper.year,
+            publisher = paper.publisher,
+            publicationName = paper.publicationName,
+            publicationType = paper.publicationType,
+            authors = paper.authors,
+        )
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/FetcherPaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/FetcherPaperResponse.kt
@@ -1,0 +1,65 @@
+package se.uulm.snowballr.backend.model.outgoing.paper
+
+import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.paper.Paper
+import se.uulm.snowballr.backend.model.dto.paper.PaperData
+import se.uulm.snowballr.backend.model.dto.paper.toGrpcAuthors
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import snowballr.PaperOuterClass
+import java.util.UUID
+
+data class FetcherPaperResponse(
+    /**
+     * If the paper already exists in the database, this is the ID of the paper. Otherwise, this is null.
+     */
+    val id: UUID?,
+    val externalId: String?,
+    val title: String,
+    val abstract: String,
+    val year: Int,
+    val publisher: String,
+    val publicationName: String,
+    val publicationType: String,
+    val authors: List<Author>,
+    val fetcherMetadata: FetcherMetadata,
+    val backwardReferencedIds: List<UUID>,
+) {
+    companion object {
+        fun fromPaper(paper: Paper) = fromPaperData(paper, paper.id)
+
+        fun fromFetcherPaper(paper: FetcherPaper) = fromPaperData(paper, null)
+
+        private fun fromPaperData(paper: PaperData, id: UUID?) = FetcherPaperResponse(
+            id = id,
+            externalId = paper.externalId,
+            title = paper.title,
+            abstract = paper.abstract,
+            year = paper.year,
+            publisher = paper.publisher,
+            publicationName = paper.publicationName,
+            publicationType = paper.publicationType,
+            authors = paper.authors,
+            fetcherMetadata = paper.fetcherMetadata,
+            backwardReferencedIds = emptyList(),
+        )
+    }
+}
+
+fun FetcherPaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBuilder()
+    .setId(id?.toString().orEmpty())
+    .setExternalId(externalId.orEmpty())
+    .setTitle(title)
+    .setAbstrakt(abstract)
+    .setYear(year)
+    .setPublisher(publisher)
+    .setPublicationName(publicationName)
+    .setPublicationType(publicationType)
+    .addAllAuthors(authors.toGrpcAuthors())
+    .putAllFetcherMetadata(fetcherMetadata)
+    .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
+    .build()
+
+fun List<FetcherPaperResponse>.toGrpc(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List.newBuilder()
+    .addAllPapers(this.map { it.toGrpc() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/PaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/PaperResponse.kt
@@ -1,0 +1,56 @@
+package se.uulm.snowballr.backend.model.outgoing.paper
+
+import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.paper.Paper
+import se.uulm.snowballr.backend.model.dto.paper.toGrpcAuthors
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
+import snowballr.PaperOuterClass
+import java.util.UUID
+
+data class PaperResponse(
+    val id: UUID,
+    val externalId: String?,
+    val title: String,
+    val abstract: String,
+    val year: Int,
+    val publisher: String,
+    val publicationName: String,
+    val publicationType: String,
+    val authors: List<Author>,
+    val fetcherMetadata: FetcherMetadata,
+    val backwardReferencedIds: List<UUID>,
+) {
+    companion object {
+        fun fromPaper(paper: Paper, backwardReferencedIds: List<UUID>) = PaperResponse(
+            id = paper.id,
+            externalId = paper.externalId,
+            title = paper.title,
+            abstract = paper.abstract,
+            year = paper.year,
+            publisher = paper.publisher,
+            publicationName = paper.publicationName,
+            publicationType = paper.publicationType,
+            authors = paper.authors,
+            fetcherMetadata = paper.fetcherMetadata,
+            backwardReferencedIds = backwardReferencedIds,
+        )
+    }
+}
+
+fun PaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBuilder()
+    .setId(id.toString())
+    .setExternalId(externalId.orEmpty())
+    .setTitle(title)
+    .setAbstrakt(abstract)
+    .setYear(year)
+    .setPublisher(publisher)
+    .setPublicationName(publicationName)
+    .setPublicationType(publicationType)
+    .addAllAuthors(authors.toGrpcAuthors())
+    .putAllFetcherMetadata(fetcherMetadata)
+    .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
+    .build()
+
+fun List<PaperResponse>.toGrpc(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List.newBuilder()
+    .addAllPapers(this.map { it.toGrpc() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import com.google.protobuf.util.FieldMaskUtil
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.eq
@@ -11,17 +10,14 @@ import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import se.uulm.snowballr.backend.db.IDatabase
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toAuthor
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.toPaper
 import java.time.OffsetDateTime
 import java.util.UUID
-import snowballr.PaperOuterClass.Author as GrpcAuthor
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 /**
  * Defines an interface for repository operations related to the [PaperTable].
@@ -61,17 +57,8 @@ interface IPaperTableRepo {
 
     /**
      * Updates an existing paper in the database with the provided new values.
-     * The following fields can be updated:
-     * - [GrpcPaper.externalId_]
-     * - [GrpcPaper.title_]
-     * - [GrpcPaper.abstrakt_]
-     * - [GrpcPaper.year_]
-     * - [GrpcPaper.publisher_]
-     * - [GrpcPaper.publicationName_]
-     * - [GrpcPaper.publicationType_]
-     * - [GrpcPaper.authors_]
      */
-    suspend fun updatePaper(request: GrpcPaper.Update): Paper
+    suspend fun updatePaper(request: UpdatePaperRequest, paths: List<String>): Paper
 
     /**
      * Retrieves a list of papers whose title partially or fully match the [query].
@@ -150,25 +137,22 @@ class PaperTableRepo(
         }
     }
 
-    override suspend fun updatePaper(request: GrpcPaper.Update): Paper = db.query {
-        val paperId = parseUUID(request.paper.id, EntityType.PAPER)
-        val fieldMask = FieldMaskUtil.normalize(request.mask)
-
-        if (fieldMask.pathsList.isEmpty()) {
-            return@query getPaperById(paperId).getOrThrow()
+    override suspend fun updatePaper(request: UpdatePaperRequest, paths: List<String>): Paper = db.query {
+        if (paths.isEmpty()) {
+            return@query getPaperById(request.paperId).getOrThrow()
         }
 
-        PaperTable.updateByIdAndGet(paperId, ResultRow::toPaper) {
-            for (field in fieldMask.pathsList) {
+        PaperTable.updateByIdAndGet(request.paperId, ResultRow::toPaper) {
+            for (field in paths) {
                 when (field) {
-                    "paper.external_id" -> it[externalId] = request.paper.externalId
-                    "paper.title" -> it[title] = request.paper.title
-                    "paper.abstrakt" -> it[abstract] = request.paper.abstrakt
-                    "paper.year" -> it[year] = request.paper.year
-                    "paper.publisher" -> it[publisher] = request.paper.publisher
-                    "paper.publication_name" -> it[publicationName] = request.paper.publicationName
-                    "paper.publication_type" -> it[publicationType] = request.paper.publicationType
-                    "paper.authors" -> it[authors] = request.paper.authorsList.map(GrpcAuthor::toAuthor)
+                    "paper.title" -> it[title] = request.title
+                    "paper.external_id" -> it[externalId] = request.externalId
+                    "paper.abstrakt" -> it[abstract] = request.abstract
+                    "paper.year" -> it[year] = request.year
+                    "paper.publisher" -> it[publisher] = request.publisher
+                    "paper.publication_name" -> it[publicationName] = request.publicationName
+                    "paper.publication_type" -> it[publicationType] = request.publicationType
+                    "paper.authors" -> it[authors] = request.authors
                 }
             }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -14,6 +14,7 @@ import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.toAuthor
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.toPaper
@@ -56,7 +57,7 @@ interface IPaperTableRepo {
     /**
      * Creates a new paper in the database with the provided values.
      */
-    suspend fun createPaper(request: GrpcPaper): Paper
+    suspend fun createPaper(request: CreatePaperRequest): Paper
 
     /**
      * Updates an existing paper in the database with the provided new values.
@@ -134,17 +135,17 @@ class PaperTableRepo(
         PaperTable.doesEntityExist { PaperTable.externalId eq externalId }
     }
 
-    override suspend fun createPaper(request: GrpcPaper): Paper = db.query {
+    override suspend fun createPaper(request: CreatePaperRequest): Paper = db.query {
         PaperTable.insertAndGet(ResultRow::toPaper) {
             it[title] = request.title
-            it[externalId] = request.externalId.ifBlank { null }
-            it[abstract] = request.abstrakt
+            it[externalId] = request.externalId
+            it[abstract] = request.abstract
             it[year] = request.year
             it[publisher] = request.publisher
             it[publicationName] = request.publicationName
             it[publicationType] = request.publicationType
-            it[authors] = request.authorsList.map(GrpcAuthor::toAuthor)
-            it[fetcherMetadata] = request.fetcherMetadataMap
+            it[authors] = request.authors
+            it[fetcherMetadata] = request.fetcherMetadata
             it[createdAt] = OffsetDateTime.now()
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -6,18 +6,17 @@ import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherInformationWithId
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import se.uulm.snowballr.backend.model.outgoing.paper.FetcherPaperResponse
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 private val logger = KotlinLogging.logger { }
@@ -31,12 +30,12 @@ interface IFetcherService {
     /**
      * Service implementation of [SnowballRService.searchLocalProjectPaperCandidates].
      */
-    suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List
+    suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): List<PaperResponse>
 
     /**
      * Service implementation of [SnowballRService.searchFetcherProjectPaperCandidates].
      */
-    suspend fun searchFetcherProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List
+    suspend fun searchFetcherProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): List<FetcherPaperResponse>
 }
 
 /**
@@ -59,7 +58,7 @@ class FetcherService(
 ) : IFetcherService {
     override suspend fun getAvailableFetchers(): Set<FetcherInformationWithId> = fetcherManager.getAvailableFetchers()
 
-    override suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List =
+    override suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): List<PaperResponse> =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
@@ -74,47 +73,47 @@ class FetcherService(
                 "Filtered out $removedPapers/${matchingPapers.size} papers that already existed in the project."
             }
 
-            GrpcPaper.List.newBuilder()
-                .addAllPapers(filteredPapers.map { it.toGrpcPaper(emptyList()) })
-                .build()
+            filteredPapers.map { PaperResponse.fromPaper(it, emptyList()) }
         }
 
-    override suspend fun searchFetcherProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): GrpcPaper.List =
-        withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+    override suspend fun searchFetcherProjectPaperCandidates(
+        request: GrpcProjectPaper.SearchQuery,
+    ): List<FetcherPaperResponse> = withUser(userRepo) { currentUser ->
+        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
-            projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
-            val project = projectRepo.getProjectById(projectId).getOrThrow()
+        projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
+        val project = projectRepo.getProjectById(projectId).getOrThrow()
 
-            val papers = mutableSetOf<FetcherPaper>()
-            for ((fetcher, options) in project.fetchers) {
-                try {
-                    papers += fetcherManager.searchPapers(fetcher, request.query, options)
-                } catch (e: FetcherException) {
-                    logger.error(e) {
-                        "Failed to search fetcher papers for fetcher '$fetcher': ${e.message ?: "<empty>"}"
-                    }
+        val papers = mutableSetOf<FetcherPaper>()
+        for ((fetcher, options) in project.fetchers) {
+            try {
+                papers += fetcherManager.searchPapers(fetcher, request.query, options)
+            } catch (e: FetcherException) {
+                logger.error(e) {
+                    "Failed to search fetcher papers for fetcher '$fetcher': ${e.message ?: "<empty>"}"
                 }
             }
-            logger.debug { "Found ${papers.size} papers for query '${request.query}'" }
-
-            val filteredPapers = filterExistingFetcherPapers(projectId, papers)
-            logger.debug {
-                val removedPapers = papers.size - filteredPapers.size
-                "Filtered out $removedPapers/${papers.size} papers that already existed in the project."
-            }
-
-            GrpcPaper.List.newBuilder()
-                .addAllPapers(filteredPapers)
-                .build()
         }
+        logger.debug { "Found ${papers.size} papers for query '${request.query}'" }
+
+        val filteredPapers = filterExistingFetcherPapers(projectId, papers)
+        logger.debug {
+            val removedPapers = papers.size - filteredPapers.size
+            "Filtered out $removedPapers/${papers.size} papers that already existed in the project."
+        }
+
+        filteredPapers
+    }
 
     /**
      * Filters out papers that are already added to the project.
      *
      * Papers that already exist in the database get their ID assigned, so that they can be associated by the client.
      */
-    private suspend fun filterExistingFetcherPapers(projectId: UUID, fetcherPapers: Set<FetcherPaper>): Set<GrpcPaper> {
+    private suspend fun filterExistingFetcherPapers(
+        projectId: UUID,
+        fetcherPapers: Set<FetcherPaper>,
+    ): List<FetcherPaperResponse> {
         val externalIds = fetcherPapers.mapNotNull { it.externalId }.distinct()
         val existingPapers = paperRepo.getPapersByExternalIds(externalIds).associateBy { it.externalId }
         val notInProjectIds = filterPapersNotInProject(projectId, existingPapers.values).map { it.id }.toSet()
@@ -122,11 +121,11 @@ class FetcherService(
         return fetcherPapers.mapNotNull { fetcherPaper ->
             val existing = existingPapers[fetcherPaper.externalId]
             when {
-                existing == null -> fetcherPaper.toGrpcPaperRequest()
-                existing.id in notInProjectIds -> existing.toGrpcPaper(emptyList())
+                existing == null -> FetcherPaperResponse.fromFetcherPaper(fetcherPaper)
+                existing.id in notInProjectIds -> FetcherPaperResponse.fromPaper(existing)
                 else -> null
             }
-        }.toSet()
+        }
     }
 
     private suspend fun filterPapersNotInProject(projectId: UUID, papers: Collection<Paper>): List<Paper> {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -3,9 +3,9 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPapers
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
@@ -16,27 +16,27 @@ interface IPaperService {
     /**
      * Service implementation of [SnowballRService.getPaperById].
      */
-    suspend fun getPaperById(paperId: UUID): GrpcPaper
+    suspend fun getPaperById(paperId: UUID): PaperResponse
 
     /**
      * Service implementation of [SnowballRService.getBackwardReferencedPapers].
      */
-    suspend fun getBackwardReferencedPapers(paperId: UUID): GrpcPaper.List
+    suspend fun getBackwardReferencedPapers(paperId: UUID): List<PaperResponse>
 
     /**
      * Service implementation of [SnowballRService.getForwardReferencedPapers].
      */
-    suspend fun getForwardReferencedPapers(paperId: UUID): GrpcPaper.List
+    suspend fun getForwardReferencedPapers(paperId: UUID): List<PaperResponse>
 
     /**
      * Service implementation of [SnowballRService.updatePaper].
      */
-    suspend fun updatePaper(request: GrpcPaper.Update): GrpcPaper
+    suspend fun updatePaper(request: GrpcPaper.Update): PaperResponse
 
     /**
      * Service implementation of [SnowballRService.createPaper].
      */
-    suspend fun createPaper(request: GrpcPaper): GrpcPaper
+    suspend fun createPaper(request: GrpcPaper): PaperResponse
 }
 
 /**
@@ -53,19 +53,15 @@ class PaperService(
     private val repo: IPaperTableRepo,
     private val citationRepo: ICitationTableRepo,
 ) : IPaperService {
-    override suspend fun getPaperById(paperId: UUID): GrpcPaper {
-        val paper = repo.getPaperById(paperId).getOrThrow()
+    override suspend fun getPaperById(paperId: UUID) = repo.getPaperById(paperId).getOrThrow().toPaperResponse()
 
-        return paper.toGrpcPaper()
-    }
-
-    override suspend fun getBackwardReferencedPapers(paperId: UUID): GrpcPaper.List =
+    override suspend fun getBackwardReferencedPapers(paperId: UUID): List<PaperResponse> =
         getReferencePapers(paperId, citationRepo::getBackwardsReferencedPaperIdsOfPaperById)
 
-    override suspend fun getForwardReferencedPapers(paperId: UUID): GrpcPaper.List =
+    override suspend fun getForwardReferencedPapers(paperId: UUID): List<PaperResponse> =
         getReferencePapers(paperId, citationRepo::getForwardReferencedPaperIdsOfPaperById)
 
-    override suspend fun updatePaper(request: GrpcPaper.Update): GrpcPaper {
+    override suspend fun updatePaper(request: GrpcPaper.Update): PaperResponse {
         val paperId = parseUUID(request.paper.id, EntityType.PAPER)
 
         repo.ensurePaperExists(paperId)
@@ -77,37 +73,35 @@ class PaperService(
             }
         }
 
-        return repo.updatePaper(request).toGrpcPaper()
+        return repo.updatePaper(request).toPaperResponse()
     }
 
-    override suspend fun createPaper(request: GrpcPaper): GrpcPaper {
+    override suspend fun createPaper(request: GrpcPaper): PaperResponse {
         if (request.externalId.isNotEmpty() && repo.doesPaperExistByExternalId(request.externalId)) {
             throw DuplicatePaperException(request.externalId)
         }
 
-        return repo.createPaper(request).toGrpcPaper()
+        return repo.createPaper(request).toPaperResponse()
     }
 
     /**
      * Retrieves a list of reference papers based on the provided paper ID and a specified function for fetching
      * references. This method ensures the validity of the paper ID and retrieves the associated metadata for each
-     * reference paper, including authors and backward references.
+     * reference paper, including backward references.
      *
      * @param paperId The ID of the paper for which references are to be retrieved.
      * @param function A function that takes a paper ID and returns a list of UUIDs of the references.
-     * @return A list of gRPC-compatible paper objects containing reference information.
+     * @return A list of paper objects containing reference information.
      * @throws NotFoundException If the paper specified in the request does not exist.
      */
-    private suspend fun getReferencePapers(paperId: UUID, function: suspend (UUID) -> List<UUID>): GrpcPaper.List {
+    private suspend fun getReferencePapers(paperId: UUID, function: suspend (UUID) -> List<UUID>): List<PaperResponse> {
         repo.ensurePaperExists(paperId)
 
         val referenceIds = function.invoke(paperId)
-        val papers = referenceIds.map {
-            val referencedPaper = repo.getPaperById(it).getOrThrow()
-            referencedPaper.toGrpcPaper()
-        }
-        return papers.toGrpcPapers()
+        val papers = referenceIds.map { getPaperById(it) }
+
+        return papers
     }
 
-    private suspend fun Paper.toGrpcPaper(): GrpcPaper = this.toGrpcPaperWithAuthorsAndBackwardReferences(citationRepo)
+    private suspend fun Paper.toPaperResponse(): PaperResponse = this.toPaperResponse(citationRepo)
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -1,17 +1,15 @@
 package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
+import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface IPaperService {
     /**
@@ -32,7 +30,7 @@ interface IPaperService {
     /**
      * Service implementation of [SnowballRService.updatePaper].
      */
-    suspend fun updatePaper(request: GrpcPaper.Update): PaperResponse
+    suspend fun updatePaper(request: UpdatePaperRequest, paths: List<String>): PaperResponse
 
     /**
      * Service implementation of [SnowballRService.createPaper].
@@ -62,19 +60,17 @@ class PaperService(
     override suspend fun getForwardReferencedPapers(paperId: UUID): List<PaperResponse> =
         getReferencePapers(paperId, citationRepo::getForwardReferencedPaperIdsOfPaperById)
 
-    override suspend fun updatePaper(request: GrpcPaper.Update): PaperResponse {
-        val paperId = parseUUID(request.paper.id, EntityType.PAPER)
+    override suspend fun updatePaper(request: UpdatePaperRequest, paths: List<String>): PaperResponse {
+        repo.ensurePaperExists(request.paperId)
 
-        repo.ensurePaperExists(paperId)
-
-        if (request.paper.externalId.isNotEmpty()) {
-            val existingPaper = repo.getPaperByExternalId(request.paper.externalId).getOrNull()
-            if (existingPaper != null && existingPaper.id != paperId) {
-                throw DuplicatePaperException(request.paper.externalId)
+        if (request.externalId != null) {
+            val existingPaper = repo.getPaperByExternalId(request.externalId).getOrNull()
+            if (existingPaper != null && existingPaper.id != request.paperId) {
+                throw DuplicatePaperException(request.externalId)
             }
         }
 
-        return repo.updatePaper(request).toPaperResponse()
+        return repo.updatePaper(request, paths).toPaperResponse()
     }
 
     override suspend fun createPaper(request: CreatePaperRequest): PaperResponse {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/PaperService.kt
@@ -5,6 +5,7 @@ import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
@@ -36,7 +37,7 @@ interface IPaperService {
     /**
      * Service implementation of [SnowballRService.createPaper].
      */
-    suspend fun createPaper(request: GrpcPaper): PaperResponse
+    suspend fun createPaper(request: CreatePaperRequest): PaperResponse
 }
 
 /**
@@ -76,8 +77,8 @@ class PaperService(
         return repo.updatePaper(request).toPaperResponse()
     }
 
-    override suspend fun createPaper(request: GrpcPaper): PaperResponse {
-        if (request.externalId.isNotEmpty() && repo.doesPaperExistByExternalId(request.externalId)) {
+    override suspend fun createPaper(request: CreatePaperRequest): PaperResponse {
+        if (request.externalId != null && repo.doesPaperExistByExternalId(request.externalId)) {
             throw DuplicatePaperException(request.externalId)
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReadingListService.kt
@@ -1,19 +1,18 @@
 package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPapers
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IReadingListTableRepo
 import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface IReadingListService {
     /**
      * Service implementation of [SnowballRService.getReadingList].
      */
-    suspend fun getReadingList(): GrpcPaper.List
+    suspend fun getReadingList(): List<PaperResponse>
 
     /**
      * Service implementation of [SnowballRService.isPaperOnReadingList].
@@ -50,12 +49,8 @@ class ReadingListService(
     private val citationRepo: ICitationTableRepo,
     private val repo: IReadingListTableRepo,
 ) : IReadingListService {
-    override suspend fun getReadingList(): GrpcPaper.List = withUser(userRepo) { currentUser ->
-        val papers = repo.getAllReadingListEntries(currentUser.id).map { paper ->
-            paper.toGrpcPaperWithAuthorsAndBackwardReferences(citationRepo)
-        }
-
-        papers.toGrpcPapers()
+    override suspend fun getReadingList(): List<PaperResponse> = withUser(userRepo) { currentUser ->
+        repo.getAllReadingListEntries(currentUser.id).map { it.toPaperResponse(citationRepo) }
     }
 
     override suspend fun isPaperOnReadingList(paperId: UUID): Boolean = withUser(userRepo) { currentUser ->

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceHelper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ServiceHelper.kt
@@ -2,13 +2,11 @@ package se.uulm.snowballr.backend.service
 
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.NotFoundException
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
-import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 /**
  * Fetches the current user using the [userRepo] and executes the [block] with the current user as parameter.
@@ -21,9 +19,9 @@ suspend fun <T> withUser(userRepo: IUserTableRepo, block: suspend (User) -> T): 
 }
 
 /**
- * Populates the given [Paper] with its backward references and converts it to a [GrpcPaper].
+ * Populates the given [Paper] with its backward references and converts it to a [PaperResponse].
  */
-suspend fun Paper.toGrpcPaperWithAuthorsAndBackwardReferences(citationRepo: ICitationTableRepo): GrpcPaper {
-    val backwardReferences = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(id).map(UUID::toString)
-    return toGrpcPaper(backwardReferences)
+suspend fun Paper.toPaperResponse(citationRepo: ICitationTableRepo): PaperResponse {
+    val backwardReferencedIds = citationRepo.getBackwardsReferencedPaperIdsOfPaperById(id)
+    return PaperResponse.fromPaper(this, backwardReferencedIds)
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -13,11 +13,11 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.repository.UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE
 import java.sql.SQLException
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
@@ -228,10 +228,10 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     } returns Result.failure(TestSpecificException())
                 }
                 coEvery {
-                    paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest())
+                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
                 } returns backwardRef
                 coEvery {
-                    paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest())
+                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
                 } returns forwardRef
 
                 // Stop at adding papers to project
@@ -249,10 +249,10 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
 
                 assertAddingPapersToProjectFailure()
                 coVerify(exactly = 1) {
-                    paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest())
+                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
                 }
                 coVerify(exactly = 1) {
-                    paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest())
+                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
                 }
             }
 
@@ -267,10 +267,10 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
 
             mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
             coEvery {
-                paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest())
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
             } throws SQLException("Creating backward paper failed")
             coEvery {
-                paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest())
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
             } throws SQLException("Creating forward paper failed")
 
             orchestrator.enqueueTestJob(job, project)

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -17,9 +17,9 @@ import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaperRequest
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
@@ -125,13 +125,13 @@ sealed class FetcherOrchestratorTest {
         for (backwardRef in backwardRefs) {
             val backwardFetcherRef = backwardRef.toFetcherPaper()
             coEvery {
-                paperRepoMock.createPaper(backwardFetcherRef.toGrpcPaperRequest())
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
             } returns backwardRef
         }
         for (forwardRef in forwardRefs) {
             val forwardFetcherRef = forwardRef.toFetcherPaper()
             coEvery {
-                paperRepoMock.createPaper(forwardFetcherRef.toGrpcPaperRequest())
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
             } returns forwardRef
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -43,6 +43,7 @@ import se.uulm.snowballr.backend.mailServiceDeps
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.email.EmailData
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.repository.RepositoryHelper
@@ -62,7 +63,6 @@ import se.uulm.snowballr.backend.service.IUserService
 import se.uulm.snowballr.backend.serviceLayerDeps
 import snowballr.Authentication
 import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 import snowballr.ProjectOuterClass.Project as GrpcProject
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
@@ -165,15 +165,18 @@ open class IntegrationTest : KoinTest {
      * @param externalId The external ID of the created paper. Defaults to null.
      */
     protected suspend fun createPaper(title: String = "Test Paper", externalId: String? = null): PaperResponse {
-        val builder = GrpcPaper.newBuilder()
-            .setTitle(title)
-            .setAbstrakt("Abstract text")
-            .setYear(2024)
-            .setPublisher("Publisher")
-            .setPublicationType("Journal")
-            .setPublicationName("Journal Name")
-        if (externalId != null) builder.setExternalId(externalId)
-        return paperService.createPaper(builder.build())
+        val request = CreatePaperRequest(
+            title = title,
+            externalId = externalId,
+            abstract = "Abstract text",
+            year = 2024,
+            publisher = "Publisher",
+            publicationType = "Journal",
+            publicationName = "Journal Name",
+            authors = emptyList(),
+            fetcherMetadata = emptyMap(),
+        )
+        return paperService.createPaper(request)
     }
 
     /**

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -44,6 +44,7 @@ import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.repository.RepositoryHelper
 import se.uulm.snowballr.backend.repositoryLayerDeps
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -163,7 +164,7 @@ open class IntegrationTest : KoinTest {
      * @param title The title of the created paper. Defaults to "Test Paper".
      * @param externalId The external ID of the created paper. Defaults to null.
      */
-    protected suspend fun createPaper(title: String = "Test Paper", externalId: String? = null): GrpcPaper {
+    protected suspend fun createPaper(title: String = "Test Paper", externalId: String? = null): PaperResponse {
         val builder = GrpcPaper.newBuilder()
             .setTitle(title)
             .setAbstrakt("Abstract text")
@@ -275,10 +276,10 @@ open class IntegrationTest : KoinTest {
     /**
      * Adds the [paper] to the [project] in stage 0.
      */
-    protected suspend fun addToProject(project: Project, paper: GrpcPaper) = projectPaperService.addPaperToProject(
+    protected suspend fun addToProject(project: Project, paper: PaperResponse) = projectPaperService.addPaperToProject(
         GrpcProjectPaper.Add.newBuilder()
             .setProjectId(project.id.toString())
-            .setPaperId(paper.id)
+            .setPaperId(paper.id.toString())
             .setStage(0)
             .build(),
     )

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -117,7 +117,7 @@ class AccessControlIntegrationTest : IntegrationTest() {
 
             val request = GrpcProjectPaper.Add.newBuilder()
                 .setProjectId(project.id.toString())
-                .setPaperId(paper.id)
+                .setPaperId(paper.id.toString())
                 .setStage(0)
                 .build()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class RegressionTest : IntegrationTest() {
@@ -54,9 +54,10 @@ class RegressionTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
             val papers = mutableSetOf<PaperResponse>()
             for (i in 1..numberOfPapers) {
-                val builder = GrpcPaper.newBuilder()
-                    .setTitle("Paper $i")
-                papers += paperService.createPaper(builder.build())
+                val request = CreatePaperRequest.fromPaper(
+                    DataBuilder.createExamplePaper(title = "Paper $i", externalId = "External ID $i"),
+                )
+                papers += paperService.createPaper(request)
             }
 
             val projectPapers = papers.map {

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
@@ -51,7 +52,7 @@ class RegressionTest : IntegrationTest() {
         runTest {
             val numberOfPapers = 10
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
-            val papers = mutableSetOf<GrpcPaper>()
+            val papers = mutableSetOf<PaperResponse>()
             for (i in 1..numberOfPapers) {
                 val builder = GrpcPaper.newBuilder()
                     .setTitle("Paper $i")
@@ -63,7 +64,7 @@ class RegressionTest : IntegrationTest() {
                     projectPaperService.addPaperToProject(
                         GrpcProjectPaper.Add.newBuilder()
                             .setProjectId(project.id.toString())
-                            .setPaperId(it.id)
+                            .setPaperId(it.id.toString())
                             .setStage(0)
                             .build(),
                     )

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
@@ -27,7 +27,7 @@ class FetcherIntegrationTest : IntegrationTest() {
 
             val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
 
-            assertTrue(result.papersList.isEmpty())
+            assertTrue(result.isEmpty())
         }
 
         @Test
@@ -37,7 +37,7 @@ class FetcherIntegrationTest : IntegrationTest() {
 
             val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
 
-            assertTrue(result.papersList.any { it.id == paper.id })
+            assertTrue(result.any { it.id == paper.id })
         }
 
         @Test
@@ -48,7 +48,7 @@ class FetcherIntegrationTest : IntegrationTest() {
 
             val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
 
-            assertFalse(result.papersList.any { it.id == paper.id })
+            assertFalse(result.any { it.id == paper.id })
         }
 
         @Test
@@ -62,8 +62,8 @@ class FetcherIntegrationTest : IntegrationTest() {
                 val result =
                     fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about"))
 
-                assertFalse(result.papersList.any { it.id == inProject.id })
-                assertTrue(result.papersList.any { it.id == notInProject.id })
+                assertFalse(result.any { it.id == inProject.id })
+                assertTrue(result.any { it.id == notInProject.id })
             }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/PaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/PaperIntegrationTest.kt
@@ -6,9 +6,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
 import snowballr.PaperOuterClass.Paper
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -19,9 +18,8 @@ class PaperIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper is created, then it can be retrieved by ID`() = runTest {
             val paper = createPaper("My Paper")
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-            val fetched = paperService.getPaperById(paperId)
+            val fetched = paperService.getPaperById(paper.id)
 
             assertEquals(paper.id, fetched.id)
             assertEquals("My Paper", fetched.title)
@@ -50,10 +48,9 @@ class PaperIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper's title is updated, then the updated title is persisted`() = runTest {
             val paper = createPaper("Original Title")
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
             val request = Paper.Update.newBuilder()
-                .setPaper(paper.toBuilder().setTitle("Updated Title").build())
+                .setPaper(paper.toGrpc().toBuilder().setTitle("Updated Title").build())
                 .setMask(FieldMaskUtil.fromStringList(listOf("paper.title")))
                 .build()
 
@@ -61,23 +58,22 @@ class PaperIntegrationTest : IntegrationTest() {
 
             assertEquals("Updated Title", result.title)
 
-            val fetched = paperService.getPaperById(paperId)
+            val fetched = paperService.getPaperById(paper.id)
             assertEquals("Updated Title", fetched.title)
         }
 
         @Test
         fun `When a paper's year is updated, then the updated year is persisted`() = runTest {
             val paper = createPaper()
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
             val request = Paper.Update.newBuilder()
-                .setPaper(paper.toBuilder().setYear(2000).build())
+                .setPaper(paper.toGrpc().toBuilder().setYear(2000).build())
                 .setMask(FieldMaskUtil.fromStringList(listOf("paper.year")))
                 .build()
 
             paperService.updatePaper(request)
 
-            val fetched = paperService.getPaperById(paperId)
+            val fetched = paperService.getPaperById(paper.id)
             assertEquals(2000, fetched.year)
         }
 
@@ -87,7 +83,7 @@ class PaperIntegrationTest : IntegrationTest() {
             val other = createPaper(externalId = "other-id")
 
             val request = Paper.Update.newBuilder()
-                .setPaper(other.toBuilder().setExternalId("taken-id").build())
+                .setPaper(other.toGrpc().toBuilder().setExternalId("taken-id").build())
                 .setMask(FieldMaskUtil.fromStringList(listOf("paper.external_id")))
                 .build()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/PaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/PaperIntegrationTest.kt
@@ -1,16 +1,14 @@
 package se.uulm.snowballr.backend.integration.services
 
-import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
-import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
-import snowballr.PaperOuterClass.Paper
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
+import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 
 class PaperIntegrationTest : IntegrationTest() {
     @Nested
@@ -48,13 +46,9 @@ class PaperIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper's title is updated, then the updated title is persisted`() = runTest {
             val paper = createPaper("Original Title")
+            val request = UpdatePaperRequest.fromPaperResponse(paper).copy(title = "Updated Title")
 
-            val request = Paper.Update.newBuilder()
-                .setPaper(paper.toGrpc().toBuilder().setTitle("Updated Title").build())
-                .setMask(FieldMaskUtil.fromStringList(listOf("paper.title")))
-                .build()
-
-            val result = paperService.updatePaper(request)
+            val result = paperService.updatePaper(request, listOf("paper.title"))
 
             assertEquals("Updated Title", result.title)
 
@@ -65,13 +59,9 @@ class PaperIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper's year is updated, then the updated year is persisted`() = runTest {
             val paper = createPaper()
+            val request = UpdatePaperRequest.fromPaperResponse(paper).copy(year = 2000)
 
-            val request = Paper.Update.newBuilder()
-                .setPaper(paper.toGrpc().toBuilder().setYear(2000).build())
-                .setMask(FieldMaskUtil.fromStringList(listOf("paper.year")))
-                .build()
-
-            paperService.updatePaper(request)
+            paperService.updatePaper(request, listOf("paper.year"))
 
             val fetched = paperService.getPaperById(paper.id)
             assertEquals(2000, fetched.year)
@@ -81,13 +71,9 @@ class PaperIntegrationTest : IntegrationTest() {
         fun `When a paper is updated with a duplicate external ID, then the update fails`() = runTest {
             createPaper(externalId = "taken-id")
             val other = createPaper(externalId = "other-id")
+            val request = UpdatePaperRequest.fromPaperResponse(other).copy(externalId = "taken-id")
 
-            val request = Paper.Update.newBuilder()
-                .setPaper(other.toGrpc().toBuilder().setExternalId("taken-id").build())
-                .setMask(FieldMaskUtil.fromStringList(listOf("paper.external_id")))
-                .build()
-
-            assertThrows<DuplicatePaperException> { paperService.updatePaper(request) }
+            assertThrows<DuplicatePaperException> { paperService.updatePaper(request, listOf("paper.external_id")) }
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -65,7 +65,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
                 projectPaperService.addPaperToProject(
                     GrpcProjectPaper.Add.newBuilder()
                         .setProjectId(project.id.toString())
-                        .setPaperId(paper.id)
+                        .setPaperId(paper.id.toString())
                         .setStage(1) // maxStage is 0 by default
                         .build(),
                 )

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReadingListIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReadingListIntegrationTest.kt
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.parseUUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -16,26 +14,23 @@ class ReadingListIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper is added to the reading list, then it appears in the reading list`() = runTest {
             val paper = createPaper()
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-            readingListService.addPaperToReadingList(paperId)
+            readingListService.addPaperToReadingList(paper.id)
 
             val readingList = readingListService.getReadingList()
-            assertTrue(readingList.papersList.any { it.id == paper.id })
+            assertTrue(readingList.any { it.id == paper.id })
         }
 
         @Test
         fun `When multiple papers are added to the reading list, then all appear in the reading list`() = runTest {
             val paperOne = createPaper("Paper One")
             val paperTwo = createPaper("Paper Two")
-            val paperOneId = parseUUID(paperOne.id, EntityType.PAPER)
-            val paperTwoId = parseUUID(paperTwo.id, EntityType.PAPER)
 
-            readingListService.addPaperToReadingList(paperOneId)
-            readingListService.addPaperToReadingList(paperTwoId)
+            readingListService.addPaperToReadingList(paperOne.id)
+            readingListService.addPaperToReadingList(paperTwo.id)
 
             val readingList = readingListService.getReadingList()
-            val ids = readingList.papersList.map { it.id }
+            val ids = readingList.map { it.id }
             assertTrue(ids.contains(paperOne.id))
             assertTrue(ids.contains(paperTwo.id))
         }
@@ -43,11 +38,10 @@ class ReadingListIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper is added to the reading list, then isPaperOnReadingList returns true`() = runTest {
             val paper = createPaper()
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-            readingListService.addPaperToReadingList(paperId)
+            readingListService.addPaperToReadingList(paper.id)
 
-            assertTrue(readingListService.isPaperOnReadingList(paperId))
+            assertTrue(readingListService.isPaperOnReadingList(paper.id))
         }
     }
 
@@ -56,40 +50,36 @@ class ReadingListIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper is removed from the reading list, then it no longer appears in the reading list`() = runTest {
             val paper = createPaper()
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-            readingListService.addPaperToReadingList(paperId)
-            readingListService.removePaperFromReadingList(paperId)
+            readingListService.addPaperToReadingList(paper.id)
+            readingListService.removePaperFromReadingList(paper.id)
 
             val readingList = readingListService.getReadingList()
-            assertFalse(readingList.papersList.any { it.id == paper.id })
+            assertFalse(readingList.any { it.id == paper.id })
         }
 
         @Test
         fun `When a paper is removed from the reading list, then isPaperOnReadingList returns false`() = runTest {
             val paper = createPaper()
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-            readingListService.addPaperToReadingList(paperId)
-            readingListService.removePaperFromReadingList(paperId)
+            readingListService.addPaperToReadingList(paper.id)
+            readingListService.removePaperFromReadingList(paper.id)
 
-            assertFalse(readingListService.isPaperOnReadingList(paperId))
+            assertFalse(readingListService.isPaperOnReadingList(paper.id))
         }
 
         @Test
         fun `When one of two papers is removed from the reading list, then the other paper remains`() = runTest {
             val paperOne = createPaper("Paper One")
             val paperTwo = createPaper("Paper Two")
-            val paperOneId = parseUUID(paperOne.id, EntityType.PAPER)
-            val paperTwoId = parseUUID(paperTwo.id, EntityType.PAPER)
 
-            readingListService.addPaperToReadingList(paperOneId)
-            readingListService.addPaperToReadingList(paperTwoId)
-            readingListService.removePaperFromReadingList(paperOneId)
+            readingListService.addPaperToReadingList(paperOne.id)
+            readingListService.addPaperToReadingList(paperTwo.id)
+            readingListService.removePaperFromReadingList(paperOne.id)
 
             val readingList = readingListService.getReadingList()
-            assertFalse(readingList.papersList.any { it.id == paperOne.id })
-            assertTrue(readingList.papersList.any { it.id == paperTwo.id })
+            assertFalse(readingList.any { it.id == paperOne.id })
+            assertTrue(readingList.any { it.id == paperTwo.id })
         }
     }
 
@@ -99,7 +89,7 @@ class ReadingListIntegrationTest : IntegrationTest() {
         fun `When no papers have been added, then the reading list is empty`() = runTest {
             val readingList = readingListService.getReadingList()
 
-            assertTrue(readingList.papersList.isEmpty())
+            assertTrue(readingList.isEmpty())
         }
 
         @Test
@@ -107,13 +97,12 @@ class ReadingListIntegrationTest : IntegrationTest() {
             runTest {
                 val otherUser = addUser(DataBuilder.createExampleUser(email = "other.user@example.com"))
                 val paper = createPaper()
-                val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-                readingListService.addPaperToReadingList(paperId)
+                readingListService.addPaperToReadingList(paper.id)
 
                 actAsUser(otherUser.id) {
                     val otherReadingList = readingListService.getReadingList()
-                    assertFalse(otherReadingList.papersList.any { it.id == paper.id })
+                    assertFalse(otherReadingList.any { it.id == paper.id })
                 }
             }
     }
@@ -123,9 +112,8 @@ class ReadingListIntegrationTest : IntegrationTest() {
         @Test
         fun `When a paper has not been added to the reading list, then isPaperOnReadingList returns false`() = runTest {
             val paper = createPaper()
-            val paperId = parseUUID(paper.id, EntityType.PAPER)
 
-            assertFalse(readingListService.isPaperOnReadingList(paperId))
+            assertFalse(readingListService.isPaperOnReadingList(paper.id))
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -25,7 +25,7 @@ class ReviewIntegrationTest : IntegrationTest() {
         val projectPaper = projectPaperService.addPaperToProject(
             GrpcProjectPaper.Add.newBuilder()
                 .setProjectId(project.id.toString())
-                .setPaperId(paper.id)
+                .setPaperId(paper.id.toString())
                 .setStage(0)
                 .build(),
         )

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -16,16 +16,17 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.isBetweenWithDelta
+import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.PaperOuterClass.Author
+import snowballr.PaperOuterClass
 import snowballr.PaperOuterClass.Paper
-import snowballr.author
 import java.sql.SQLException
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -144,23 +145,17 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
 
     @Nested
     inner class CreatePaper {
-        fun getExamplePaperRequest(externalId: String = "ExternalId"): Paper = Paper.newBuilder()
-            .setExternalId(externalId)
-            .setTitle("Title")
-            .setAbstrakt("Abstract")
-            .setYear(2025)
-            .setPublisher("Publisher")
-            .setPublicationName("PublicationName")
-            .setPublicationType("PublicationType")
-            .addAllAuthors(
-                listOf(
-                    author {
-                        firstName = "FirstName"
-                        lastName = "LastName"
-                    },
-                ),
-            )
-            .build()
+        fun getExamplePaperRequest(externalId: String? = "ExternalId") = CreatePaperRequest(
+            title = "Title",
+            externalId = externalId,
+            abstract = "Abstract",
+            year = 2025,
+            publisher = "Publisher",
+            publicationName = "PublicationName",
+            publicationType = "PublicationType",
+            authors = listOf(Author("FirstName", "LastName")),
+            fetcherMetadata = emptyMap(),
+        )
 
         @Test
         fun `When a paper is created, then the created paper is returned`() = runTest {
@@ -201,13 +196,23 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
             }
 
         @Test
-        fun `When a paper is created with an empty external ID, then the paper is created with a null external ID`() =
+        fun `When a paper is created with a null external ID, then the paper is created with a null external ID`() =
+            runTest {
+                val request = getExamplePaperRequest(externalId = null)
+
+                val createdPaper = repo.createPaper(request)
+
+                assertNull(createdPaper.externalId)
+            }
+
+        @Test
+        fun `When a paper is created with an empty external ID, then the paper is created with an empty external ID`() =
             runTest {
                 val request = getExamplePaperRequest(externalId = "")
 
                 val createdPaper = repo.createPaper(request)
 
-                assertNull(createdPaper.externalId)
+                assertEquals("", createdPaper.externalId)
             }
 
         @Test
@@ -216,10 +221,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
                 "id" to UUID.randomUUID().toString(),
                 "foo" to "bar",
             )
-            val request = getExamplePaperRequest()
-                .toBuilder()
-                .putAllFetcherMetadata(metadata)
-                .build()
+            val request = getExamplePaperRequest().copy(fetcherMetadata = metadata)
 
             val createdPaper = repo.createPaper(request)
 
@@ -253,7 +255,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
                 .setPublicationType("Updated PublicationType")
                 .addAllAuthors(
                     listOf(
-                        Author.newBuilder()
+                        PaperOuterClass.Author.newBuilder()
                             .setFirstName("UpdatedFirstName")
                             .setLastName("UpdatedLastName")
                             .build(),

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.repository
 
-import com.google.protobuf.util.FieldMaskUtil
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -17,16 +16,14 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.isBetweenWithDelta
 import se.uulm.snowballr.backend.model.dto.paper.Author
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
+import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.repository.RepositoryHelper.insertPaperAndGetId
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.PaperOuterClass
-import snowballr.PaperOuterClass.Paper
 import java.sql.SQLException
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -245,31 +242,20 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
             val paperId = insertPaperAndGetId(externalId = externalId)
             val paper = repo.getPaperById(paperId).getOrThrow()
 
-            val updatedPaperDetails = paper.toGrpcPaper(emptyList()).toBuilder()
-                .setExternalId("updated-external-id")
-                .setTitle("Updated Title")
-                .setAbstrakt("Updated Abstract")
-                .setYear(paper.year - 10)
-                .setPublisher("Updated Publisher")
-                .setPublicationName("Updated PublicationName")
-                .setPublicationType("Updated PublicationType")
-                .addAllAuthors(
-                    listOf(
-                        PaperOuterClass.Author.newBuilder()
-                            .setFirstName("UpdatedFirstName")
-                            .setLastName("UpdatedLastName")
-                            .build(),
-                    ),
-                )
-                .build()
-
-            val request = Paper.Update.newBuilder()
-                .setPaper(updatedPaperDetails)
-                .setMask(FieldMaskUtil.fromStringList(fieldMask))
-                .build()
+            val updatedPaperDetails = paper.copy(
+                title = "Updated Title",
+                externalId = "updated-external-id",
+                abstract = "Updated Abstract",
+                year = paper.year - 10,
+                publisher = "Updated Publisher",
+                publicationName = "Updated PublicationName",
+                publicationType = "Updated PublicationType",
+                authors = listOf(Author("UpdatedFirstName", "UpdatedLastName")),
+            )
+            val request = UpdatePaperRequest.fromPaper(updatedPaperDetails)
 
             val start = OffsetDateTime.now()
-            val updatedPaper = repo.updatePaper(request)
+            val updatedPaper = repo.updatePaper(request, fieldMask)
             val end = OffsetDateTime.now()
 
             if ("paper.external_id" in fieldMask) {
@@ -322,13 +308,9 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable), false) {
         fun `When a paper is updated with an empty field mask, then nothing is updated`() = runTest {
             val paperId = insertPaperAndGetId()
             val paper = repo.getPaperById(paperId).getOrThrow()
+            val request = UpdatePaperRequest.fromPaper(paper)
 
-            val request = Paper.Update.newBuilder()
-                .setPaper(paper.toGrpcPaper(emptyList()))
-                .setMask(FieldMaskUtil.fromStringList(emptyList()))
-                .build()
-
-            val updatedPaper = repo.updatePaper(request)
+            val updatedPaper = repo.updatePaper(request, emptyList())
 
             assertThat(updatedPaper).isEqualTo(paper)
             assertThat(updatedPaper.modifiedAt).isNull()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
@@ -4,6 +4,8 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -11,8 +13,6 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.exception.FetcherException
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
@@ -46,11 +46,11 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, barPaper.id) } returns false
 
-        val papers = service.searchFetcherProjectPaperCandidates(request).papersList
+        val papers = service.searchFetcherProjectPaperCandidates(request)
 
         assertEquals(2, papers.size)
-        assertTrue(papers.any { p -> p.id == fooPaper.id.toString() })
-        assertTrue(papers.any { p -> p.id == barPaper.id.toString() })
+        assertTrue(papers.any { p -> p.id == fooPaper.id })
+        assertTrue(papers.any { p -> p.id == barPaper.id })
     }
 
     @Test
@@ -106,10 +106,10 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
 
-        val papers = service.searchFetcherProjectPaperCandidates(request).papersList
+        val papers = service.searchFetcherProjectPaperCandidates(request)
 
         assertEquals(1, papers.size)
-        assertEquals(papers[0].id, fooPaper.id.toString())
+        assertEquals(fooPaper.id, papers[0].id)
     }
 
     @Test
@@ -129,7 +129,7 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns true
 
-        val papers = service.searchFetcherProjectPaperCandidates(request).papersList
+        val papers = service.searchFetcherProjectPaperCandidates(request)
 
         assertEquals(0, papers.size)
     }
@@ -150,11 +150,11 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns emptyList()
 
-        val papers = service.searchFetcherProjectPaperCandidates(request).papersList
+        val papers = service.searchFetcherProjectPaperCandidates(request)
 
         assertEquals(1, papers.size)
-        assertEquals(papers[0].title, fooPaper.title)
-        assertEquals(papers[0].id, "")
+        assertEquals(fooPaper.title, papers[0].title)
+        assertEquals(null, papers[0].id)
         coVerify(exactly = 0) { projectPaperRepoMock.doesProjectPaperExist(any(), any()) }
     }
 
@@ -175,11 +175,11 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
             coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
             coEvery { paperRepoMock.getPapersByExternalIds(emptyList()) } returns emptyList()
 
-            val papers = service.searchFetcherProjectPaperCandidates(request).papersList
+            val papers = service.searchFetcherProjectPaperCandidates(request)
 
             assertEquals(1, papers.size)
-            assertEquals(papers[0].title, fooPaper.title)
-            assertEquals(papers[0].id, "")
+            assertEquals(fooPaper.title, papers[0].title)
+            assertEquals(null, papers[0].id)
             coVerify(exactly = 0) { paperRepoMock.getPaperByExternalId(any()) }
             coVerify(exactly = 0) { projectPaperRepoMock.doesProjectPaperExist(any(), any()) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
@@ -32,11 +32,11 @@ class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, barPaper.id) } returns false
 
-        val papers = service.searchLocalProjectPaperCandidates(request).papersList
+        val papers = service.searchLocalProjectPaperCandidates(request)
 
         assertEquals(2, papers.size)
-        assertTrue(papers.any { p -> p.id == fooPaper.id.toString() })
-        assertTrue(papers.any { p -> p.id == barPaper.id.toString() })
+        assertTrue(papers.any { p -> p.id == fooPaper.id })
+        assertTrue(papers.any { p -> p.id == barPaper.id })
     }
 
     @Test
@@ -65,7 +65,7 @@ class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
         coEvery { paperRepoMock.getPapersBySearchQuery(request.query) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns true
 
-        val papers = service.searchLocalProjectPaperCandidates(request).papersList
+        val papers = service.searchLocalProjectPaperCandidates(request)
 
         assertEquals(0, papers.size)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/CreatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/CreatePaperTest.kt
@@ -6,18 +6,18 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
-import snowballr.PaperOuterClass
+import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import java.util.UUID
 
 class CreatePaperTest : PaperServiceTest() {
     @Test
     fun `When a paper is created, then the created paper has the correct values`() = runTest {
-        val paper = DataBuilder.createExamplePaper(title = "Test Paper Title", externalId = "new-external-id")
-        val request = paper.toGrpcPaper(emptyList())
+        val externalId = "new-external-id"
+        val paper = DataBuilder.createExamplePaper(title = "Test Paper Title", externalId = externalId)
+        val request = CreatePaperRequest.fromPaper(paper)
 
-        coEvery { paperRepoMock.doesPaperExistByExternalId(request.externalId) } returns false
+        coEvery { paperRepoMock.doesPaperExistByExternalId(externalId) } returns false
         coEvery { paperRepoMock.createPaper(request) } returns paper
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
 
@@ -28,27 +28,24 @@ class CreatePaperTest : PaperServiceTest() {
 
     @Test
     fun `When a paper is created with an existent external ID, then a DuplicatePaperException is thrown`() = runTest {
-        val request = PaperOuterClass.Paper.newBuilder()
-            .setExternalId("existing-external-id")
-            .build()
+        val externalId = "existent-external-id"
+        val request = CreatePaperRequest.fromPaper(DataBuilder.createExamplePaper(externalId = externalId))
 
-        coEvery { paperRepoMock.doesPaperExistByExternalId(request.externalId) } returns true
+        coEvery { paperRepoMock.doesPaperExistByExternalId(externalId) } returns true
 
         assertThrows<DuplicatePaperException> { service.createPaper(request) }
     }
 
     @Test
-    fun `When a paper is created with an empty external ID, then it is not checked whether a paper with an empty external ID already exists`() =
+    fun `When a paper is created without an external ID, then it is not checked whether a paper with an external ID already exists`() =
         runTest {
             val paperId = UUID.randomUUID()
-            val request = PaperOuterClass.Paper.newBuilder()
-                .setExternalId("")
-                .build()
+            val request = CreatePaperRequest.fromPaper(DataBuilder.createExamplePaper(externalId = null))
 
             coEvery { paperRepoMock.createPaper(request) } returns DataBuilder.createExamplePaper(id = paperId)
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
             service.createPaper(request)
-            coVerify(exactly = 0) { paperRepoMock.doesPaperExistByExternalId(request.externalId) }
+            coVerify(exactly = 0) { paperRepoMock.doesPaperExistByExternalId(any()) }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -58,8 +58,8 @@ class GetBackwardReferencedPapersTest : PaperServiceTest() {
 
             val result = service.getBackwardReferencedPapers(paper.id)
 
-            assertEquals(1, result.papersCount)
-            val resultElement = result.papersList.first()
+            assertEquals(1, result.size)
+            val resultElement = result.first()
             assertPaperEquality(referencedPaper, resultElement)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -59,8 +59,8 @@ class GetForwardReferencedPapersTest : PaperServiceTest() {
 
             val result = service.getForwardReferencedPapers(paper.id)
 
-            assertEquals(1, result.papersCount)
-            val resultElement = result.papersList.first()
+            assertEquals(1, result.size)
+            val resultElement = result.first()
             assertPaperEquality(citingPaper, resultElement)
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/PaperServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/PaperServiceTest.kt
@@ -4,11 +4,11 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.Paper
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.PaperService
-import snowballr.PaperOuterClass
 
 /**
  * Base test class for the [PaperService].
@@ -26,21 +26,21 @@ sealed class PaperServiceTest : BaseServiceTest {
 
     override fun getAllMocks(): Array<Any> = allMocks
 
-    protected fun assertPaperEquality(expected: Paper, actual: PaperOuterClass.Paper) {
+    protected fun assertPaperEquality(expected: Paper, actual: PaperResponse) {
         assertEquals(expected.title, actual.title)
         assertEquals(expected.externalId, actual.externalId)
-        assertEquals(expected.abstract, actual.abstrakt)
+        assertEquals(expected.abstract, actual.abstract)
         assertEquals(expected.year, actual.year)
         assertEquals(expected.publisher, actual.publisher)
         assertEquals(expected.publicationType, actual.publicationType)
         assertEquals(expected.publicationName, actual.publicationName)
         for (i in expected.authors.indices) {
-            assertAuthorEquality(expected.authors[i], actual.authorsList[i])
+            assertAuthorEquality(expected.authors[i], actual.authors[i])
         }
-        assertEquals(expected.fetcherMetadata, actual.fetcherMetadataMap)
+        assertEquals(expected.fetcherMetadata, actual.fetcherMetadata)
     }
 
-    private fun assertAuthorEquality(expected: Author, actual: PaperOuterClass.Author) {
+    private fun assertAuthorEquality(expected: Author, actual: Author) {
         assertEquals(expected.firstName, actual.firstName)
         assertEquals(expected.lastName, actual.lastName)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
@@ -10,24 +10,21 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
+import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 class UpdatePaperTest : PaperServiceTest() {
     private val paperId = UUID.randomUUID()
 
-    private fun getExamplePaperBuilder() = GrpcPaper
-        .newBuilder()
-        .setId(paperId.toString())
-        .setTitle("Updated Title")
-        .setAbstrakt("Updated Abstract")
-        .setExternalId("10.1000/updateddoi")
-        .setYear(2023)
-
-    private fun getExampleRequest() = GrpcPaper.Update
-        .newBuilder()
-        .setPaper(getExamplePaperBuilder().build())
-        .build()
+    private fun getExampleRequest() = UpdatePaperRequest.fromPaper(
+        DataBuilder.createExamplePaper(
+            id = paperId,
+            title = "Updated Title",
+            abstract = "Updated Abstract",
+            externalId = "10.1000/updateddoi",
+            year = 2023,
+        ),
+    )
 
     @Test
     fun `When an existent paper is updated, then the updated paper is returned`() = runTest {
@@ -36,11 +33,11 @@ class UpdatePaperTest : PaperServiceTest() {
         val examplePaper = DataBuilder.createExamplePaper(id = paperId, authors = listOf(exampleAuthor))
 
         coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-        coEvery { paperRepoMock.getPaperByExternalId(request.paper.externalId) } returns Result.failure(Exception())
-        coEvery { paperRepoMock.updatePaper(request) } returns examplePaper
+        coEvery { paperRepoMock.getPaperByExternalId(request.externalId.orEmpty()) } returns Result.failure(Exception())
+        coEvery { paperRepoMock.updatePaper(request, emptyList()) } returns examplePaper
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-        val result = service.updatePaper(request)
+        val result = service.updatePaper(request, emptyList())
 
         assertPaperEquality(examplePaper, result)
     }
@@ -52,30 +49,26 @@ class UpdatePaperTest : PaperServiceTest() {
         coEvery { paperRepoMock.ensurePaperExists(paperId) } throws PaperNotFoundException(paperId)
 
         assertThrows<PaperNotFoundException> {
-            service.updatePaper(request)
+            service.updatePaper(request, emptyList())
         }
     }
 
     @Test
     fun `When a paper is updated with an external ID that already exists, then a DuplicateEntityException is thrown`() =
         runTest {
-            val request = GrpcPaper.Update
-                .newBuilder()
-                .setPaper(
-                    getExamplePaperBuilder().setExternalId("10.1000/existingdoi").build(),
-                )
-                .build()
+            val externalId = "10.1000/existingdoi"
+            val request = getExampleRequest().copy(externalId = externalId)
             val existingPaperWithSameExternalId = DataBuilder.createExamplePaper(
                 id = UUID.randomUUID(),
-                externalId = "10.1000/existingdoi",
+                externalId = externalId,
             )
 
             coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-            coEvery { paperRepoMock.getPaperByExternalId("10.1000/existingdoi") } returns Result.success(
-                existingPaperWithSameExternalId,
-            )
+            coEvery {
+                paperRepoMock.getPaperByExternalId(externalId)
+            } returns Result.success(existingPaperWithSameExternalId)
 
-            assertThrows<DuplicatePaperException> { service.updatePaper(request) }
+            assertThrows<DuplicatePaperException> { service.updatePaper(request, emptyList()) }
         }
 
     @Test
@@ -85,27 +78,24 @@ class UpdatePaperTest : PaperServiceTest() {
             val exampleAuthor = DataBuilder.createExampleAuthor()
             val existingPaperWithSameExternalId = DataBuilder.createExamplePaper(
                 id = paperId,
-                externalId = request.paper.externalId,
+                externalId = request.externalId,
                 authors = listOf(exampleAuthor),
             )
 
             coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-            coEvery { paperRepoMock.getPaperByExternalId(request.paper.externalId) } returns
+            coEvery { paperRepoMock.getPaperByExternalId(request.externalId.orEmpty()) } returns
                 Result.success(existingPaperWithSameExternalId)
-            coEvery { paperRepoMock.updatePaper(request) } returns existingPaperWithSameExternalId
+            coEvery { paperRepoMock.updatePaper(request, emptyList()) } returns existingPaperWithSameExternalId
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-            val result = service.updatePaper(request)
+            val result = service.updatePaper(request, emptyList())
 
             assertPaperEquality(existingPaperWithSameExternalId, result)
         }
 
     @Test
     fun `When a paper is updated without external ID, then duplicate lookup by external ID is skipped`() = runTest {
-        val request = GrpcPaper.Update
-            .newBuilder()
-            .setPaper(getExamplePaperBuilder().setExternalId("").build())
-            .build()
+        val request = getExampleRequest().copy(externalId = null)
         val exampleAuthor = DataBuilder.createExampleAuthor()
         val updatedPaper = DataBuilder.createExamplePaper(
             id = paperId,
@@ -114,10 +104,10 @@ class UpdatePaperTest : PaperServiceTest() {
         )
 
         coEvery { paperRepoMock.ensurePaperExists(paperId) } just Runs
-        coEvery { paperRepoMock.updatePaper(request) } returns updatedPaper
+        coEvery { paperRepoMock.updatePaper(request, emptyList()) } returns updatedPaper
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paperId) } returns emptyList()
 
-        service.updatePaper(request)
+        service.updatePaper(request, emptyList())
         coVerify(exactly = 0) { paperRepoMock.getPaperByExternalId(any()) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/readinglist/GetReadingListTest.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 
 class GetReadingListTest : ReadingListServiceTest() {
     @Test
@@ -22,9 +22,9 @@ class GetReadingListTest : ReadingListServiceTest() {
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper1.id) } returns emptyList()
             coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } returns listOf(paper1, paper2)
 
-            assertThat(service.getReadingList().papersList).containsExactlyInAnyOrder(
-                paper1.toGrpcPaper(emptyList()),
-                paper2.toGrpcPaper(listOf(paper1.id.toString())),
+            assertThat(service.getReadingList()).containsExactlyInAnyOrder(
+                PaperResponse.fromPaper(paper1, emptyList()),
+                PaperResponse.fromPaper(paper2, listOf(paper1.id)),
             )
             coVerify(exactly = 1) { readingListRepoMock.getAllReadingListEntries(user.id) }
         }
@@ -36,7 +36,8 @@ class GetReadingListTest : ReadingListServiceTest() {
         mockCurrentUser(user)
         coEvery { readingListRepoMock.getAllReadingListEntries(user.id) } returns emptyList()
 
-        val papers = service.getReadingList().papersList
+        val papers = service.getReadingList()
+
         assertThat(papers).isEmpty()
         coVerify(exactly = 1) { readingListRepoMock.getAllReadingListEntries(user.id) }
         coVerify(exactly = 0) { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(any()) }


### PR DESCRIPTION
Closes #558

## What I have made

Waits for #546

This removes any grpc related types from the service and repo layer for the paper domain.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
