### PR TITLE
Use non grpc request types for export and authentication domain

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -41,6 +41,7 @@ import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
+import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.toGrpc
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
@@ -435,7 +436,10 @@ class SnowballRServer(
             exportService.getAvailableExportFormats().toGrpc()
 
         override suspend fun exportProject(request: Export.ExportRequest): Export.ExportResponse =
-            exportService.exportProject(request).toGrpc()
+            exportService.exportProject(
+                projectId = parseUUID(request.id, EntityType.PROJECT),
+                format = ExportFormat.valueOf(request.format),
+            ).toGrpc()
 
         override suspend fun softDeleteProject(request: Base.Id) = returnNothing {
             projectService.softDeleteProject(parseProjectId(request))

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -24,22 +24,16 @@ import se.uulm.snowballr.backend.grpc.interceptor.loggingInterceptor
 import se.uulm.snowballr.backend.grpc.interceptor.validationInterceptor
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
-import se.uulm.snowballr.backend.model.dto.criterion.toGrpc
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
-import se.uulm.snowballr.backend.model.dto.project.toGrpc
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
-import se.uulm.snowballr.backend.model.dto.projectmember.toGrpc
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import se.uulm.snowballr.backend.model.dto.user.toGrpc
 import se.uulm.snowballr.backend.model.export.ExportFormat
-import se.uulm.snowballr.backend.model.export.toGrpc
-import se.uulm.snowballr.backend.model.fetcher.toGrpc
 import se.uulm.snowballr.backend.model.incoming.authentication.ChangePasswordRequest
 import se.uulm.snowballr.backend.model.incoming.authentication.LoginRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
@@ -53,12 +47,6 @@ import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMembe
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
-import se.uulm.snowballr.backend.model.outgoing.invitation.toGrpc
-import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
-import se.uulm.snowballr.backend.model.outgoing.project.toGrpc
-import se.uulm.snowballr.backend.model.outgoing.projectpaper.toGrpc
-import se.uulm.snowballr.backend.model.outgoing.review.toGrpc
-import se.uulm.snowballr.backend.model.outgoing.review.toGrpcReviews
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.scheduler.SchedulerManager
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -547,7 +535,7 @@ class SnowballRServer(
             reviewService.getReviewById(parseReviewId(request)).toGrpc()
 
         override suspend fun getAllReviewsForProjectPaper(request: Base.Id): ReviewOuterClass.Review.List =
-            reviewService.getAllReviewsForProjectPaper(parseProjectPaperId(request)).toGrpcReviews()
+            reviewService.getAllReviewsForProjectPaper(parseProjectPaperId(request)).toGrpc()
 
         override suspend fun createReview(request: ReviewOuterClass.Review.Create): ReviewOuterClass.Review =
             reviewService.createReview(

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -41,6 +41,7 @@ import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
 import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
+import se.uulm.snowballr.backend.model.export.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.toGrpc
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
@@ -431,10 +432,10 @@ class SnowballRServer(
             ).toGrpcProject()
 
         override suspend fun getAvailableExportFormats(request: Base.Nothing): Export.AvailableExportFormatsResponse =
-            exportService.getAvailableExportFormats()
+            exportService.getAvailableExportFormats().toGrpc()
 
         override suspend fun exportProject(request: Export.ExportRequest): Export.ExportResponse =
-            exportService.exportProject(request)
+            exportService.exportProject(request).toGrpc()
 
         override suspend fun softDeleteProject(request: Base.Id) = returnNothing {
             projectService.softDeleteProject(parseProjectId(request))

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -44,6 +44,8 @@ import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.toGrpc
+import se.uulm.snowballr.backend.model.incoming.authentication.ChangePasswordRequest
+import se.uulm.snowballr.backend.model.incoming.authentication.LoginRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
@@ -259,11 +261,11 @@ class SnowballRServer(
         }
 
         override suspend fun verifyEmail(request: Authentication.VerifyEmailRequest) = returnNothing {
-            authenticationService.verifyEmail(request)
+            authenticationService.verifyEmail(request.token)
         }
 
         override suspend fun login(request: Authentication.LoginRequest) = returnNothing {
-            authenticationService.login(request)
+            authenticationService.login(LoginRequest(email = request.email, password = request.password))
         }
 
         override suspend fun logout(request: Base.Nothing) = returnNothing {
@@ -285,7 +287,12 @@ class SnowballRServer(
             super.resetPassword(request)
 
         override suspend fun changePassword(request: Authentication.PasswordChangeRequest) = returnNothing {
-            authenticationService.changePassword(request)
+            authenticationService.changePassword(
+                ChangePasswordRequest(
+                    oldPassword = request.oldPassword,
+                    newPassword = request.newPassword,
+                ),
+            )
         }
 
         override suspend fun getAllUsers(request: Base.Nothing): UserOuterClass.User.List =

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -24,23 +24,19 @@ import se.uulm.snowballr.backend.grpc.interceptor.loggingInterceptor
 import se.uulm.snowballr.backend.grpc.interceptor.validationInterceptor
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
-import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
-import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriterion
+import se.uulm.snowballr.backend.model.dto.criterion.toGrpc
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
-import se.uulm.snowballr.backend.model.dto.project.toGrpcProject
-import se.uulm.snowballr.backend.model.dto.project.toGrpcProjects
+import se.uulm.snowballr.backend.model.dto.project.toGrpc
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
-import se.uulm.snowballr.backend.model.dto.projectmember.toGrpcProjectMembers
+import se.uulm.snowballr.backend.model.dto.projectmember.toGrpc
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUserSettings
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUsers
+import se.uulm.snowballr.backend.model.dto.user.toGrpc
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.toGrpc
@@ -296,16 +292,16 @@ class SnowballRServer(
         }
 
         override suspend fun getAllUsers(request: Base.Nothing): UserOuterClass.User.List =
-            userService.getAllUsers().toGrpcUsers()
+            userService.getAllUsers().toGrpc()
 
         override suspend fun getCurrentUser(request: Base.Nothing): UserOuterClass.User =
-            userService.getCurrentUser().toGrpcUser()
+            userService.getCurrentUser().toGrpc()
 
         override suspend fun getUserById(request: Base.Id): UserOuterClass.User =
-            userService.getUserById(parseUserId(request)).toGrpcUser()
+            userService.getUserById(parseUserId(request)).toGrpc()
 
         override suspend fun getUserByEmail(request: Base.Email): UserOuterClass.User =
-            userService.getUserByEmail(request.email).toGrpcUser()
+            userService.getUserByEmail(request.email).toGrpc()
 
         override suspend fun updateUser(request: UserOuterClass.User.Update): UserOuterClass.User =
             userService.updateUser(
@@ -318,7 +314,7 @@ class SnowballRServer(
                     status = UserStatus.fromGrpc(request.user.status),
                 ),
                 FieldMaskUtil.normalize(request.mask).pathsList,
-            ).toGrpcUser()
+            ).toGrpc()
 
         override suspend fun softDeleteUser(request: Base.Id) = returnNothing {
             userService.softDeleteUser(parseUserId(request))
@@ -342,7 +338,7 @@ class SnowballRServer(
             projectPaperService.getPreviousPaper(parseProjectPaperId(request)).toGrpc()
 
         override suspend fun getUserSettings(request: Base.Nothing): UserSettingsOuterClass.UserSettings =
-            userService.getUserSettings().toGrpcUserSettings()
+            userService.getUserSettings().toGrpc()
 
         override suspend fun updateUserSettings(
             request: UserSettingsOuterClass.UserSettings.Update,
@@ -368,7 +364,7 @@ class SnowballRServer(
         ): UserOuterClass.User.List = invitationService.getInviteCandidates(
             projectId = runCatching { parseUUID(request.projectId, EntityType.PROJECT) }.getOrDefault(null),
             query = request.query,
-        ).toGrpcUsers()
+        ).toGrpc()
 
         override suspend fun inviteUserToProject(request: ProjectOuterClass.Project.Member.Invite) = returnNothing {
             invitationService.inviteUserToProject(
@@ -385,7 +381,7 @@ class SnowballRServer(
             invitationService.getPendingInvitationsForProject(parseProjectId(request)).toGrpc()
 
         override suspend fun getProjectMembers(request: Base.Id): ProjectOuterClass.Project.Member.List =
-            projectMemberService.getProjectMembers(parseProjectId(request)).toGrpcProjectMembers()
+            projectMemberService.getProjectMembers(parseProjectId(request)).toGrpc()
 
         override suspend fun removeProjectMember(request: ProjectOuterClass.Project.Member.Remove) = returnNothing {
             projectMemberService.removeProjectMember(
@@ -395,28 +391,28 @@ class SnowballRServer(
         }
 
         override suspend fun getAllProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
-            projectService.getAllProjects().toGrpcProjects()
+            projectService.getAllProjects().toGrpc()
 
         override suspend fun getAllDeletedProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
             super.getAllDeletedProjects(request)
 
         override suspend fun getAllDeletedProjectsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            projectService.getAllDeletedProjectsForUser(parseUserId(request)).toGrpcProjects()
+            projectService.getAllDeletedProjectsForUser(parseUserId(request)).toGrpc()
 
         override suspend fun getAllArchivedProjects(request: Base.Nothing): ProjectOuterClass.Project.List =
             super.getAllArchivedProjects(request)
 
         override suspend fun getAllProjectsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            projectService.getAllProjectsForUser(parseUserId(request)).toGrpcProjects()
+            projectService.getAllProjectsForUser(parseUserId(request)).toGrpc()
 
         override suspend fun getAllArchivedProjectsForUser(request: Base.Id): ProjectOuterClass.Project.List =
-            projectService.getAllArchivedProjectsForUser(parseUserId(request)).toGrpcProjects()
+            projectService.getAllArchivedProjectsForUser(parseUserId(request)).toGrpc()
 
         override suspend fun createProject(request: ProjectOuterClass.Project.Create): ProjectOuterClass.Project =
-            projectService.createProject(CreateProjectRequest(name = request.name)).toGrpcProject()
+            projectService.createProject(CreateProjectRequest(name = request.name)).toGrpc()
 
         override suspend fun getProjectById(request: Base.Id): ProjectOuterClass.Project =
-            projectService.getProjectById(parseProjectId(request)).toGrpcProject()
+            projectService.getProjectById(parseProjectId(request)).toGrpc()
 
         override suspend fun updateProject(request: ProjectOuterClass.Project.Update): ProjectOuterClass.Project =
             projectService.updateProject(
@@ -437,7 +433,7 @@ class SnowballRServer(
                     ),
                 ),
                 FieldMaskUtil.normalize(request.mask).pathsList.toSet(),
-            ).toGrpcProject()
+            ).toGrpc()
 
         override suspend fun getAvailableExportFormats(request: Base.Nothing): Export.AvailableExportFormatsResponse =
             exportService.getAvailableExportFormats().toGrpc()
@@ -479,10 +475,10 @@ class SnowballRServer(
         }
 
         override suspend fun getCriterionById(request: Base.Id): CriterionOuterClass.Criterion =
-            criterionService.getCriterionById(parseCriterionId(request)).toGrpcCriterion()
+            criterionService.getCriterionById(parseCriterionId(request)).toGrpc()
 
         override suspend fun getAllCriteriaForProject(request: Base.Id): CriterionOuterClass.Criterion.List =
-            criterionService.getAllCriteriaForProject(parseProjectId(request)).toGrpcCriteria()
+            criterionService.getAllCriteriaForProject(parseProjectId(request)).toGrpc()
 
         override suspend fun createCriterion(
             request: CriterionOuterClass.Criterion.Create,
@@ -501,7 +497,7 @@ class SnowballRServer(
                     category = CriterionCategory.fromGrpc(request.category),
                     projectId = projectId,
                 ),
-            ).toGrpcCriterion()
+            ).toGrpc()
         }
 
         override suspend fun updateCriterion(
@@ -515,7 +511,7 @@ class SnowballRServer(
                 category = CriterionCategory.fromGrpc(request.criterion.category),
             ),
             FieldMaskUtil.normalize(request.mask).pathsList,
-        ).toGrpcCriterion()
+        ).toGrpc()
 
         override suspend fun deleteCriterion(request: Base.Id): Base.Nothing = super.deleteCriterion(request)
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/ToGrpcConversion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/ToGrpcConversion.kt
@@ -1,0 +1,277 @@
+@file:Suppress("TooManyFunctions")
+
+package se.uulm.snowballr.backend.grpc
+
+import com.google.protobuf.kotlin.toByteString
+import com.google.protobuf.timestamp
+import se.uulm.snowballr.backend.model.dto.criterion.Criterion
+import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.project.Project
+import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
+import se.uulm.snowballr.backend.model.dto.user.User
+import se.uulm.snowballr.backend.model.dto.user.UserSettingsWithCriteria
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.model.export.FileExport
+import se.uulm.snowballr.backend.model.fetcher.FetcherInformation
+import se.uulm.snowballr.backend.model.fetcher.FetcherInformationWithId
+import se.uulm.snowballr.backend.model.fetcher.FetcherOptionsSchema
+import se.uulm.snowballr.backend.model.fetcher.Link
+import se.uulm.snowballr.backend.model.outgoing.invitation.InvitationResponse
+import se.uulm.snowballr.backend.model.outgoing.paper.FetcherPaperResponse
+import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionCount
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionStatistics
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectInformation
+import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
+import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
+import snowballr.Base
+import snowballr.CriterionOuterClass
+import snowballr.Export
+import snowballr.Fetcher
+import snowballr.PaperOuterClass
+import snowballr.ProjectOuterClass
+import snowballr.ReviewOuterClass
+import snowballr.UserOuterClass
+import snowballr.UserSettingsOuterClass
+
+fun Criterion.toGrpc(): CriterionOuterClass.Criterion = CriterionOuterClass.Criterion
+    .newBuilder()
+    .setId(this.id.toString())
+    .setTag(this.tag)
+    .setName(this.name)
+    .setDescription(this.description)
+    .setCategory(this.category.toGrpc())
+    .build()
+
+@JvmName("toGrpcCriterionList")
+fun List<Criterion>.toGrpc(): CriterionOuterClass.Criterion.List {
+    val builder = CriterionOuterClass.Criterion.List.newBuilder()
+    this.forEach { builder.addCriteria(it.toGrpc()) }
+    return builder.build()
+}
+
+fun Author.toGrpc(): PaperOuterClass.Author = PaperOuterClass.Author.newBuilder()
+    .setFirstName(firstName)
+    .setLastName(lastName)
+    .build()
+
+fun List<Author>.toGrpc(): List<PaperOuterClass.Author> = this.map(Author::toGrpc)
+
+fun Project.toGrpc(): ProjectOuterClass.Project {
+    val settings =
+        ProjectOuterClass.Project.Settings
+            .newBuilder()
+            .setSimilarityThreshold(this.similarityThreshold)
+            .setDecisionMatrix(this.reviewDecisionMatrix.toGrpc())
+            .setSnowballingType(this.snowballingType.toGrpc())
+            .setReviewMaybeAllowed(this.reviewMaybeAllowed)
+            .putAllFetchers(
+                this.fetchers.mapValues {
+                    Fetcher.FetcherOptions
+                        .newBuilder()
+                        .putAllOptions(it.value)
+                        .build()
+                },
+            )
+            .build()
+
+    return ProjectOuterClass.Project
+        .newBuilder()
+        .setId(this.id.toString())
+        .setName(this.name)
+        .setStatus(this.status.toGrpc())
+        .setCurrentStage(this.currentStage.toLong())
+        .setMaxStage(this.maxStage.toLong())
+        .setSettings(settings)
+        .build()
+}
+
+@JvmName("toGrpcProjectList")
+fun List<Project>.toGrpc(): ProjectOuterClass.Project.List {
+    val builder = ProjectOuterClass.Project.List.newBuilder()
+    this.forEach { builder.addProjects(it.toGrpc()) }
+    return builder.build()
+}
+
+fun ProjectMemberWithUser.toGrpc(): ProjectOuterClass.Project.Member = ProjectOuterClass.Project.Member
+    .newBuilder()
+    .setRole(this.projectMember.role.toGrpc())
+    .setUser(this.user.toGrpc())
+    .build()
+
+@JvmName("toGrpcProjectMemberList")
+fun List<ProjectMemberWithUser>.toGrpc(): ProjectOuterClass.Project.Member.List = ProjectOuterClass.Project.Member.List
+    .newBuilder()
+    .addAllMembers(this.map { it.toGrpc() })
+    .build()
+
+fun User.toGrpc(): UserOuterClass.User = UserOuterClass.User
+    .newBuilder()
+    .setId(this.id.toString())
+    .setEmail(this.email)
+    .setFirstName(this.firstName)
+    .setLastName(this.lastName)
+    .setRole(this.role.toGrpc())
+    .setStatus(this.status.toGrpc())
+    .build()
+
+@JvmName("toGrpcUserList")
+fun List<User>.toGrpc(): UserOuterClass.User.List {
+    val builder = UserOuterClass.User.List.newBuilder()
+    this.forEach { builder.addUsers(it.toGrpc()) }
+    return builder.build()
+}
+
+fun UserSettingsWithCriteria.toGrpc(): UserSettingsOuterClass.UserSettings =
+    UserSettingsOuterClass.UserSettings.newBuilder()
+        .setShowHotkeys(settings.areHotkeysShown)
+        .setReviewMode(settings.isReviewModeEnabled)
+        .setDefaultCriteria(criteria.toGrpc())
+        .setDefaultProjectSettings(
+            ProjectOuterClass.Project.Settings.newBuilder()
+                .setSimilarityThreshold(settings.similarityThreshold)
+                .setDecisionMatrix(settings.decisionMatrix.toGrpc())
+                .putAllFetchers(
+                    settings.fetchers.mapValues {
+                        Fetcher.FetcherOptions
+                            .newBuilder()
+                            .putAllOptions(it.value)
+                            .build()
+                    },
+                )
+                .setSnowballingType(settings.snowballingType.toGrpc())
+                .setReviewMaybeAllowed(settings.reviewMaybeAllowed)
+                .build(),
+        )
+        .build()
+
+fun InvitationResponse.toGrpc(): UserOuterClass.User = UserOuterClass.User.newBuilder()
+    .setId(userId?.toString().orEmpty())
+    .setEmail(email)
+    .setFirstName(firstName)
+    .setLastName(lastName)
+    .setRole(role.toGrpc())
+    .setStatus(status.toGrpc())
+    .build()
+
+@JvmName("toGrpcInviteesList")
+fun List<InvitationResponse>.toGrpc(): UserOuterClass.User.List = UserOuterClass.User.List.newBuilder()
+    .addAllUsers(this.map { it.toGrpc() })
+    .build()
+
+fun FetcherPaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBuilder()
+    .setId(id?.toString().orEmpty())
+    .setExternalId(externalId.orEmpty())
+    .setTitle(title)
+    .setAbstrakt(abstract)
+    .setYear(year)
+    .setPublisher(publisher)
+    .setPublicationName(publicationName)
+    .setPublicationType(publicationType)
+    .addAllAuthors(authors.toGrpc())
+    .putAllFetcherMetadata(fetcherMetadata)
+    .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
+    .build()
+
+@JvmName("toGrpcFetcherPaperList")
+fun List<FetcherPaperResponse>.toGrpc(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List.newBuilder()
+    .addAllPapers(this.map { it.toGrpc() })
+    .build()
+
+fun ProjectDecisionCount.toGrpc(): ProjectOuterClass.Project.Information.DecisionStatistics.Statistic =
+    ProjectOuterClass.Project.Information.DecisionStatistics.Statistic.newBuilder()
+        .setDecision(decision.toGrpc())
+        .setCount(count.toLong())
+        .build()
+
+fun PaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBuilder()
+    .setId(id.toString())
+    .setExternalId(externalId.orEmpty())
+    .setTitle(title)
+    .setAbstrakt(abstract)
+    .setYear(year)
+    .setPublisher(publisher)
+    .setPublicationName(publicationName)
+    .setPublicationType(publicationType)
+    .addAllAuthors(authors.toGrpc())
+    .putAllFetcherMetadata(fetcherMetadata)
+    .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
+    .build()
+
+@JvmName("toGrpcPaperList")
+fun List<PaperResponse>.toGrpc(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List.newBuilder()
+    .addAllPapers(this.map { it.toGrpc() })
+    .build()
+
+fun ProjectDecisionStatistics.toGrpc(): ProjectOuterClass.Project.Information.DecisionStatistics =
+    ProjectOuterClass.Project.Information.DecisionStatistics.newBuilder()
+        .addAllStatistics(statistics.map { it.toGrpc() })
+        .build()
+
+fun ProjectInformation.toGrpc(): ProjectOuterClass.Project.Information =
+    ProjectOuterClass.Project.Information.newBuilder()
+        .setProjectProgress(progress)
+        .setCreationDate(timestamp { seconds = creationDate.toEpochSecond() })
+        .setLastStageStarted(timestamp { seconds = lastStageStarted.toEpochSecond() })
+        .build()
+
+fun ProjectPaperResponse.toGrpc(): ProjectOuterClass.Project.Paper = ProjectOuterClass.Project.Paper.newBuilder()
+    .setId(this.id.toString())
+    .setPaper(this.paper.toGrpc())
+    .setStage(this.stage.toLong())
+    .setDecision(this.decision.toGrpc())
+    .addAllReviews(reviews.map { it.toGrpc() })
+    .setLocalId(this.localPaperId.toString())
+    .build()
+
+@JvmName("toGrpcProjectPaperList")
+fun List<ProjectPaperResponse>.toGrpc(): ProjectOuterClass.Project.Paper.List =
+    ProjectOuterClass.Project.Paper.List.newBuilder()
+        .addAllProjectPapers(this.map { it.toGrpc() })
+        .build()
+
+fun ReviewResponse.toGrpc(): ReviewOuterClass.Review = ReviewOuterClass.Review
+    .newBuilder()
+    .setId(id.toString())
+    .setUserId(userId.toString())
+    .setDecision(decision.toGrpc())
+    .addAllSelectedCriteriaIds(selectedCriteriaIds.map { it.toString() })
+    .build()
+
+@JvmName("toGrpcReviewList")
+fun List<ReviewResponse>.toGrpc(): ReviewOuterClass.Review.List = ReviewOuterClass.Review.List
+    .newBuilder()
+    .addAllReviews(this.map { it.toGrpc() })
+    .build()
+
+fun FileExport.toGrpc(): Export.ExportResponse = Export.ExportResponse.newBuilder()
+    .setData(data.toByteString())
+    .setFileName(filename)
+    .build()
+
+fun FetcherInformation.toGrpc(fetcherId: String): Fetcher.FetcherInformation = Fetcher.FetcherInformation.newBuilder()
+    .setId(fetcherId)
+    .setName(name)
+    .setDescription(description)
+    .addAllLinks(links.map { it.toGrpc() })
+    .putAllOptionsSchema(optionsSchema.mapValues { it.value.toGrpc() })
+    .build()
+
+fun FetcherInformationWithId.toGrpc(): Fetcher.FetcherInformation = information.toGrpc(id)
+fun FetcherOptionsSchema.toGrpc(): Fetcher.FetcherOptionSchema = Fetcher.FetcherOptionSchema.newBuilder()
+    .setName(name)
+    .setDescription(description)
+    .setRequired(isRequired)
+    .setIsSecret(isSecret)
+    .apply { if (defaultValue != null) setDefaultValue(defaultValue) }
+    .build()
+
+fun Link.toGrpc(): Base.Link = Base.Link.newBuilder()
+    .setLabel(label)
+    .setUrl(url)
+    .build()
+
+fun Set<ExportFormat>.toGrpc(): Export.AvailableExportFormatsResponse = Export.AvailableExportFormatsResponse
+    .newBuilder()
+    .addAllFormats(this.map { it.toString() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/criterion/Criterion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/criterion/Criterion.kt
@@ -48,7 +48,7 @@ sealed interface Criterion {
 /**
  * Creates a [CriterionOuterClass.Criterion] from this [Criterion].
  */
-fun Criterion.toGrpcCriterion(): CriterionOuterClass.Criterion = CriterionOuterClass.Criterion
+fun Criterion.toGrpc(): CriterionOuterClass.Criterion = CriterionOuterClass.Criterion
     .newBuilder()
     .setId(this.id.toString())
     .setTag(this.tag)
@@ -60,8 +60,8 @@ fun Criterion.toGrpcCriterion(): CriterionOuterClass.Criterion = CriterionOuterC
 /**
  * Creates a list of [CriterionOuterClass.Criterion]s from this list of [Criterion]s.
  */
-fun List<Criterion>.toGrpcCriteria(): CriterionOuterClass.Criterion.List {
+fun List<Criterion>.toGrpc(): CriterionOuterClass.Criterion.List {
     val builder = CriterionOuterClass.Criterion.List.newBuilder()
-    this.forEach { builder.addCriteria(it.toGrpcCriterion()) }
+    this.forEach { builder.addCriteria(it.toGrpc()) }
     return builder.build()
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/criterion/Criterion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/criterion/Criterion.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.criterion
 
 import se.uulm.snowballr.backend.table.CriterionTable
-import snowballr.CriterionOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -43,25 +42,4 @@ sealed interface Criterion {
         override val createdAt: OffsetDateTime,
         override val createdBy: UUID,
     ) : Criterion
-}
-
-/**
- * Creates a [CriterionOuterClass.Criterion] from this [Criterion].
- */
-fun Criterion.toGrpc(): CriterionOuterClass.Criterion = CriterionOuterClass.Criterion
-    .newBuilder()
-    .setId(this.id.toString())
-    .setTag(this.tag)
-    .setName(this.name)
-    .setDescription(this.description)
-    .setCategory(this.category.toGrpc())
-    .build()
-
-/**
- * Creates a list of [CriterionOuterClass.Criterion]s from this list of [Criterion]s.
- */
-fun List<Criterion>.toGrpc(): CriterionOuterClass.Criterion.List {
-    val builder = CriterionOuterClass.Criterion.List.newBuilder()
-    this.forEach { builder.addCriteria(it.toGrpc()) }
-    return builder.build()
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Author.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Author.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.model.dto.paper
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import se.uulm.snowballr.backend.table.PaperTable
-import snowballr.PaperOuterClass.Author as GrpcAuthor
 
 /**
  * Author DTO of [PaperTable].
@@ -15,16 +14,3 @@ data class Author(
     @SerialName("last_name")
     val lastName: String,
 )
-
-/**
- * Creates a [GrpcAuthor] from this [Author].
- */
-fun Author.toGrpc(): GrpcAuthor = GrpcAuthor.newBuilder()
-    .setFirstName(firstName)
-    .setLastName(lastName)
-    .build()
-
-/**
- * Creates a list of [GrpcAuthor] from this list of [Author].
- */
-fun List<Author>.toGrpc(): List<GrpcAuthor> = this.map(Author::toGrpc)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Author.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Author.kt
@@ -19,7 +19,7 @@ data class Author(
 /**
  * Creates a [GrpcAuthor] from this [Author].
  */
-fun Author.toGrpcAuthor(): GrpcAuthor = GrpcAuthor.newBuilder()
+fun Author.toGrpc(): GrpcAuthor = GrpcAuthor.newBuilder()
     .setFirstName(firstName)
     .setLastName(lastName)
     .build()
@@ -27,4 +27,4 @@ fun Author.toGrpcAuthor(): GrpcAuthor = GrpcAuthor.newBuilder()
 /**
  * Creates a list of [GrpcAuthor] from this list of [Author].
  */
-fun List<Author>.toGrpcAuthors(): List<GrpcAuthor> = this.map(Author::toGrpcAuthor)
+fun List<Author>.toGrpc(): List<GrpcAuthor> = this.map(Author::toGrpc)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Paper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/Paper.kt
@@ -5,7 +5,6 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import se.uulm.snowballr.backend.table.PaperTable
 import java.time.OffsetDateTime
 import java.util.UUID
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 /**
  * DTO of [PaperTable].
@@ -26,16 +25,6 @@ data class Paper(
     val modifiedAt: OffsetDateTime?,
     val modifiedBy: UUID?,
 ) : PaperData
-
-/**
- * Creates a [GrpcPaper] from this [Paper].
- */
-fun Paper.toGrpcPaper(backwardReferencedIdsList: List<String>): GrpcPaper = this.toGrpcPaperRequest()
-    .toBuilder()
-    .setId(id.toString())
-    .setHasPdf(pdfId != null)
-    .addAllBackwardReferencedIds(backwardReferencedIdsList)
-    .build()
 
 /**
  * Creates a [FetcherPaper] from this [Paper].

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/PaperData.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/PaperData.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.model.dto.paper
 
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import snowballr.paper
-import snowballr.PaperOuterClass.Paper as GrpcPaper
 
 interface PaperData {
     val title: String
@@ -14,23 +13,4 @@ interface PaperData {
     val publicationName: String
     val authors: List<Author>
     val fetcherMetadata: FetcherMetadata
-}
-
-/**
- * Creates a [GrpcPaper] request from this [PaperData].
- */
-fun PaperData.toGrpcPaperRequest(): GrpcPaper {
-    val paper = this
-    return paper {
-        title = paper.title
-        val paperExternalId = paper.externalId
-        if (paperExternalId != null) externalId = paperExternalId
-        abstrakt = paper.abstract
-        year = paper.year
-        publisher = paper.publisher
-        publicationType = paper.publicationType
-        publicationName = paper.publicationName
-        authors.addAll(paper.authors.toGrpcAuthors())
-        fetcherMetadata.putAll(paper.fetcherMetadata)
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/PaperData.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/PaperData.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.paper
 
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
-import snowballr.paper
 
 interface PaperData {
     val title: String

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/Project.kt
@@ -35,7 +35,7 @@ data class Project(
 /**
  * Creates a [ProjectOuterClass.Project] from this [Project].
  */
-fun Project.toGrpcProject(): ProjectOuterClass.Project {
+fun Project.toGrpc(): ProjectOuterClass.Project {
     val settings =
         ProjectOuterClass.Project.Settings
             .newBuilder()
@@ -67,9 +67,9 @@ fun Project.toGrpcProject(): ProjectOuterClass.Project {
 /**
  * Creates a list of [ProjectOuterClass.Project]s from this list of [Project]s.
  */
-fun List<Project>.toGrpcProjects(): ProjectOuterClass.Project.List {
+fun List<Project>.toGrpc(): ProjectOuterClass.Project.List {
     val builder = ProjectOuterClass.Project.List.newBuilder()
-    this.forEach { builder.addProjects(it.toGrpcProject()) }
+    this.forEach { builder.addProjects(it.toGrpc()) }
     return builder.build()
 }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/Project.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.model.dto.project
 
 import se.uulm.snowballr.backend.model.fetcher.FetcherMap
 import se.uulm.snowballr.backend.table.ProjectTable
-import snowballr.Fetcher.FetcherOptions
-import snowballr.ProjectOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -31,47 +29,6 @@ data class Project(
     val archivedAt: OffsetDateTime?,
     val archivedBy: UUID?,
 )
-
-/**
- * Creates a [ProjectOuterClass.Project] from this [Project].
- */
-fun Project.toGrpc(): ProjectOuterClass.Project {
-    val settings =
-        ProjectOuterClass.Project.Settings
-            .newBuilder()
-            .setSimilarityThreshold(this.similarityThreshold)
-            .setDecisionMatrix(this.reviewDecisionMatrix.toGrpc())
-            .setSnowballingType(this.snowballingType.toGrpc())
-            .setReviewMaybeAllowed(this.reviewMaybeAllowed)
-            .putAllFetchers(
-                this.fetchers.mapValues {
-                    FetcherOptions
-                        .newBuilder()
-                        .putAllOptions(it.value)
-                        .build()
-                },
-            )
-            .build()
-
-    return ProjectOuterClass.Project
-        .newBuilder()
-        .setId(this.id.toString())
-        .setName(this.name)
-        .setStatus(this.status.toGrpc())
-        .setCurrentStage(this.currentStage.toLong())
-        .setMaxStage(this.maxStage.toLong())
-        .setSettings(settings)
-        .build()
-}
-
-/**
- * Creates a list of [ProjectOuterClass.Project]s from this list of [Project]s.
- */
-fun List<Project>.toGrpc(): ProjectOuterClass.Project.List {
-    val builder = ProjectOuterClass.Project.List.newBuilder()
-    this.forEach { builder.addProjects(it.toGrpc()) }
-    return builder.build()
-}
 
 /**
  * Checks whether the project is active.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/ProjectMemberWithUser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/ProjectMemberWithUser.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.projectmember
 
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.toGrpc
-import snowballr.ProjectOuterClass
 
 /**
  * Represents a data transfer object that combines information about a project member
@@ -21,24 +19,3 @@ data class ProjectMemberWithUser(
     val projectMember: ProjectMember,
     val user: User,
 )
-
-/**
- * Converts this instance of [ProjectMemberWithUser] to a [ProjectOuterClass.Project.Member].
- *
- * @return an instance of [ProjectOuterClass.Project.Member] with the role and user fields populated.
- */
-fun ProjectMemberWithUser.toGrpc(): ProjectOuterClass.Project.Member = ProjectOuterClass.Project.Member
-    .newBuilder()
-    .setRole(this.projectMember.role.toGrpc())
-    .setUser(this.user.toGrpc())
-    .build()
-
-/**
- * Converts a list of [ProjectMemberWithUser] objects into a gRPC list of project members.
- *
- * @return A [ProjectOuterClass.Project.Member.List] containing the gRPC representation of the project members.
- */
-fun List<ProjectMemberWithUser>.toGrpc(): ProjectOuterClass.Project.Member.List = ProjectOuterClass.Project.Member.List
-    .newBuilder()
-    .addAllMembers(this.map { it.toGrpc() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/ProjectMemberWithUser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/ProjectMemberWithUser.kt
@@ -1,7 +1,7 @@
 package se.uulm.snowballr.backend.model.dto.projectmember
 
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.toGrpcUser
+import se.uulm.snowballr.backend.model.dto.user.toGrpc
 import snowballr.ProjectOuterClass
 
 /**
@@ -27,10 +27,10 @@ data class ProjectMemberWithUser(
  *
  * @return an instance of [ProjectOuterClass.Project.Member] with the role and user fields populated.
  */
-fun ProjectMemberWithUser.toGrpcProjectMember(): ProjectOuterClass.Project.Member = ProjectOuterClass.Project.Member
+fun ProjectMemberWithUser.toGrpc(): ProjectOuterClass.Project.Member = ProjectOuterClass.Project.Member
     .newBuilder()
     .setRole(this.projectMember.role.toGrpc())
-    .setUser(this.user.toGrpcUser())
+    .setUser(this.user.toGrpc())
     .build()
 
 /**
@@ -38,8 +38,7 @@ fun ProjectMemberWithUser.toGrpcProjectMember(): ProjectOuterClass.Project.Membe
  *
  * @return A [ProjectOuterClass.Project.Member.List] containing the gRPC representation of the project members.
  */
-fun List<ProjectMemberWithUser>.toGrpcProjectMembers(): ProjectOuterClass.Project.Member.List =
-    ProjectOuterClass.Project.Member.List
-        .newBuilder()
-        .addAllMembers(this.map { it.toGrpcProjectMember() })
-        .build()
+fun List<ProjectMemberWithUser>.toGrpc(): ProjectOuterClass.Project.Member.List = ProjectOuterClass.Project.Member.List
+    .newBuilder()
+    .addAllMembers(this.map { it.toGrpc() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/Review.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/Review.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.review
 
 import se.uulm.snowballr.backend.table.ReviewTable
-import snowballr.ReviewOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -16,14 +15,6 @@ data class Review(
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
 )
-
-fun Review.toGrpcReview(selectedCriteriaIds: List<String>): ReviewOuterClass.Review = ReviewOuterClass.Review
-    .newBuilder()
-    .setId(id.toString())
-    .setUserId(userId.toString())
-    .setDecision(decision.toGrpc())
-    .addAllSelectedCriteriaIds(selectedCriteriaIds)
-    .build()
 
 /**
  * Checks whether the review accepts the paper.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/User.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/User.kt
@@ -23,7 +23,7 @@ data class User(
 /**
  * Creates a [UserOuterClass.User] from this [User].
  */
-fun User.toGrpcUser(): UserOuterClass.User = UserOuterClass.User
+fun User.toGrpc(): UserOuterClass.User = UserOuterClass.User
     .newBuilder()
     .setId(this.id.toString())
     .setEmail(this.email)
@@ -36,9 +36,9 @@ fun User.toGrpcUser(): UserOuterClass.User = UserOuterClass.User
 /**
  * Creates a list of [UserOuterClass.User]s from this list of [User]s.
  */
-fun List<User>.toGrpcUsers(): UserOuterClass.User.List {
+fun List<User>.toGrpc(): UserOuterClass.User.List {
     val builder = UserOuterClass.User.List.newBuilder()
-    this.forEach { builder.addUsers(it.toGrpcUser()) }
+    this.forEach { builder.addUsers(it.toGrpc()) }
     return builder.build()
 }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/User.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/User.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.user
 
 import se.uulm.snowballr.backend.table.UserTable
-import snowballr.UserOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -19,28 +18,6 @@ data class User(
     val modifiedAt: OffsetDateTime?,
     val deletedAt: OffsetDateTime?,
 )
-
-/**
- * Creates a [UserOuterClass.User] from this [User].
- */
-fun User.toGrpc(): UserOuterClass.User = UserOuterClass.User
-    .newBuilder()
-    .setId(this.id.toString())
-    .setEmail(this.email)
-    .setFirstName(this.firstName)
-    .setLastName(this.lastName)
-    .setRole(this.role.toGrpc())
-    .setStatus(this.status.toGrpc())
-    .build()
-
-/**
- * Creates a list of [UserOuterClass.User]s from this list of [User]s.
- */
-fun List<User>.toGrpc(): UserOuterClass.User.List {
-    val builder = UserOuterClass.User.List.newBuilder()
-    this.forEach { builder.addUsers(it.toGrpc()) }
-    return builder.build()
-}
 
 /**
  * Checks whether the user is a server admin.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettingsWithCriteria.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettingsWithCriteria.kt
@@ -1,35 +1,8 @@
 package se.uulm.snowballr.backend.model.dto.user
 
 import se.uulm.snowballr.backend.model.dto.criterion.Criterion
-import se.uulm.snowballr.backend.model.dto.criterion.toGrpc
-import snowballr.Fetcher.FetcherOptions
-import snowballr.ProjectOuterClass
-import snowballr.UserSettingsOuterClass
 
 data class UserSettingsWithCriteria(
     val settings: UserSettings,
     val criteria: List<Criterion>,
 )
-
-fun UserSettingsWithCriteria.toGrpc(): UserSettingsOuterClass.UserSettings =
-    UserSettingsOuterClass.UserSettings.newBuilder()
-        .setShowHotkeys(settings.areHotkeysShown)
-        .setReviewMode(settings.isReviewModeEnabled)
-        .setDefaultCriteria(criteria.toGrpc())
-        .setDefaultProjectSettings(
-            ProjectOuterClass.Project.Settings.newBuilder()
-                .setSimilarityThreshold(settings.similarityThreshold)
-                .setDecisionMatrix(settings.decisionMatrix.toGrpc())
-                .putAllFetchers(
-                    settings.fetchers.mapValues {
-                        FetcherOptions
-                            .newBuilder()
-                            .putAllOptions(it.value)
-                            .build()
-                    },
-                )
-                .setSnowballingType(settings.snowballingType.toGrpc())
-                .setReviewMaybeAllowed(settings.reviewMaybeAllowed)
-                .build(),
-        )
-        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettingsWithCriteria.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserSettingsWithCriteria.kt
@@ -1,7 +1,7 @@
 package se.uulm.snowballr.backend.model.dto.user
 
 import se.uulm.snowballr.backend.model.dto.criterion.Criterion
-import se.uulm.snowballr.backend.model.dto.criterion.toGrpcCriteria
+import se.uulm.snowballr.backend.model.dto.criterion.toGrpc
 import snowballr.Fetcher.FetcherOptions
 import snowballr.ProjectOuterClass
 import snowballr.UserSettingsOuterClass
@@ -11,11 +11,11 @@ data class UserSettingsWithCriteria(
     val criteria: List<Criterion>,
 )
 
-fun UserSettingsWithCriteria.toGrpcUserSettings(): UserSettingsOuterClass.UserSettings =
+fun UserSettingsWithCriteria.toGrpc(): UserSettingsOuterClass.UserSettings =
     UserSettingsOuterClass.UserSettings.newBuilder()
         .setShowHotkeys(settings.areHotkeysShown)
         .setReviewMode(settings.isReviewModeEnabled)
-        .setDefaultCriteria(criteria.toGrpcCriteria())
+        .setDefaultCriteria(criteria.toGrpc())
         .setDefaultProjectSettings(
             ProjectOuterClass.Project.Settings.newBuilder()
                 .setSimilarityThreshold(settings.similarityThreshold)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
@@ -1,15 +1,8 @@
 package se.uulm.snowballr.backend.model.export
 
-import snowballr.Export
-
 /**
  * Formats used for exporting data.
  */
 enum class ExportFormat {
     JSON,
 }
-
-fun Set<ExportFormat>.toGrpc(): Export.AvailableExportFormatsResponse = Export.AvailableExportFormatsResponse
-    .newBuilder()
-    .addAllFormats(this.map { it.toString() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/ExportFormat.kt
@@ -1,8 +1,15 @@
 package se.uulm.snowballr.backend.model.export
 
+import snowballr.Export
+
 /**
  * Formats used for exporting data.
  */
 enum class ExportFormat {
     JSON,
 }
+
+fun Set<ExportFormat>.toGrpc(): Export.AvailableExportFormatsResponse = Export.AvailableExportFormatsResponse
+    .newBuilder()
+    .addAllFormats(this.map { it.toString() })
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/FileExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/FileExport.kt
@@ -1,5 +1,8 @@
 package se.uulm.snowballr.backend.model.export
 
+import com.google.protobuf.kotlin.toByteString
+import snowballr.Export
+
 /**
  * Data class that represents a file that has been exported.
  */
@@ -23,3 +26,8 @@ data class FileExport(
         return result
     }
 }
+
+fun FileExport.toGrpc(): Export.ExportResponse = Export.ExportResponse.newBuilder()
+    .setData(data.toByteString())
+    .setFileName(filename)
+    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/export/FileExport.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/export/FileExport.kt
@@ -1,8 +1,5 @@
 package se.uulm.snowballr.backend.model.export
 
-import com.google.protobuf.kotlin.toByteString
-import snowballr.Export
-
 /**
  * Data class that represents a file that has been exported.
  */
@@ -26,8 +23,3 @@ data class FileExport(
         return result
     }
 }
-
-fun FileExport.toGrpc(): Export.ExportResponse = Export.ExportResponse.newBuilder()
-    .setData(data.toByteString())
-    .setFileName(filename)
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherInformation.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherInformation.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.model.fetcher
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import snowballr.Fetcher
 
 @Serializable
 data class FetcherInformation(
@@ -15,11 +14,3 @@ data class FetcherInformation(
     @SerialName("options_schema")
     val optionsSchema: Map<String, FetcherOptionsSchema>,
 )
-
-fun FetcherInformation.toGrpc(fetcherId: String): Fetcher.FetcherInformation = Fetcher.FetcherInformation.newBuilder()
-    .setId(fetcherId)
-    .setName(name)
-    .setDescription(description)
-    .addAllLinks(links.map { it.toGrpc() })
-    .putAllOptionsSchema(optionsSchema.mapValues { it.value.toGrpc() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherInformationWithId.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherInformationWithId.kt
@@ -1,10 +1,6 @@
 package se.uulm.snowballr.backend.model.fetcher
 
-import snowballr.Fetcher
-
 data class FetcherInformationWithId(
     val id: String,
     val information: FetcherInformation,
 )
-
-fun FetcherInformationWithId.toGrpc(): Fetcher.FetcherInformation = information.toGrpc(id)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherOptionsSchema.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherOptionsSchema.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.model.fetcher
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import snowballr.Fetcher
 
 @Serializable
 data class FetcherOptionsSchema(
@@ -17,11 +16,3 @@ data class FetcherOptionsSchema(
     @SerialName("default_value")
     val defaultValue: String?,
 )
-
-fun FetcherOptionsSchema.toGrpc(): Fetcher.FetcherOptionSchema = Fetcher.FetcherOptionSchema.newBuilder()
-    .setName(name)
-    .setDescription(description)
-    .setRequired(isRequired)
-    .setIsSecret(isSecret)
-    .apply { if (defaultValue != null) setDefaultValue(defaultValue) }
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/Link.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/Link.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.model.fetcher
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import snowballr.Base
 
 @Serializable
 data class Link(
@@ -11,8 +10,3 @@ data class Link(
     @SerialName("url")
     val url: String,
 )
-
-fun Link.toGrpc(): Base.Link = Base.Link.newBuilder()
-    .setLabel(label)
-    .setUrl(url)
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/authentication/ChangePasswordRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/authentication/ChangePasswordRequest.kt
@@ -1,0 +1,6 @@
+package se.uulm.snowballr.backend.model.incoming.authentication
+
+data class ChangePasswordRequest(
+    val oldPassword: String,
+    val newPassword: String,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/authentication/LoginRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/authentication/LoginRequest.kt
@@ -1,0 +1,6 @@
+package se.uulm.snowballr.backend.model.incoming.authentication
+
+data class LoginRequest(
+    val email: String,
+    val password: String,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/invitation/InvitationResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/invitation/InvitationResponse.kt
@@ -3,7 +3,6 @@ package se.uulm.snowballr.backend.model.outgoing.invitation
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import snowballr.UserOuterClass
 import java.util.UUID
 
 data class InvitationResponse(
@@ -34,16 +33,3 @@ data class InvitationResponse(
         )
     }
 }
-
-fun InvitationResponse.toGrpc(): UserOuterClass.User = UserOuterClass.User.newBuilder()
-    .setId(userId?.toString().orEmpty())
-    .setEmail(email)
-    .setFirstName(firstName)
-    .setLastName(lastName)
-    .setRole(role.toGrpc())
-    .setStatus(status.toGrpc())
-    .build()
-
-fun List<InvitationResponse>.toGrpc(): UserOuterClass.User.List = UserOuterClass.User.List.newBuilder()
-    .addAllUsers(this.map { it.toGrpc() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/FetcherPaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/FetcherPaperResponse.kt
@@ -3,10 +3,8 @@ package se.uulm.snowballr.backend.model.outgoing.paper
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.PaperData
-import se.uulm.snowballr.backend.model.dto.paper.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
-import snowballr.PaperOuterClass
 import java.util.UUID
 
 data class FetcherPaperResponse(
@@ -45,21 +43,3 @@ data class FetcherPaperResponse(
         )
     }
 }
-
-fun FetcherPaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBuilder()
-    .setId(id?.toString().orEmpty())
-    .setExternalId(externalId.orEmpty())
-    .setTitle(title)
-    .setAbstrakt(abstract)
-    .setYear(year)
-    .setPublisher(publisher)
-    .setPublicationName(publicationName)
-    .setPublicationType(publicationType)
-    .addAllAuthors(authors.toGrpc())
-    .putAllFetcherMetadata(fetcherMetadata)
-    .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
-    .build()
-
-fun List<FetcherPaperResponse>.toGrpc(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List.newBuilder()
-    .addAllPapers(this.map { it.toGrpc() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/FetcherPaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/FetcherPaperResponse.kt
@@ -3,7 +3,7 @@ package se.uulm.snowballr.backend.model.outgoing.paper
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.PaperData
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcAuthors
+import se.uulm.snowballr.backend.model.dto.paper.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import snowballr.PaperOuterClass
@@ -55,7 +55,7 @@ fun FetcherPaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper
     .setPublisher(publisher)
     .setPublicationName(publicationName)
     .setPublicationType(publicationType)
-    .addAllAuthors(authors.toGrpcAuthors())
+    .addAllAuthors(authors.toGrpc())
     .putAllFetcherMetadata(fetcherMetadata)
     .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
     .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/PaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/PaperResponse.kt
@@ -2,9 +2,7 @@ package se.uulm.snowballr.backend.model.outgoing.paper
 
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
-import snowballr.PaperOuterClass
 import java.util.UUID
 
 data class PaperResponse(
@@ -36,21 +34,3 @@ data class PaperResponse(
         )
     }
 }
-
-fun PaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBuilder()
-    .setId(id.toString())
-    .setExternalId(externalId.orEmpty())
-    .setTitle(title)
-    .setAbstrakt(abstract)
-    .setYear(year)
-    .setPublisher(publisher)
-    .setPublicationName(publicationName)
-    .setPublicationType(publicationType)
-    .addAllAuthors(authors.toGrpc())
-    .putAllFetcherMetadata(fetcherMetadata)
-    .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
-    .build()
-
-fun List<PaperResponse>.toGrpc(): PaperOuterClass.Paper.List = PaperOuterClass.Paper.List.newBuilder()
-    .addAllPapers(this.map { it.toGrpc() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/PaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/paper/PaperResponse.kt
@@ -2,7 +2,7 @@ package se.uulm.snowballr.backend.model.outgoing.paper
 
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.Paper
-import se.uulm.snowballr.backend.model.dto.paper.toGrpcAuthors
+import se.uulm.snowballr.backend.model.dto.paper.toGrpc
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import snowballr.PaperOuterClass
 import java.util.UUID
@@ -46,7 +46,7 @@ fun PaperResponse.toGrpc(): PaperOuterClass.Paper = PaperOuterClass.Paper.newBui
     .setPublisher(publisher)
     .setPublicationName(publicationName)
     .setPublicationType(publicationType)
-    .addAllAuthors(authors.toGrpcAuthors())
+    .addAllAuthors(authors.toGrpc())
     .putAllFetcherMetadata(fetcherMetadata)
     .addAllBackwardReferencedIds(backwardReferencedIds.map { it.toString() })
     .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectDecisionCount.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectDecisionCount.kt
@@ -1,15 +1,8 @@
 package se.uulm.snowballr.backend.model.outgoing.project
 
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
-import snowballr.ProjectOuterClass
 
 data class ProjectDecisionCount(
     val decision: PaperDecision,
     val count: Int,
 )
-
-fun ProjectDecisionCount.toGrpc(): ProjectOuterClass.Project.Information.DecisionStatistics.Statistic =
-    ProjectOuterClass.Project.Information.DecisionStatistics.Statistic.newBuilder()
-        .setDecision(decision.toGrpc())
-        .setCount(count.toLong())
-        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectDecisionStatistics.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectDecisionStatistics.kt
@@ -1,12 +1,5 @@
 package se.uulm.snowballr.backend.model.outgoing.project
 
-import snowballr.ProjectOuterClass
-
 data class ProjectDecisionStatistics(
     val statistics: List<ProjectDecisionCount>,
 )
-
-fun ProjectDecisionStatistics.toGrpc(): ProjectOuterClass.Project.Information.DecisionStatistics =
-    ProjectOuterClass.Project.Information.DecisionStatistics.newBuilder()
-        .addAllStatistics(statistics.map { it.toGrpc() })
-        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectInformation.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectInformation.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.outgoing.project
 
-import com.google.protobuf.timestamp
-import snowballr.ProjectOuterClass
 import java.time.OffsetDateTime
 
 data class ProjectInformation(
@@ -18,10 +16,3 @@ data class ProjectInformation(
      */
     val lastStageStarted: OffsetDateTime,
 )
-
-fun ProjectInformation.toGrpc(): ProjectOuterClass.Project.Information =
-    ProjectOuterClass.Project.Information.newBuilder()
-        .setProjectProgress(progress)
-        .setCreationDate(timestamp { seconds = creationDate.toEpochSecond() })
-        .setLastStageStarted(timestamp { seconds = lastStageStarted.toEpochSecond() })
-        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/projectpaper/ProjectPaperResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/projectpaper/ProjectPaperResponse.kt
@@ -3,10 +3,7 @@ package se.uulm.snowballr.backend.model.outgoing.projectpaper
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
 import se.uulm.snowballr.backend.model.dto.projectpaper.ProjectPaperWithPaper
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
-import se.uulm.snowballr.backend.model.outgoing.paper.toGrpc
 import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
-import se.uulm.snowballr.backend.model.outgoing.review.toGrpc
-import snowballr.ProjectOuterClass
 import java.util.UUID
 
 data class ProjectPaperResponse(
@@ -32,17 +29,3 @@ data class ProjectPaperResponse(
         )
     }
 }
-
-fun ProjectPaperResponse.toGrpc(): ProjectOuterClass.Project.Paper = ProjectOuterClass.Project.Paper.newBuilder()
-    .setId(this.id.toString())
-    .setPaper(this.paper.toGrpc())
-    .setStage(this.stage.toLong())
-    .setDecision(this.decision.toGrpc())
-    .addAllReviews(reviews.map { it.toGrpc() })
-    .setLocalId(this.localPaperId.toString())
-    .build()
-
-fun List<ProjectPaperResponse>.toGrpc(): ProjectOuterClass.Project.Paper.List =
-    ProjectOuterClass.Project.Paper.List.newBuilder()
-        .addAllProjectPapers(this.map { it.toGrpc() })
-        .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/review/ReviewResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/review/ReviewResponse.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.model.outgoing.review
 
 import se.uulm.snowballr.backend.model.dto.review.Review
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
-import snowballr.ReviewOuterClass
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -27,16 +26,3 @@ data class ReviewResponse(
         )
     }
 }
-
-fun ReviewResponse.toGrpc(): ReviewOuterClass.Review = ReviewOuterClass.Review
-    .newBuilder()
-    .setId(id.toString())
-    .setUserId(userId.toString())
-    .setDecision(decision.toGrpc())
-    .addAllSelectedCriteriaIds(selectedCriteriaIds.map { it.toString() })
-    .build()
-
-fun List<ReviewResponse>.toGrpcReviews(): ReviewOuterClass.Review.List = ReviewOuterClass.Review.List
-    .newBuilder()
-    .addAllReviews(this.map { it.toGrpc() })
-    .build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
@@ -12,17 +12,18 @@ import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.failedprecondition.EntityNotActiveException
 import se.uulm.snowballr.backend.model.exception.invalidargument.IncorrectOldPasswordException
 import se.uulm.snowballr.backend.model.exception.notfound.VerificationTokenNotFoundException
+import se.uulm.snowballr.backend.model.incoming.authentication.ChangePasswordRequest
+import se.uulm.snowballr.backend.model.incoming.authentication.LoginRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
-import snowballr.Authentication
 import java.time.OffsetDateTime
 
 interface IAuthenticationService {
     /**
      * Service implementation of [SnowballRService.verifyEmail].
      */
-    suspend fun verifyEmail(request: Authentication.VerifyEmailRequest)
+    suspend fun verifyEmail(token: String)
 
     /**
      * Service implementation of [SnowballRService.logout].
@@ -32,12 +33,12 @@ interface IAuthenticationService {
     /**
      * Service implementation of [SnowballRService.login].
      */
-    suspend fun login(request: Authentication.LoginRequest)
+    suspend fun login(request: LoginRequest)
 
     /**
      * Service implementation of [SnowballRService.changePassword].
      */
-    suspend fun changePassword(request: Authentication.PasswordChangeRequest)
+    suspend fun changePassword(request: ChangePasswordRequest)
 }
 
 /**
@@ -57,12 +58,12 @@ class AuthenticationService(
     private val verificationTokenRepo: IVerificationTokenTableRepo,
     private val jwtManager: IJwtManager,
 ) : IAuthenticationService {
-    override suspend fun verifyEmail(request: Authentication.VerifyEmailRequest) {
-        val verificationToken = verificationTokenRepo.getVerificationTokenByValue(request.token).getOrThrow()
+    override suspend fun verifyEmail(token: String) {
+        val verificationToken = verificationTokenRepo.getVerificationTokenByValue(token).getOrThrow()
 
         // Check if the token has expired
         if (OffsetDateTime.now().isAfter(verificationToken.expiresAt)) {
-            verificationTokenRepo.deleteVerificationToken(request.token)
+            verificationTokenRepo.deleteVerificationToken(token)
             throw VerificationTokenNotFoundException()
         }
 
@@ -82,7 +83,7 @@ class AuthenticationService(
         repo.updateUser(userUpdate, listOf("user.status"))
 
         // Remove the verification token after successful verification
-        verificationTokenRepo.deleteVerificationToken(request.token)
+        verificationTokenRepo.deleteVerificationToken(token)
     }
 
     override suspend fun logout() {
@@ -90,7 +91,7 @@ class AuthenticationService(
     }
 
     @Suppress("ThrowsCount")
-    override suspend fun login(request: Authentication.LoginRequest) {
+    override suspend fun login(request: LoginRequest) {
         // Check whether a user with the given email exists
         val user =
             try {
@@ -119,7 +120,7 @@ class AuthenticationService(
         GrpcContext.setAuthCookiesInContext(accessToken, refreshToken)
     }
 
-    override suspend fun changePassword(request: Authentication.PasswordChangeRequest) = withUser(repo) { currentUser ->
+    override suspend fun changePassword(request: ChangePasswordRequest) = withUser(repo) { currentUser ->
         if (!currentUser.isActiveAndConfirmed()) {
             throw EntityNotActiveException(EntityType.USER, currentUser.id)
         }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -3,18 +3,16 @@ package se.uulm.snowballr.backend.service
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
-import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.projectpaper.toProjectPaperFull
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
-import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
 import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
-import snowballr.Export.ExportRequest
+import java.util.UUID
 
 interface IExportService {
     /**
@@ -25,7 +23,7 @@ interface IExportService {
     /**
      * Service implementation of [SnowballRService.exportProject].
      */
-    suspend fun exportProject(request: ExportRequest): FileExport
+    suspend fun exportProject(projectId: UUID, format: ExportFormat): FileExport
 }
 
 /**
@@ -55,22 +53,20 @@ class ExportService(
 ) : IExportService {
     override suspend fun getAvailableExportFormats(): Set<ExportFormat> = ProjectExportManager.getSupportedFormats()
 
-    override suspend fun exportProject(request: ExportRequest): FileExport = withUser(userRepo) { currentUser ->
-        val format = ProjectExportManager.getSupportedFormats().first { it.toString() == request.format }
-        val projectId = parseUUID(request.id, EntityType.PROJECT)
+    override suspend fun exportProject(projectId: UUID, format: ExportFormat): FileExport =
+        withUser(userRepo) { currentUser ->
+            projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
 
-        projectAccessChecker.isAllowedToReadProject(currentUser, projectId)
+            val project = projectRepo.getProjectById(projectId).getOrThrow()
+            val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
+            val projectPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
+                .map {
+                    val reviewsWithSelectedCriteriaIds =
+                        reviewRepo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(it.projectPaper.id)
+                    it.toProjectPaperFull(reviewsWithSelectedCriteriaIds)
+                }
+            val projectCriteria = criterionRepo.getAllProjectCriteria(projectId)
 
-        val project = projectRepo.getProjectById(projectId).getOrThrow()
-        val projectMembers = projectMemberRepo.getProjectMembersWithUsers(projectId)
-        val projectPapers = projectPaperRepo.getAllProjectPapersWithPapers(projectId)
-            .map {
-                val reviewsWithSelectedCriteriaIds =
-                    reviewRepo.getAllReviewsWithSelectedCriteriaIdsForProjectPaper(it.projectPaper.id)
-                it.toProjectPaperFull(reviewsWithSelectedCriteriaIds)
-            }
-        val projectCriteria = criterionRepo.getAllProjectCriteria(projectId)
-
-        ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
-    }
+            ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
+        }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ExportService.kt
@@ -1,11 +1,12 @@
 package se.uulm.snowballr.backend.service
 
-import com.google.protobuf.kotlin.toByteString
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.projectpaper.toProjectPaperFull
+import se.uulm.snowballr.backend.model.export.ExportFormat
+import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.model.parseUUID
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -13,21 +14,18 @@ import se.uulm.snowballr.backend.repository.IReviewTableRepo
 import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectMemberTableRepo
 import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
-import snowballr.Export.AvailableExportFormatsResponse
 import snowballr.Export.ExportRequest
-import snowballr.Export.ExportResponse
-import snowballr.exportResponse
 
 interface IExportService {
     /**
      * Service implementation of [SnowballRService.getAvailableExportFormats].
      */
-    suspend fun getAvailableExportFormats(): AvailableExportFormatsResponse
+    suspend fun getAvailableExportFormats(): Set<ExportFormat>
 
     /**
      * Service implementation of [SnowballRService.exportProject].
      */
-    suspend fun exportProject(request: ExportRequest): ExportResponse
+    suspend fun exportProject(request: ExportRequest): FileExport
 }
 
 /**
@@ -55,12 +53,9 @@ class ExportService(
     private val userRepo: IUserTableRepo,
     private val projectAccessChecker: IProjectAccessChecker,
 ) : IExportService {
-    override suspend fun getAvailableExportFormats(): AvailableExportFormatsResponse =
-        AvailableExportFormatsResponse.newBuilder()
-            .addAllFormats(ProjectExportManager.getSupportedFormats().map { it.toString() })
-            .build()
+    override suspend fun getAvailableExportFormats(): Set<ExportFormat> = ProjectExportManager.getSupportedFormats()
 
-    override suspend fun exportProject(request: ExportRequest): ExportResponse = withUser(userRepo) { currentUser ->
+    override suspend fun exportProject(request: ExportRequest): FileExport = withUser(userRepo) { currentUser ->
         val format = ProjectExportManager.getSupportedFormats().first { it.toString() == request.format }
         val projectId = parseUUID(request.id, EntityType.PROJECT)
 
@@ -76,11 +71,6 @@ class ExportService(
             }
         val projectCriteria = criterionRepo.getAllProjectCriteria(projectId)
 
-        val fileExport =
-            ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
-        exportResponse {
-            data = fileExport.data.toByteString()
-            fileName = fileExport.filename
-        }
+        ProjectExportManager.exportProject(format, project, projectMembers, projectPapers, projectCriteria)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -61,7 +61,6 @@ import se.uulm.snowballr.backend.service.IReadingListService
 import se.uulm.snowballr.backend.service.IReviewService
 import se.uulm.snowballr.backend.service.IUserService
 import se.uulm.snowballr.backend.serviceLayerDeps
-import snowballr.Authentication
 import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
@@ -201,10 +200,7 @@ open class IntegrationTest : KoinTest {
         userService.register(registerUserRequest)
 
         // Verify the user's email
-        val verifyEmailRequest = Authentication.VerifyEmailRequest.newBuilder()
-            .setToken(verificationToken.captured)
-            .build()
-        authenticationService.verifyEmail(verifyEmailRequest)
+        authenticationService.verifyEmail(verificationToken.captured)
 
         // Retrieve the user to ensure it was added successfully
         return userService.getUserByEmail(user.email)

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/AuthenticationIntegrationTest.kt
@@ -15,8 +15,9 @@ import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.invalidargument.IncorrectOldPasswordException
+import se.uulm.snowballr.backend.model.incoming.authentication.ChangePasswordRequest
+import se.uulm.snowballr.backend.model.incoming.authentication.LoginRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
-import snowballr.Authentication
 
 @ExtendWith(GrpcTestContextExtension::class)
 class AuthenticationIntegrationTest : IntegrationTest() {
@@ -27,12 +28,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
             val user = addUser(DataBuilder.createExampleUser(email = "login.user@example.com"))
 
             assertDoesNotThrow {
-                authenticationService.login(
-                    Authentication.LoginRequest.newBuilder()
-                        .setEmail(user.email)
-                        .setPassword("SecureP@ssw0rd!")
-                        .build(),
-                )
+                authenticationService.login(LoginRequest(user.email, "SecureP@ssw0rd!"))
             }
         }
 
@@ -41,24 +37,14 @@ class AuthenticationIntegrationTest : IntegrationTest() {
             val user = addUser(DataBuilder.createExampleUser(email = "wrong.pass@example.com"))
 
             assertThrows<UnauthenticatedException> {
-                authenticationService.login(
-                    Authentication.LoginRequest.newBuilder()
-                        .setEmail(user.email)
-                        .setPassword("WrongP@ssw0rd!")
-                        .build(),
-                )
+                authenticationService.login(LoginRequest(user.email, "WrongP@ssw0rd!"))
             }
         }
 
         @Test
         fun `When a login is attempted with a non-existent email, then login fails`() = runTest {
             assertThrows<UnauthenticatedException> {
-                authenticationService.login(
-                    Authentication.LoginRequest.newBuilder()
-                        .setEmail("ghost@example.com")
-                        .setPassword("AnyP@ssw0rd!")
-                        .build(),
-                )
+                authenticationService.login(LoginRequest("ghost@example.com", "AnyP@ssw0rd!"))
             }
         }
 
@@ -79,12 +65,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
             )
 
             assertThrows<UnauthenticatedException> {
-                authenticationService.login(
-                    Authentication.LoginRequest.newBuilder()
-                        .setEmail(newUser.email)
-                        .setPassword("SecureP@ssw0rd!")
-                        .build(),
-                )
+                authenticationService.login(LoginRequest(newUser.email, "SecureP@ssw0rd!"))
             }
         }
     }
@@ -94,12 +75,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
         @Test
         fun `When a logged-in user logs out, then logout succeeds`() = runTest {
             val user = addUser(DataBuilder.createExampleUser(email = "logout.user@example.com"))
-            authenticationService.login(
-                Authentication.LoginRequest.newBuilder()
-                    .setEmail(user.email)
-                    .setPassword("SecureP@ssw0rd!")
-                    .build(),
-            )
+            authenticationService.login(LoginRequest(user.email, "SecureP@ssw0rd!"))
 
             assertDoesNotThrow { authenticationService.logout() }
         }
@@ -115,30 +91,15 @@ class AuthenticationIntegrationTest : IntegrationTest() {
 
             actAsUser(user.id) {
                 assertDoesNotThrow {
-                    authenticationService.changePassword(
-                        Authentication.PasswordChangeRequest.newBuilder()
-                            .setOldPassword(oldPassword)
-                            .setNewPassword(newPassword)
-                            .build(),
-                    )
+                    authenticationService.changePassword(ChangePasswordRequest(oldPassword, newPassword))
                 }
             }
 
             assertThrows<UnauthenticatedException> {
-                authenticationService.login(
-                    Authentication.LoginRequest.newBuilder()
-                        .setEmail(user.email)
-                        .setPassword(oldPassword)
-                        .build(),
-                )
+                authenticationService.login(LoginRequest(user.email, oldPassword))
             }
             assertDoesNotThrow {
-                authenticationService.login(
-                    Authentication.LoginRequest.newBuilder()
-                        .setEmail(user.email)
-                        .setPassword(newPassword)
-                        .build(),
-                )
+                authenticationService.login(LoginRequest(user.email, newPassword))
             }
         }
 
@@ -149,12 +110,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
 
             actAsUser(user.id) {
                 assertThrows<FailedPreconditionException> {
-                    authenticationService.changePassword(
-                        Authentication.PasswordChangeRequest.newBuilder()
-                            .setOldPassword("SecureP@ssw0rd!")
-                            .setNewPassword("NewP@ssw0rd!!22")
-                            .build(),
-                    )
+                    authenticationService.changePassword(ChangePasswordRequest("SecureP@ssw0rd!", "NewP@ssw0rd!!22"))
                 }
             }
         }
@@ -165,12 +121,7 @@ class AuthenticationIntegrationTest : IntegrationTest() {
 
             actAsUser(user.id) {
                 assertThrows<IncorrectOldPasswordException> {
-                    authenticationService.changePassword(
-                        Authentication.PasswordChangeRequest.newBuilder()
-                            .setOldPassword("wrong-password")
-                            .setNewPassword("NewP@ssw0rd!!22")
-                            .build(),
-                    )
+                    authenticationService.changePassword(ChangePasswordRequest("wrong-password", "NewP@ssw0rd!!22"))
                 }
             }
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ExportIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ExportIntegrationTest.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.integration.IntegrationTest
+import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import snowballr.Export.ExportRequest
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -16,14 +16,14 @@ class ExportIntegrationTest : IntegrationTest() {
         fun `When available export formats are requested, then JSON is included`() = runTest {
             val response = exportService.getAvailableExportFormats()
 
-            assertTrue(response.formatsList.contains("JSON"))
+            assertTrue(response.contains(ExportFormat.JSON))
         }
 
         @Test
         fun `When available export formats are requested, then the list is not empty`() = runTest {
             val response = exportService.getAvailableExportFormats()
 
-            assertFalse(response.formatsList.isEmpty())
+            assertFalse(response.isEmpty())
         }
     }
 
@@ -33,29 +33,19 @@ class ExportIntegrationTest : IntegrationTest() {
         fun `When a project is exported as JSON, then the response contains non-empty data`() = runTest {
             val project = projectService.createProject(CreateProjectRequest(name = "Export Project"))
 
-            val response = exportService.exportProject(
-                ExportRequest.newBuilder()
-                    .setId(project.id.toString())
-                    .setFormat("JSON")
-                    .build(),
-            )
+            val response = exportService.exportProject(project.id, ExportFormat.JSON)
 
-            assertFalse(response.data.isEmpty)
-            assertFalse(response.fileName.isEmpty())
+            assertFalse(response.data.isEmpty())
+            assertFalse(response.filename.isEmpty())
         }
 
         @Test
         fun `When a project is exported, then the file name reflects the project name`() = runTest {
             val project = projectService.createProject(CreateProjectRequest(name = "Named Export"))
 
-            val response = exportService.exportProject(
-                ExportRequest.newBuilder()
-                    .setId(project.id.toString())
-                    .setFormat("JSON")
-                    .build(),
-            )
+            val response = exportService.exportProject(project.id, ExportFormat.JSON)
 
-            assertTrue(response.fileName.isNotBlank())
+            assertTrue(response.filename.isNotBlank())
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -17,7 +17,6 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAl
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
-import snowballr.Authentication
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -44,11 +43,7 @@ class UserIntegrationTest : IntegrationTest() {
             val unverifiedUser = userService.getUserByEmail(newUser.email)
             assertEquals(UserStatus.ACTIVE_UNCONFIRMED, unverifiedUser.status)
 
-            authenticationService.verifyEmail(
-                Authentication.VerifyEmailRequest.newBuilder()
-                    .setToken(tokenSlot.captured)
-                    .build(),
-            )
+            authenticationService.verifyEmail(tokenSlot.captured)
 
             val verifiedUser = userService.getUserByEmail(newUser.email)
             assertEquals(UserStatus.ACTIVE, verifiedUser.status)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -29,7 +29,6 @@ import se.uulm.snowballr.backend.table.ProjectTable
 import se.uulm.snowballr.backend.table.UserTable
 import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
-import snowballr.ProjectOuterClass.ReviewDecisionMatrix
 import java.sql.SQLException
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -521,10 +520,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             assertThat(userSettings.criteriaIds).isEmpty()
             assertEquals(0F, userSettings.similarityThreshold)
             assertEquals(2, userSettings.decisionMatrix.numberOfReviewers)
-            assertNotEquals(
-                ReviewDecisionMatrix.getDefaultInstance().toByteArray(),
-                userSettings.decisionMatrix.toByteArray(),
-            )
+            assertNotEquals(ByteArray(0), userSettings.decisionMatrix.toByteArray())
             assertThat(userSettings.fetchers).isEmpty()
             assertEquals(SnowballingType.BOTH, userSettings.snowballingType)
             assertTrue(userSettings.reviewMaybeAllowed)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/ChangePasswordTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/ChangePasswordTest.kt
@@ -14,16 +14,13 @@ import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.invalidargument.IncorrectOldPasswordException
-import snowballr.Authentication
+import se.uulm.snowballr.backend.model.incoming.authentication.ChangePasswordRequest
 
 class ChangePasswordTest : AuthenticationServiceTest() {
     @Test
     fun `When the current user is not active, then a FailedPreconditionException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(status = UserStatus.DELETED)
-        val request = Authentication.PasswordChangeRequest.newBuilder()
-            .setOldPassword("AAbb__00")
-            .setNewPassword("CCdd__11")
-            .build()
+        val request = ChangePasswordRequest("AAbb__00", "CCdd__11")
 
         mockCurrentUser(currentUser)
 
@@ -33,10 +30,7 @@ class ChangePasswordTest : AuthenticationServiceTest() {
     @Test
     fun `When getPasswordHashByEmail returns a failure, then an exception is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(status = UserStatus.ACTIVE)
-        val request = Authentication.PasswordChangeRequest.newBuilder()
-            .setOldPassword("AAbb__00")
-            .setNewPassword("CCdd__11")
-            .build()
+        val request = ChangePasswordRequest("AAbb__00", "CCdd__11")
 
         mockCurrentUser(currentUser)
         coEvery { userRepoMock.getPasswordHashByEmail(currentUser.email) } returns
@@ -48,10 +42,7 @@ class ChangePasswordTest : AuthenticationServiceTest() {
     @Test
     fun `When the provided old password is incorrect, then an InvalidOldPasswordException is thrown`() = runTest {
         val currentUser = DataBuilder.createExampleUser(status = UserStatus.ACTIVE)
-        val request = Authentication.PasswordChangeRequest.newBuilder()
-            .setOldPassword("wrong-password")
-            .setNewPassword("CCdd__11")
-            .build()
+        val request = ChangePasswordRequest("wrong-password", "CCdd__11")
         val storedPasswordHash = PasswordUtils.hashPassword("AAbb__00")
 
         mockCurrentUser(currentUser)
@@ -65,10 +56,7 @@ class ChangePasswordTest : AuthenticationServiceTest() {
         val currentUser = DataBuilder.createExampleUser(status = UserStatus.ACTIVE)
         val oldPassword = "AAbb__00"
         val newPassword = "CCdd__11"
-        val request = Authentication.PasswordChangeRequest.newBuilder()
-            .setOldPassword(oldPassword)
-            .setNewPassword(newPassword)
-            .build()
+        val request = ChangePasswordRequest("AAbb__00", "CCdd__11")
         val storedPasswordHash = PasswordUtils.hashPassword(oldPassword)
 
         val passwordHashSlot = slot<String>()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/LoginTest.kt
@@ -16,15 +16,15 @@ import se.uulm.snowballr.backend.auth.PasswordUtils
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
+import se.uulm.snowballr.backend.model.incoming.authentication.LoginRequest
 import se.uulm.snowballr.backend.model.jwt.JwtAuthTokens
-import snowballr.Authentication.LoginRequest
 
 @ExtendWith(GrpcTestContextExtension::class)
 class LoginTest : AuthenticationServiceTest() {
     @Test
     fun `When a user provides an invalid email, then an UnauthenticatedException is thrown`() = runTest {
         val email = "wrongEmail"
-        val request = LoginRequest.newBuilder().setEmail(email).build()
+        val request = LoginRequest(email = email, password = "")
 
         val exception = UserNotFoundByEmailException("wrongEmail")
         coEvery { userRepoMock.getUserByEmail(email) } returns Result.failure(exception)
@@ -36,10 +36,7 @@ class LoginTest : AuthenticationServiceTest() {
     fun `When a user with an unconfirmed email tries to log in, then an UnauthenticatedException is thrown`() =
         runTest {
             val testUser = DataBuilder.createExampleUser(status = UserStatus.ACTIVE_UNCONFIRMED)
-            val request = LoginRequest.newBuilder()
-                .setEmail(testUser.email)
-                .setPassword("anyPassword")
-                .build()
+            val request = LoginRequest(email = testUser.email, password = "anyPassword")
 
             coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
@@ -49,10 +46,7 @@ class LoginTest : AuthenticationServiceTest() {
     @Test
     fun `When a deleted user tries to log in, then an UnauthenticatedException is thrown`() = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.DELETED)
-        val request = LoginRequest.newBuilder()
-            .setEmail(testUser.email)
-            .setPassword("anyPassword")
-            .build()
+        val request = LoginRequest(email = testUser.email, password = "anyPassword")
 
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
@@ -65,11 +59,7 @@ class LoginTest : AuthenticationServiceTest() {
         status: UserStatus,
     ) = runTest {
         val testUser = DataBuilder.createExampleUser(status = status)
-        val request = LoginRequest.newBuilder()
-            .setEmail(testUser.email)
-            .setPassword("anyPassword")
-            .build()
-
+        val request = LoginRequest(email = testUser.email, password = "anyPassword")
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
 
         assertThrows<UnauthenticatedException> { service.login(request) }
@@ -79,10 +69,7 @@ class LoginTest : AuthenticationServiceTest() {
     fun `When the password hash cannot be retrieved, then an UnauthenticatedException is thrown`() = runTest {
         val testUser = DataBuilder.createExampleUser(status = UserStatus.ACTIVE)
 
-        val request = LoginRequest.newBuilder()
-            .setEmail(testUser.email)
-            .setPassword("anyPassword")
-            .build()
+        val request = LoginRequest(email = testUser.email, password = "anyPassword")
 
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
         val exception = UserNotFoundByEmailException(testUser.email)
@@ -97,10 +84,7 @@ class LoginTest : AuthenticationServiceTest() {
         val userPassword = "AAbb__00"
         val passwordHash = PasswordUtils.hashPassword(userPassword)
 
-        val request = LoginRequest.newBuilder()
-            .setEmail(testUser.email)
-            .setPassword("wrongPassword")
-            .build()
+        val request = LoginRequest(email = testUser.email, password = "wrongPassword")
 
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns Result.success(passwordHash)
@@ -117,10 +101,7 @@ class LoginTest : AuthenticationServiceTest() {
         val passwordHash = PasswordUtils.hashPassword(userPassword)
         val tokens = JwtAuthTokens("accessToken", "refreshToken")
 
-        val request = LoginRequest.newBuilder()
-            .setEmail(testUser.email)
-            .setPassword(userPassword)
-            .build()
+        val request = LoginRequest(email = testUser.email, password = userPassword)
 
         coEvery { userRepoMock.getUserByEmail(testUser.email) } returns Result.success(testUser)
         coEvery { userRepoMock.getPasswordHashByEmail(testUser.email) } returns Result.success(passwordHash)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/VerifyEmailTest.kt
@@ -12,20 +12,18 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.exception.notfound.VerificationTokenNotFoundException
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
-import snowballr.Authentication
 import java.time.OffsetDateTime
 
 class VerifyEmailTest : AuthenticationServiceTest() {
     @Test
     fun `When the verification token is not found, then a VerificationTokenNotFoundException is thrown`() = runTest {
         val token = "non-existent-token"
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token) } returns Result.failure(
             VerificationTokenNotFoundException(),
         )
 
-        assertThrows<VerificationTokenNotFoundException> { service.verifyEmail(request) }
+        assertThrows<VerificationTokenNotFoundException> { service.verifyEmail(token) }
     }
 
     @Test
@@ -33,25 +31,23 @@ class VerifyEmailTest : AuthenticationServiceTest() {
         val expiredToken = DataBuilder.createExampleVerificationToken(
             expiresAt = OffsetDateTime.now().minusMinutes(1),
         )
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(expiredToken.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(expiredToken.token) } returns Result.success(
             expiredToken,
         )
         coJustRun { verificationTokenRepoMock.deleteVerificationToken(expiredToken.token) }
 
-        assertThrows<VerificationTokenNotFoundException> { service.verifyEmail(request) }
+        assertThrows<VerificationTokenNotFoundException> { service.verifyEmail(expiredToken.token) }
     }
 
     @Test
     fun `When the user associated with the token is not found, then a TestSpecificException is thrown`() = runTest {
         val token = DataBuilder.createExampleVerificationToken()
-        val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
 
         coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns Result.success(token)
         coEvery { userRepoMock.getUserById(token.userId) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { service.verifyEmail(request) }
+        assertThrows<TestSpecificException> { service.verifyEmail(token.token) }
     }
 
     @Test
@@ -59,7 +55,6 @@ class VerifyEmailTest : AuthenticationServiceTest() {
         runTest {
             val user = DataBuilder.createExampleUser(status = UserStatus.ACTIVE_UNCONFIRMED)
             val token = DataBuilder.createExampleVerificationToken(userId = user.id)
-            val request = Authentication.VerifyEmailRequest.newBuilder().setToken(token.token).build()
             val userUpdateSlot = slot<UpdateUserRequest>()
 
             coEvery { verificationTokenRepoMock.getVerificationTokenByValue(token.token) } returns Result.success(token)
@@ -67,7 +62,7 @@ class VerifyEmailTest : AuthenticationServiceTest() {
             coEvery { userRepoMock.updateUser(capture(userUpdateSlot), any()) } returns user
             coJustRun { verificationTokenRepoMock.deleteVerificationToken(token.token) }
 
-            service.verifyEmail(request)
+            service.verifyEmail(token.token)
 
             coVerify(exactly = 1) {
                 verificationTokenRepoMock.deleteVerificationToken(token.token)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -47,8 +47,8 @@ class ExportProjectTest : ExportServiceTest() {
 
         val result = service.exportProject(request)
 
-        assertEquals("test.json", result.fileName)
-        assertEquals(ByteArray(0).toList(), result.data.toByteArray().toList())
+        assertEquals("test.json", result.filename)
+        assertEquals(ByteArray(0).toList(), result.data.toList())
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -13,22 +13,16 @@ import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
-import snowballr.copy
-import snowballr.exportRequest
 import java.util.UUID
 import kotlin.test.assertEquals
 
 class ExportProjectTest : ExportServiceTest() {
-    fun getExampleRequest() = exportRequest {
-        id = UUID.randomUUID().toString()
-        format = ExportFormat.JSON.toString()
-    }
+    private val testFormat = ExportFormat.JSON
 
     @Test
     fun `When a user exports a project and has access, then the result has the correct values`() = runTest {
         val user = DataBuilder.createExampleUser()
         val projectId = UUID.randomUUID()
-        val request = getExampleRequest().copy { id = projectId.toString() }
 
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
@@ -45,7 +39,7 @@ class ExportProjectTest : ExportServiceTest() {
             ProjectExportManager.exportProject(any(), any(), any(), any(), any())
         } returns FileExport(ByteArray(0), "test.json")
 
-        val result = service.exportProject(request)
+        val result = service.exportProject(projectId, testFormat)
 
         assertEquals("test.json", result.filename)
         assertEquals(ByteArray(0).toList(), result.data.toList())
@@ -55,21 +49,19 @@ class ExportProjectTest : ExportServiceTest() {
     fun `When a user exports a project, but has no access, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.DEFAULT)
         val project = DataBuilder.createExampleProject()
-        val request = getExampleRequest().copy { id = project.id.toString() }
 
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
         every { ProjectExportManager.getSupportedFormats() } returns setOf(ExportFormat.JSON)
         coEvery { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) } throws TestSpecificException()
 
-        assertThrows<TestSpecificException> { service.exportProject(request) }
+        assertThrows<TestSpecificException> { service.exportProject(project.id, testFormat) }
     }
 
     @Test
     fun `When retrieving the project fails, then a TestSpecificException is thrown`() = runTest {
         val user = DataBuilder.createExampleUser(role = UserRole.DEFAULT)
         val project = DataBuilder.createExampleProject()
-        val request = getExampleRequest().copy { id = project.id.toString() }
 
         mockCurrentUser(user)
         mockkObject(ProjectExportManager)
@@ -77,6 +69,6 @@ class ExportProjectTest : ExportServiceTest() {
         coJustRun { projectAccessCheckerMock.isAllowedToReadProject(user, project.id) }
         coEvery { projectRepoMock.getProjectById(project.id) } returns Result.failure(TestSpecificException())
 
-        assertThrows<TestSpecificException> { service.exportProject(request) }
+        assertThrows<TestSpecificException> { service.exportProject(project.id, testFormat) }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
@@ -16,6 +16,6 @@ class GetAvailableExportFormatsTest : ExportServiceTest() {
 
         val formats = service.getAvailableExportFormats()
 
-        assertEquals(ExportFormat.entries.map { it.toString() }.toSet(), formats.formatsList.toSet())
+        assertEquals(ExportFormat.entries.toSet(), formats)
     }
 }


### PR DESCRIPTION
Closes #561

## What I have made

Waits for #560

This removes any grpc related types from the service and repo layer for the project paper and project member domain.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
