### PR TITLE
Use non grpc request types for project paper and project member domain

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -27,7 +27,6 @@ import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.isUniqueConstraintViolation
 import java.sql.SQLException
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 private val logger = KotlinLogging.logger { }
 
@@ -298,10 +297,6 @@ class FetcherOrchestrator(
      * to the project is a reference of a paper in an earlier stage.
      */
     private suspend fun runAddingPapersToProject(job: FetcherProcessingJob, creationResults: PaperCreationResults) {
-        val baseRequest = GrpcProjectPaper.Add.newBuilder()
-            .setProjectId(job.projectId.toString())
-            .setStage(job.targetStage.toLong())
-
         val filteredRefs = mutableListOf<Paper>()
         for (createdRef in creationResults.allRefs) {
             val doesAlreadyExist = projectPaperRepo.doesProjectPaperExist(job.projectId, createdRef.id)
@@ -325,8 +320,7 @@ class FetcherOrchestrator(
 
         for (ref in filteredRefs) {
             try {
-                val request = baseRequest.setPaperId(ref.id.toString()).build()
-                projectPaperRepo.addPaperToProject(request, job.triggeringUserId)
+                projectPaperRepo.addPaperToProject(job.projectId, ref.id, job.targetStage, job.triggeringUserId)
             } catch (ex: SQLException) {
                 logger.error(ex) {
                     "Failed to add paper ${ref.id} to project ${job.projectId} in stage ${job.targetStage}: " +

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -359,7 +359,10 @@ class SnowballRServer(
         ): UserOuterClass.User.List = invitationService.getInviteCandidates(request).toGrpcUsers()
 
         override suspend fun inviteUserToProject(request: ProjectOuterClass.Project.Member.Invite) = returnNothing {
-            invitationService.inviteUserToProject(request)
+            invitationService.inviteUserToProject(
+                projectId = parseUUID(request.projectId, EntityType.PROJECT),
+                userEmail = request.userEmail,
+            )
         }
 
         override suspend fun acceptProjectInvitation(request: ProjectOuterClass.Project.Member.Accept) = returnNothing {

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -52,6 +52,7 @@ import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.project.toGrpc
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.review.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.review.toGrpcReviews
 import se.uulm.snowballr.backend.model.parseUUID
@@ -316,16 +317,16 @@ class SnowballRServer(
             super.getAllPapersToReview(request)
 
         override suspend fun getPapersToReviewForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
-            projectPaperService.getPapersToReviewForProject(parseProjectId(request))
+            projectPaperService.getPapersToReviewForProject(parseProjectId(request)).toGrpc()
 
         override suspend fun getNextPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
-            projectPaperService.getNextPaper(parseProjectPaperId(request))
+            projectPaperService.getNextPaper(parseProjectPaperId(request)).toGrpc()
 
         override suspend fun getNextPaperToReview(request: Base.Id): ProjectOuterClass.Project.Paper =
-            projectPaperService.getNextPaperToReview(parseProjectPaperId(request))
+            projectPaperService.getNextPaperToReview(parseProjectPaperId(request)).toGrpc()
 
         override suspend fun getPreviousPaper(request: Base.Id): ProjectOuterClass.Project.Paper =
-            projectPaperService.getPreviousPaper(parseProjectPaperId(request))
+            projectPaperService.getPreviousPaper(parseProjectPaperId(request)).toGrpc()
 
         override suspend fun getUserSettings(request: Base.Nothing): UserSettingsOuterClass.UserSettings =
             userService.getUserSettings().toGrpcUserSettings()
@@ -488,18 +489,18 @@ class SnowballRServer(
         override suspend fun deleteCriterion(request: Base.Id): Base.Nothing = super.deleteCriterion(request)
 
         override suspend fun getProjectPaperById(request: Base.Id): ProjectOuterClass.Project.Paper =
-            projectPaperService.getProjectPaperById(parseProjectPaperId(request))
+            projectPaperService.getProjectPaperById(parseProjectPaperId(request)).toGrpc()
 
         override suspend fun getProjectPaperByRelativeId(
             request: ProjectOuterClass.Project.Paper.Get,
-        ): ProjectOuterClass.Project.Paper = projectPaperService.getProjectPaperByRelativeId(request)
+        ): ProjectOuterClass.Project.Paper = projectPaperService.getProjectPaperByRelativeId(request).toGrpc()
 
         override suspend fun getAllProjectPapersForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
-            projectPaperService.getAllProjectPapersForProject(parseProjectId(request))
+            projectPaperService.getAllProjectPapersForProject(parseProjectId(request)).toGrpc()
 
         override suspend fun addPaperToProject(
             request: ProjectOuterClass.Project.Paper.Add,
-        ): ProjectOuterClass.Project.Paper = projectPaperService.addPaperToProject(request)
+        ): ProjectOuterClass.Project.Paper = projectPaperService.addPaperToProject(request).toGrpc()
 
         override suspend fun updateProjectPaper(
             request: ProjectOuterClass.Project.Paper.Update,

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -560,11 +560,17 @@ class SnowballRServer(
 
         override suspend fun searchLocalProjectPaperCandidates(
             request: ProjectOuterClass.Project.Paper.SearchQuery,
-        ): PaperOuterClass.Paper.List = fetcherService.searchLocalProjectPaperCandidates(request).toGrpc()
+        ): PaperOuterClass.Paper.List = fetcherService.searchLocalProjectPaperCandidates(
+            projectId = parseUUID(request.projectId, EntityType.PROJECT),
+            query = request.query,
+        ).toGrpc()
 
         override suspend fun searchFetcherProjectPaperCandidates(
             request: ProjectOuterClass.Project.Paper.SearchQuery,
-        ): PaperOuterClass.Paper.List = fetcherService.searchFetcherProjectPaperCandidates(request).toGrpc()
+        ): PaperOuterClass.Paper.List = fetcherService.searchFetcherProjectPaperCandidates(
+            projectId = parseUUID(request.projectId, EntityType.PROJECT),
+            query = request.query,
+        ).toGrpc()
 
         override suspend fun createPaper(request: PaperOuterClass.Paper): PaperOuterClass.Paper =
             paperService.createPaper(

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -33,6 +33,7 @@ import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.dto.project.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.project.toGrpcProjects
+import se.uulm.snowballr.backend.model.dto.projectmember.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
@@ -366,7 +367,7 @@ class SnowballRServer(
             invitationService.getPendingInvitationsForProject(parseProjectId(request))
 
         override suspend fun getProjectMembers(request: Base.Id): ProjectOuterClass.Project.Member.List =
-            projectMemberService.getProjectMembers(parseProjectId(request))
+            projectMemberService.getProjectMembers(parseProjectId(request)).toGrpcProjectMembers()
 
         override suspend fun removeProjectMember(request: ProjectOuterClass.Project.Member.Remove) = returnNothing {
             projectMemberService.removeProjectMember(request)

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -493,7 +493,10 @@ class SnowballRServer(
 
         override suspend fun getProjectPaperByRelativeId(
             request: ProjectOuterClass.Project.Paper.Get,
-        ): ProjectOuterClass.Project.Paper = projectPaperService.getProjectPaperByRelativeId(request).toGrpc()
+        ): ProjectOuterClass.Project.Paper = projectPaperService.getProjectPaperByRelativeId(
+            projectId = parseUUID(request.projectId, EntityType.PROJECT),
+            relativeId = request.relativeProjectPaperId.toInt(),
+        ).toGrpc()
 
         override suspend fun getAllProjectPapersForProject(request: Base.Id): ProjectOuterClass.Project.Paper.List =
             projectPaperService.getAllProjectPapersForProject(parseProjectId(request)).toGrpc()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -363,7 +363,7 @@ class SnowballRServer(
         }
 
         override suspend fun acceptProjectInvitation(request: ProjectOuterClass.Project.Member.Accept) = returnNothing {
-            invitationService.acceptProjectInvitation(request)
+            invitationService.acceptProjectInvitation(request.token)
         }
 
         override suspend fun getPendingInvitationsForProject(request: Base.Id): UserOuterClass.User.List =

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -33,6 +33,7 @@ import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.dto.project.toGrpcProject
 import se.uulm.snowballr.backend.model.dto.project.toGrpcProjects
+import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.projectmember.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.user.UserRole
@@ -48,6 +49,7 @@ import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectSettingRequest
+import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
@@ -448,7 +450,13 @@ class SnowballRServer(
         ).toGrpc()
 
         override suspend fun updateProjectMemberRole(request: ProjectOuterClass.Project.Member.Update) = returnNothing {
-            projectMemberService.updateProjectMemberRole(request)
+            projectMemberService.updateProjectMemberRole(
+                UpdateProjectMemberRoleRequest(
+                    projectId = parseUUID(request.projectId, EntityType.PROJECT),
+                    userId = parseUUID(request.userId, EntityType.USER),
+                    newRole = MemberRole.fromGrpc(request.newRole),
+                ),
+            )
         }
 
         override suspend fun getCriterionById(request: Base.Id): CriterionOuterClass.Criterion =

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -356,7 +356,10 @@ class SnowballRServer(
 
         override suspend fun getInviteCandidates(
             request: ProjectOuterClass.Project.InviteCandidatesRequest,
-        ): UserOuterClass.User.List = invitationService.getInviteCandidates(request).toGrpcUsers()
+        ): UserOuterClass.User.List = invitationService.getInviteCandidates(
+            projectId = parseUUID(request.projectId, EntityType.PROJECT),
+            query = request.query,
+        ).toGrpcUsers()
 
         override suspend fun inviteUserToProject(request: ProjectOuterClass.Project.Member.Invite) = returnNothing {
             invitationService.inviteUserToProject(

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -357,7 +357,7 @@ class SnowballRServer(
         override suspend fun getInviteCandidates(
             request: ProjectOuterClass.Project.InviteCandidatesRequest,
         ): UserOuterClass.User.List = invitationService.getInviteCandidates(
-            projectId = parseUUID(request.projectId, EntityType.PROJECT),
+            projectId = runCatching { parseUUID(request.projectId, EntityType.PROJECT) }.getOrDefault(null),
             query = request.query,
         ).toGrpcUsers()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -53,6 +53,7 @@ import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMembe
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
+import se.uulm.snowballr.backend.model.outgoing.invitation.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.project.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.toGrpc
@@ -355,7 +356,7 @@ class SnowballRServer(
 
         override suspend fun getInviteCandidates(
             request: ProjectOuterClass.Project.InviteCandidatesRequest,
-        ): UserOuterClass.User.List = invitationService.getInviteCandidates(request)
+        ): UserOuterClass.User.List = invitationService.getInviteCandidates(request).toGrpcUsers()
 
         override suspend fun inviteUserToProject(request: ProjectOuterClass.Project.Member.Invite) = returnNothing {
             invitationService.inviteUserToProject(request)
@@ -366,7 +367,7 @@ class SnowballRServer(
         }
 
         override suspend fun getPendingInvitationsForProject(request: Base.Id): UserOuterClass.User.List =
-            invitationService.getPendingInvitationsForProject(parseProjectId(request))
+            invitationService.getPendingInvitationsForProject(parseProjectId(request)).toGrpc()
 
         override suspend fun getProjectMembers(request: Base.Id): ProjectOuterClass.Project.Member.List =
             projectMemberService.getProjectMembers(parseProjectId(request)).toGrpcProjectMembers()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -500,7 +500,11 @@ class SnowballRServer(
 
         override suspend fun addPaperToProject(
             request: ProjectOuterClass.Project.Paper.Add,
-        ): ProjectOuterClass.Project.Paper = projectPaperService.addPaperToProject(request).toGrpc()
+        ): ProjectOuterClass.Project.Paper = projectPaperService.addPaperToProject(
+            projectId = parseUUID(request.projectId, EntityType.PROJECT),
+            paperId = parseUUID(request.paperId, EntityType.PAPER),
+            stage = request.stage.toInt(),
+        ).toGrpc()
 
         override suspend fun updateProjectPaper(
             request: ProjectOuterClass.Project.Paper.Update,

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -370,7 +370,10 @@ class SnowballRServer(
             projectMemberService.getProjectMembers(parseProjectId(request)).toGrpcProjectMembers()
 
         override suspend fun removeProjectMember(request: ProjectOuterClass.Project.Member.Remove) = returnNothing {
-            projectMemberService.removeProjectMember(request)
+            projectMemberService.removeProjectMember(
+                projectId = parseUUID(request.projectId, EntityType.PROJECT),
+                userEmail = request.userEmail,
+            )
         }
 
         override suspend fun getAllProjects(request: Base.Nothing): ProjectOuterClass.Project.List =

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/ProjectPaperWithPaper.kt
@@ -1,11 +1,10 @@
 package se.uulm.snowballr.backend.model.dto.projectpaper
 
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcPaper
-import se.uulm.snowballr.backend.model.dto.review.Review
 import se.uulm.snowballr.backend.model.dto.review.ReviewWithSelectedCriteriaIds
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
-import snowballr.ReviewOuterClass.Review as GrpcReview
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
+import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
+import java.util.UUID
 
 /**
  * Represents a relationship between a [ProjectPaper] and its associated [Paper].
@@ -22,46 +21,16 @@ data class ProjectPaperWithPaper(
     val paper: Paper,
 )
 
-/**
- * Converts a [ProjectPaperWithPaper] instance into a gRPC [GrpcProjectPaper] object.
- *
- * @param backwardReferencedIds A list of strings representing the IDs of [Paper]s referenced by the current [Paper].
- * @param reviews A list of reviews represented as [GrpcReview], associated with the [Paper].
- * @return A [GrpcProjectPaper] object constructed with data from the [ProjectPaperWithPaper] instance and the provided
- * backward references and [Review]s.
- */
-fun ProjectPaperWithPaper.toGrpcProjectPaper(
-    backwardReferencedIds: List<String>,
-    reviews: List<GrpcReview>,
-): GrpcProjectPaper = GrpcProjectPaper
-    .newBuilder()
-    .setId(projectPaper.id.toString())
-    .setPaper(paper.toGrpcPaper(backwardReferencedIds))
-    .setStage(projectPaper.stage.toLong())
-    .setDecision(projectPaper.decision.toGrpc())
-    .addAllReviews(reviews)
-    .setLocalId(projectPaper.localPaperId.toString())
-    .build()
-
-/**
- * Converts a list of [ProjectPaperWithPaper] objects into a gRPC list of [ProjectPaper]s.
- *
- * @return A [GrpcProjectPaper.List] containing the gRPC representation of the [ProjectPaper]s.
- */
-fun List<ProjectPaperWithPaper>.toGrpcProjectPapers(
-    paperBackwardReferencesMap: Map<Paper, List<String>>,
-    paperReviewsMap: Map<ProjectPaper, List<GrpcReview>>,
-): GrpcProjectPaper.List = GrpcProjectPaper.List
-    .newBuilder()
-    .addAllProjectPapers(
-        this.map { projectPaper ->
-            val backwardRefs = paperBackwardReferencesMap[projectPaper.paper].orEmpty()
-            val reviews = paperReviewsMap[projectPaper.projectPaper].orEmpty()
-
-            projectPaper.toGrpcProjectPaper(backwardRefs, reviews)
-        },
+fun List<ProjectPaperWithPaper>.toProjectPaperResponses(
+    paperBackwardReferencesMap: Map<Paper, List<UUID>>,
+    paperReviewsMap: Map<ProjectPaper, List<ReviewResponse>>,
+): List<ProjectPaperResponse> = this.map {
+    ProjectPaperResponse.fromProjectPaperWithPaper(
+        paper = it,
+        backwardReferencedIds = paperBackwardReferencesMap[it.paper].orEmpty(),
+        reviews = paperReviewsMap[it.projectPaper].orEmpty(),
     )
-    .build()
+}
 
 /**
  * Converts a [ProjectPaperWithPaper] instance into a [ProjectPaperFull] object.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/projectmember/UpdateProjectMemberRoleRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/projectmember/UpdateProjectMemberRoleRequest.kt
@@ -1,0 +1,10 @@
+package se.uulm.snowballr.backend.model.incoming.projectmember
+
+import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
+import java.util.UUID
+
+data class UpdateProjectMemberRoleRequest(
+    val projectId: UUID,
+    val userId: UUID,
+    val newRole: MemberRole,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/invitation/InvitationResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/invitation/InvitationResponse.kt
@@ -1,0 +1,49 @@
+package se.uulm.snowballr.backend.model.outgoing.invitation
+
+import se.uulm.snowballr.backend.model.dto.user.User
+import se.uulm.snowballr.backend.model.dto.user.UserRole
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
+import snowballr.UserOuterClass
+import java.util.UUID
+
+data class InvitationResponse(
+    val userId: UUID?,
+    val email: String,
+    val firstName: String,
+    val lastName: String,
+    val role: UserRole,
+    val status: UserStatus,
+) {
+    companion object {
+        fun fromUser(user: User) = InvitationResponse(
+            userId = user.id,
+            email = user.email,
+            firstName = user.firstName,
+            lastName = user.lastName,
+            role = user.role,
+            status = user.status,
+        )
+
+        fun fromEmail(email: String) = InvitationResponse(
+            userId = null,
+            email = email,
+            firstName = "",
+            lastName = "",
+            role = UserRole.DEFAULT,
+            status = UserStatus.ACTIVE_UNCONFIRMED,
+        )
+    }
+}
+
+fun InvitationResponse.toGrpc(): UserOuterClass.User = UserOuterClass.User.newBuilder()
+    .setId(userId?.toString().orEmpty())
+    .setEmail(email)
+    .setFirstName(firstName)
+    .setLastName(lastName)
+    .setRole(role.toGrpc())
+    .setStatus(status.toGrpc())
+    .build()
+
+fun List<InvitationResponse>.toGrpc(): UserOuterClass.User.List = UserOuterClass.User.List.newBuilder()
+    .addAllUsers(this.map { it.toGrpc() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/projectpaper/ProjectPaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/projectpaper/ProjectPaperResponse.kt
@@ -1,0 +1,48 @@
+package se.uulm.snowballr.backend.model.outgoing.projectpaper
+
+import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
+import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaperWithPaper
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
+import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
+import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
+import se.uulm.snowballr.backend.model.outgoing.review.toGrpc
+import snowballr.ProjectOuterClass
+import java.util.UUID
+
+data class ProjectPaperResponse(
+    val id: UUID,
+    val stage: Int,
+    val decision: PaperDecision,
+    val localPaperId: Int,
+    val paper: PaperResponse,
+    val reviews: List<ReviewResponse>,
+) {
+    companion object {
+        fun fromProjectPaperWithPaper(
+            paper: ProjectPaperWithPaper,
+            backwardReferencedIds: List<UUID>,
+            reviews: List<ReviewResponse>,
+        ) = ProjectPaperResponse(
+            id = paper.projectPaper.id,
+            stage = paper.projectPaper.stage,
+            decision = paper.projectPaper.decision,
+            localPaperId = paper.projectPaper.localPaperId,
+            paper = PaperResponse.fromPaper(paper.paper, backwardReferencedIds),
+            reviews = reviews,
+        )
+    }
+}
+
+fun ProjectPaperResponse.toGrpc(): ProjectOuterClass.Project.Paper = ProjectOuterClass.Project.Paper.newBuilder()
+    .setId(this.id.toString())
+    .setPaper(this.paper.toGrpc())
+    .setStage(this.stage.toLong())
+    .setDecision(this.decision.toGrpc())
+    .addAllReviews(reviews.map { it.toGrpc() })
+    .setLocalId(this.localPaperId.toString())
+    .build()
+
+fun List<ProjectPaperResponse>.toGrpc(): ProjectOuterClass.Project.Paper.List =
+    ProjectOuterClass.Project.Paper.List.newBuilder()
+        .addAllProjectPapers(this.map { it.toGrpc() })
+        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepo.kt
@@ -20,7 +20,6 @@ import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectPaperNotFoundException
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.doesEntityExist
 import se.uulm.snowballr.backend.repository.getEntities
 import se.uulm.snowballr.backend.repository.getEntityByIdOrNull
@@ -35,7 +34,6 @@ import se.uulm.snowballr.backend.table.association.toProjectPaper
 import se.uulm.snowballr.backend.table.association.toProjectPaperWithPaper
 import java.sql.Connection
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 /**
  * Defines an interface for repository operations related to the [ProjectPaperTable].
@@ -118,13 +116,14 @@ interface IProjectPaperTableRepo {
      * entry, linking the provided paper and project. The local paper ID of the new [ProjectPaper] gets increased by 1,
      * depending on the maximum local paper ID of the current papers in the project.
      *
-     * @param request The request object containing the information necessary to add the paper
-     *                to the project, such as the paper and project IDs.
+     * @param projectId The ID of the project to which the paper should be added
+     * @param paperId The ID of the paper to be added to the project
+     * @param stage The stage to which the paper should be added
      * @param userId The unique identifier of the user performing the operation.
      * @return The created [ProjectPaper] object representing the association between the paper
      *         and the project.
      */
-    suspend fun addPaperToProject(request: GrpcProjectPaper.Add, userId: UUID): ProjectPaper
+    suspend fun addPaperToProject(projectId: UUID, paperId: UUID, stage: Int, userId: UUID): ProjectPaper
 
     /**
      * Calculates and returns the progress of a project as a float value between 0.0 and 1.0.
@@ -257,11 +256,8 @@ class ProjectPaperTableRepo(
      * with a higher local paper ID. The second transaction unblocks after lock is removed and then sees fresh snapshot
      * from first transaction.
      */
-    override suspend fun addPaperToProject(request: GrpcProjectPaper.Add, userId: UUID): ProjectPaper =
+    override suspend fun addPaperToProject(projectId: UUID, paperId: UUID, stage: Int, userId: UUID): ProjectPaper =
         db.query(transactionIsolation = Connection.TRANSACTION_READ_COMMITTED) {
-            val paperId = parseUUID(request.paperId, EntityType.PAPER)
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
             // Lock the project row so that concurrent calls for the same project block here and then re-read MAX with a
             // fresh snapshot after the previous transaction commits.
             ProjectTable.selectAll()
@@ -276,7 +272,7 @@ class ProjectPaperTableRepo(
                     it[ProjectPaperTable.paperId] = paperId
                     it[ProjectPaperTable.projectId] = projectId
                     it[ProjectPaperTable.localPaperId] = localPaperId
-                    it[stage] = request.stage.toInt()
+                    it[ProjectPaperTable.stage] = stage
                     it[decision] = PaperDecision.UNREVIEWED
                     it[createdBy] = userId
                 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/FetcherService.kt
@@ -4,20 +4,17 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.exception.FetcherException
 import se.uulm.snowballr.backend.model.fetcher.FetcherInformationWithId
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import se.uulm.snowballr.backend.model.outgoing.paper.FetcherPaperResponse
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 private val logger = KotlinLogging.logger { }
 
@@ -30,12 +27,12 @@ interface IFetcherService {
     /**
      * Service implementation of [SnowballRService.searchLocalProjectPaperCandidates].
      */
-    suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): List<PaperResponse>
+    suspend fun searchLocalProjectPaperCandidates(projectId: UUID, query: String): List<PaperResponse>
 
     /**
      * Service implementation of [SnowballRService.searchFetcherProjectPaperCandidates].
      */
-    suspend fun searchFetcherProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): List<FetcherPaperResponse>
+    suspend fun searchFetcherProjectPaperCandidates(projectId: UUID, query: String): List<FetcherPaperResponse>
 }
 
 /**
@@ -58,14 +55,12 @@ class FetcherService(
 ) : IFetcherService {
     override suspend fun getAvailableFetchers(): Set<FetcherInformationWithId> = fetcherManager.getAvailableFetchers()
 
-    override suspend fun searchLocalProjectPaperCandidates(request: GrpcProjectPaper.SearchQuery): List<PaperResponse> =
+    override suspend fun searchLocalProjectPaperCandidates(projectId: UUID, query: String): List<PaperResponse> =
         withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
             projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
-            val matchingPapers = paperRepo.getPapersBySearchQuery(request.query)
-            logger.debug { "Found ${matchingPapers.size} papers for query '${request.query}'" }
+            val matchingPapers = paperRepo.getPapersBySearchQuery(query)
+            logger.debug { "Found ${matchingPapers.size} papers for query '$query'" }
 
             val filteredPapers = filterPapersNotInProject(projectId, matchingPapers)
             logger.debug {
@@ -77,24 +72,23 @@ class FetcherService(
         }
 
     override suspend fun searchFetcherProjectPaperCandidates(
-        request: GrpcProjectPaper.SearchQuery,
+        projectId: UUID,
+        query: String,
     ): List<FetcherPaperResponse> = withUser(userRepo) { currentUser ->
-        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
         projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
         val project = projectRepo.getProjectById(projectId).getOrThrow()
 
         val papers = mutableSetOf<FetcherPaper>()
         for ((fetcher, options) in project.fetchers) {
             try {
-                papers += fetcherManager.searchPapers(fetcher, request.query, options)
+                papers += fetcherManager.searchPapers(fetcher, query, options)
             } catch (e: FetcherException) {
                 logger.error(e) {
                     "Failed to search fetcher papers for fetcher '$fetcher': ${e.message ?: "<empty>"}"
                 }
             }
         }
-        logger.debug { "Found ${papers.size} papers for query '${request.query}'" }
+        logger.debug { "Found ${papers.size} papers for query '$query'" }
 
         val filteredPapers = filterExistingFetcherPapers(projectId, papers)
         logger.debug {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -26,7 +26,6 @@ import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.ProjectOuterClass.Project
 import java.time.OffsetDateTime
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project as GrpcProject
 
 val Logger = KotlinLogging.logger { }
 
@@ -39,7 +38,7 @@ interface IInvitationService {
     /**
      * Service implementation of [SnowballRService.inviteUserToProject].
      */
-    suspend fun inviteUserToProject(request: GrpcProject.Member.Invite)
+    suspend fun inviteUserToProject(projectId: UUID, userEmail: String)
 
     /**
      * Service implementation of [SnowballRService.acceptProjectInvitation].
@@ -107,34 +106,32 @@ class InvitationService(
             userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
         }
 
-    override suspend fun inviteUserToProject(request: GrpcProject.Member.Invite) = withUser(userRepo) { currentUser ->
-        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
+    override suspend fun inviteUserToProject(projectId: UUID, userEmail: String) = withUser(userRepo) { currentUser ->
         val projectResult = projectRepo.getProjectById(projectId)
         accessChecker.isAllowedToInviteUserToProject(currentUser, projectId, projectResult)
         val project = projectResult.getOrThrow()
 
         // Check if the user is already a member
         val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
-        val doesAlreadyExists = projectMembers.any { it.user.email == request.userEmail }
+        val doesAlreadyExists = projectMembers.any { it.user.email == userEmail }
         if (doesAlreadyExists) {
             return@withUser
         }
 
         // Check if the user is already invited
         val isAlreadyInvited =
-            invitationTokenRepo.getInvitationTokenByEmailAndProjectId(request.userEmail, projectId).isSuccess
+            invitationTokenRepo.getInvitationTokenByEmailAndProjectId(userEmail, projectId).isSuccess
         if (isAlreadyInvited) {
             return@withUser
         }
 
         // Generate and save invitation token
         val invitationToken = NanoId.generate(INVITATION_TOKEN_LENGTH)
-        invitationTokenRepo.saveInvitationToken(request.userEmail, projectId, invitationToken)
+        invitationTokenRepo.saveInvitationToken(userEmail, projectId, invitationToken)
 
         // Get first name of user if exists
         val userFirstName = try {
-            userRepo.getUserByEmail(request.userEmail).getOrThrow().firstName
+            userRepo.getUserByEmail(userEmail).getOrThrow().firstName
         } catch (_: NotFoundException) {
             "User"
         }
@@ -150,7 +147,7 @@ class InvitationService(
             invitationLink,
             daysToHumanReadable(expirationTimeInDays),
         )
-        emailManager.sendAcceptProjectInvitationEmail(request.userEmail, data)
+        emailManager.sendAcceptProjectInvitationEmail(userEmail, data)
     }
 
     override suspend fun acceptProjectInvitation(token: String) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -26,7 +26,7 @@ interface IInvitationService {
     /**
      * Service implementation of [SnowballRService.getInviteCandidates].
      */
-    suspend fun getInviteCandidates(projectId: UUID, query: String): List<User>
+    suspend fun getInviteCandidates(projectId: UUID?, query: String): List<User>
 
     /**
      * Service implementation of [SnowballRService.inviteUserToProject].
@@ -75,7 +75,7 @@ class InvitationService(
         private const val MINIMUM_LENGTH_OF_SEARCH_QUERY = 3
     }
 
-    override suspend fun getInviteCandidates(projectId: UUID, query: String): List<User> =
+    override suspend fun getInviteCandidates(projectId: UUID?, query: String): List<User> =
         withUser(userRepo) { currentUser ->
             val searchQuery = query.trim()
 
@@ -85,11 +85,13 @@ class InvitationService(
             }
 
             val excludedUsersFromSearch = mutableSetOf(currentUser.email)
-            val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
-            excludedUsersFromSearch += projectMembers.map { it.user.email }
+            if (projectId != null) {
+                val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
+                excludedUsersFromSearch += projectMembers.map { it.user.email }
 
-            val invitedMembers = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
-            excludedUsersFromSearch += invitedMembers.map { it.email }
+                val invitedMembers = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
+                excludedUsersFromSearch += invitedMembers.map { it.email }
+            }
 
             userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -44,7 +44,7 @@ interface IInvitationService {
     /**
      * Service implementation of [SnowballRService.acceptProjectInvitation].
      */
-    suspend fun acceptProjectInvitation(request: GrpcProject.Member.Accept)
+    suspend fun acceptProjectInvitation(token: String)
 
     /**
      * Service implementation of [SnowballRService.getPendingInvitationsForProject].
@@ -153,8 +153,8 @@ class InvitationService(
         emailManager.sendAcceptProjectInvitationEmail(request.userEmail, data)
     }
 
-    override suspend fun acceptProjectInvitation(request: GrpcProject.Member.Accept) {
-        val invitationToken = invitationTokenRepo.getInvitationTokenByValue(request.token).getOrThrow()
+    override suspend fun acceptProjectInvitation(token: String) {
+        val invitationToken = invitationTokenRepo.getInvitationTokenByValue(token).getOrThrow()
 
         // Check if the token has expired
         if (OffsetDateTime.now().isAfter(invitationToken.expiresAt)) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -9,26 +9,24 @@ import se.uulm.snowballr.backend.formatting.daysToHumanReadable
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.dto.user.getFullName
 import se.uulm.snowballr.backend.model.dto.user.isActiveAndConfirmed
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.invalidargument.InvalidUUIDException
 import se.uulm.snowballr.backend.model.exception.notfound.InvitationTokenNotFoundException
+import se.uulm.snowballr.backend.model.outgoing.invitation.InvitationResponse
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import snowballr.ProjectOuterClass.Project
-import snowballr.UserOuterClass.User
 import java.time.OffsetDateTime
 import java.util.UUID
 import snowballr.ProjectOuterClass.Project as GrpcProject
-import snowballr.UserOuterClass.User as GrpcUser
 
 val Logger = KotlinLogging.logger { }
 
@@ -36,7 +34,7 @@ interface IInvitationService {
     /**
      * Service implementation of [SnowballRService.getInviteCandidates].
      */
-    suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): GrpcUser.List
+    suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): List<User>
 
     /**
      * Service implementation of [SnowballRService.inviteUserToProject].
@@ -51,7 +49,7 @@ interface IInvitationService {
     /**
      * Service implementation of [SnowballRService.getPendingInvitationsForProject].
      */
-    suspend fun getPendingInvitationsForProject(projectId: UUID): GrpcUser.List
+    suspend fun getPendingInvitationsForProject(projectId: UUID): List<InvitationResponse>
 }
 
 /**
@@ -85,13 +83,13 @@ class InvitationService(
         private const val MINIMUM_LENGTH_OF_SEARCH_QUERY = 3
     }
 
-    override suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): GrpcUser.List =
+    override suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): List<User> =
         withUser(userRepo) { currentUser ->
             val searchQuery = request.query.trim()
 
             // Check whether the search query is too short, i.e., 3 or fewer characters long
             if (searchQuery.length < MINIMUM_LENGTH_OF_SEARCH_QUERY) {
-                return@withUser GrpcUser.List.getDefaultInstance()
+                return@withUser emptyList()
             }
 
             val excludedUsersFromSearch = mutableSetOf(currentUser.email)
@@ -106,8 +104,7 @@ class InvitationService(
                 Logger.warn { "Invalid project ID in invite candidates request: ${request.projectId}" }
             }
 
-            val candidates = userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
-            candidates.toGrpcUsers()
+            userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
         }
 
     override suspend fun inviteUserToProject(request: GrpcProject.Member.Invite) = withUser(userRepo) { currentUser ->
@@ -185,7 +182,7 @@ class InvitationService(
         invitationTokenRepo.deleteInvitationToken(invitationToken.token)
     }
 
-    override suspend fun getPendingInvitationsForProject(projectId: UUID): GrpcUser.List =
+    override suspend fun getPendingInvitationsForProject(projectId: UUID): List<InvitationResponse> =
         withUser(userRepo) { currentUser ->
             projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
@@ -193,12 +190,13 @@ class InvitationService(
 
             val invitees = tokens.map { token ->
                 try {
-                    userRepo.getUserByEmail(token.email).getOrThrow().toGrpcUser()
+                    val user = userRepo.getUserByEmail(token.email).getOrThrow()
+                    InvitationResponse.fromUser(user)
                 } catch (_: NotFoundException) {
-                    User.newBuilder().setEmail(token.email).build()
+                    InvitationResponse.fromEmail(token.email)
                 }
             }
 
-            User.List.newBuilder().addAllUsers(invitees).build()
+            invitees
         }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.service
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.viascom.nanoid.NanoId
 import se.uulm.snowballr.backend.access.IInvitationAccessChecker
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
@@ -8,32 +7,26 @@ import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.formatting.daysToHumanReadable
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.dto.user.getFullName
 import se.uulm.snowballr.backend.model.dto.user.isActiveAndConfirmed
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
-import se.uulm.snowballr.backend.model.exception.invalidargument.InvalidUUIDException
 import se.uulm.snowballr.backend.model.exception.notfound.InvitationTokenNotFoundException
 import se.uulm.snowballr.backend.model.outgoing.invitation.InvitationResponse
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
-import snowballr.ProjectOuterClass.Project
 import java.time.OffsetDateTime
 import java.util.UUID
-
-val Logger = KotlinLogging.logger { }
 
 interface IInvitationService {
     /**
      * Service implementation of [SnowballRService.getInviteCandidates].
      */
-    suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): List<User>
+    suspend fun getInviteCandidates(projectId: UUID, query: String): List<User>
 
     /**
      * Service implementation of [SnowballRService.inviteUserToProject].
@@ -82,9 +75,9 @@ class InvitationService(
         private const val MINIMUM_LENGTH_OF_SEARCH_QUERY = 3
     }
 
-    override suspend fun getInviteCandidates(request: Project.InviteCandidatesRequest): List<User> =
+    override suspend fun getInviteCandidates(projectId: UUID, query: String): List<User> =
         withUser(userRepo) { currentUser ->
-            val searchQuery = request.query.trim()
+            val searchQuery = query.trim()
 
             // Check whether the search query is too short, i.e., 3 or fewer characters long
             if (searchQuery.length < MINIMUM_LENGTH_OF_SEARCH_QUERY) {
@@ -92,16 +85,11 @@ class InvitationService(
             }
 
             val excludedUsersFromSearch = mutableSetOf(currentUser.email)
-            try {
-                val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-                val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
-                excludedUsersFromSearch += projectMembers.map { it.user.email }
+            val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
+            excludedUsersFromSearch += projectMembers.map { it.user.email }
 
-                val invitedMembers = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
-                excludedUsersFromSearch += invitedMembers.map { it.email }
-            } catch (_: InvalidUUIDException) {
-                Logger.warn { "Invalid project ID in invite candidates request: ${request.projectId}" }
-            }
+            val invitedMembers = invitationTokenRepo.getActiveInvitationTokensForProject(projectId)
+            excludedUsersFromSearch += invitedMembers.map { it.email }
 
             userRepo.getUsersMatchingSearchQuery(searchQuery, excludedUsersFromSearch)
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -34,7 +34,7 @@ interface IProjectMemberService {
     /**
      * Service implementation of [SnowballRService.removeProjectMember].
      */
-    suspend fun removeProjectMember(request: GrpcProjectMember.Remove)
+    suspend fun removeProjectMember(projectId: UUID, userEmail: String)
 }
 
 /**
@@ -92,15 +92,14 @@ class ProjectMemberService(
         }
     }
 
-    override suspend fun removeProjectMember(request: GrpcProjectMember.Remove) = withUser(userRepo) { currentUser ->
-        val projectId = parseUUID(request.projectId, EntityType.PROJECT)
+    override suspend fun removeProjectMember(projectId: UUID, userEmail: String) = withUser(userRepo) { currentUser ->
         val invitationToken =
-            invitationTokenRepo.getInvitationTokenByEmailAndProjectId(request.userEmail, projectId).getOrNull()
+            invitationTokenRepo.getInvitationTokenByEmailAndProjectId(userEmail, projectId).getOrNull()
 
         if (invitationToken != null) {
             removeProjectMemberInvitation(currentUser, projectId, invitationToken)
         } else {
-            val requestedUser = userRepo.getUserByEmail(request.userEmail).getOrThrow()
+            val requestedUser = userRepo.getUserByEmail(userEmail).getOrThrow()
             removeProjectMemberUser(currentUser, requestedUser, projectId)
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -6,8 +6,8 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.projectmember.InvitationToken
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
+import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.projectmember.isProjectAdmin
-import se.uulm.snowballr.backend.model.dto.projectmember.toGrpcProjectMembers
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
@@ -24,7 +24,7 @@ interface IProjectMemberService {
     /**
      * Service implementation of [SnowballRService.getProjectMembers].
      */
-    suspend fun getProjectMembers(projectId: UUID): GrpcProjectMember.List
+    suspend fun getProjectMembers(projectId: UUID): List<ProjectMemberWithUser>
 
     /**
      * Service implementation of [SnowballRService.updateProjectMemberRole].
@@ -59,12 +59,11 @@ class ProjectMemberService(
     private val accessChecker: IProjectMemberAccessChecker,
     private val projectAccessChecker: IProjectAccessChecker,
 ) : IProjectMemberService {
-    override suspend fun getProjectMembers(projectId: UUID): GrpcProjectMember.List =
+    override suspend fun getProjectMembers(projectId: UUID): List<ProjectMemberWithUser> =
         withUser(userRepo) { currentUser ->
             projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
-            val projectMembersWithUsers = repo.getProjectMembersWithUsers(projectId)
-            projectMembersWithUsers.toGrpcProjectMembers()
+            repo.getProjectMembersWithUsers(projectId)
         }
 
     override suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IProjectMemberAccessChecker
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.projectmember.InvitationToken
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
@@ -12,13 +11,12 @@ import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 interface IProjectMemberService {
     /**
@@ -29,7 +27,7 @@ interface IProjectMemberService {
     /**
      * Service implementation of [SnowballRService.updateProjectMemberRole].
      */
-    suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update)
+    suspend fun updateProjectMemberRole(request: UpdateProjectMemberRoleRequest)
 
     /**
      * Service implementation of [SnowballRService.removeProjectMember].
@@ -66,29 +64,25 @@ class ProjectMemberService(
             repo.getProjectMembersWithUsers(projectId)
         }
 
-    override suspend fun updateProjectMemberRole(request: GrpcProjectMember.Update) {
+    override suspend fun updateProjectMemberRole(request: UpdateProjectMemberRoleRequest) {
         withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-            val userId = parseUUID(request.userId, EntityType.USER)
+            accessChecker.isAllowedToUpdateMemberRole(currentUser, request.projectId)
 
-            accessChecker.isAllowedToUpdateMemberRole(currentUser, projectId)
-
-            val user = userRepo.getUserById(userId).getOrThrow()
+            val user = userRepo.getUserById(request.userId).getOrThrow()
 
             val member = try {
-                repo.getProjectMemberByComposedId(projectId, userId).getOrThrow()
+                repo.getProjectMemberByComposedId(request.projectId, request.userId).getOrThrow()
             } catch (_: NotFoundException) {
                 throw FailedPreconditionException(
-                    "User with ID '$userId' is not a member of project with ID '$projectId'.",
+                    "User with ID '${request.userId}' is not a member of project with ID '${request.projectId}'.",
                 )
             }
 
-            val newRole = MemberRole.fromGrpc(request.newRole)
-            if (member.isProjectAdmin() && newRole != MemberRole.ADMIN) {
-                projectAccessChecker.isNotLastProjectAdmin(user, projectId, "Cannot demote the user")
+            if (member.isProjectAdmin() && request.newRole != MemberRole.ADMIN) {
+                projectAccessChecker.isNotLastProjectAdmin(user, request.projectId, "Cannot demote the user")
             }
 
-            repo.updateProjectMemberRole(projectId, userId, newRole)
+            repo.updateProjectMemberRole(request.projectId, request.userId, request.newRole)
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -11,15 +11,15 @@ import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaperWithReviewsCount
 import se.uulm.snowballr.backend.model.dto.projectpaper.hasNoFinalDecision
-import se.uulm.snowballr.backend.model.dto.projectpaper.toGrpcProjectPaper
-import se.uulm.snowballr.backend.model.dto.projectpaper.toGrpcProjectPapers
-import se.uulm.snowballr.backend.model.dto.review.toGrpcReview
+import se.uulm.snowballr.backend.model.dto.projectpaper.toProjectPaperResponses
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateProjectPaperException
 import se.uulm.snowballr.backend.model.exception.invalidargument.InvalidUUIDException
 import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRangeException
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
+import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -36,46 +36,46 @@ interface IProjectPaperService {
     /**
      * Service implementation of [SnowballRService.getProjectPaperById].
      */
-    suspend fun getProjectPaperById(projectPaperId: UUID): GrpcProjectPaper
+    suspend fun getProjectPaperById(projectPaperId: UUID): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getProjectPaperByRelativeId].
      */
-    suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): GrpcProjectPaper
+    suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getAllProjectPapersForProject].
      */
-    suspend fun getAllProjectPapersForProject(projectId: UUID): GrpcProjectPaper.List
+    suspend fun getAllProjectPapersForProject(projectId: UUID): List<ProjectPaperResponse>
 
     /**
      * Service implementation of [SnowballRService.getPapersToReviewForProject].
      */
-    suspend fun getPapersToReviewForProject(projectId: UUID): GrpcProjectPaper.List
+    suspend fun getPapersToReviewForProject(projectId: UUID): List<ProjectPaperResponse>
 
     /**
      * Service implementation of [SnowballRService.addPaperToProject].
      */
-    suspend fun addPaperToProject(request: GrpcProjectPaper.Add): GrpcProjectPaper
+    suspend fun addPaperToProject(request: GrpcProjectPaper.Add): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getNextPaper].
      */
-    suspend fun getNextPaper(projectPaperId: UUID): GrpcProjectPaper
+    suspend fun getNextPaper(projectPaperId: UUID): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getPreviousPaper].
      */
-    suspend fun getPreviousPaper(projectPaperId: UUID): GrpcProjectPaper
+    suspend fun getPreviousPaper(projectPaperId: UUID): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getNextPaperToReview].
      */
-    suspend fun getNextPaperToReview(projectPaperId: UUID): GrpcProjectPaper
+    suspend fun getNextPaperToReview(projectPaperId: UUID): ProjectPaperResponse
 }
 
 private typealias ProjectPaperFilter =
-    (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean)
+    (suspend (ProjectPaperWithPaper, Map<ProjectPaper, List<ReviewResponse>>, UUID) -> Boolean)
 
 /**
  * The [ProjectPaperService] class handles operations related to project papers by implementing the
@@ -107,16 +107,16 @@ class ProjectPaperService(
     private val accessChecker: IProjectPaperAccessChecker,
     private val projectAccessChecker: IProjectAccessChecker,
 ) : IProjectPaperService {
-    override suspend fun getProjectPaperById(projectPaperId: UUID): GrpcProjectPaper =
+    override suspend fun getProjectPaperById(projectPaperId: UUID): ProjectPaperResponse =
         withUser(userRepo) { currentUser ->
             val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
             projectAccessChecker.isAllowedToReadProject(currentUser, projectPaper.projectId)
 
-            projectPaper.toGrpcProjectPaperWithData()
+            projectPaper.toProjectPaperResponse()
         }
 
-    override suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): GrpcProjectPaper =
+    override suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): ProjectPaperResponse =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
 
@@ -125,14 +125,14 @@ class ProjectPaperService(
             val relativeId = request.relativeProjectPaperId.toInt()
             val projectPaper = repo.getProjectPaperByRelativeId(projectId, relativeId).getOrThrow()
 
-            projectPaper.toGrpcProjectPaperWithData()
+            projectPaper.toProjectPaperResponse()
         }
 
-    override suspend fun getAllProjectPapersForProject(projectId: UUID): GrpcProjectPaper.List =
+    override suspend fun getAllProjectPapersForProject(projectId: UUID): List<ProjectPaperResponse> =
         getProjectPapers(projectId)
 
-    override suspend fun getPapersToReviewForProject(projectId: UUID): GrpcProjectPaper.List {
-        val predicate: (ProjectPaperWithPaper, Map<ProjectPaper, List<GrpcReview>>, String) -> Boolean =
+    override suspend fun getPapersToReviewForProject(projectId: UUID): List<ProjectPaperResponse> {
+        val predicate: (ProjectPaperWithPaper, Map<ProjectPaper, List<ReviewResponse>>, UUID) -> Boolean =
             { projectPaper, projectPaperReviewsMap, currentUserId ->
                 val isAlreadyReviewedByCurrentUser = projectPaperReviewsMap[projectPaper.projectPaper]
                     ?.any { review -> review.userId == currentUserId } == true
@@ -142,7 +142,7 @@ class ProjectPaperService(
         return getProjectPapers(projectId, predicate)
     }
 
-    override suspend fun addPaperToProject(request: GrpcProjectPaper.Add): GrpcProjectPaper =
+    override suspend fun addPaperToProject(request: GrpcProjectPaper.Add): ProjectPaperResponse =
         withUser(userRepo) { currentUser ->
             val projectId = parseUUID(request.projectId, EntityType.PROJECT)
             val paperId = parseUUID(request.paperId, EntityType.PAPER)
@@ -162,16 +162,16 @@ class ProjectPaperService(
 
             val projectPaper = repo.addPaperToProject(request, currentUser.id)
 
-            projectPaper.toGrpcProjectPaperWithData(paper)
+            projectPaper.toProjectPaperResponse(paper)
         }
 
-    override suspend fun getNextPaper(projectPaperId: UUID): GrpcProjectPaper =
+    override suspend fun getNextPaper(projectPaperId: UUID): ProjectPaperResponse =
         getAdjacentPaper(projectPaperId, PaperNavigationDirection.NEXT)
 
-    override suspend fun getPreviousPaper(projectPaperId: UUID): GrpcProjectPaper =
+    override suspend fun getPreviousPaper(projectPaperId: UUID): ProjectPaperResponse =
         getAdjacentPaper(projectPaperId, PaperNavigationDirection.PREVIOUS)
 
-    override suspend fun getNextPaperToReview(projectPaperId: UUID): GrpcProjectPaper =
+    override suspend fun getNextPaperToReview(projectPaperId: UUID): ProjectPaperResponse =
         withUser(userRepo) { currentUser ->
             val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
             val projectId = projectPaper.projectId
@@ -191,30 +191,35 @@ class ProjectPaperService(
             val sortedPapers = sortPapersByStageAndReviewsCount(projectPapersWithReviewsCount)
             val papersWithoutFinalDecision = sortedPapers.filter(ProjectPaper::hasNoFinalDecision)
 
-            (papersWithoutFinalDecision.firstOrNull() ?: sortedPapers.first()).toGrpcProjectPaperWithData()
+            (papersWithoutFinalDecision.firstOrNull() ?: sortedPapers.first()).toProjectPaperResponse()
         }
 
     /**
-     * Populates the given [ProjectPaper] with its authors, backward references, and reviews.
+     * Populates the given [ProjectPaper] with its backward references, and reviews.
      *
      * @param associatedPaper The [Paper] that is associated with this [ProjectPaper]. If not provided, it is requested
      * from the database using the paper id from the project paper.
-     * @return The gRPC representation of the project paper, including the associated data.
+     * @return The response representation of the project paper, including the associated data.
      */
-    private suspend fun ProjectPaper.toGrpcProjectPaperWithData(associatedPaper: Paper? = null): GrpcProjectPaper {
+    private suspend fun ProjectPaper.toProjectPaperResponse(associatedPaper: Paper? = null): ProjectPaperResponse {
         val paper = associatedPaper ?: paperRepo.getPaperById(paperId).getOrThrow()
-
-        val backwardReferences = citationTableRepo
-            .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map(UUID::toString)
+        val paperResponse = paper.toPaperResponse(citationTableRepo)
 
         val reviews = reviewTableRepo
             .getAllReviewsForProjectPaper(id)
             .map {
                 val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
-                it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+                ReviewResponse.fromReviewAndIds(it, selectedCriteriaIds)
             }
 
-        return ProjectPaperWithPaper(this, paper).toGrpcProjectPaper(backwardReferences, reviews)
+        return ProjectPaperResponse(
+            id = this.id,
+            stage = this.stage,
+            decision = this.decision,
+            localPaperId = this.localPaperId,
+            paper = paperResponse,
+            reviews = reviews,
+        )
     }
 
     /**
@@ -233,30 +238,29 @@ class ProjectPaperService(
     private suspend fun getProjectPapers(
         projectId: UUID,
         predicate: ProjectPaperFilter? = null,
-    ): GrpcProjectPaper.List = withUser(userRepo) { currentUser ->
+    ): List<ProjectPaperResponse> = withUser(userRepo) { currentUser ->
         projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
         var projectPapersWithPapers = repo.getAllProjectPapersWithPapers(projectId)
-        val paperBackwardReferencesMap = mutableMapOf<Paper, List<String>>()
-        val projectPaperReviewsMap = mutableMapOf<ProjectPaper, List<GrpcReview>>()
+        val paperBackwardReferencesMap = mutableMapOf<Paper, List<UUID>>()
+        val projectPaperReviewsMap = mutableMapOf<ProjectPaper, List<ReviewResponse>>()
 
         for (projectPaper in projectPapersWithPapers) {
             val paper = projectPaper.paper
-            paperBackwardReferencesMap[paper] = citationTableRepo
-                .getBackwardsReferencedPaperIdsOfPaperById(paper.id).map(UUID::toString)
+            paperBackwardReferencesMap[paper] = citationTableRepo.getBackwardsReferencedPaperIdsOfPaperById(paper.id)
             projectPaperReviewsMap[projectPaper.projectPaper] = reviewTableRepo
                 .getAllReviewsForProjectPaper(projectPaper.projectPaper.id)
                 .map {
                     val selectedCriteriaIds = reviewHasCriterionTableRepo.getSelectedCriteriaIdsForReviewById(it.id)
-                    it.toGrpcReview(selectedCriteriaIds.map(UUID::toString))
+                    ReviewResponse.fromReviewAndIds(it, selectedCriteriaIds)
                 }
         }
 
         projectPapersWithPapers = predicate?.let { pred ->
-            projectPapersWithPapers.filter { pred(it, projectPaperReviewsMap, currentUser.id.toString()) }
+            projectPapersWithPapers.filter { pred(it, projectPaperReviewsMap, currentUser.id) }
         } ?: projectPapersWithPapers
 
-        projectPapersWithPapers.toGrpcProjectPapers(paperBackwardReferencesMap, projectPaperReviewsMap)
+        projectPapersWithPapers.toProjectPaperResponses(paperBackwardReferencesMap, projectPaperReviewsMap)
     }
 
     /**
@@ -271,18 +275,20 @@ class ProjectPaperService(
      * @throws InvalidUUIDException If the given project paper ID is not a valid UUID.
      * @throws UnauthorizedException If the user does not have the required access to the project.
      */
-    private suspend fun getAdjacentPaper(projectPaperId: UUID, direction: PaperNavigationDirection): GrpcProjectPaper =
-        withUser(userRepo) { currentUser ->
-            val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
+    private suspend fun getAdjacentPaper(
+        projectPaperId: UUID,
+        direction: PaperNavigationDirection,
+    ): ProjectPaperResponse = withUser(userRepo) { currentUser ->
+        val projectPaper = repo.getProjectPaperById(projectPaperId).getOrThrow()
 
-            projectAccessChecker.isAllowedToReadProject(currentUser, projectPaper.projectId)
+        projectAccessChecker.isAllowedToReadProject(currentUser, projectPaper.projectId)
 
-            val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
-            val adjacentPaper = repo.getAdjacentPaper(projectId, projectPaper.localPaperId, direction).getOrThrow()
-            val paper = paperRepo.getPaperById(adjacentPaper.paperId).getOrThrow()
+        val projectId = projectRepo.getProjectById(projectPaper.projectId).getOrThrow().id
+        val adjacentPaper = repo.getAdjacentPaper(projectId, projectPaper.localPaperId, direction).getOrThrow()
+        val paper = paperRepo.getPaperById(adjacentPaper.paperId).getOrThrow()
 
-            adjacentPaper.toGrpcProjectPaperWithData(paper)
-        }
+        adjacentPaper.toProjectPaperResponse(paper)
+    }
 
     /**
      * Sorts a list of project papers paired with their corresponding review counts.

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IProjectPaperAccessChecker
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.PaperNavigationDirection
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.project.Project
@@ -20,7 +19,6 @@ import se.uulm.snowballr.backend.model.exception.invalidargument.InvalidUUIDExce
 import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRangeException
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
@@ -29,8 +27,6 @@ import se.uulm.snowballr.backend.repository.association.ICitationTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTableRepo
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
-import snowballr.ReviewOuterClass.Review as GrpcReview
 
 interface IProjectPaperService {
     /**
@@ -41,7 +37,7 @@ interface IProjectPaperService {
     /**
      * Service implementation of [SnowballRService.getProjectPaperByRelativeId].
      */
-    suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): ProjectPaperResponse
+    suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Int): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getAllProjectPapersForProject].
@@ -116,13 +112,10 @@ class ProjectPaperService(
             projectPaper.toProjectPaperResponse()
         }
 
-    override suspend fun getProjectPaperByRelativeId(request: GrpcProjectPaper.Get): ProjectPaperResponse =
+    override suspend fun getProjectPaperByRelativeId(projectId: UUID, relativeId: Int): ProjectPaperResponse =
         withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-
             projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
-            val relativeId = request.relativeProjectPaperId.toInt()
             val projectPaper = repo.getProjectPaperByRelativeId(projectId, relativeId).getOrThrow()
 
             projectPaper.toProjectPaperResponse()
@@ -225,11 +218,10 @@ class ProjectPaperService(
      * based on custom criteria.
      *
      * @param projectId The ID of the [Project] for which [ProjectPaper]s are to be retrieved.
-     * @param predicate An optional lambda function that takes a [ProjectPaperWithPaper], a map of [GrpcReview], and a
-     * user ID. This function should return a boolean value to filter the [ProjectPaperWithPaper]s. If null, no
+     * @param predicate An optional lambda function that takes a [ProjectPaperWithPaper], a map of [ReviewResponse],
+     * and a user ID. This function should return a boolean value to filter the [ProjectPaperWithPaper]s. If null, no
      * filtering is applied.
-     * @return A list of [GrpcProjectPaper] including associated metadata such as authors, backward references, and
-     * reviews.
+     * @return A list of [ProjectPaperResponse] including associated metadata such as backward references, and reviews.
      * @throws UnauthorizedException If the user does not have the required access to the project.
      */
     private suspend fun getProjectPapers(

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectPaperService.kt
@@ -56,7 +56,7 @@ interface IProjectPaperService {
     /**
      * Service implementation of [SnowballRService.addPaperToProject].
      */
-    suspend fun addPaperToProject(request: GrpcProjectPaper.Add): ProjectPaperResponse
+    suspend fun addPaperToProject(projectId: UUID, paperId: UUID, stage: Int): ProjectPaperResponse
 
     /**
      * Service implementation of [SnowballRService.getNextPaper].
@@ -142,11 +142,8 @@ class ProjectPaperService(
         return getProjectPapers(projectId, predicate)
     }
 
-    override suspend fun addPaperToProject(request: GrpcProjectPaper.Add): ProjectPaperResponse =
+    override suspend fun addPaperToProject(projectId: UUID, paperId: UUID, stage: Int): ProjectPaperResponse =
         withUser(userRepo) { currentUser ->
-            val projectId = parseUUID(request.projectId, EntityType.PROJECT)
-            val paperId = parseUUID(request.paperId, EntityType.PAPER)
-
             val projectResult = projectRepo.getProjectById(projectId)
             accessChecker.isAllowedToAddPaperToProject(currentUser, projectId, projectResult)
             val project = projectResult.getOrThrow()
@@ -156,11 +153,11 @@ class ProjectPaperService(
                 throw DuplicateProjectPaperException(projectId, paperId)
             }
 
-            if (request.stage !in 0..project.maxStage) {
-                throw StageOutOfRangeException(request.stage.toInt(), project.maxStage)
+            if (stage !in 0..project.maxStage) {
+                throw StageOutOfRangeException(stage, project.maxStage)
             }
 
-            val projectPaper = repo.addPaperToProject(request, currentUser.id)
+            val projectPaper = repo.addPaperToProject(projectId, paperId, stage, currentUser.id)
 
             projectPaper.toProjectPaperResponse(paper)
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -20,7 +20,6 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.repository.UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE
 import java.sql.SQLException
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
@@ -416,27 +415,27 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
                 val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
                 val targetStage = job.projectPaper.stage + 1
-                val baseRequest = GrpcProjectPaper.Add.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setStage(targetStage.toLong())
-                val backwardRequest = baseRequest.setPaperId(backwardRef.id.toString()).build()
-                val forwardRequest = baseRequest.setPaperId(forwardRef.id.toString()).build()
 
                 mockRunPaperCitation(job, setOf(backwardRef), setOf(forwardRef))
                 coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id) } returns false
                 coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, forwardRef.id) } returns false
                 coJustRun { projectRepoMock.updateMaxStageIfExceeded(project.id, targetStage) }
                 coEvery {
-                    projectPaperRepoMock.addPaperToProject(backwardRequest, job.triggeringUserId)
+                    projectPaperRepoMock.addPaperToProject(
+                        project.id,
+                        backwardRef.id,
+                        targetStage,
+                        job.triggeringUserId,
+                    )
                 } throws SQLException("Adding backward paper to project failed")
                 coEvery {
-                    projectPaperRepoMock.addPaperToProject(forwardRequest, job.triggeringUserId)
+                    projectPaperRepoMock.addPaperToProject(project.id, forwardRef.id, targetStage, job.triggeringUserId)
                 } throws SQLException("Adding forward paper to project failed")
 
                 orchestrator.enqueueTestJob(job, project)
 
                 // Only the two failure calls were made
-                coVerify(exactly = 2) { projectPaperRepoMock.addPaperToProject(any(), any()) }
+                coVerify(exactly = 2) { projectPaperRepoMock.addPaperToProject(any(), any(), any(), any()) }
             }
 
         @Test
@@ -447,23 +446,27 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalId = null)
                 val forwardRef = DataBuilder.createExamplePaper(title = "For", externalId = null)
                 val targetStage = job.projectPaper.stage + 1
-                val baseRequest = GrpcProjectPaper.Add.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setStage(targetStage.toLong())
-                val backwardRequest = baseRequest.setPaperId(backwardRef.id.toString()).build()
-                val forwardRequest = baseRequest.setPaperId(forwardRef.id.toString()).build()
 
                 mockRunPaperCitation(job, setOf(backwardRef), setOf(forwardRef))
                 coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id) } returns false
                 coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, forwardRef.id) } returns false
                 coJustRun { projectRepoMock.updateMaxStageIfExceeded(project.id, targetStage) }
-                coJustRun { projectPaperRepoMock.addPaperToProject(backwardRequest, job.triggeringUserId) }
-                coJustRun { projectPaperRepoMock.addPaperToProject(forwardRequest, job.triggeringUserId) }
+                coJustRun {
+                    projectPaperRepoMock.addPaperToProject(
+                        project.id,
+                        backwardRef.id,
+                        targetStage,
+                        job.triggeringUserId,
+                    )
+                }
+                coJustRun {
+                    projectPaperRepoMock.addPaperToProject(project.id, forwardRef.id, targetStage, job.triggeringUserId)
+                }
 
                 orchestrator.enqueueTestJob(job, project)
 
                 // Two successful calls were made
-                coVerify(exactly = 2) { projectPaperRepoMock.addPaperToProject(any(), any()) }
+                coVerify(exactly = 2) { projectPaperRepoMock.addPaperToProject(any(), any(), any(), any()) }
             }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -97,7 +97,7 @@ sealed class FetcherOrchestratorTest {
     }
 
     protected fun assertAddingPapersToProjectFailure() {
-        coVerify(exactly = 0) { projectPaperRepoMock.addPaperToProject(any(), any()) }
+        coVerify(exactly = 0) { projectPaperRepoMock.addPaperToProject(any(), any(), any(), any()) }
     }
 
     protected fun mockRunFetching(

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -63,7 +63,6 @@ import se.uulm.snowballr.backend.service.IUserService
 import se.uulm.snowballr.backend.serviceLayerDeps
 import snowballr.Authentication
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Tag("integration")
@@ -263,11 +262,7 @@ open class IntegrationTest : KoinTest {
             EmailData.AcceptProjectInvitation(inviteeFirstName, "Test User", project.name, link, "in 7 days")
         coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(any(), invitationData) }
 
-        val inviteUserRequest = GrpcProject.Member.Invite.newBuilder()
-            .setProjectId(project.id.toString())
-            .setUserEmail(inviteeEmail)
-            .build()
-        invitationService.inviteUserToProject(inviteUserRequest)
+        invitationService.inviteUserToProject(project.id, inviteeEmail)
 
         return invitationToken
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -64,7 +64,6 @@ import se.uulm.snowballr.backend.serviceLayerDeps
 import snowballr.Authentication
 import java.util.UUID
 import snowballr.ProjectOuterClass.Project as GrpcProject
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Tag("integration")
@@ -279,11 +278,6 @@ open class IntegrationTest : KoinTest {
     /**
      * Adds the [paper] to the [project] in stage 0.
      */
-    protected suspend fun addToProject(project: Project, paper: PaperResponse) = projectPaperService.addPaperToProject(
-        GrpcProjectPaper.Add.newBuilder()
-            .setProjectId(project.id.toString())
-            .setPaperId(paper.id.toString())
-            .setStage(0)
-            .build(),
-    )
+    protected suspend fun addToProject(project: Project, paper: PaperResponse) =
+        projectPaperService.addPaperToProject(project.id, paper.id, 0)
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -223,10 +223,7 @@ open class IntegrationTest : KoinTest {
         val invitationToken = inviteHelper(project, user.firstName, user.email)
 
         if (acceptInvitation) {
-            val acceptRequest = GrpcProject.Member.Accept.newBuilder()
-                .setToken(invitationToken.captured)
-                .build()
-            invitationService.acceptProjectInvitation(acceptRequest)
+            invitationService.acceptProjectInvitation(invitationToken.captured)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -16,7 +16,6 @@ import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import snowballr.ProjectOuterClass.MemberRole
 import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class AccessControlIntegrationTest : IntegrationTest() {
     private suspend fun setupProjectWithMember(): Pair<Project, User> {
@@ -115,14 +114,8 @@ class AccessControlIntegrationTest : IntegrationTest() {
             val (project, member) = setupProjectWithMember()
             val paper = createPaper()
 
-            val request = GrpcProjectPaper.Add.newBuilder()
-                .setProjectId(project.id.toString())
-                .setPaperId(paper.id.toString())
-                .setStage(0)
-                .build()
-
             actAsUser(member.id) {
-                assertThrows<UnauthorizedException> { projectPaperService.addPaperToProject(request) }
+                assertThrows<UnauthorizedException> { projectPaperService.addPaperToProject(project.id, paper.id, 0) }
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -162,13 +162,10 @@ class AccessControlIntegrationTest : IntegrationTest() {
             val secondMember = addUser(DataBuilder.createExampleUser(email = "second.member@example.com"))
             inviteUserToProject(project, secondMember, acceptInvitation = true)
 
-            val request = GrpcProjectMember.Remove.newBuilder()
-                .setProjectId(project.id.toString())
-                .setUserEmail(secondMember.email)
-                .build()
-
             actAsUser(member.id) {
-                assertThrows<UnauthorizedException> { projectMemberService.removeProjectMember(request) }
+                assertThrows<UnauthorizedException> {
+                    projectMemberService.removeProjectMember(project.id, secondMember.email)
+                }
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -16,7 +16,6 @@ import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class AccessControlIntegrationTest : IntegrationTest() {
     private suspend fun setupProjectWithMember(): Pair<Project, User> {
@@ -127,13 +126,10 @@ class AccessControlIntegrationTest : IntegrationTest() {
         fun `When a non-admin member tries to invite a user to a project, then access is denied`() = runTest {
             val (project, member) = setupProjectWithMember()
 
-            val request = GrpcProjectMember.Invite.newBuilder()
-                .setProjectId(project.id.toString())
-                .setUserEmail("uninvited@example.com")
-                .build()
-
             actAsUser(member.id) {
-                assertThrows<UnauthorizedException> { invitationService.inviteUserToProject(request) }
+                assertThrows<UnauthorizedException> {
+                    invitationService.inviteUserToProject(project.id, "uninvited@exmaple.com")
+                }
             }
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -8,13 +8,14 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.project.Project
+import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
-import snowballr.ProjectOuterClass.MemberRole
+import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
 import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class AccessControlIntegrationTest : IntegrationTest() {
@@ -145,11 +146,11 @@ class AccessControlIntegrationTest : IntegrationTest() {
             val secondMember = addUser(DataBuilder.createExampleUser(email = "second.member@example.com"))
             inviteUserToProject(project, secondMember, acceptInvitation = true)
 
-            val request = GrpcProjectMember.Update.newBuilder()
-                .setProjectId(project.id.toString())
-                .setUserId(secondMember.id.toString())
-                .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
-                .build()
+            val request = UpdateProjectMemberRoleRequest(
+                projectId = project.id,
+                userId = secondMember.id,
+                newRole = MemberRole.ADMIN,
+            )
 
             actAsUser(member.id) {
                 assertThrows<UnauthorizedException> { projectMemberService.updateProjectMemberRole(request) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -10,7 +10,6 @@ import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
-import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
 
@@ -36,11 +35,7 @@ class RegressionTest : IntegrationTest() {
             assertEquals(UserStatus.USER_STATUS_ACTIVE, pendingInvitations[0].status)
 
             // Remove the other user's invitation from the project
-            val removeInvitationRequest = Project.Member.Remove.newBuilder()
-                .setProjectId(project.id.toString())
-                .setUserEmail(otherUser.email)
-                .build()
-            projectMemberService.removeProjectMember(removeInvitationRequest)
+            projectMemberService.removeProjectMember(project.id, otherUser.email)
 
             pendingInvitations = invitationService.getPendingInvitationsForProject(project.id).usersList
             assertEquals(0, pendingInvitations.size)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -62,13 +62,7 @@ class RegressionTest : IntegrationTest() {
 
             val projectPapers = papers.map {
                 async {
-                    projectPaperService.addPaperToProject(
-                        GrpcProjectPaper.Add.newBuilder()
-                            .setProjectId(project.id.toString())
-                            .setPaperId(it.id.toString())
-                            .setStage(0)
-                            .build(),
-                    )
+                    projectPaperService.addPaperToProject(project.id, it.id, 0)
                 }
             }.awaitAll()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
-import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
 
 class RegressionTest : IntegrationTest() {
@@ -27,17 +27,17 @@ class RegressionTest : IntegrationTest() {
             // Invite the other user to the project
             inviteUserToProject(project, otherUser)
 
-            var pendingInvitations = invitationService.getPendingInvitationsForProject(project.id).usersList
+            var pendingInvitations = invitationService.getPendingInvitationsForProject(project.id)
             assertEquals(1, pendingInvitations.size)
             assertEquals(otherUser.email, pendingInvitations[0].email)
             assertEquals(otherUser.firstName, pendingInvitations[0].firstName)
             assertEquals(otherUser.lastName, pendingInvitations[0].lastName)
-            assertEquals(UserStatus.USER_STATUS_ACTIVE, pendingInvitations[0].status)
+            assertEquals(UserStatus.ACTIVE, pendingInvitations[0].status)
 
             // Remove the other user's invitation from the project
             projectMemberService.removeProjectMember(project.id, otherUser.email)
 
-            pendingInvitations = invitationService.getPendingInvitationsForProject(project.id).usersList
+            pendingInvitations = invitationService.getPendingInvitationsForProject(project.id)
             assertEquals(0, pendingInvitations.size)
         }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -72,7 +72,7 @@ class RegressionTest : IntegrationTest() {
                 }
             }.awaitAll()
 
-            val localIds = projectPapers.map { it.localId }.distinct()
+            val localIds = projectPapers.map { it.localPaperId }.distinct()
             assertEquals(numberOfPapers, localIds.size)
 
             val projectPaper = projectPapers.first()
@@ -81,7 +81,7 @@ class RegressionTest : IntegrationTest() {
                 projectPaperService.getProjectPaperByRelativeId(
                     GrpcProjectPaper.Get.newBuilder()
                         .setProjectId(project.id.toString())
-                        .setRelativeProjectPaperId(projectPaper.localId)
+                        .setRelativeProjectPaperId(projectPaper.localPaperId.toString())
                         .build(),
                 )
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -13,7 +13,6 @@ import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import snowballr.ProjectOuterClass.Project
 import snowballr.UserOuterClass.UserStatus
 import kotlin.test.assertEquals
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class RegressionTest : IntegrationTest() {
     @Test
@@ -72,12 +71,7 @@ class RegressionTest : IntegrationTest() {
             val projectPaper = projectPapers.first()
             assertDoesNotThrow {
                 // If several papers have the same local ID this would throw
-                projectPaperService.getProjectPaperByRelativeId(
-                    GrpcProjectPaper.Get.newBuilder()
-                        .setProjectId(project.id.toString())
-                        .setRelativeProjectPaperId(projectPaper.localPaperId.toString())
-                        .build(),
-                )
+                projectPaperService.getProjectPaperByRelativeId(project.id, projectPaper.localPaperId)
             }
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
@@ -8,24 +8,17 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import java.util.UUID
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class FetcherIntegrationTest : IntegrationTest() {
-    private fun searchQuery(projectId: UUID, query: String) = GrpcProjectPaper.SearchQuery.newBuilder()
-        .setProjectId(projectId.toString())
-        .setQuery(query)
-        .build()
-
     @Nested
     inner class SearchLocalProjectPaperCandidates {
         @Test
         fun `When no papers exist, then the result is empty`() = runTest {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
 
-            val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+            val result = fetcherService.searchLocalProjectPaperCandidates(project.id, "Something about IT")
 
             assertTrue(result.isEmpty())
         }
@@ -35,7 +28,7 @@ class FetcherIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
             val paper = createPaper("Something about IT")
 
-            val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+            val result = fetcherService.searchLocalProjectPaperCandidates(project.id, "Something about IT")
 
             assertTrue(result.any { it.id == paper.id })
         }
@@ -46,7 +39,7 @@ class FetcherIntegrationTest : IntegrationTest() {
             val paper = createPaper("Something about IT")
             addToProject(project, paper)
 
-            val result = fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+            val result = fetcherService.searchLocalProjectPaperCandidates(project.id, "Something about IT")
 
             assertFalse(result.any { it.id == paper.id })
         }
@@ -60,7 +53,7 @@ class FetcherIntegrationTest : IntegrationTest() {
                 addToProject(project, inProject)
 
                 val result =
-                    fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about"))
+                    fetcherService.searchLocalProjectPaperCandidates(project.id, "Something about")
 
                 assertFalse(result.any { it.id == inProject.id })
                 assertTrue(result.any { it.id == notInProject.id })
@@ -73,7 +66,7 @@ class FetcherIntegrationTest : IntegrationTest() {
 
             actAsUser(outsider.id) {
                 assertThrows<UnauthorizedException> {
-                    fetcherService.searchLocalProjectPaperCandidates(searchQuery(project.id, "Something about IT"))
+                    fetcherService.searchLocalProjectPaperCandidates(project.id, "Something about IT")
                 }
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
@@ -55,12 +55,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                 inviteEmailToProject(project, inviteeEmail)
 
                 // Second invite for already-pending user: service short-circuits without sending another email
-                invitationService.inviteUserToProject(
-                    Project.Member.Invite.newBuilder()
-                        .setProjectId(project.id.toString())
-                        .setUserEmail(inviteeEmail)
-                        .build(),
-                )
+                invitationService.inviteUserToProject(project.id, inviteeEmail)
 
                 val pending = invitationService.getPendingInvitationsForProject(project.id)
                 assertEquals(1, pending.count { it.email == inviteeEmail })

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import snowballr.ProjectOuterClass.Project
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -69,12 +68,7 @@ class InvitationIntegrationTest : IntegrationTest() {
             addUser(DataBuilder.createExampleUser(email = "searchable.user@example.com"))
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
 
-            val candidates = invitationService.getInviteCandidates(
-                Project.InviteCandidatesRequest.newBuilder()
-                    .setQuery("ab")
-                    .setProjectId(project.id.toString())
-                    .build(),
-            )
+            val candidates = invitationService.getInviteCandidates(project.id, "ab")
 
             assertTrue(candidates.isEmpty())
         }
@@ -84,12 +78,7 @@ class InvitationIntegrationTest : IntegrationTest() {
             val otherUser = addUser(DataBuilder.createExampleUser(email = "findable.candidate@example.com"))
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
 
-            val candidates = invitationService.getInviteCandidates(
-                Project.InviteCandidatesRequest.newBuilder()
-                    .setQuery(otherUser.email.take(6))
-                    .setProjectId(project.id.toString())
-                    .build(),
-            )
+            val candidates = invitationService.getInviteCandidates(project.id, otherUser.email.take(6))
 
             assertTrue(candidates.any { it.id == otherUser.id })
         }
@@ -101,12 +90,7 @@ class InvitationIntegrationTest : IntegrationTest() {
 
             inviteUserToProject(project, otherUser, acceptInvitation = true)
 
-            val candidates = invitationService.getInviteCandidates(
-                Project.InviteCandidatesRequest.newBuilder()
-                    .setQuery(otherUser.email.take(6))
-                    .setProjectId(project.id.toString())
-                    .build(),
-            )
+            val candidates = invitationService.getInviteCandidates(project.id, otherUser.email.take(6))
 
             assertFalse(candidates.any { it.id == otherUser.id })
         }
@@ -118,12 +102,7 @@ class InvitationIntegrationTest : IntegrationTest() {
 
             inviteUserToProject(project, otherUser)
 
-            val candidates = invitationService.getInviteCandidates(
-                Project.InviteCandidatesRequest.newBuilder()
-                    .setQuery(otherUser.email.take(7))
-                    .setProjectId(project.id.toString())
-                    .build(),
-            )
+            val candidates = invitationService.getInviteCandidates(project.id, otherUser.email.take(7))
 
             assertFalse(candidates.any { it.id == otherUser.id })
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
@@ -23,7 +23,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                 inviteEmailToProject(project, inviteeEmail)
 
                 val pending = invitationService.getPendingInvitationsForProject(project.id)
-                assertTrue(pending.usersList.any { it.email == inviteeEmail })
+                assertTrue(pending.any { it.email == inviteeEmail })
             }
 
         @Test
@@ -35,7 +35,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                 inviteUserToProject(project, otherUser, acceptInvitation = true)
 
                 val pending = invitationService.getPendingInvitationsForProject(project.id)
-                assertFalse(pending.usersList.any { it.email == otherUser.email })
+                assertFalse(pending.any { it.email == otherUser.email })
             }
 
         @Test
@@ -43,7 +43,7 @@ class InvitationIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
 
             val pending = invitationService.getPendingInvitationsForProject(project.id)
-            assertTrue(pending.usersList.isEmpty())
+            assertTrue(pending.isEmpty())
         }
 
         @Test
@@ -63,7 +63,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                 )
 
                 val pending = invitationService.getPendingInvitationsForProject(project.id)
-                assertEquals(1, pending.usersList.count { it.email == inviteeEmail })
+                assertEquals(1, pending.count { it.email == inviteeEmail })
             }
     }
 
@@ -81,7 +81,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertTrue(candidates.usersList.isEmpty())
+            assertTrue(candidates.isEmpty())
         }
 
         @Test
@@ -96,7 +96,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertTrue(candidates.usersList.any { it.id == otherUser.id.toString() })
+            assertTrue(candidates.any { it.id == otherUser.id })
         }
 
         @Test
@@ -113,7 +113,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertFalse(candidates.usersList.any { it.id == otherUser.id.toString() })
+            assertFalse(candidates.any { it.id == otherUser.id })
         }
 
         @Test
@@ -130,7 +130,7 @@ class InvitationIntegrationTest : IntegrationTest() {
                     .build(),
             )
 
-            assertFalse(candidates.usersList.any { it.id == otherUser.id.toString() })
+            assertFalse(candidates.any { it.id == otherUser.id })
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
@@ -56,12 +56,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
 
             inviteUserToProject(project, otherUser, acceptInvitation = true)
 
-            projectMemberService.removeProjectMember(
-                GrpcProjectMember.Remove.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setUserEmail(otherUser.email)
-                    .build(),
-            )
+            projectMemberService.removeProjectMember(project.id, otherUser.email)
 
             val members = projectMemberService.getProjectMembers(project.id)
             assertFalse(members.any { it.user.id == otherUser.id })
@@ -76,12 +71,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 inviteUserToProject(project, otherUser, acceptInvitation = true)
 
                 actAsUser(otherUser.id) {
-                    projectMemberService.removeProjectMember(
-                        GrpcProjectMember.Remove.newBuilder()
-                            .setProjectId(project.id.toString())
-                            .setUserEmail(otherUser.email)
-                            .build(),
-                    )
+                    projectMemberService.removeProjectMember(project.id, otherUser.email)
                 }
 
                 val members = projectMemberService.getProjectMembers(project.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
@@ -11,7 +11,6 @@ import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMembe
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class ProjectMemberIntegrationTest : IntegrationTest() {
     @Nested
@@ -36,12 +35,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 inviteUserToProject(project, otherUser, acceptInvitation = true)
 
                 // Second invite for an already-accepted member: service short-circuits without sending email
-                invitationService.inviteUserToProject(
-                    GrpcProjectMember.Invite.newBuilder()
-                        .setProjectId(project.id.toString())
-                        .setUserEmail(otherUser.email)
-                        .build(),
-                )
+                invitationService.inviteUserToProject(project.id, otherUser.email)
 
                 val members = projectMemberService.getProjectMembers(project.id)
                 assertEquals(2, members.size) // creator + other user, no duplicate

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
@@ -7,6 +7,7 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
+import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -89,11 +90,11 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             inviteUserToProject(project, otherUser, acceptInvitation = true)
 
             projectMemberService.updateProjectMemberRole(
-                GrpcProjectMember.Update.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setUserId(otherUser.id.toString())
-                    .setNewRole(MemberRole.ADMIN.toGrpc())
-                    .build(),
+                UpdateProjectMemberRoleRequest(
+                    projectId = project.id,
+                    userId = otherUser.id,
+                    newRole = MemberRole.ADMIN,
+                ),
             )
 
             val members = projectMemberService.getProjectMembers(project.id)
@@ -110,20 +111,20 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
 
             // Promote first
             projectMemberService.updateProjectMemberRole(
-                GrpcProjectMember.Update.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setUserId(otherUser.id.toString())
-                    .setNewRole(MemberRole.ADMIN.toGrpc())
-                    .build(),
+                UpdateProjectMemberRoleRequest(
+                    projectId = project.id,
+                    userId = otherUser.id,
+                    newRole = MemberRole.ADMIN,
+                ),
             )
 
             // Then demote — still valid because testUser (creator) remains an admin
             projectMemberService.updateProjectMemberRole(
-                GrpcProjectMember.Update.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setUserId(otherUser.id.toString())
-                    .setNewRole(MemberRole.DEFAULT.toGrpc())
-                    .build(),
+                UpdateProjectMemberRoleRequest(
+                    projectId = project.id,
+                    userId = otherUser.id,
+                    newRole = MemberRole.DEFAULT,
+                ),
             )
 
             val members = projectMemberService.getProjectMembers(project.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
+import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import snowballr.ProjectOuterClass.MemberRole
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -23,7 +23,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             inviteUserToProject(project, otherUser, acceptInvitation = true)
 
             val members = projectMemberService.getProjectMembers(project.id)
-            assertTrue(members.membersList.any { it.user.id == otherUser.id.toString() })
+            assertTrue(members.any { it.user.id == otherUser.id })
         }
 
         @Test
@@ -43,7 +43,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 )
 
                 val members = projectMemberService.getProjectMembers(project.id)
-                assertEquals(2, members.membersList.size) // creator + other user, no duplicate
+                assertEquals(2, members.size) // creator + other user, no duplicate
             }
     }
 
@@ -64,7 +64,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
             )
 
             val members = projectMemberService.getProjectMembers(project.id)
-            assertFalse(members.membersList.any { it.user.id == otherUser.id.toString() })
+            assertFalse(members.any { it.user.id == otherUser.id })
         }
 
         @Test
@@ -85,7 +85,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 }
 
                 val members = projectMemberService.getProjectMembers(project.id)
-                assertFalse(members.membersList.any { it.user.id == otherUser.id.toString() })
+                assertFalse(members.any { it.user.id == otherUser.id })
             }
     }
 
@@ -102,13 +102,13 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 GrpcProjectMember.Update.newBuilder()
                     .setProjectId(project.id.toString())
                     .setUserId(otherUser.id.toString())
-                    .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+                    .setNewRole(MemberRole.ADMIN.toGrpc())
                     .build(),
             )
 
             val members = projectMemberService.getProjectMembers(project.id)
-            val updatedMember = members.membersList.find { it.user.id == otherUser.id.toString() }
-            assertEquals(MemberRole.MEMBER_ROLE_ADMIN, updatedMember?.role)
+            val updatedMember = members.first { it.user.id == otherUser.id }
+            assertEquals(MemberRole.ADMIN, updatedMember.projectMember.role)
         }
 
         @Test
@@ -123,7 +123,7 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 GrpcProjectMember.Update.newBuilder()
                     .setProjectId(project.id.toString())
                     .setUserId(otherUser.id.toString())
-                    .setNewRole(MemberRole.MEMBER_ROLE_ADMIN)
+                    .setNewRole(MemberRole.ADMIN.toGrpc())
                     .build(),
             )
 
@@ -132,13 +132,13 @@ class ProjectMemberIntegrationTest : IntegrationTest() {
                 GrpcProjectMember.Update.newBuilder()
                     .setProjectId(project.id.toString())
                     .setUserId(otherUser.id.toString())
-                    .setNewRole(MemberRole.MEMBER_ROLE_DEFAULT)
+                    .setNewRole(MemberRole.DEFAULT.toGrpc())
                     .build(),
             )
 
             val members = projectMemberService.getProjectMembers(project.id)
-            val demotedMember = members.membersList.find { it.user.id == otherUser.id.toString() }
-            assertEquals(MemberRole.MEMBER_ROLE_DEFAULT, demotedMember?.role)
+            val demotedMember = members.first { it.user.id == otherUser.id }
+            assertEquals(MemberRole.DEFAULT, demotedMember.projectMember.role)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -19,7 +19,6 @@ import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperRespons
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class ProjectPaperIntegrationTest : IntegrationTest() {
     private suspend fun reviewPaper(projectPaper: ProjectPaperResponse, decision: ReviewDecision) =
@@ -87,12 +86,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
             val added = addToProject(project, createPaper())
 
-            val fetched = projectPaperService.getProjectPaperByRelativeId(
-                GrpcProjectPaper.Get.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setRelativeProjectPaperId(added.localPaperId.toString())
-                    .build(),
-            )
+            val fetched = projectPaperService.getProjectPaperByRelativeId(project.id, added.localPaperId)
 
             assertEquals(added.id, fetched.id)
         }
@@ -103,18 +97,8 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             val ppA = addToProject(project, createPaper("A"))
             val ppB = addToProject(project, createPaper("B"))
 
-            val fetchedA = projectPaperService.getProjectPaperByRelativeId(
-                GrpcProjectPaper.Get.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setRelativeProjectPaperId(ppA.localPaperId.toString())
-                    .build(),
-            )
-            val fetchedB = projectPaperService.getProjectPaperByRelativeId(
-                GrpcProjectPaper.Get.newBuilder()
-                    .setProjectId(project.id.toString())
-                    .setRelativeProjectPaperId(ppB.localPaperId.toString())
-                    .build(),
-            )
+            val fetchedA = projectPaperService.getProjectPaperByRelativeId(project.id, ppA.localPaperId)
+            val fetchedB = projectPaperService.getProjectPaperByRelativeId(project.id, ppB.localPaperId)
 
             assertEquals(ppA.id, fetchedA.id)
             assertEquals(ppB.id, fetchedB.id)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -61,13 +61,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             val paper = createPaper()
 
             assertThrows<StageOutOfRangeException> {
-                projectPaperService.addPaperToProject(
-                    GrpcProjectPaper.Add.newBuilder()
-                        .setProjectId(project.id.toString())
-                        .setPaperId(paper.id.toString())
-                        .setStage(1) // maxStage is 0 by default
-                        .build(),
-                )
+                projectPaperService.addPaperToProject(project.id, paper.id, 1) // maxStage is 0 by default
             }
         }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
@@ -16,17 +15,17 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedCreate
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
-import se.uulm.snowballr.backend.model.parseUUID
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class ProjectPaperIntegrationTest : IntegrationTest() {
-    private suspend fun reviewPaper(projectPaper: GrpcProjectPaper, decision: ReviewDecision) =
+    private suspend fun reviewPaper(projectPaper: ProjectPaperResponse, decision: ReviewDecision) =
         reviewService.createReview(
             CreateReviewRequest(
-                projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                projectPaperId = projectPaper.id,
                 decision = decision,
                 selectedCriteriaIds = emptyList(),
             ),
@@ -97,7 +96,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             val fetched = projectPaperService.getProjectPaperByRelativeId(
                 GrpcProjectPaper.Get.newBuilder()
                     .setProjectId(project.id.toString())
-                    .setRelativeProjectPaperId(added.localId)
+                    .setRelativeProjectPaperId(added.localPaperId.toString())
                     .build(),
             )
 
@@ -113,13 +112,13 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             val fetchedA = projectPaperService.getProjectPaperByRelativeId(
                 GrpcProjectPaper.Get.newBuilder()
                     .setProjectId(project.id.toString())
-                    .setRelativeProjectPaperId(ppA.localId)
+                    .setRelativeProjectPaperId(ppA.localPaperId.toString())
                     .build(),
             )
             val fetchedB = projectPaperService.getProjectPaperByRelativeId(
                 GrpcProjectPaper.Get.newBuilder()
                     .setProjectId(project.id.toString())
-                    .setRelativeProjectPaperId(ppB.localId)
+                    .setRelativeProjectPaperId(ppB.localPaperId.toString())
                     .build(),
             )
 
@@ -136,7 +135,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
 
             val toReview = projectPaperService.getPapersToReviewForProject(project.id)
 
-            assertTrue(toReview.projectPapersList.isEmpty())
+            assertTrue(toReview.isEmpty())
         }
 
         @Test
@@ -146,7 +145,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
 
             val toReview = projectPaperService.getPapersToReviewForProject(project.id)
 
-            assertTrue(toReview.projectPapersList.any { it.id == pp.id })
+            assertTrue(toReview.any { it.id == pp.id })
         }
 
         @Test
@@ -158,7 +157,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
 
             val toReview = projectPaperService.getPapersToReviewForProject(project.id)
 
-            assertFalse(toReview.projectPapersList.any { it.id == pp.id })
+            assertFalse(toReview.any { it.id == pp.id })
         }
 
         @Test
@@ -178,7 +177,7 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
 
                 val toReview = projectPaperService.getPapersToReviewForProject(project.id)
 
-                assertFalse(toReview.projectPapersList.any { it.id == pp.id })
+                assertFalse(toReview.any { it.id == pp.id })
             }
 
         @Test
@@ -192,8 +191,8 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
 
                 val toReview = projectPaperService.getPapersToReviewForProject(project.id)
 
-                assertFalse(toReview.projectPapersList.any { it.id == ppA.id })
-                assertTrue(toReview.projectPapersList.any { it.id == ppB.id })
+                assertFalse(toReview.any { it.id == ppA.id })
+                assertTrue(toReview.any { it.id == ppB.id })
             }
     }
 
@@ -206,9 +205,8 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
                 val ppA = addToProject(project, createPaper("A"))
                 val ppB = addToProject(project, createPaper("B"))
                 addToProject(project, createPaper("C"))
-                val ppAId = parseUUID(ppA.id, EntityType.PROJECT_PAPER)
 
-                val next = projectPaperService.getNextPaper(ppAId)
+                val next = projectPaperService.getNextPaper(ppA.id)
 
                 assertEquals(ppB.id, next.id)
             }
@@ -220,9 +218,8 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
                 addToProject(project, createPaper("A"))
                 val ppB = addToProject(project, createPaper("B"))
                 val ppC = addToProject(project, createPaper("C"))
-                val ppCId = parseUUID(ppC.id, EntityType.PROJECT_PAPER)
 
-                val previous = projectPaperService.getPreviousPaper(ppCId)
+                val previous = projectPaperService.getPreviousPaper(ppC.id)
 
                 assertEquals(ppB.id, previous.id)
             }
@@ -231,18 +228,16 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
         fun `When there is no next paper, then getNextPaper throws a FailedPreconditionException`() = runTest {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
             val ppA = addToProject(project, createPaper())
-            val ppAId = parseUUID(ppA.id, EntityType.PROJECT_PAPER)
 
-            assertThrows<FailedPreconditionException> { projectPaperService.getNextPaper(ppAId) }
+            assertThrows<FailedPreconditionException> { projectPaperService.getNextPaper(ppA.id) }
         }
 
         @Test
         fun `When there is no previous paper, then getPreviousPaper throws a FailedPreconditionException`() = runTest {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
             val ppA = addToProject(project, createPaper())
-            val ppAId = parseUUID(ppA.id, EntityType.PROJECT_PAPER)
 
-            assertThrows<FailedPreconditionException> { projectPaperService.getPreviousPaper(ppAId) }
+            assertThrows<FailedPreconditionException> { projectPaperService.getPreviousPaper(ppA.id) }
         }
     }
 
@@ -253,9 +248,8 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
             val ppA = addToProject(project, createPaper("A"))
             val ppB = addToProject(project, createPaper("B"))
-            val ppAId = parseUUID(ppA.id, EntityType.PROJECT_PAPER)
 
-            val next = projectPaperService.getNextPaperToReview(ppAId)
+            val next = projectPaperService.getNextPaperToReview(ppA.id)
 
             assertEquals(ppB.id, next.id)
         }
@@ -265,9 +259,8 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             runTest {
                 val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
                 val ppA = addToProject(project, createPaper())
-                val ppAId = parseUUID(ppA.id, EntityType.PROJECT_PAPER)
 
-                assertThrows<FailedPreconditionException> { projectPaperService.getNextPaperToReview(ppAId) }
+                assertThrows<FailedPreconditionException> { projectPaperService.getNextPaperToReview(ppA.id) }
             }
 
         @Test
@@ -276,11 +269,10 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
                 val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
                 val ppA = addToProject(project, createPaper("A"))
                 val ppB = addToProject(project, createPaper("B"))
-                val ppAId = parseUUID(ppA.id, EntityType.PROJECT_PAPER)
 
                 reviewPaper(ppB, ReviewDecision.ACCEPTED)
 
-                assertThrows<FailedPreconditionException> { projectPaperService.getNextPaperToReview(ppAId) }
+                assertThrows<FailedPreconditionException> { projectPaperService.getNextPaperToReview(ppA.id) }
             }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -5,21 +5,20 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.project.Project
+import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
-import se.uulm.snowballr.backend.model.parseUUID
-import snowballr.ProjectOuterClass.PaperDecision
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class ReviewIntegrationTest : IntegrationTest() {
-    private suspend fun setupProjectAndPaper(): Pair<Project, GrpcProjectPaper> {
+    private suspend fun setupProjectAndPaper(): Pair<Project, ProjectPaperResponse> {
         var project = projectService.createProject(CreateProjectRequest(name = "Review Test Project"))
         val paper = createPaper()
         val projectPaper = projectPaperService.addPaperToProject(
@@ -50,17 +49,16 @@ class ReviewIntegrationTest : IntegrationTest() {
         @Test
         fun `When a review is created, then it appears in the reviews list for the project paper`() = runTest {
             val (_, projectPaper) = setupProjectAndPaper()
-            val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
             reviewService.createReview(
                 CreateReviewRequest(
-                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    projectPaperId = projectPaper.id,
                     decision = ReviewDecision.ACCEPTED,
                     selectedCriteriaIds = emptyList(),
                 ),
             )
 
-            val reviews = reviewService.getAllReviewsForProjectPaper(projectPaperId)
+            val reviews = reviewService.getAllReviewsForProjectPaper(projectPaper.id)
             assertTrue(reviews.isNotEmpty())
         }
 
@@ -70,7 +68,7 @@ class ReviewIntegrationTest : IntegrationTest() {
 
             val review = reviewService.createReview(
                 CreateReviewRequest(
-                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    projectPaperId = projectPaper.id,
                     decision = ReviewDecision.DECLINED,
                     selectedCriteriaIds = emptyList(),
                 ),
@@ -85,44 +83,41 @@ class ReviewIntegrationTest : IntegrationTest() {
         @Test
         fun `When an accepted review is created, then the paper decision is updated to accepted`() = runTest {
             val (_, projectPaper) = setupProjectAndPaper()
-            val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
             reviewService.createReview(
                 CreateReviewRequest(
-                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    projectPaperId = projectPaper.id,
                     decision = ReviewDecision.ACCEPTED,
                     selectedCriteriaIds = emptyList(),
                 ),
             )
 
-            val updatedProjectPaper = projectPaperService.getProjectPaperById(projectPaperId)
-            assertEquals(PaperDecision.PAPER_DECISION_ACCEPTED, updatedProjectPaper.decision)
+            val updatedProjectPaper = projectPaperService.getProjectPaperById(projectPaper.id)
+            assertEquals(PaperDecision.ACCEPTED, updatedProjectPaper.decision)
         }
 
         @Test
         fun `When a declined review is created, then the paper decision is updated to declined`() = runTest {
             val (_, projectPaper) = setupProjectAndPaper()
-            val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
             reviewService.createReview(
                 CreateReviewRequest(
-                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    projectPaperId = projectPaper.id,
                     decision = ReviewDecision.DECLINED,
                     selectedCriteriaIds = emptyList(),
                 ),
             )
 
-            val updatedProjectPaper = projectPaperService.getProjectPaperById(projectPaperId)
-            assertEquals(PaperDecision.PAPER_DECISION_DECLINED, updatedProjectPaper.decision)
+            val updatedProjectPaper = projectPaperService.getProjectPaperById(projectPaper.id)
+            assertEquals(PaperDecision.DECLINED, updatedProjectPaper.decision)
         }
 
         @Test
         fun `When a paper is added to a project, then it initially has an unreviewed decision`() = runTest {
             val (_, projectPaper) = setupProjectAndPaper()
-            val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
-            val fetchedProjectPaper = projectPaperService.getProjectPaperById(projectPaperId)
-            assertEquals(PaperDecision.PAPER_DECISION_UNREVIEWED, fetchedProjectPaper.decision)
+            val fetchedProjectPaper = projectPaperService.getProjectPaperById(projectPaper.id)
+            assertEquals(PaperDecision.UNREVIEWED, fetchedProjectPaper.decision)
         }
 
         @Test
@@ -131,7 +126,7 @@ class ReviewIntegrationTest : IntegrationTest() {
 
             reviewService.createReview(
                 CreateReviewRequest(
-                    projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER),
+                    projectPaperId = projectPaper.id,
                     decision = ReviewDecision.ACCEPTED,
                     selectedCriteriaIds = emptyList(),
                 ),
@@ -154,15 +149,14 @@ class ReviewIntegrationTest : IntegrationTest() {
 
             val papers = projectPaperService.getAllProjectPapersForProject(project.id)
 
-            assertTrue(papers.projectPapersList.any { it.id == projectPaper.id })
+            assertTrue(papers.any { it.id == projectPaper.id })
         }
 
         @Test
         fun `When a paper is added to a project, then it can be retrieved by its project paper ID`() = runTest {
             val (_, projectPaper) = setupProjectAndPaper()
-            val projectPaperId = parseUUID(projectPaper.id, EntityType.PROJECT_PAPER)
 
-            val fetched = projectPaperService.getProjectPaperById(projectPaperId)
+            val fetched = projectPaperService.getProjectPaperById(projectPaper.id)
             assertEquals(projectPaper.id, fetched.id)
         }
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -15,19 +15,12 @@ import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class ReviewIntegrationTest : IntegrationTest() {
     private suspend fun setupProjectAndPaper(): Pair<Project, ProjectPaperResponse> {
         var project = projectService.createProject(CreateProjectRequest(name = "Review Test Project"))
         val paper = createPaper()
-        val projectPaper = projectPaperService.addPaperToProject(
-            GrpcProjectPaper.Add.newBuilder()
-                .setProjectId(project.id.toString())
-                .setPaperId(paper.id.toString())
-                .setStage(0)
-                .build(),
-        )
+        val projectPaper = projectPaperService.addPaperToProject(project.id, paper.id, 0)
 
         val modifiedProject = project.copy(
             reviewDecisionMatrix = project.reviewDecisionMatrix.copy(

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/ProjectPaperTableRepoTest.kt
@@ -25,7 +25,6 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.association.ProjectPaperTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.ProjectOuterClass.Project
 import java.util.UUID
 import kotlin.random.Random
 
@@ -341,13 +340,8 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             runTest {
                 val paperId = insertPaperAndGetId()
                 val projectId = insertProjectAndGetId(createdBy = testUserId)
-                val request = Project.Paper.Add.newBuilder()
-                    .setPaperId(paperId.toString())
-                    .setProjectId(projectId.toString())
-                    .setStage(0)
-                    .build()
 
-                val projectPaper = repo.addPaperToProject(request, testUserId)
+                val projectPaper = repo.addPaperToProject(projectId, paperId, 0, testUserId)
 
                 assertEquals(paperId, projectPaper.paperId)
                 assertEquals(projectId, projectPaper.projectId)
@@ -362,21 +356,10 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             runTest {
                 val paperId1 = insertPaperAndGetId()
                 val projectId = insertProjectAndGetId(createdBy = testUserId)
-                val request1 = Project.Paper.Add.newBuilder()
-                    .setPaperId(paperId1.toString())
-                    .setProjectId(projectId.toString())
-                    .setStage(0)
-                    .build()
-
                 val paperId2 = insertPaperAndGetId()
-                val request2 = Project.Paper.Add.newBuilder()
-                    .setPaperId(paperId2.toString())
-                    .setProjectId(projectId.toString())
-                    .setStage(0)
-                    .build()
 
-                repo.addPaperToProject(request1, testUserId)
-                val projectPaper2 = repo.addPaperToProject(request2, testUserId)
+                repo.addPaperToProject(projectId, paperId1, 0, testUserId)
+                val projectPaper2 = repo.addPaperToProject(projectId, paperId2, 0, testUserId)
 
                 assertEquals(1, projectPaper2.localPaperId)
             }
@@ -386,22 +369,12 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
             runTest {
                 val paperId1 = insertPaperAndGetId()
                 val projectId1 = insertProjectAndGetId(createdBy = testUserId)
-                val request1 = Project.Paper.Add.newBuilder()
-                    .setPaperId(paperId1.toString())
-                    .setProjectId(projectId1.toString())
-                    .setStage(0)
-                    .build()
 
                 val paperId2 = insertPaperAndGetId()
                 val projectId2 = insertProjectAndGetId(createdBy = testUserId)
-                val request2 = Project.Paper.Add.newBuilder()
-                    .setPaperId(paperId2.toString())
-                    .setProjectId(projectId2.toString())
-                    .setStage(0)
-                    .build()
 
-                val projectPaper1 = repo.addPaperToProject(request1, testUserId)
-                val projectPaper2 = repo.addPaperToProject(request2, testUserId)
+                val projectPaper1 = repo.addPaperToProject(projectId1, paperId1, 0, testUserId)
+                val projectPaper2 = repo.addPaperToProject(projectId2, paperId2, 0, testUserId)
 
                 assertEquals(0, projectPaper1.localPaperId)
                 assertEquals(0, projectPaper2.localPaperId)
@@ -428,13 +401,8 @@ class ProjectPaperTableRepoTest : RepositoryTest(arrayOf(ProjectPaperTable, Proj
                 )
 
                 val paperIdToAdd = insertPaperAndGetId()
-                val request = Project.Paper.Add.newBuilder()
-                    .setPaperId(paperIdToAdd.toString())
-                    .setProjectId(projectId.toString())
-                    .setStage(0)
-                    .build()
 
-                val projectPaper = repo.addPaperToProject(request, testUserId)
+                val projectPaper = repo.addPaperToProject(projectId, paperIdToAdd, 0, testUserId)
 
                 assertEquals(6, projectPaper.localPaperId)
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchFetcherProjectPaperCandidatesTest.kt
@@ -13,13 +13,8 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.exception.FetcherException
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
-    fun getExampleRequest(project: Project): GrpcProjectPaper.SearchQuery = GrpcProjectPaper.SearchQuery.newBuilder()
-        .setProjectId(project.id.toString())
-        .build()
-
     @Test
     fun `When a user searches papers and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
@@ -35,18 +30,16 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         val barPaper = DataBuilder.createExamplePaper(externalId = "barId")
         val barFetcherPaper = barPaper.toFetcherPaper()
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-        coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
-        coEvery { fetcherManagerMock.searchPapers("bar", request.query, any()) } returns setOf(barFetcherPaper)
+        coEvery { fetcherManagerMock.searchPapers("foo", "exampleQuery", any()) } returns setOf(fooFetcherPaper)
+        coEvery { fetcherManagerMock.searchPapers("bar", "exampleQuery", any()) } returns setOf(barFetcherPaper)
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId", "barId")) } returns listOf(fooPaper, barPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, barPaper.id) } returns false
 
-        val papers = service.searchFetcherProjectPaperCandidates(request)
+        val papers = service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery")
 
         assertEquals(2, papers.size)
         assertTrue(papers.any { p -> p.id == fooPaper.id })
@@ -58,12 +51,10 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.searchFetcherProjectPaperCandidates(request) }
+        assertThrows<TestSpecificException> { service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery") }
     }
 
     @Test
@@ -72,13 +63,11 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         val project = DataBuilder.createExampleProject()
         val projectResult = Result.failure<Project>(TestSpecificException())
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
 
-        assertThrows<TestSpecificException> { service.searchFetcherProjectPaperCandidates(request) }
+        assertThrows<TestSpecificException> { service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery") }
     }
 
     @Test
@@ -94,19 +83,17 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
         val fooFetcherPaper = fooPaper.toFetcherPaper()
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-        coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
+        coEvery { fetcherManagerMock.searchPapers("foo", "exampleQuery", any()) } returns setOf(fooFetcherPaper)
         coEvery {
-            fetcherManagerMock.searchPapers("bar", request.query, any())
+            fetcherManagerMock.searchPapers("bar", "exampleQuery", any())
         } throws FetcherException("Failed to search bar papers")
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
 
-        val papers = service.searchFetcherProjectPaperCandidates(request)
+        val papers = service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery")
 
         assertEquals(1, papers.size)
         assertEquals(fooPaper.id, papers[0].id)
@@ -120,16 +107,14 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
         val fooFetcherPaper = fooPaper.toFetcherPaper()
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-        coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
+        coEvery { fetcherManagerMock.searchPapers("foo", "exampleQuery", any()) } returns setOf(fooFetcherPaper)
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns true
 
-        val papers = service.searchFetcherProjectPaperCandidates(request)
+        val papers = service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery")
 
         assertEquals(0, papers.size)
     }
@@ -142,15 +127,13 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
         val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
         val fooFetcherPaper = fooPaper.toFetcherPaper()
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-        coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
+        coEvery { fetcherManagerMock.searchPapers("foo", "exampleQuery", any()) } returns setOf(fooFetcherPaper)
         coEvery { paperRepoMock.getPapersByExternalIds(listOf("fooId")) } returns emptyList()
 
-        val papers = service.searchFetcherProjectPaperCandidates(request)
+        val papers = service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery")
 
         assertEquals(1, papers.size)
         assertEquals(fooPaper.title, papers[0].title)
@@ -167,15 +150,13 @@ class SearchFetcherProjectPaperCandidatesTest : FetcherServiceTest() {
             val fooPaper = DataBuilder.createExamplePaper(externalId = null)
             val fooFetcherPaper = fooPaper.toFetcherPaper()
 
-            val request = getExampleRequest(project)
-
             mockCurrentUser(user)
             coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
             coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
-            coEvery { fetcherManagerMock.searchPapers("foo", request.query, any()) } returns setOf(fooFetcherPaper)
+            coEvery { fetcherManagerMock.searchPapers("foo", "exampleQuery", any()) } returns setOf(fooFetcherPaper)
             coEvery { paperRepoMock.getPapersByExternalIds(emptyList()) } returns emptyList()
 
-            val papers = service.searchFetcherProjectPaperCandidates(request)
+            val papers = service.searchFetcherProjectPaperCandidates(project.id, "exampleQuery")
 
             assertEquals(1, papers.size)
             assertEquals(fooPaper.title, papers[0].title)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
@@ -7,16 +7,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import se.uulm.snowballr.backend.model.dto.project.Project
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
-    fun getExampleRequest(project: Project): GrpcProjectPaper.SearchQuery = GrpcProjectPaper.SearchQuery.newBuilder()
-        .setProjectId(project.id.toString())
-        .build()
-
     @Test
     fun `When a user searches papers and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
@@ -24,15 +18,13 @@ class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
         val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
         val barPaper = DataBuilder.createExamplePaper(externalId = "barId")
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
-        coEvery { paperRepoMock.getPapersBySearchQuery(request.query) } returns listOf(fooPaper, barPaper)
+        coEvery { paperRepoMock.getPapersBySearchQuery("foo") } returns listOf(fooPaper, barPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns false
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, barPaper.id) } returns false
 
-        val papers = service.searchLocalProjectPaperCandidates(request)
+        val papers = service.searchLocalProjectPaperCandidates(project.id, "foo")
 
         assertEquals(2, papers.size)
         assertTrue(papers.any { p -> p.id == fooPaper.id })
@@ -44,12 +36,10 @@ class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
         val user = DataBuilder.createExampleUser()
         val project = DataBuilder.createExampleProject()
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.searchLocalProjectPaperCandidates(request) }
+        assertThrows<TestSpecificException> { service.searchLocalProjectPaperCandidates(project.id, "foo") }
     }
 
     @Test
@@ -58,14 +48,12 @@ class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
         val project = DataBuilder.createExampleProject()
         val fooPaper = DataBuilder.createExamplePaper(externalId = "fooId")
 
-        val request = getExampleRequest(project)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
-        coEvery { paperRepoMock.getPapersBySearchQuery(request.query) } returns listOf(fooPaper)
+        coEvery { paperRepoMock.getPapersBySearchQuery("foo") } returns listOf(fooPaper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, fooPaper.id) } returns true
 
-        val papers = service.searchLocalProjectPaperCandidates(request)
+        val papers = service.searchLocalProjectPaperCandidates(project.id, "foo")
 
         assertEquals(0, papers.size)
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/AcceptProjectInvitationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/AcceptProjectInvitationTest.kt
@@ -15,17 +15,15 @@ import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.notfound.InvitationTokenNotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
 import java.time.OffsetDateTime
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class AcceptProjectInvitationTest : InvitationServiceTest() {
     @Test
     fun `When the invitation token is not found, then a InvitationTokenNotFoundException is thrown`() = runTest {
-        val request = GrpcProjectMember.Accept.newBuilder().setToken("non-existent-token").build()
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(any()) } returns Result.failure(
             InvitationTokenNotFoundException(),
         )
 
-        assertThrows<InvitationTokenNotFoundException> { service.acceptProjectInvitation(request) }
+        assertThrows<InvitationTokenNotFoundException> { service.acceptProjectInvitation("non-existent-token") }
     }
 
     @Test
@@ -33,52 +31,48 @@ class AcceptProjectInvitationTest : InvitationServiceTest() {
         val expiredToken = DataBuilder.createExampleInvitationToken(
             expiresAt = OffsetDateTime.now().minusDays(1),
         )
-        val request = GrpcProjectMember.Accept.newBuilder().setToken(expiredToken.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(expiredToken.token) } returns Result.success(
             expiredToken,
         )
         coJustRun { invitationTokenRepoMock.deleteInvitationToken(expiredToken.token) }
 
-        assertThrows<InvitationTokenNotFoundException> { service.acceptProjectInvitation(request) }
+        assertThrows<InvitationTokenNotFoundException> { service.acceptProjectInvitation(expiredToken.token) }
     }
 
     @Test
     fun `When the user associated with the token is not registered, then a FailedPreconditionException is thrown`() =
         runTest {
             val token = DataBuilder.createExampleInvitationToken()
-            val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
             coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
             coEvery { userRepoMock.getUserByEmail(token.email) } returns
                 Result.failure(UserNotFoundByEmailException(token.email))
 
-            assertThrows<FailedPreconditionException> { service.acceptProjectInvitation(request) }
+            assertThrows<FailedPreconditionException> { service.acceptProjectInvitation(token.token) }
         }
 
     @Test
     fun `When the user has not verified their email, then a FailedPreconditionException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(status = UserStatus.ACTIVE_UNCONFIRMED)
         val token = DataBuilder.createExampleInvitationToken(email = user.email)
-        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
 
-        assertThrows<FailedPreconditionException> { service.acceptProjectInvitation(request) }
+        assertThrows<FailedPreconditionException> { service.acceptProjectInvitation(token.token) }
     }
 
     @Test
     fun `When adding the user to the project fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(status = UserStatus.ACTIVE)
         val token = DataBuilder.createExampleInvitationToken(email = user.email)
-        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
         coEvery { projectMemberRepoMock.addUserToProject(user.id, token.projectId) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.acceptProjectInvitation(request) }
+        assertThrows<TestSpecificException> { service.acceptProjectInvitation(token.token) }
     }
 
     @Test
@@ -92,14 +86,13 @@ class AcceptProjectInvitationTest : InvitationServiceTest() {
             createdAt = OffsetDateTime.now(),
             modifiedAt = null,
         )
-        val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
         coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
         coEvery { projectMemberRepoMock.addUserToProject(user.id, token.projectId) } returns userMember
         coEvery { invitationTokenRepoMock.deleteInvitationToken(token.token) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.acceptProjectInvitation(request) }
+        assertThrows<TestSpecificException> { service.acceptProjectInvitation(token.token) }
     }
 
     @Test
@@ -114,14 +107,13 @@ class AcceptProjectInvitationTest : InvitationServiceTest() {
                 createdAt = OffsetDateTime.now(),
                 modifiedAt = null,
             )
-            val request = GrpcProjectMember.Accept.newBuilder().setToken(token.token).build()
 
             coEvery { invitationTokenRepoMock.getInvitationTokenByValue(token.token) } returns Result.success(token)
             coEvery { userRepoMock.getUserByEmail(token.email) } returns Result.success(user)
             coEvery { projectMemberRepoMock.addUserToProject(user.id, token.projectId) } returns userMember
             coJustRun { invitationTokenRepoMock.deleteInvitationToken(token.token) }
 
-            service.acceptProjectInvitation(request)
+            service.acceptProjectInvitation(token.token)
 
             coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationToken(token.token) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
@@ -54,6 +54,18 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
     }
 
     @Test
+    fun `When a null project ID is passed, then project members and invitation are not excluded from the candidates`() =
+        runTest {
+            mockGetInviteCandidates(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
+            coEvery { userRepoMock.getUsersMatchingSearchQuery(searchQuery, any()) } returns emptyList()
+
+            service.getInviteCandidates(null, searchQuery)
+
+            coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembersWithUsers(any()) }
+            coVerify(exactly = 0) { invitationTokenRepoMock.getActiveInvitationTokensForProject(any()) }
+        }
+
+    @Test
     fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
         mockGetInviteCandidates()
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.assertNull
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
 import se.uulm.snowballr.backend.model.dto.user.User
-import snowballr.ProjectOuterClass.Project.InviteCandidatesRequest
 import java.util.UUID
 import kotlin.reflect.KFunction
 
@@ -17,9 +16,6 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
     private val requestingUserEmail = "test.user@example.com"
     private val searchQuery = "john"
     private val projectId = UUID.randomUUID()
-    private val validGetInviteCandidatesRequestBuilder = InviteCandidatesRequest.newBuilder()
-        .setQuery(searchQuery)
-        .setProjectId(projectId.toString())
 
     private fun mockGetInviteCandidates(
         projectMembers: List<User> = emptyList(),
@@ -53,31 +49,15 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
     fun `When the search query is too short, then an empty list is returned`() = runTest {
         mockGetInviteCandidates(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
 
-        val shortGetInviteCandidatesRequest = validGetInviteCandidatesRequestBuilder.setQuery("jo")
-
-        val candidates = service.getInviteCandidates(shortGetInviteCandidatesRequest.build())
+        val candidates = service.getInviteCandidates(projectId, "jo")
         assertThat(candidates).isEmpty()
-    }
-
-    @Test
-    fun `When parsing the project id fails, then only a warning is logged`() = runTest {
-        mockGetInviteCandidates(stopBefore = projectMemberRepoMock::getProjectMembersWithUsers)
-        coEvery {
-            userRepoMock.getUsersMatchingSearchQuery(searchQuery, any())
-        } returns emptyList()
-
-        val requestWithInvalidProjectId = validGetInviteCandidatesRequestBuilder.setProjectId("invalid-uuid")
-
-        service.getInviteCandidates(requestWithInvalidProjectId.build())
-        coVerify(exactly = 0) { projectMemberRepoMock.getProjectMembersWithUsers(any()) }
-        coVerify(exactly = 0) { invitationTokenRepoMock.getActiveInvitationTokensForProject(any()) }
     }
 
     @Test
     fun `When no project members exist, then no users except for the current user are excluded`() = runTest {
         mockGetInviteCandidates()
 
-        service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
+        service.getInviteCandidates(projectId, searchQuery)
         coVerify(exactly = 1) { userRepoMock.getUsersMatchingSearchQuery(searchQuery, setOf(requestingUserEmail)) }
     }
 
@@ -86,7 +66,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
         runTest {
             mockGetInviteCandidates()
 
-            val inviteCandidates = service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
+            val inviteCandidates = service.getInviteCandidates(projectId, searchQuery)
             assertThat(inviteCandidates).hasSize(1)
             assertNull(inviteCandidates.find { it.email == requestingUserEmail })
         }
@@ -97,7 +77,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
             val projectMember = DataBuilder.createExampleUser(email = "project.member@example.com")
             mockGetInviteCandidates(projectMembers = listOf(projectMember))
 
-            val inviteCandidates = service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
+            val inviteCandidates = service.getInviteCandidates(projectId, searchQuery)
             assertNull(inviteCandidates.find { it.email == projectMember.email })
         }
 
@@ -107,7 +87,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
             val invitee = DataBuilder.createExampleUser(email = "invited.user@example.com")
             mockGetInviteCandidates(invitees = listOf(invitee))
 
-            val inviteCandidates = service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
+            val inviteCandidates = service.getInviteCandidates(projectId, searchQuery)
             assertNull(inviteCandidates.find { it.email == invitee.email })
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetInviteCandidatesTest.kt
@@ -56,7 +56,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
         val shortGetInviteCandidatesRequest = validGetInviteCandidatesRequestBuilder.setQuery("jo")
 
         val candidates = service.getInviteCandidates(shortGetInviteCandidatesRequest.build())
-        assertThat(candidates.usersList).isEmpty()
+        assertThat(candidates).isEmpty()
     }
 
     @Test
@@ -87,8 +87,8 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
             mockGetInviteCandidates()
 
             val inviteCandidates = service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
-            assertThat(inviteCandidates.usersList).hasSize(1)
-            assertNull(inviteCandidates.usersList.find { it.email == requestingUserEmail })
+            assertThat(inviteCandidates).hasSize(1)
+            assertNull(inviteCandidates.find { it.email == requestingUserEmail })
         }
 
     @Test
@@ -98,7 +98,7 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
             mockGetInviteCandidates(projectMembers = listOf(projectMember))
 
             val inviteCandidates = service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
-            assertNull(inviteCandidates.usersList.find { it.email == projectMember.email })
+            assertNull(inviteCandidates.find { it.email == projectMember.email })
         }
 
     @Test
@@ -108,6 +108,6 @@ class GetInviteCandidatesTest : InvitationServiceTest() {
             mockGetInviteCandidates(invitees = listOf(invitee))
 
             val inviteCandidates = service.getInviteCandidates(validGetInviteCandidatesRequestBuilder.build())
-            assertNull(inviteCandidates.usersList.find { it.email == invitee.email })
+            assertNull(inviteCandidates.find { it.email == invitee.email })
         }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetPendingInvitationsForProjectTest.kt
@@ -12,7 +12,6 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
-import snowballr.UserOuterClass
 
 class GetPendingInvitationsForProjectTest : InvitationServiceTest() {
     @Test
@@ -38,8 +37,8 @@ class GetPendingInvitationsForProjectTest : InvitationServiceTest() {
 
             val result = service.getPendingInvitationsForProject(project.id)
 
-            assertEquals(1, result.usersCount)
-            val resultElement = result.usersList.first()
+            assertEquals(1, result.size)
+            val resultElement = result.first()
             assertEquals(registeredUser.email, resultElement.email)
         }
 
@@ -74,20 +73,20 @@ class GetPendingInvitationsForProjectTest : InvitationServiceTest() {
 
             val pendingInvitations = service.getPendingInvitationsForProject(project.id)
 
-            val invitationForRegisteredUser = pendingInvitations.usersList.find { it.email == registeredUser.email }
-            val invitationForNotRegisteredUser = pendingInvitations.usersList.find { it.email == notRegisteredEmail }
-            assertEquals(2, pendingInvitations.usersList.size)
+            val invitationForRegisteredUser = pendingInvitations.find { it.email == registeredUser.email }
+            val invitationForNotRegisteredUser = pendingInvitations.find { it.email == notRegisteredEmail }
+            assertEquals(2, pendingInvitations.size)
             assertNotNull(invitationForRegisteredUser)
             assertNotNull(invitationForNotRegisteredUser)
 
             // Registered user should have user details
-            assertEquals(registeredUser.id.toString(), invitationForRegisteredUser?.id)
-            assertEquals(UserOuterClass.UserStatus.USER_STATUS_ACTIVE, invitationForRegisteredUser?.status)
+            assertEquals(registeredUser.id, invitationForRegisteredUser?.userId)
+            assertEquals(UserStatus.ACTIVE, invitationForRegisteredUser?.status)
             assertEquals(registeredUser.firstName, invitationForRegisteredUser?.firstName)
 
             // Not registered user should not have user details
-            assertEquals("", invitationForNotRegisteredUser?.id)
-            assertEquals(UserOuterClass.UserStatus.USER_STATUS_UNSPECIFIED, invitationForNotRegisteredUser?.status)
+            assertEquals(null, invitationForNotRegisteredUser?.userId)
+            assertEquals(UserStatus.ACTIVE_UNCONFIRMED, invitationForNotRegisteredUser?.status)
             assertEquals("", invitationForNotRegisteredUser?.firstName)
         }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/InviteUserToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/InviteUserToProjectTest.kt
@@ -16,16 +16,12 @@ import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
-import snowballr.ProjectOuterClass
 import java.util.UUID
 import kotlin.reflect.KFunction
 
 class InviteUserToProjectTest : InvitationServiceTest() {
     private val invitedUserEmail = "invited.user@example.com"
     private val projectId = UUID.randomUUID()
-    private val validInviteUserRequest = ProjectOuterClass.Project.Member.Invite.newBuilder()
-        .setUserEmail(invitedUserEmail)
-        .setProjectId(projectId.toString())
 
     @Suppress("ReturnCount")
     private fun mockInviteUserToProject(
@@ -88,7 +84,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
             invitationAccessCheckerMock.isAllowedToInviteUserToProject(currentUser, project.id, projectResult)
         } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.inviteUserToProject(validInviteUserRequest.build()) }
+        assertThrows<TestSpecificException> { service.inviteUserToProject(projectId, invitedUserEmail) }
         coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
     }
 
@@ -104,7 +100,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
             invitationAccessCheckerMock.isAllowedToInviteUserToProject(currentUser, project.id, projectResult)
         }
 
-        assertThrows<TestSpecificException> { service.inviteUserToProject(validInviteUserRequest.build()) }
+        assertThrows<TestSpecificException> { service.inviteUserToProject(projectId, invitedUserEmail) }
         coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
     }
 
@@ -116,7 +112,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
             invitationTokenRepoMock.getInvitationTokenByEmailAndProjectId(invitedUserEmail, projectId)
         } returns Result.success(invitationToken)
 
-        service.inviteUserToProject(validInviteUserRequest.build())
+        service.inviteUserToProject(projectId, invitedUserEmail)
 
         coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(any(), any(), any()) }
     }
@@ -128,7 +124,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
             invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, any())
         } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.inviteUserToProject(validInviteUserRequest.build()) }
+        assertThrows<TestSpecificException> { service.inviteUserToProject(projectId, invitedUserEmail) }
         coVerify(exactly = 0) { emailManagerMock.sendAcceptProjectInvitationEmail(any(), any()) }
     }
 
@@ -139,7 +135,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
             emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, any())
         } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.inviteUserToProject(validInviteUserRequest.build()) }
+        assertThrows<TestSpecificException> { service.inviteUserToProject(projectId, invitedUserEmail) }
     }
 
     @Test
@@ -157,7 +153,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
         every { envReaderMock.env.lifetime.invitationTokenLifeTimeInDays } returns 30
         coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(invitedUserEmail, capture(emailDataSlot)) }
 
-        service.inviteUserToProject(validInviteUserRequest.build())
+        service.inviteUserToProject(projectId, invitedUserEmail)
 
         val capturedToken = tokenSlot.captured
         assertThat(capturedToken).isNotBlank()
@@ -180,9 +176,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
         every { envReaderMock.env.lifetime.invitationTokenLifeTimeInDays } returns 30
         coJustRun { emailManagerMock.sendAcceptProjectInvitationEmail(any(), capture(emailDataSlot)) }
 
-        val inviteNonExistentUserRequest = validInviteUserRequest.setUserEmail(emailOfNonExistentUser)
-
-        service.inviteUserToProject(inviteNonExistentUserRequest.build())
+        service.inviteUserToProject(projectId, emailOfNonExistentUser)
 
         assertEquals("User", emailDataSlot.captured.inviteeFirstName)
     }
@@ -200,7 +194,7 @@ class InviteUserToProjectTest : InvitationServiceTest() {
                 projectMemberRepoMock.getProjectMembersWithUsers(projectId)
             } returns listOf(projectMemberWithUser)
 
-            service.inviteUserToProject(validInviteUserRequest.build())
+            service.inviteUserToProject(projectId, invitedUserEmail)
 
             coVerify(exactly = 0) { invitationTokenRepoMock.saveInvitationToken(invitedUserEmail, projectId, any()) }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -25,9 +25,9 @@ class GetProjectMembersTest : ProjectMemberServiceTest() {
 
         val projectMembers = service.getProjectMembers(project.id)
 
-        assertEquals(1, projectMembers.membersCount)
-        val actualProjectMember = projectMembers.membersList.first()
-        assertEquals(projectMember.userId.toString(), actualProjectMember.user.id)
+        assertEquals(1, projectMembers.size)
+        val actualProjectMember = projectMembers.first()
+        assertEquals(projectMember.userId, actualProjectMember.user.id)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/RemoveProjectMemberTest.kt
@@ -11,15 +11,9 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectNotFoundException
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class RemoveProjectMemberTest : ProjectMemberServiceTest() {
     private val userEmail = "user@example.com"
-
-    private fun getExampleRequest(projectId: UUID = UUID.randomUUID()) = GrpcProjectMember.Remove.newBuilder()
-        .setProjectId(projectId.toString())
-        .setUserEmail(userEmail)
-        .build()
 
     @Test
     fun `When a user removes a project member, then the member is successfully deleted`() = runTest {
@@ -41,7 +35,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         coJustRun { projectAccessCheckerMock.isNotLastProjectAdmin(userToRemove, project.id, any()) }
         coJustRun { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
 
-        service.removeProjectMember(getExampleRequest(project.id))
+        service.removeProjectMember(project.id, userEmail)
 
         coVerify(exactly = 1) { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
     }
@@ -57,7 +51,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         } returns Result.failure(TestSpecificException())
         coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { service.removeProjectMember(getExampleRequest(project.id)) }
+        assertThrows<TestSpecificException> { service.removeProjectMember(project.id, userEmail) }
     }
 
     @Test
@@ -73,7 +67,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
         coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns false
 
-        service.removeProjectMember(getExampleRequest(project.id))
+        service.removeProjectMember(project.id, userEmail)
 
         coVerify(exactly = 0) { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
     }
@@ -90,16 +84,10 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         } returns Result.failure(TestSpecificException())
         coEvery { userRepoMock.getUserByEmail(userEmail) } returns Result.success(userToRemove)
         coEvery { projectMemberRepoMock.isProjectMember(project.id, userToRemove.id) } returns true
-        coJustRun {
-            projectMemberAccessCheckerMock.isAllowedToRemoveMember(
-                currentUser,
-                userToRemove.id,
-                project.id,
-            )
-        }
+        coJustRun { projectMemberAccessCheckerMock.isAllowedToRemoveMember(currentUser, userToRemove.id, project.id) }
         coEvery { projectRepoMock.doesProjectExistById(project.id) } returns false
 
-        assertThrows<ProjectNotFoundException> { service.removeProjectMember(getExampleRequest(project.id)) }
+        assertThrows<ProjectNotFoundException> { service.removeProjectMember(project.id, userEmail) }
     }
 
     @Test
@@ -121,7 +109,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         coJustRun { projectRepoMock.softDeleteProject(project.id) }
         coJustRun { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
 
-        service.removeProjectMember(getExampleRequest(project.id))
+        service.removeProjectMember(project.id, userEmail)
 
         coVerify(exactly = 1) { projectRepoMock.softDeleteProject(project.id) }
         coVerify(exactly = 1) { projectMemberRepoMock.removeProjectMember(project.id, userToRemove.id) }
@@ -140,7 +128,7 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
         coJustRun { projectMemberAccessCheckerMock.isAllowedToRemoveInvitation(currentUser, project.id) }
         coJustRun { invitationTokenRepoMock.deleteInvitationToken(invitationToken.token) }
 
-        service.removeProjectMember(getExampleRequest(project.id))
+        service.removeProjectMember(project.id, userEmail)
 
         coVerify(exactly = 1) { invitationTokenRepoMock.deleteInvitationToken(invitationToken.token) }
     }
@@ -159,6 +147,6 @@ class RemoveProjectMemberTest : ProjectMemberServiceTest() {
             projectMemberAccessCheckerMock.isAllowedToRemoveInvitation(currentUser, project.id)
         } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.removeProjectMember(getExampleRequest(project.id)) }
+        assertThrows<TestSpecificException> { service.removeProjectMember(project.id, userEmail) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/UpdateProjectMemberRoleTest.kt
@@ -12,17 +12,12 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectMemberNotFoundException
+import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
 import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Member as GrpcProjectMember
 
 class UpdateProjectMemberRoleTest : ProjectMemberServiceTest() {
     private fun getRequest(userId: UUID, projectId: UUID, newRole: MemberRole = MemberRole.ADMIN) =
-        GrpcProjectMember.Update
-            .newBuilder()
-            .setProjectId(projectId.toString())
-            .setUserId(userId.toString())
-            .setNewRole(newRole.toGrpc())
-            .build()
+        UpdateProjectMemberRoleRequest(projectId = projectId, userId = userId, newRole = newRole)
 
     @Test
     fun `When a user updates a member role, but has no access, then a TestSpecificException is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
@@ -56,20 +56,20 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
 
             val addedProjectPaper = service.addPaperToProject(request)
 
-            assertEquals(2, addedProjectPaper.reviewsCount)
-            val review0 = addedProjectPaper.getReviews(0)
-            val review1 = addedProjectPaper.getReviews(1)
-            assertEquals(review0.id, reviews[0].id.toString())
-            assertEquals(review1.id, reviews[1].id.toString())
+            assertEquals(2, addedProjectPaper.reviews.size)
+            val review0 = addedProjectPaper.reviews[0]
+            val review1 = addedProjectPaper.reviews[1]
+            assertEquals(review0.id, reviews[0].id)
+            assertEquals(review1.id, reviews[1].id)
 
-            val criteriaIdsReview0 = review0.selectedCriteriaIdsList
-            val criteriaIdsReview1 = review1.selectedCriteriaIdsList
+            val criteriaIdsReview0 = review0.selectedCriteriaIds
+            val criteriaIdsReview1 = review1.selectedCriteriaIds
             assertEquals(2, criteriaIdsReview0.size)
             assertEquals(2, criteriaIdsReview1.size)
-            assertEquals(criteriaIds0[0].toString(), criteriaIdsReview0[0].toString())
-            assertEquals(criteriaIds0[1].toString(), criteriaIdsReview0[1].toString())
-            assertEquals(criteriaIds1[0].toString(), criteriaIdsReview1[0].toString())
-            assertEquals(criteriaIds1[1].toString(), criteriaIdsReview1[1].toString())
+            assertEquals(criteriaIds0[0], criteriaIdsReview0[0])
+            assertEquals(criteriaIds0[1], criteriaIdsReview0[1])
+            assertEquals(criteriaIds1[0], criteriaIdsReview1[0])
+            assertEquals(criteriaIds1[1], criteriaIdsReview1[1])
         }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
@@ -13,16 +13,9 @@ import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateP
 import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRangeException
 import java.util.UUID
 import kotlin.test.assertEquals
-import snowballr.ProjectOuterClass.Project as GrpcProject
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AddPaperToProjectTest : ProjectPaperServiceTest() {
-    private fun getRequest(projectId: UUID, paperId: UUID, stage: Long = 0) = GrpcProject.Paper.Add.newBuilder()
-        .setProjectId(projectId.toString())
-        .setPaperId(paperId.toString())
-        .setStage(stage)
-        .build()
-
     @Test
     fun `When a user adds a paper to a project and has access, then the created project paper has the correct values`() =
         runTest {
@@ -37,14 +30,12 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
             val criteriaIds0 = listOf(UUID.randomUUID(), UUID.randomUUID())
             val criteriaIds1 = listOf(UUID.randomUUID(), UUID.randomUUID())
 
-            val request = getRequest(project.id, paper.id)
-
             mockCurrentUser(user)
             coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
             coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
             coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
             coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
-            coEvery { projectPaperRepoMock.addPaperToProject(request, user.id) } returns projectPaper
+            coEvery { projectPaperRepoMock.addPaperToProject(project.id, paper.id, 0, user.id) } returns projectPaper
             coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns backwardReferences
             coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns reviews
             coEvery {
@@ -54,7 +45,7 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
                 reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(reviews[1].id)
             } returns criteriaIds1
 
-            val addedProjectPaper = service.addPaperToProject(request)
+            val addedProjectPaper = service.addPaperToProject(project.id, paper.id, 0)
 
             assertEquals(2, addedProjectPaper.reviews.size)
             val review0 = addedProjectPaper.reviews[0]
@@ -79,15 +70,13 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
         val projectResult = Result.success(project)
         val paper = DataBuilder.createExamplePaper()
 
-        val request = getRequest(project.id, paper.id)
-
         mockCurrentUser(user)
         coEvery {
             projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult)
         } throws TestSpecificException()
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
 
-        assertThrows<TestSpecificException> { service.addPaperToProject(request) }
+        assertThrows<TestSpecificException> { service.addPaperToProject(project.id, paper.id, 0) }
     }
 
     @Test
@@ -97,13 +86,11 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
         val projectResult = Result.failure<Project>(TestSpecificException())
         val paper = DataBuilder.createExamplePaper()
 
-        val request = getRequest(project.id, paper.id)
-
         mockCurrentUser(user)
         coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
 
-        assertThrows<TestSpecificException> { service.addPaperToProject(request) }
+        assertThrows<TestSpecificException> { service.addPaperToProject(project.id, paper.id, 0) }
     }
 
     @Test
@@ -113,14 +100,12 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
         val projectResult = Result.success(project)
         val paper = DataBuilder.createExamplePaper()
 
-        val request = getRequest(project.id, paper.id)
-
         mockCurrentUser(user)
         coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { paperRepoMock.getPaperById(paper.id) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.addPaperToProject(request) }
+        assertThrows<TestSpecificException> { service.addPaperToProject(project.id, paper.id, 0) }
     }
 
     @Test
@@ -130,15 +115,13 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
         val projectResult = Result.success(project)
         val paper = DataBuilder.createExamplePaper()
 
-        val request = getRequest(project.id, paper.id)
-
         mockCurrentUser(user)
         coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns true
 
-        assertThrows<DuplicateProjectPaperException> { service.addPaperToProject(request) }
+        assertThrows<DuplicateProjectPaperException> { service.addPaperToProject(project.id, paper.id, 0) }
     }
 
     @Test
@@ -149,15 +132,13 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
             val projectResult = Result.success(project)
             val paper = DataBuilder.createExamplePaper()
 
-            val request = getRequest(project.id, paper.id, stage = 1)
-
             mockCurrentUser(user)
             coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
             coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
             coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
             coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
 
-            assertThrows<StageOutOfRangeException> { service.addPaperToProject(request) }
+            assertThrows<StageOutOfRangeException> { service.addPaperToProject(project.id, paper.id, 1) }
         }
 
     @Test
@@ -167,14 +148,12 @@ class AddPaperToProjectTest : ProjectPaperServiceTest() {
         val projectResult = Result.success(project)
         val paper = DataBuilder.createExamplePaper()
 
-        val request = getRequest(project.id, paper.id, stage = -1)
-
         mockCurrentUser(user)
         coJustRun { projectPaperAccessCheckerMock.isAllowedToAddPaperToProject(user, project.id, projectResult) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns projectResult
         coEvery { paperRepoMock.getPaperById(paper.id) } returns Result.success(paper)
         coEvery { projectPaperRepoMock.doesProjectPaperExist(project.id, paper.id) } returns false
 
-        assertThrows<StageOutOfRangeException> { service.addPaperToProject(request) }
+        assertThrows<StageOutOfRangeException> { service.addPaperToProject(project.id, paper.id, -1) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -61,39 +61,39 @@ class GetAllProjectPapersForProjectTest : ProjectPaperServiceTest() {
                 reviewHasCriterionRepoMock.getSelectedCriteriaIdsForReviewById(projectPaper1Review1.id)
             } returns listOf(criterion0.id, criterion2.id)
 
-            val projectPapers = service.getAllProjectPapersForProject(project.id).projectPapersList
+            val projectPapers = service.getAllProjectPapersForProject(project.id)
 
             assertEquals(2, projectPapers.size)
-            assertEquals(projectPaper0.projectPaper.id.toString(), projectPapers[0].id)
-            assertEquals(projectPaper1.projectPaper.id.toString(), projectPapers[1].id)
+            assertEquals(projectPaper0.projectPaper.id, projectPapers[0].id)
+            assertEquals(projectPaper1.projectPaper.id, projectPapers[1].id)
             val projectPaper0Result = projectPapers[0]
             val projectPaper1Result = projectPapers[1]
-            val backwardRefs0 = projectPaper0Result.paper.backwardReferencedIdsList
-            val backwardRefs1 = projectPaper1Result.paper.backwardReferencedIdsList
+            val backwardRefs0 = projectPaper0Result.paper.backwardReferencedIds
+            val backwardRefs1 = projectPaper1Result.paper.backwardReferencedIds
             assertEquals(projectPaper0Refs.size, backwardRefs0.size)
             assertEquals(projectPaper1Refs.size, backwardRefs1.size)
-            projectPaper0Refs.forEach { refId -> assertContains(backwardRefs0, refId.toString()) }
-            projectPaper1Refs.forEach { refId -> assertContains(backwardRefs1, refId.toString()) }
-            val reviews0 = projectPaper0Result.reviewsList
-            val reviews1 = projectPaper1Result.reviewsList
+            projectPaper0Refs.forEach { refId -> assertContains(backwardRefs0, refId) }
+            projectPaper1Refs.forEach { refId -> assertContains(backwardRefs1, refId) }
+            val reviews0 = projectPaper0Result.reviews
+            val reviews1 = projectPaper1Result.reviews
             assertEquals(2, reviews0.size)
             assertEquals(2, reviews1.size)
-            val review0CriterionIds0 = reviews0[0].selectedCriteriaIdsList
-            val review0CriterionIds1 = reviews0[1].selectedCriteriaIdsList
-            val review1CriterionIds0 = reviews1[0].selectedCriteriaIdsList
-            val review1CriterionIds1 = reviews1[1].selectedCriteriaIdsList
+            val review0CriterionIds0 = reviews0[0].selectedCriteriaIds
+            val review0CriterionIds1 = reviews0[1].selectedCriteriaIds
+            val review1CriterionIds0 = reviews1[0].selectedCriteriaIds
+            val review1CriterionIds1 = reviews1[1].selectedCriteriaIds
             assertEquals(2, review0CriterionIds0.size)
             assertEquals(2, review0CriterionIds1.size)
             assertEquals(2, review1CriterionIds0.size)
             assertEquals(2, review1CriterionIds1.size)
-            assertContains(review0CriterionIds0, criterion0.id.toString())
-            assertContains(review0CriterionIds0, criterion1.id.toString())
-            assertContains(review0CriterionIds1, criterion2.id.toString())
-            assertContains(review0CriterionIds1, criterion1.id.toString())
-            assertContains(review1CriterionIds0, criterion2.id.toString())
-            assertContains(review1CriterionIds0, criterion0.id.toString())
-            assertContains(review1CriterionIds1, criterion0.id.toString())
-            assertContains(review1CriterionIds1, criterion2.id.toString())
+            assertContains(review0CriterionIds0, criterion0.id)
+            assertContains(review0CriterionIds0, criterion1.id)
+            assertContains(review0CriterionIds1, criterion2.id)
+            assertContains(review0CriterionIds1, criterion1.id)
+            assertContains(review1CriterionIds0, criterion2.id)
+            assertContains(review1CriterionIds0, criterion0.id)
+            assertContains(review1CriterionIds1, criterion0.id)
+            assertContains(review1CriterionIds1, criterion2.id)
         }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetPapersToReviewForProjectTest.kt
@@ -54,9 +54,9 @@ class GetPapersToReviewForProjectTest : ProjectPaperServiceTest() {
         } returns listOf(UUID.randomUUID())
 
         val projectPapers = service.getPapersToReviewForProject(project.id)
-        assertThat(projectPapers.projectPapersList).hasSize(1)
-        assertThat(projectPapers.projectPapersList).anyMatch { it.id == projectPaperNotAlreadyDecided.id.toString() }
-        assertThat(projectPapers.projectPapersList).noneMatch { it.id == projectPaperAlreadyDecided.id.toString() }
+        assertThat(projectPapers).hasSize(1)
+        assertThat(projectPapers).anyMatch { it.id == projectPaperNotAlreadyDecided.id }
+        assertThat(projectPapers).noneMatch { it.id == projectPaperAlreadyDecided.id }
     }
 
     @Test
@@ -103,11 +103,9 @@ class GetPapersToReviewForProjectTest : ProjectPaperServiceTest() {
             } returns listOf(UUID.randomUUID())
 
             val projectPapers = service.getPapersToReviewForProject(project.id)
-            assertThat(projectPapers.projectPapersList).hasSize(1)
-            assertThat(projectPapers.projectPapersList)
-                .anyMatch { it.id == projectPaperWithoutCurrentUserReview.id.toString() }
-            assertThat(projectPapers.projectPapersList)
-                .noneMatch { it.id == projectPaperWithCurrentUserReview.id.toString() }
+            assertThat(projectPapers).hasSize(1)
+            assertThat(projectPapers).anyMatch { it.id == projectPaperWithoutCurrentUserReview.id }
+            assertThat(projectPapers).noneMatch { it.id == projectPaperWithCurrentUserReview.id }
         }
 
     @Test
@@ -130,8 +128,8 @@ class GetPapersToReviewForProjectTest : ProjectPaperServiceTest() {
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
 
         val result = service.getPapersToReviewForProject(project.id)
-        assertThat(result.projectPapersList).hasSize(1)
-        assertThat(result.projectPapersList.first().id).isEqualTo(projectPaper.id.toString())
+        assertThat(result).hasSize(1)
+        assertThat(result.first().id).isEqualTo(projectPaper.id)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetProjectPaperByRelativeIdTest.kt
@@ -8,17 +8,9 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import java.util.UUID
-import snowballr.ProjectOuterClass.Project.Paper as GrpcProjectPaper
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
-    private fun getRequest(projectId: UUID, relativeId: Int = -1) = GrpcProjectPaper.Get
-        .newBuilder()
-        .setProjectId(projectId.toString())
-        .setRelativeProjectPaperId(relativeId.toString())
-        .build()
-
     @Test
     fun `When a user request the project paper and has access, then the correct values are returned`() = runTest {
         val user = DataBuilder.createExampleUser()
@@ -26,8 +18,6 @@ class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
         val relativeId = 1
         val paper = DataBuilder.createExamplePaper()
         val projectPaper = DataBuilder.createExampleProjectPaper(paperId = paper.id)
-
-        val request = getRequest(project.id, relativeId)
 
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
@@ -38,7 +28,7 @@ class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
         coEvery { citationRepoMock.getBackwardsReferencedPaperIdsOfPaperById(paper.id) } returns emptyList()
         coEvery { reviewRepoMock.getAllReviewsForProjectPaper(projectPaper.id) } returns emptyList()
 
-        val result = service.getProjectPaperByRelativeId(request)
+        val result = service.getProjectPaperByRelativeId(project.id, relativeId)
 
         assertProjectPaperEquality(projectPaper, result)
     }
@@ -49,14 +39,12 @@ class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
             val user = DataBuilder.createExampleUser()
             val project = DataBuilder.createExampleProject()
 
-            val request = getRequest(project.id)
-
             mockCurrentUser(user)
             coEvery {
                 projectAccessCheckerMock.isAllowedToReadProject(user, project.id)
             } throws TestSpecificException()
 
-            assertThrows<TestSpecificException> { service.getProjectPaperByRelativeId(request) }
+            assertThrows<TestSpecificException> { service.getProjectPaperByRelativeId(project.id, -1) }
         }
 
     @Test
@@ -65,14 +53,12 @@ class GetProjectPaperByRelativeIdTest : ProjectPaperServiceTest() {
         val project = DataBuilder.createExampleProject()
         val relativeId = 2
 
-        val request = getRequest(project.id, relativeId)
-
         mockCurrentUser(user)
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery {
             projectPaperRepoMock.getProjectPaperByRelativeId(project.id, relativeId)
         } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { service.getProjectPaperByRelativeId(request) }
+        assertThrows<TestSpecificException> { service.getProjectPaperByRelativeId(project.id, relativeId) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/ProjectPaperServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/ProjectPaperServiceTest.kt
@@ -9,6 +9,7 @@ import se.uulm.snowballr.backend.access.IProjectPaperAccessChecker
 import se.uulm.snowballr.backend.auth.GrpcContext
 import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaper
 import se.uulm.snowballr.backend.model.dto.user.User
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import se.uulm.snowballr.backend.repository.IPaperTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
@@ -19,7 +20,6 @@ import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTable
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ProjectPaperService
 import se.uulm.snowballr.backend.service.withUser
-import snowballr.ProjectOuterClass
 
 /**
  * Base test class for [ProjectPaperService].
@@ -69,10 +69,10 @@ sealed class ProjectPaperServiceTest : BaseServiceTest {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
     }
 
-    protected fun assertProjectPaperEquality(expected: ProjectPaper, actual: ProjectOuterClass.Project.Paper) {
-        assertEquals(expected.paperId.toString(), actual.paper.id)
-        assertEquals(expected.localPaperId.toString(), actual.localId)
-        assertEquals(expected.stage.toLong(), actual.stage)
-        assertEquals(expected.decision.toGrpc(), actual.decision)
+    protected fun assertProjectPaperEquality(expected: ProjectPaper, actual: ProjectPaperResponse) {
+        assertEquals(expected.paperId, actual.paper.id)
+        assertEquals(expected.localPaperId, actual.localPaperId)
+        assertEquals(expected.stage, actual.stage)
+        assertEquals(expected.decision, actual.decision)
     }
 }


### PR DESCRIPTION
Closes #560

## What I have made

Waits for #558

This removes any grpc related types from the service and repo layer for the project paper and project member domain.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
