### PR TITLE
Remove remaining grpc imports outside of grpc package

### DIFF
--- a/src/main/kotlin/se/uulm/snowballr/backend/access/ProjectAccessChecker.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/access/ProjectAccessChecker.kt
@@ -10,10 +10,7 @@ import se.uulm.snowballr.backend.access.rules.orElse
 import se.uulm.snowballr.backend.access.rules.orElseThrow
 import se.uulm.snowballr.backend.model.AccessType
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.dto.project.isActive
-import se.uulm.snowballr.backend.model.dto.project.isDeleted
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.isServerAdmin
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.exception.failedprecondition.EntityNotActiveException
@@ -175,12 +172,12 @@ class ProjectAccessChecker(
 
     override fun isProjectExistent() = AccessRule<UUID> { user, projectId ->
         val project = projectRepo.getProjectById(projectId).getOrNull()
-        project != null && (!project.isDeleted() || user.isServerAdmin())
+        project != null && (!project.isDeleted || user.isServerAdmin)
     }.orElseThrow { _, projectId -> ProjectNotFoundException(projectId) }
 
     override fun isProjectActiveById() = AccessRule<UUID> { _, projectId ->
         val project = projectRepo.getProjectById(projectId).getOrNull()
-        project != null && project.isActive()
+        project != null && project.isActive
     }.orElseThrow { _, projectId -> EntityNotActiveException(EntityType.PROJECT, projectId) }
 
     override fun isProjectOrServerAdmin(accessType: AccessType, entityType: EntityType) = isProjectAdmin()

--- a/src/main/kotlin/se/uulm/snowballr/backend/access/rules/ProjectAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/access/rules/ProjectAccessRule.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.access.rules
 
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.project.Project
-import se.uulm.snowballr.backend.model.dto.project.isActive
 import se.uulm.snowballr.backend.model.exception.failedprecondition.EntityNotActiveException
 import javax.annotation.CheckReturnValue
 
@@ -12,6 +11,5 @@ import javax.annotation.CheckReturnValue
  * @throws EntityNotActiveException if the project is not active.
  */
 @CheckReturnValue
-fun isProjectActive() = AccessRule<Project> { _, project ->
-    project.isActive()
-}.orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id) }
+fun isProjectActive() = AccessRule<Project> { _, project -> project.isActive }
+    .orElseThrow { _, project -> EntityNotActiveException(EntityType.PROJECT, project.id) }

--- a/src/main/kotlin/se/uulm/snowballr/backend/access/rules/UserAccessRule.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/access/rules/UserAccessRule.kt
@@ -1,8 +1,6 @@
 package se.uulm.snowballr.backend.access.rules
 
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.isActive
-import se.uulm.snowballr.backend.model.dto.user.isServerAdmin
 import java.util.UUID
 import javax.annotation.CheckReturnValue
 
@@ -10,7 +8,7 @@ import javax.annotation.CheckReturnValue
  * Check whether the requesting user is a server admin.
  */
 @CheckReturnValue
-fun isServerAdmin() = AccessRule<Unit> { requester, _ -> requester.isServerAdmin() }
+fun isServerAdmin() = AccessRule<Unit> { requester, _ -> requester.isServerAdmin }
 
 /**
  * Check whether the requesting user and the target user are the same by checking whether they have the same user ID.
@@ -28,7 +26,7 @@ fun isServerAdminOrSameUser() = isServerAdmin().forTarget<UUID>().orElse(isSameU
  * Check whether the target user is active (according to [User.isActive]).
  */
 @CheckReturnValue
-fun isTargetUserActive() = AccessRule<User> { _, target -> target.isActive() }
+fun isTargetUserActive() = AccessRule<User> { _, target -> target.isActive }
 
 /**
  * Check whether the requester is a server admin (according to [isServerAdmin]) **OR** the target user is active
@@ -41,4 +39,4 @@ fun isServerAdminOrTargetUserActive() = isServerAdmin().forTarget<User>().orElse
  * Check whether the target user is not a server admin (according to [User.isServerAdmin]).
  */
 @CheckReturnValue
-fun isTargetUserNotAdmin() = AccessRule<User> { _, target -> !target.isServerAdmin() }
+fun isTargetUserNotAdmin() = AccessRule<User> { _, target -> !target.isServerAdmin }

--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/AuthenticationManager.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/AuthenticationManager.kt
@@ -3,8 +3,8 @@ package se.uulm.snowballr.backend.auth
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.jsonwebtoken.JwtException
 import se.uulm.snowballr.backend.context.RequestContext
+import se.uulm.snowballr.backend.model.auth.AuthenticationStatus
 import se.uulm.snowballr.backend.model.jwt.ParsedJwtAuthClaims
-import snowballr.Authentication
 
 private val logger = KotlinLogging.logger {}
 
@@ -52,14 +52,13 @@ class AuthenticationManager(private val jwtManager: IJwtManager) : IAuthenticati
         }
 
         val (status, result) = if (parsedAccessTokenResult.isSuccess) {
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED to parsedAccessTokenResult
+            AuthenticationStatus.AUTHENTICATED to parsedAccessTokenResult
         } else {
             val refreshResult = attemptTokenRefresh(refreshToken, skipRefresh, requestContext)
             if (refreshResult.isSuccess) {
-                Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED to refreshResult
+                AuthenticationStatus.ACCESS_TOKEN_EXPIRED to refreshResult
             } else {
-                Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED to Result
-                    .failure(JwtException("Authentication failed"))
+                AuthenticationStatus.UNAUTHENTICATED to Result.failure(JwtException("Authentication failed"))
             }
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/auth/DummyUser.kt
@@ -2,8 +2,6 @@ package se.uulm.snowballr.backend.auth
 
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import se.uulm.snowballr.backend.model.fetcher.FetcherMap
-import snowballr.ProjectOuterClass
 import java.util.UUID
 
 /**
@@ -23,14 +21,4 @@ object DummyUser {
     var passwordHash: String = PasswordUtils.hashPassword(password)
     var role: UserRole = UserRole.ADMIN
     var status: UserStatus = UserStatus.ACTIVE
-
-    // user settings
-    var areHotkeysShown: Boolean = true
-    var isReviewModeEnabled: Boolean = false
-    var criteriaIds: List<UUID> = emptyList()
-    var similarityThreshold: Float = 0F
-    var decisionMatrix: ByteArray = ProjectOuterClass.ReviewDecisionMatrix.getDefaultInstance().toByteArray()
-    var fetchers: FetcherMap = emptyMap()
-    var snowballingType: ProjectOuterClass.SnowballingType = ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
-    var reviewMaybeAllowed: Boolean = true
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/context/RequestContext.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/context/RequestContext.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.context
 
 import kotlinx.coroutines.ThreadContextElement
+import se.uulm.snowballr.backend.model.auth.AuthenticationStatus
 import se.uulm.snowballr.backend.model.exception.internal.missingcontext.MissingRequestContextException
 import se.uulm.snowballr.backend.model.exception.internal.missingcontext.MissingUserIdException
-import snowballr.Authentication.AuthenticationStatus
 import java.util.Optional
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -28,7 +28,7 @@ import kotlin.jvm.optionals.getOrNull
  */
 class RequestContext(
     userId: UUID? = null,
-    authStatus: AuthenticationStatus = AuthenticationStatus.AUTHENTICATION_STATUS_UNSPECIFIED,
+    authStatus: AuthenticationStatus = AuthenticationStatus.UNAUTHENTICATED,
 ) : AbstractCoroutineContextElement(RequestContext), ThreadContextElement<RequestContext?> {
     @Volatile
     var userId: UUID? = userId

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -155,13 +155,13 @@ class FetcherOrchestrator(
      * fetched by calling the [fetcherManager].
      */
     private suspend fun runFetching(job: FetcherProcessingJob, paper: Paper): FetchingResults {
-        val backwardReferences = if (job.snowballingType.isBackwardOrBoth()) {
+        val backwardReferences = if (job.snowballingType.isBackwardOrBoth) {
             fetch(job.fetchers, paper, FetchingDirection.BACKWARD)
         } else {
             emptySet()
         }
 
-        val forwardReferences = if (job.snowballingType.isForwardOrBoth()) {
+        val forwardReferences = if (job.snowballingType.isForwardOrBoth) {
             fetch(job.fetchers, paper, FetchingDirection.FORWARD)
         } else {
             emptySet()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/FromGrpcConversion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/FromGrpcConversion.kt
@@ -1,0 +1,116 @@
+package se.uulm.snowballr.backend.grpc
+
+import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
+import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
+import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPatternEntry
+import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
+import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
+import se.uulm.snowballr.backend.model.dto.project.SnowballingType
+import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
+import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
+import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
+import se.uulm.snowballr.backend.model.dto.user.UserRole
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
+import snowballr.CriterionOuterClass
+import snowballr.ProjectOuterClass
+import snowballr.ReviewOuterClass
+import snowballr.UserOuterClass
+
+private const val INVALID_CONVERSION_MESSAGE = "Invalid conversion"
+
+fun criterionCategoryFromGrpc(category: CriterionOuterClass.CriterionCategory): CriterionCategory = when (category) {
+    CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_INCLUSION -> CriterionCategory.INCLUSION
+    CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION -> CriterionCategory.EXCLUSION
+    CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION -> CriterionCategory.HARD_EXCLUSION
+    CriterionOuterClass.CriterionCategory.UNRECOGNIZED,
+    CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED,
+    ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun decisionMatrixPatternFromGrpc(pattern: ProjectOuterClass.ReviewDecisionMatrix.Pattern) = DecisionMatrixPattern(
+    decision = paperDecisionFromGrpc(pattern.decision),
+    entries = pattern.entriesList.map { decisionMatrixPatternEntryFromGrpc(it) },
+)
+
+fun decisionMatrixPatternEntryFromGrpc(entry: ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry) =
+    DecisionMatrixPatternEntry(
+        decision = reviewDecisionFromGrpc(entry.reviewDecision),
+        count = entry.count.toInt(),
+    )
+
+fun reviewDecisionMatrixFromGrpc(decisionMatrix: ProjectOuterClass.ReviewDecisionMatrix) = ReviewDecisionMatrix(
+    numberOfReviewers = decisionMatrix.numberOfReviewers,
+    patterns = decisionMatrix.patternsList.map { decisionMatrixPatternFromGrpc(it) },
+)
+
+fun projectStatusFromGrpc(status: ProjectOuterClass.ProjectStatus): ProjectStatus = when (status) {
+    ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE -> ProjectStatus.ACTIVE
+    ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED -> ProjectStatus.ARCHIVED
+    ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED -> ProjectStatus.DELETED
+    ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED -> ProjectStatus.ACTIVE_LOCKED
+    ProjectOuterClass.ProjectStatus.UNRECOGNIZED,
+    ProjectOuterClass.ProjectStatus.PROJECT_STATUS_UNSPECIFIED,
+    ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun snowballingTypeFromGrpc(type: ProjectOuterClass.SnowballingType): SnowballingType = when (type) {
+    ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD -> SnowballingType.FORWARD
+    ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BACKWARD -> SnowballingType.BACKWARD
+    ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH -> SnowballingType.BOTH
+    ProjectOuterClass.SnowballingType.UNRECOGNIZED,
+    ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_UNSPECIFIED,
+    ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun memberRoleFromGrpc(role: ProjectOuterClass.MemberRole): MemberRole = when (role) {
+    ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT -> MemberRole.DEFAULT
+    ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN -> MemberRole.ADMIN
+    ProjectOuterClass.MemberRole.UNRECOGNIZED, ProjectOuterClass.MemberRole.MEMBER_ROLE_UNSPECIFIED ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun paperDecisionFromGrpc(decision: ProjectOuterClass.PaperDecision): PaperDecision = when (decision) {
+    ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED -> PaperDecision.UNREVIEWED
+    ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW -> PaperDecision.IN_REVIEW
+    ProjectOuterClass.PaperDecision.PAPER_DECISION_DECLINED -> PaperDecision.DECLINED
+    ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED -> PaperDecision.ACCEPTED
+    ProjectOuterClass.PaperDecision.UNRECOGNIZED, ProjectOuterClass.PaperDecision.PAPER_DECISION_UNSPECIFIED,
+    ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun reviewDecisionFromGrpc(decision: ReviewOuterClass.ReviewDecision): ReviewDecision = when (decision) {
+    ReviewOuterClass.ReviewDecision.REVIEW_DECISION_DECLINED -> ReviewDecision.DECLINED
+    ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE -> ReviewDecision.MAYBE
+    ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED -> ReviewDecision.ACCEPTED
+    ReviewOuterClass.ReviewDecision.UNRECOGNIZED,
+    ReviewOuterClass.ReviewDecision.REVIEW_DECISION_UNSPECIFIED,
+    ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun userRoleFromGrpc(role: UserOuterClass.UserRole): UserRole = when (role) {
+    UserOuterClass.UserRole.USER_ROLE_DEFAULT -> UserRole.DEFAULT
+    UserOuterClass.UserRole.USER_ROLE_ADMIN -> UserRole.ADMIN
+    UserOuterClass.UserRole.UNRECOGNIZED, UserOuterClass.UserRole.USER_ROLE_UNSPECIFIED ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}
+
+fun userStatusFromGrpc(status: UserOuterClass.UserStatus): UserStatus = when (status) {
+    UserOuterClass.UserStatus.USER_STATUS_ACTIVE -> UserStatus.ACTIVE
+    UserOuterClass.UserStatus.USER_STATUS_DELETED -> UserStatus.DELETED
+    UserOuterClass.UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED -> UserStatus.ACTIVE_UNCONFIRMED
+    UserOuterClass.UserStatus.UNRECOGNIZED, UserOuterClass.UserStatus.USER_STATUS_UNSPECIFIED ->
+        @Suppress("UseCheckOrError")
+        throw IllegalStateException(INVALID_CONVERSION_MESSAGE)
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -24,16 +24,7 @@ import se.uulm.snowballr.backend.grpc.interceptor.loggingInterceptor
 import se.uulm.snowballr.backend.grpc.interceptor.requestContextCoroutineInterceptor
 import se.uulm.snowballr.backend.grpc.interceptor.validationInterceptor
 import se.uulm.snowballr.backend.model.EntityType
-import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.paper.Author
-import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
-import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
-import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
-import se.uulm.snowballr.backend.model.dto.project.SnowballingType
-import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
-import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
-import se.uulm.snowballr.backend.model.dto.user.UserRole
-import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.incoming.authentication.ChangePasswordRequest
 import se.uulm.snowballr.backend.model.incoming.authentication.LoginRequest
@@ -303,8 +294,8 @@ class SnowballRServer(
                     firstName = request.user.firstName,
                     lastName = request.user.lastName,
                     email = request.user.email,
-                    role = UserRole.fromGrpc(request.user.role),
-                    status = UserStatus.fromGrpc(request.user.status),
+                    role = userRoleFromGrpc(request.user.role),
+                    status = userStatusFromGrpc(request.user.status),
                 ),
                 FieldMaskUtil.normalize(request.mask).pathsList,
             ).toGrpc()
@@ -412,17 +403,13 @@ class SnowballRServer(
                 UpdateProjectRequest(
                     projectId = parseUUID(request.project.id, EntityType.PROJECT),
                     name = request.project.name,
-                    status = ProjectStatus.fromGrpc(request.project.status),
+                    status = projectStatusFromGrpc(request.project.status),
                     settings = UpdateProjectSettingRequest(
                         similarityThreshold = request.project.settings.similarityThreshold,
-                        snowballingType = SnowballingType.fromGrpc(request.project.settings.snowballingType),
+                        snowballingType = snowballingTypeFromGrpc(request.project.settings.snowballingType),
                         reviewMaybeAllowed = request.project.settings.reviewMaybeAllowed,
                         fetchers = request.project.settings.fetchersMap.mapValues { it.value.optionsMap },
-                        decisionMatrix = ReviewDecisionMatrix(
-                            numberOfReviewers = request.project.settings.decisionMatrix.numberOfReviewers,
-                            patterns = request.project.settings.decisionMatrix.patternsList
-                                .map { DecisionMatrixPattern.fromGrpc(it) },
-                        ),
+                        decisionMatrix = reviewDecisionMatrixFromGrpc(request.project.settings.decisionMatrix),
                     ),
                 ),
                 FieldMaskUtil.normalize(request.mask).pathsList.toSet(),
@@ -462,7 +449,7 @@ class SnowballRServer(
                 UpdateProjectMemberRoleRequest(
                     projectId = parseUUID(request.projectId, EntityType.PROJECT),
                     userId = parseUUID(request.userId, EntityType.USER),
-                    newRole = MemberRole.fromGrpc(request.newRole),
+                    newRole = memberRoleFromGrpc(request.newRole),
                 ),
             )
         }
@@ -487,7 +474,7 @@ class SnowballRServer(
                     tag = request.tag,
                     name = request.name,
                     description = request.description,
-                    category = CriterionCategory.fromGrpc(request.category),
+                    category = criterionCategoryFromGrpc(request.category),
                     projectId = projectId,
                 ),
             ).toGrpc()
@@ -501,7 +488,7 @@ class SnowballRServer(
                 tag = request.criterion.tag,
                 name = request.criterion.name,
                 description = request.criterion.description,
-                category = CriterionCategory.fromGrpc(request.criterion.category),
+                category = criterionCategoryFromGrpc(request.criterion.category),
             ),
             FieldMaskUtil.normalize(request.mask).pathsList,
         ).toGrpc()
@@ -546,7 +533,7 @@ class SnowballRServer(
             reviewService.createReview(
                 CreateReviewRequest(
                     projectPaperId = parseUUID(request.projectPaperId, EntityType.PROJECT_PAPER),
-                    decision = ReviewDecision.fromGrpc(request.decision),
+                    decision = reviewDecisionFromGrpc(request.decision),
                     selectedCriteriaIds = request.selectedCriteriaIdsList.map { parseUUID(it, EntityType.CRITERION) },
                 ),
             ).toGrpc()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -264,7 +264,7 @@ class SnowballRServer(
         override suspend fun getAuthenticationStatus(
             request: Base.Nothing,
         ): Authentication.AuthenticationStatusResponse = Authentication.AuthenticationStatusResponse.newBuilder()
-            .setAuthenticationStatus(RequestContext.current().authStatus).build()
+            .setAuthenticationStatus(RequestContext.current().authStatus.toGrpc()).build()
 
         /** Renew Session is handled in the [authenticationInterceptor]. */
         override suspend fun renewSession(request: Base.Nothing): Base.Nothing = Base.Nothing.getDefaultInstance()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/ToGrpcConversion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/ToGrpcConversion.kt
@@ -4,12 +4,24 @@ package se.uulm.snowballr.backend.grpc
 
 import com.google.protobuf.kotlin.toByteString
 import com.google.protobuf.timestamp
+import se.uulm.snowballr.backend.model.auth.AuthenticationStatus
 import se.uulm.snowballr.backend.model.dto.criterion.Criterion
+import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
+import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPatternEntry
 import se.uulm.snowballr.backend.model.dto.project.Project
+import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
+import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
+import se.uulm.snowballr.backend.model.dto.project.SnowballingType
+import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
+import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
+import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.dto.user.User
+import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserSettingsWithCriteria
+import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
 import se.uulm.snowballr.backend.model.fetcher.FetcherInformation
@@ -24,6 +36,7 @@ import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionStatistic
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectInformation
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
+import snowballr.Authentication
 import snowballr.Base
 import snowballr.CriterionOuterClass
 import snowballr.Export
@@ -275,3 +288,79 @@ fun Set<ExportFormat>.toGrpc(): Export.AvailableExportFormatsResponse = Export.A
     .newBuilder()
     .addAllFormats(this.map { it.toString() })
     .build()
+
+fun CriterionCategory.toGrpc() = when (this) {
+    CriterionCategory.INCLUSION -> CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_INCLUSION
+    CriterionCategory.EXCLUSION -> CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION
+    CriterionCategory.HARD_EXCLUSION -> CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION
+}
+
+fun DecisionMatrixPattern.toGrpc(): ProjectOuterClass.ReviewDecisionMatrix.Pattern =
+    ProjectOuterClass.ReviewDecisionMatrix.Pattern.newBuilder()
+        .setDecision(decision.toGrpc())
+        .addAllEntries(entries.map { it.toGrpc() })
+        .build()
+
+fun DecisionMatrixPatternEntry.toGrpc(): ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry =
+    ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry.newBuilder()
+        .setReviewDecision(decision.toGrpc())
+        .setCount(count.toLong())
+        .build()
+
+fun ReviewDecisionMatrix.toGrpc(): ProjectOuterClass.ReviewDecisionMatrix =
+    ProjectOuterClass.ReviewDecisionMatrix.newBuilder()
+        .setNumberOfReviewers(numberOfReviewers)
+        .addAllPatterns(patterns.map { it.toGrpc() })
+        .build()
+
+fun ProjectStatus.toGrpc() = when (this) {
+    ProjectStatus.ACTIVE -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
+    ProjectStatus.ACTIVE_LOCKED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
+    ProjectStatus.ARCHIVED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED
+    ProjectStatus.DELETED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED
+    ProjectStatus.CLEARED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_UNSPECIFIED
+}
+
+fun SnowballingType.toGrpc(): ProjectOuterClass.SnowballingType = when (this) {
+    SnowballingType.FORWARD -> ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD
+    SnowballingType.BACKWARD -> ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BACKWARD
+    SnowballingType.BOTH -> ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
+}
+
+fun MemberRole.toGrpc() = when (this) {
+    MemberRole.DEFAULT -> ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
+    MemberRole.ADMIN -> ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
+}
+
+fun PaperDecision.toGrpc(): ProjectOuterClass.PaperDecision = when (this) {
+    PaperDecision.UNREVIEWED -> ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED
+    PaperDecision.IN_REVIEW -> ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW
+    PaperDecision.DECLINED -> ProjectOuterClass.PaperDecision.PAPER_DECISION_DECLINED
+    PaperDecision.ACCEPTED -> ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED
+}
+
+fun ReviewDecision.toGrpc() = when (this) {
+    ReviewDecision.DECLINED -> ReviewOuterClass.ReviewDecision.REVIEW_DECISION_DECLINED
+    ReviewDecision.MAYBE -> ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE
+    ReviewDecision.ACCEPTED -> ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED
+}
+
+fun UserRole.toGrpc() = when (this) {
+    UserRole.DEFAULT -> UserOuterClass.UserRole.USER_ROLE_DEFAULT
+    UserRole.ADMIN -> UserOuterClass.UserRole.USER_ROLE_ADMIN
+}
+
+fun UserStatus.toGrpc() = when (this) {
+    UserStatus.ACTIVE_UNCONFIRMED -> UserOuterClass.UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
+    UserStatus.ACTIVE -> UserOuterClass.UserStatus.USER_STATUS_ACTIVE
+    UserStatus.DELETED -> UserOuterClass.UserStatus.USER_STATUS_DELETED
+    UserStatus.CLEARED -> UserOuterClass.UserStatus.USER_STATUS_UNSPECIFIED
+}
+
+fun AuthenticationStatus.toGrpc() = when (this) {
+    AuthenticationStatus.UNAUTHENTICATED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED
+    AuthenticationStatus.ACCESS_TOKEN_EXPIRED ->
+        Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED
+
+    AuthenticationStatus.AUTHENTICATED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/AuthenticationInterceptor.kt
@@ -19,7 +19,7 @@ import se.uulm.snowballr.backend.auth.REFRESH_TOKEN_COOKIE_NAME
 import se.uulm.snowballr.backend.context.RequestContext
 import se.uulm.snowballr.backend.env.EnvReader
 import se.uulm.snowballr.backend.model.auth.AuthRequestState
-import snowballr.Authentication.AuthenticationStatus
+import se.uulm.snowballr.backend.model.auth.AuthenticationStatus
 import snowballr.SnowballRGrpcKt
 import io.grpc.reflection.v1.ServerReflectionGrpc as ServerReflectionV1Grpc
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc as ServerReflectionV1AlphaGrpc
@@ -109,7 +109,7 @@ val authenticationInterceptor: ServerInterceptor =
          */
         private fun <ReqT> emptyListener(): ServerCall.Listener<ReqT?> = object : ServerCall.Listener<ReqT?>() {}
 
-        override fun <ReqT : Any?, RespT : Any?> interceptCall(
+        override fun <ReqT, RespT> interceptCall(
             call: ServerCall<ReqT?, RespT?>?,
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>?,
@@ -177,7 +177,7 @@ val authenticationInterceptor: ServerInterceptor =
          * @param methodName The full method name being called, used to determine if the call should proceed.
          * @return A [ServerCall.Listener] that will handle the call, or an empty listener if authentication fails.
          */
-        private fun <ReqT : Any?, RespT : Any?> handleAuthentication(
+        private fun <ReqT, RespT> handleAuthentication(
             authState: AuthRequestState<ReqT, RespT>,
             requestContext: RequestContext,
             skipRefresh: Boolean,
@@ -221,7 +221,7 @@ val authenticationInterceptor: ServerInterceptor =
          * @param requestContext The per-call [RequestContext] to populate with the dummy user.
          * @return A [ServerCall.Listener] that will handle the call, or an empty listener if the method is not allowed.
          */
-        private fun <ReqT : Any?, RespT : Any?> proceedWithDummyUser(
+        private fun <ReqT, RespT> proceedWithDummyUser(
             authState: AuthRequestState<ReqT, RespT>,
             requestContext: RequestContext,
         ): ServerCall.Listener<ReqT?>? {
@@ -236,7 +236,7 @@ val authenticationInterceptor: ServerInterceptor =
             }
 
             requestContext.userId = DummyUser.id
-            requestContext.authStatus = AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED
+            requestContext.authStatus = AuthenticationStatus.AUTHENTICATED
             return authState.next?.startCall(authState.call, authState.headers)
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/auth/AuthenticationStatus.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/auth/AuthenticationStatus.kt
@@ -1,0 +1,37 @@
+package se.uulm.snowballr.backend.model.auth
+
+import snowballr.Authentication
+
+/**
+ * The status of the user's authentication.
+ *
+ * It is required to be authenticated to use the SnowballR app.
+ */
+enum class AuthenticationStatus {
+    /**
+     * The user is unauthenticated.
+     *
+     * They have to sign in to the app.
+     */
+    UNAUTHENTICATED,
+
+    /**
+     * The user's access token is expired.
+     *
+     * They have to use the refresh token to get a new access token.
+     */
+    ACCESS_TOKEN_EXPIRED,
+
+    /**
+     * The user is authenticated.
+     */
+    AUTHENTICATED,
+
+    ;
+
+    fun toGrpc() = when (this) {
+        UNAUTHENTICATED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED
+        ACCESS_TOKEN_EXPIRED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED
+        AUTHENTICATED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/auth/AuthenticationStatus.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/auth/AuthenticationStatus.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.auth
 
-import snowballr.Authentication
-
 /**
  * The status of the user's authentication.
  *
@@ -26,12 +24,4 @@ enum class AuthenticationStatus {
      * The user is authenticated.
      */
     AUTHENTICATED,
-
-    ;
-
-    fun toGrpc() = when (this) {
-        UNAUTHENTICATED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED
-        ACCESS_TOKEN_EXPIRED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED
-        AUTHENTICATED -> Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/criterion/CriterionCategory.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/criterion/CriterionCategory.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.criterion
 
-import snowballr.CriterionOuterClass
-
 /**
  * Category of a criterion.
  */
@@ -20,25 +18,4 @@ enum class CriterionCategory {
      * If this criterion is fulfilled, the paper is definitely declined.
      */
     HARD_EXCLUSION,
-
-    ;
-
-    companion object {
-        fun fromGrpc(category: CriterionOuterClass.CriterionCategory): CriterionCategory = when (category) {
-            CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_INCLUSION -> INCLUSION
-            CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION -> EXCLUSION
-            CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION -> HARD_EXCLUSION
-            CriterionOuterClass.CriterionCategory.UNRECOGNIZED,
-            CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_UNSPECIFIED,
-            ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc() = when (this) {
-        INCLUSION -> CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_INCLUSION
-        EXCLUSION -> CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_EXCLUSION
-        HARD_EXCLUSION -> CriterionOuterClass.CriterionCategory.CRITERION_CATEGORY_HARD_EXCLUSION
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPattern.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPattern.kt
@@ -2,7 +2,6 @@ package se.uulm.snowballr.backend.model.dto.project
 
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
-import snowballr.ProjectOuterClass
 
 /**
  * A single pattern in the [ReviewDecisionMatrix].
@@ -12,17 +11,4 @@ import snowballr.ProjectOuterClass
 data class DecisionMatrixPattern(
     val decision: PaperDecision,
     val entries: List<DecisionMatrixPatternEntry>,
-) {
-    companion object {
-        fun fromGrpc(pattern: ProjectOuterClass.ReviewDecisionMatrix.Pattern) = DecisionMatrixPattern(
-            decision = PaperDecision.fromGrpc(pattern.decision),
-            entries = pattern.entriesList.map { DecisionMatrixPatternEntry.fromGrpc(it) },
-        )
-    }
-
-    fun toGrpc(): ProjectOuterClass.ReviewDecisionMatrix.Pattern =
-        ProjectOuterClass.ReviewDecisionMatrix.Pattern.newBuilder()
-            .setDecision(decision.toGrpc())
-            .addAllEntries(entries.map { it.toGrpc() })
-            .build()
-}
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPattern.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPattern.kt
@@ -1,5 +1,7 @@
 package se.uulm.snowballr.backend.model.dto.project
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 
@@ -8,7 +10,10 @@ import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
  *
  * Defines the pattern of [ReviewDecision]s and in what final [PaperDecision] that results.
  */
+@Serializable
 data class DecisionMatrixPattern(
+    @SerialName("decision")
     val decision: PaperDecision,
+    @SerialName("entries")
     val entries: List<DecisionMatrixPatternEntry>,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPatternEntry.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPatternEntry.kt
@@ -1,7 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.project
 
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
-import snowballr.ProjectOuterClass
 
 /**
  * An entry in the [DecisionMatrixPattern] containing the decision and the number of occurrences of said decision.
@@ -9,17 +8,4 @@ import snowballr.ProjectOuterClass
 data class DecisionMatrixPatternEntry(
     val decision: ReviewDecision,
     val count: Int,
-) {
-    companion object {
-        fun fromGrpc(entry: ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry) = DecisionMatrixPatternEntry(
-            decision = ReviewDecision.fromGrpc(entry.reviewDecision),
-            count = entry.count.toInt(),
-        )
-    }
-
-    fun toGrpc(): ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry =
-        ProjectOuterClass.ReviewDecisionMatrix.Pattern.Entry.newBuilder()
-            .setReviewDecision(decision.toGrpc())
-            .setCount(count.toLong())
-            .build()
-}
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPatternEntry.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/DecisionMatrixPatternEntry.kt
@@ -1,11 +1,16 @@
 package se.uulm.snowballr.backend.model.dto.project
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 
 /**
  * An entry in the [DecisionMatrixPattern] containing the decision and the number of occurrences of said decision.
  */
+@Serializable
 data class DecisionMatrixPatternEntry(
+    @SerialName("decision")
     val decision: ReviewDecision,
+    @SerialName("count")
     val count: Int,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/Project.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/Project.kt
@@ -28,18 +28,18 @@ data class Project(
     val deletedBy: UUID?,
     val archivedAt: OffsetDateTime?,
     val archivedBy: UUID?,
-)
+) {
+    /**
+     * Checks whether the project is active.
+     *
+     * A project is considered active if its status is either [ProjectStatus.ACTIVE] or [ProjectStatus.ACTIVE_LOCKED].
+     */
+    val isActive get() = this.status == ProjectStatus.ACTIVE || this.status == ProjectStatus.ACTIVE_LOCKED
 
-/**
- * Checks whether the project is active.
- *
- * A project is considered active if its status is either [ProjectStatus.ACTIVE] or [ProjectStatus.ACTIVE_LOCKED].
- */
-fun Project.isActive() = this.status == ProjectStatus.ACTIVE || this.status == ProjectStatus.ACTIVE_LOCKED
-
-/**
- * Checks whether the project is deleted.
- *
- * A project is considered deleted if its status is [ProjectStatus.DELETED].
- */
-fun Project.isDeleted() = this.status == ProjectStatus.DELETED
+    /**
+     * Checks whether the project is deleted.
+     *
+     * A project is considered deleted if its status is [ProjectStatus.DELETED].
+     */
+    val isDeleted get() = this.status == ProjectStatus.DELETED
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/ProjectStatus.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/ProjectStatus.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.project
 
-import snowballr.ProjectOuterClass
-
 /**
  * Status of a project. Can be considered the stage in the lifecycle of a project.
  */
@@ -31,28 +29,4 @@ enum class ProjectStatus {
      * Project data has been cleared after the project has been soft-deleted.
      */
     CLEARED,
-
-    ;
-
-    companion object {
-        fun fromGrpc(status: ProjectOuterClass.ProjectStatus): ProjectStatus = when (status) {
-            ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE -> ACTIVE
-            ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED -> ARCHIVED
-            ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED -> DELETED
-            ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED -> ACTIVE_LOCKED
-            ProjectOuterClass.ProjectStatus.UNRECOGNIZED,
-            ProjectOuterClass.ProjectStatus.PROJECT_STATUS_UNSPECIFIED,
-            ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc() = when (this) {
-        ACTIVE -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE
-        ACTIVE_LOCKED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ACTIVE_LOCKED
-        ARCHIVED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_ARCHIVED
-        DELETED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_DELETED
-        CLEARED -> ProjectOuterClass.ProjectStatus.PROJECT_STATUS_UNSPECIFIED
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/ReviewDecisionMatrix.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/ReviewDecisionMatrix.kt
@@ -1,5 +1,7 @@
 package se.uulm.snowballr.backend.model.dto.project
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 /**
@@ -8,8 +10,11 @@ import kotlinx.serialization.json.Json
  * This matrix defines how a paper is decided based on its reviews.
  * For this to work, the entries need to be unique and the patterns exhaustive.
  */
+@Serializable
 data class ReviewDecisionMatrix(
+    @SerialName("number_of_reviewers")
     val numberOfReviewers: Int,
+    @SerialName("patterns")
     val patterns: List<DecisionMatrixPattern>,
 ) {
     companion object {

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/ReviewDecisionMatrix.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/ReviewDecisionMatrix.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.dto.project
 
-import snowballr.ProjectOuterClass
+import kotlinx.serialization.json.Json
 
 /**
  * Matrix containing the paper decision based on reviews made for a paper.
@@ -13,19 +13,9 @@ data class ReviewDecisionMatrix(
     val patterns: List<DecisionMatrixPattern>,
 ) {
     companion object {
-        fun fromGrpc(decisionMatrix: ProjectOuterClass.ReviewDecisionMatrix) = ReviewDecisionMatrix(
-            numberOfReviewers = decisionMatrix.numberOfReviewers,
-            patterns = decisionMatrix.patternsList.map { DecisionMatrixPattern.fromGrpc(it) },
-        )
-
         fun parseFrom(bytes: ByteArray): ReviewDecisionMatrix =
-            fromGrpc(ProjectOuterClass.ReviewDecisionMatrix.parseFrom(bytes))
+            Json.decodeFromString<ReviewDecisionMatrix>(bytes.decodeToString())
     }
 
-    fun toGrpc(): ProjectOuterClass.ReviewDecisionMatrix = ProjectOuterClass.ReviewDecisionMatrix.newBuilder()
-        .setNumberOfReviewers(numberOfReviewers)
-        .addAllPatterns(patterns.map { it.toGrpc() })
-        .build()
-
-    fun toByteArray(): ByteArray = toGrpc().toByteArray()
+    fun toByteArray(): ByteArray = Json.encodeToString(this).toByteArray()
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/SnowballingType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/SnowballingType.kt
@@ -33,10 +33,10 @@ enum class SnowballingType {
     /**
      * Returns true if this [SnowballingType] is [BACKWARD] or [BOTH]; otherwise false.
      */
-    fun isBackwardOrBoth() = this == BACKWARD || this == BOTH
+    val isBackwardOrBoth get() = this == BACKWARD || this == BOTH
 
     /**
      * Returns true if this [SnowballingType] is [FORWARD] or [BOTH]; otherwise false.
      */
-    fun isForwardOrBoth() = this == FORWARD || this == BOTH
+    val isForwardOrBoth get() = this == FORWARD || this == BOTH
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/SnowballingType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/project/SnowballingType.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.project
 
-import snowballr.ProjectOuterClass
-
 /**
  * The type of snowballing, according to Wohlin (2014).
  *
@@ -31,25 +29,6 @@ enum class SnowballingType {
     BOTH,
 
     ;
-
-    companion object {
-        fun fromGrpc(type: ProjectOuterClass.SnowballingType): SnowballingType = when (type) {
-            ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD -> FORWARD
-            ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BACKWARD -> BACKWARD
-            ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH -> BOTH
-            ProjectOuterClass.SnowballingType.UNRECOGNIZED,
-            ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_UNSPECIFIED,
-            ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc(): ProjectOuterClass.SnowballingType = when (this) {
-        FORWARD -> ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_FORWARD
-        BACKWARD -> ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BACKWARD
-        BOTH -> ProjectOuterClass.SnowballingType.SNOWBALLING_TYPE_BOTH
-    }
 
     /**
      * Returns true if this [SnowballingType] is [BACKWARD] or [BOTH]; otherwise false.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/MemberRole.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/MemberRole.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.projectmember
 
-import snowballr.ProjectOuterClass
-
 /**
  * Role of a user inside a project.
  */
@@ -15,21 +13,4 @@ enum class MemberRole {
      * Admin project member role. Has elevated rights.
      */
     ADMIN,
-
-    ;
-
-    companion object {
-        fun fromGrpc(role: ProjectOuterClass.MemberRole): MemberRole = when (role) {
-            ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT -> DEFAULT
-            ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN -> ADMIN
-            ProjectOuterClass.MemberRole.UNRECOGNIZED, ProjectOuterClass.MemberRole.MEMBER_ROLE_UNSPECIFIED ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc() = when (this) {
-        DEFAULT -> ProjectOuterClass.MemberRole.MEMBER_ROLE_DEFAULT
-        ADMIN -> ProjectOuterClass.MemberRole.MEMBER_ROLE_ADMIN
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/ProjectMember.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectmember/ProjectMember.kt
@@ -13,11 +13,11 @@ data class ProjectMember(
     val role: MemberRole,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
-)
-
-/**
- * Checks whether the project member is a project admin.
- *
- * A project member is considered a project admin if their role is set to [MemberRole.ADMIN].
- */
-fun ProjectMember.isProjectAdmin() = this.role == MemberRole.ADMIN
+) {
+    /**
+     * Checks whether the project member is a project admin.
+     *
+     * A project member is considered a project admin if their role is set to [MemberRole.ADMIN].
+     */
+    val isProjectAdmin get() = this.role == MemberRole.ADMIN
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/PaperDecision.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/PaperDecision.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.projectpaper
 
-import snowballr.ProjectOuterClass
-
 /**
  * The decision on how the paper is treated in respect to the SLR.
  */
@@ -27,26 +25,4 @@ enum class PaperDecision {
      * The paper was accepted and is considered part of the final SLR paper set.
      */
     ACCEPTED,
-
-    ;
-
-    companion object {
-        fun fromGrpc(decision: ProjectOuterClass.PaperDecision): PaperDecision = when (decision) {
-            ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED -> UNREVIEWED
-            ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW -> IN_REVIEW
-            ProjectOuterClass.PaperDecision.PAPER_DECISION_DECLINED -> DECLINED
-            ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED -> ACCEPTED
-            ProjectOuterClass.PaperDecision.UNRECOGNIZED, ProjectOuterClass.PaperDecision.PAPER_DECISION_UNSPECIFIED,
-            ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc(): ProjectOuterClass.PaperDecision = when (this) {
-        UNREVIEWED -> ProjectOuterClass.PaperDecision.PAPER_DECISION_UNREVIEWED
-        IN_REVIEW -> ProjectOuterClass.PaperDecision.PAPER_DECISION_IN_REVIEW
-        DECLINED -> ProjectOuterClass.PaperDecision.PAPER_DECISION_DECLINED
-        ACCEPTED -> ProjectOuterClass.PaperDecision.PAPER_DECISION_ACCEPTED
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/ProjectPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/ProjectPaper.kt
@@ -18,20 +18,20 @@ data class ProjectPaper(
     val createdBy: UUID,
     val modifiedAt: OffsetDateTime?,
     val modifiedBy: UUID?,
-)
+) {
+    /**
+     * Checks whether this [ProjectPaper] has a final decision.
+     *
+     * A [ProjectPaper] is considered to have a final decision if its decision is set to [PaperDecision.ACCEPTED] or
+     * [PaperDecision.DECLINED].
+     */
+    val hasFinalDecision get() = this.decision == PaperDecision.ACCEPTED || this.decision == PaperDecision.DECLINED
 
-/**
- * Checks whether this [ProjectPaper] has a final decision.
- *
- * A [ProjectPaper] is considered to have a final decision if its decision is set to [PaperDecision.ACCEPTED] or
- * [PaperDecision.DECLINED].
- */
-fun ProjectPaper.hasFinalDecision() = this.decision == PaperDecision.ACCEPTED || this.decision == PaperDecision.DECLINED
-
-/**
- * Checks whether this [ProjectPaper] has no final decision yet.
- *
- * A [ProjectPaper] is considered to have no final decision if its decision is set to [PaperDecision.UNREVIEWED] or
- * [PaperDecision.IN_REVIEW].
- */
-fun ProjectPaper.hasNoFinalDecision() = !this.hasFinalDecision()
+    /**
+     * Checks whether this [ProjectPaper] has no final decision yet.
+     *
+     * A [ProjectPaper] is considered to have no final decision if its decision is set to [PaperDecision.UNREVIEWED] or
+     * [PaperDecision.IN_REVIEW].
+     */
+    val hasNoFinalDecision get() = !this.hasFinalDecision
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/ProjectPaperWithPaper.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/projectpaper/ProjectPaperWithPaper.kt
@@ -50,6 +50,6 @@ fun ProjectPaperWithPaper.toProjectPaperFull(
 /**
  * Checks if the [ProjectPaper] within this [ProjectPaperWithPaper] has no final decision.
  *
- * @see ProjectPaper.hasNoFinalDecision
+ * @see ProjectPaper.getHasNoFinalDecision
  */
-fun ProjectPaperWithPaper.hasNoFinalDecision() = this.projectPaper.hasNoFinalDecision()
+fun ProjectPaperWithPaper.hasNoFinalDecision() = this.projectPaper.hasNoFinalDecision

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/Review.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/Review.kt
@@ -14,18 +14,18 @@ data class Review(
     val decision: ReviewDecision,
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
-)
+) {
+    /**
+     * Checks whether the review accepts the paper.
+     *
+     * A review is considered to accept the paper if its decision is set to [ReviewDecision.ACCEPTED].
+     */
+    val doesAcceptPaper get() = this.decision == ReviewDecision.ACCEPTED
 
-/**
- * Checks whether the review accepts the paper.
- *
- * A review is considered to accept the paper if its decision is set to [ReviewDecision.ACCEPTED].
- */
-fun Review.doesAcceptPaper() = this.decision == ReviewDecision.ACCEPTED
-
-/**
- * Checks whether the review declines the paper.
- *
- * A review is considered to decline the paper if its decision is set to [ReviewDecision.DECLINED].
- */
-fun Review.doesDeclinePaper() = this.decision == ReviewDecision.DECLINED
+    /**
+     * Checks whether the review declines the paper.
+     *
+     * A review is considered to decline the paper if its decision is set to [ReviewDecision.DECLINED].
+     */
+    val doesDeclinePaper get() = this.decision == ReviewDecision.DECLINED
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/ReviewDecision.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/review/ReviewDecision.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.review
 
-import snowballr.ReviewOuterClass
-
 /**
  * The decision based on the review of a paper.
  */
@@ -20,25 +18,4 @@ enum class ReviewDecision {
      * The reviewer accepted the paper.
      */
     ACCEPTED,
-
-    ;
-
-    companion object {
-        fun fromGrpc(decision: ReviewOuterClass.ReviewDecision): ReviewDecision = when (decision) {
-            ReviewOuterClass.ReviewDecision.REVIEW_DECISION_DECLINED -> DECLINED
-            ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE -> MAYBE
-            ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED -> ACCEPTED
-            ReviewOuterClass.ReviewDecision.UNRECOGNIZED,
-            ReviewOuterClass.ReviewDecision.REVIEW_DECISION_UNSPECIFIED,
-            ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc() = when (this) {
-        DECLINED -> ReviewOuterClass.ReviewDecision.REVIEW_DECISION_DECLINED
-        MAYBE -> ReviewOuterClass.ReviewDecision.REVIEW_DECISION_MAYBE
-        ACCEPTED -> ReviewOuterClass.ReviewDecision.REVIEW_DECISION_ACCEPTED
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/User.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/User.kt
@@ -17,40 +17,40 @@ data class User(
     val createdAt: OffsetDateTime,
     val modifiedAt: OffsetDateTime?,
     val deletedAt: OffsetDateTime?,
-)
+) {
+    /**
+     * Checks whether the user is a server admin.
+     *
+     * A user is considered a server admin if their role is set to [UserRole.ADMIN].
+     */
+    val isServerAdmin get() = this.role == UserRole.ADMIN
 
-/**
- * Checks whether the user is a server admin.
- *
- * A user is considered a server admin if their role is set to [UserRole.ADMIN].
- */
-fun User.isServerAdmin() = this.role == UserRole.ADMIN
+    /**
+     * Checks whether the user is active and confirmed.
+     *
+     * A user is considered active and confirmed if their status is set to [UserStatus.ACTIVE].
+     * The status [UserStatus.ACTIVE_UNCONFIRMED] does count as active, but not as confirmed.
+     */
+    val isActiveAndConfirmed get() = this.status == UserStatus.ACTIVE
 
-/**
- * Checks whether the user is active and confirmed.
- *
- * A user is considered active and confirmed if their status is set to [UserStatus.ACTIVE].
- * The status [UserStatus.ACTIVE_UNCONFIRMED] does count as active, but not as confirmed.
- */
-fun User.isActiveAndConfirmed() = this.status == UserStatus.ACTIVE
+    /**
+     * Checks whether the user is active.
+     *
+     * A user is considered active if their status is either [UserStatus.ACTIVE] or [UserStatus.ACTIVE_UNCONFIRMED].
+     */
+    val isActive get() = this.isActiveAndConfirmed || this.status == UserStatus.ACTIVE_UNCONFIRMED
 
-/**
- * Checks whether the user is active.
- *
- * A user is considered active if their status is either [UserStatus.ACTIVE] or [UserStatus.ACTIVE_UNCONFIRMED].
- */
-fun User.isActive() = this.isActiveAndConfirmed() || this.status == UserStatus.ACTIVE_UNCONFIRMED
-
-/**
- * Returns the full name of the user by concatenating the first name and last name.
- *
- * If either the first name or last name is empty, it will return the non-empty part as the full name.
- * If both are empty, it will return an empty string.
- *
- * Example:
- * - If firstName is "John" and lastName is "Doe", it will return "John Doe".
- * - If firstName is "John" and lastName is "", it will return "John".
- * - If firstName is "" and lastName is "Doe", it will return "Doe".
- * - If both firstName and lastName are "", it will return "".
- */
-fun User.getFullName(): String = "${this.firstName} ${this.lastName}".trim()
+    /**
+     * Returns the full name of the user by concatenating the first name and last name.
+     *
+     * If either the first name or last name is empty, it will return the non-empty part as the full name.
+     * If both are empty, it will return an empty string.
+     *
+     * Example:
+     * - If firstName is "John" and lastName is "Doe", it will return "John Doe".
+     * - If firstName is "John" and lastName is "", it will return "John".
+     * - If firstName is "" and lastName is "Doe", it will return "Doe".
+     * - If both firstName and lastName are "", it will return "".
+     */
+    val fullName get() = "${this.firstName} ${this.lastName}".trim()
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserRole.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserRole.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.user
 
-import snowballr.UserOuterClass
-
 /**
  * Role of a user inside the SnowballR app.
  */
@@ -15,21 +13,4 @@ enum class UserRole {
      * Admin user role. Has elevated rights.
      */
     ADMIN,
-
-    ;
-
-    companion object {
-        fun fromGrpc(role: UserOuterClass.UserRole): UserRole = when (role) {
-            UserOuterClass.UserRole.USER_ROLE_DEFAULT -> DEFAULT
-            UserOuterClass.UserRole.USER_ROLE_ADMIN -> ADMIN
-            UserOuterClass.UserRole.UNRECOGNIZED, UserOuterClass.UserRole.USER_ROLE_UNSPECIFIED ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc() = when (this) {
-        DEFAULT -> UserOuterClass.UserRole.USER_ROLE_DEFAULT
-        ADMIN -> UserOuterClass.UserRole.USER_ROLE_ADMIN
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserStatus.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/user/UserStatus.kt
@@ -1,7 +1,5 @@
 package se.uulm.snowballr.backend.model.dto.user
 
-import snowballr.UserOuterClass
-
 /**
  * Status of a user. Can be considered the stage in the lifecycle of a user.
  */
@@ -25,24 +23,4 @@ enum class UserStatus {
      * User data has been cleared after the user has been soft-deleted.
      */
     CLEARED,
-
-    ;
-
-    companion object {
-        fun fromGrpc(status: UserOuterClass.UserStatus): UserStatus = when (status) {
-            UserOuterClass.UserStatus.USER_STATUS_ACTIVE -> ACTIVE
-            UserOuterClass.UserStatus.USER_STATUS_DELETED -> DELETED
-            UserOuterClass.UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED -> ACTIVE_UNCONFIRMED
-            UserOuterClass.UserStatus.UNRECOGNIZED, UserOuterClass.UserStatus.USER_STATUS_UNSPECIFIED ->
-                @Suppress("UseCheckOrError")
-                throw IllegalStateException("Invalid conversion")
-        }
-    }
-
-    fun toGrpc() = when (this) {
-        ACTIVE_UNCONFIRMED -> UserOuterClass.UserStatus.USER_STATUS_ACTIVE_UNCONFIRMED
-        ACTIVE -> UserOuterClass.UserStatus.USER_STATUS_ACTIVE
-        DELETED -> UserOuterClass.UserStatus.USER_STATUS_DELETED
-        CLEARED -> UserOuterClass.UserStatus.USER_STATUS_UNSPECIFIED
-    }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/AuthenticationService.kt
@@ -7,7 +7,6 @@ import se.uulm.snowballr.backend.context.RequestContext
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import se.uulm.snowballr.backend.model.dto.user.isActiveAndConfirmed
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
 import se.uulm.snowballr.backend.model.exception.failedprecondition.EntityNotActiveException
@@ -101,7 +100,7 @@ class AuthenticationService(
                 throw UnauthenticatedException()
             }
 
-        if (!user.isActiveAndConfirmed()) {
+        if (!user.isActiveAndConfirmed) {
             throw UnauthenticatedException()
         }
 
@@ -122,7 +121,7 @@ class AuthenticationService(
     }
 
     override suspend fun changePassword(request: ChangePasswordRequest) = withUser(repo) { currentUser ->
-        if (!currentUser.isActiveAndConfirmed()) {
+        if (!currentUser.isActiveAndConfirmed) {
             throw EntityNotActiveException(EntityType.USER, currentUser.id)
         }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/InvitationService.kt
@@ -8,8 +8,6 @@ import se.uulm.snowballr.backend.formatting.daysToHumanReadable
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.model.dto.user.User
-import se.uulm.snowballr.backend.model.dto.user.getFullName
-import se.uulm.snowballr.backend.model.dto.user.isActiveAndConfirmed
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
@@ -127,7 +125,7 @@ class InvitationService(
         }
 
         // Send invitation email
-        val inviterName = currentUser.getFullName()
+        val inviterName = currentUser.fullName
         val invitationLink = emailManager.createAcceptProjectInvitationLink(invitationToken)
         val expirationTimeInDays = envReader.env.lifetime.invitationTokenLifeTimeInDays
         val data = EmailData.AcceptProjectInvitation(
@@ -156,7 +154,7 @@ class InvitationService(
             throw FailedPreconditionException("The user with the email ${invitationToken.email} is not registered.")
         }
 
-        if (!user.isActiveAndConfirmed()) {
+        if (!user.isActiveAndConfirmed) {
             throw FailedPreconditionException(
                 "The user with the email ${invitationToken.email} has not verified their email address.",
             )

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectMemberService.kt
@@ -6,7 +6,6 @@ import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.dto.projectmember.InvitationToken
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
-import se.uulm.snowballr.backend.model.dto.projectmember.isProjectAdmin
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.NotFoundException
@@ -78,7 +77,7 @@ class ProjectMemberService(
                 )
             }
 
-            if (member.isProjectAdmin() && request.newRole != MemberRole.ADMIN) {
+            if (member.isProjectAdmin && request.newRole != MemberRole.ADMIN) {
                 projectAccessChecker.isNotLastProjectAdmin(user, request.projectId, "Cannot demote the user")
             }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ReviewService.kt
@@ -9,11 +9,8 @@ import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
-import se.uulm.snowballr.backend.model.dto.projectpaper.hasFinalDecision
 import se.uulm.snowballr.backend.model.dto.review.Review
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
-import se.uulm.snowballr.backend.model.dto.review.doesAcceptPaper
-import se.uulm.snowballr.backend.model.dto.review.doesDeclinePaper
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.DuplicateReviewException
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
@@ -112,7 +109,7 @@ class ReviewService(
                 throw DuplicateReviewException(request.projectPaperId, currentUser.id)
             }
 
-            if (projectPaper.hasFinalDecision()) {
+            if (projectPaper.hasFinalDecision) {
                 throw FailedPreconditionException(
                     "The project paper must be either unreviewed or still in review. " +
                         "Finally decided project papers cannot be reviewed anymore.",
@@ -124,7 +121,7 @@ class ReviewService(
 
             val hasSelectedExclusionCriterion = hasSelectedHardExclusionCriterion(project.id, selectedCriteriaIds)
 
-            val decision = if (hasSelectedExclusionCriterion && review.doesDeclinePaper()) {
+            val decision = if (hasSelectedExclusionCriterion && review.doesDeclinePaper) {
                 PaperDecision.DECLINED
             } else {
                 determinePaperDecision(reviewsForProjectPaper + review, project.reviewDecisionMatrix)
@@ -189,7 +186,7 @@ class ReviewService(
         }
 
         val decidingReview = reviews.last()
-        return if (decidingReview.doesAcceptPaper()) {
+        return if (decidingReview.doesAcceptPaper) {
             PaperDecision.ACCEPTED
         } else {
             PaperDecision.DECLINED

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -6,6 +6,7 @@ package se.uulm.snowballr.backend.arch
 
 import com.tngtech.archunit.base.DescribedPredicate.not
 import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage
+import com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage
 import com.tngtech.archunit.core.domain.JavaClasses
 import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.junit.AnalyzeClasses
@@ -15,6 +16,7 @@ import com.tngtech.archunit.lang.conditions.ArchConditions.haveNameMatching
 import com.tngtech.archunit.lang.conditions.ArchConditions.haveSimpleName
 import com.tngtech.archunit.lang.conditions.ArchConditions.haveSimpleNameEndingWith
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
 import com.tngtech.archunit.library.Architectures
 import com.tngtech.archunit.library.Architectures.layeredArchitecture
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
@@ -147,6 +149,19 @@ private class StructureRules {
             .matching("$BASE_PACKAGE.(*)..")
             .should()
             .beFreeOfCycles()
+            .check(classes)
+    }
+
+    @ArchTest
+    fun `When a class is in the base package, then it should not access the generated gRPC code`(classes: JavaClasses) {
+        noClasses()
+            .that()
+            .resideInAPackage("$BASE_PACKAGE..")
+            .and(not(resideInAnyPackage("$BASE_PACKAGE.grpc..", "$BASE_PACKAGE.validation..")))
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("snowballr..")
+            .because("Only the gRPC and validation layers may access the generated gRPC code")
             .check(classes)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -15,6 +15,7 @@ import com.tngtech.archunit.lang.conditions.ArchConditions.haveNameMatching
 import com.tngtech.archunit.lang.conditions.ArchConditions.haveSimpleName
 import com.tngtech.archunit.lang.conditions.ArchConditions.haveSimpleNameEndingWith
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.library.Architectures
 import com.tngtech.archunit.library.Architectures.layeredArchitecture
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
 import com.tngtech.archunit.library.metrics.ArchitectureMetrics
@@ -36,59 +37,76 @@ class LayerArchitectureTest {
 }
 
 private class StructureRules {
+    companion object {
+        // Layer names
+        private const val MAIN = "Main"
+        private const val VALIDATION = "Input Validation"
+        private const val GRPC = "gRPC Server"
+        private const val SERVICE = "Service"
+        private const val ACCESS = "Access"
+        private const val REPO = "Repository"
+        private const val TABLE = "Table"
+        private const val DB = "DB"
+        private const val SCHEDULER = "Scheduler"
+        private const val FETCHER = "Fetcher"
+    }
+
+    private fun Architectures.LayeredArchitecture.snowballRLayers() = this
+        // Main layer: Main.kt and Module.kt
+        .layer(MAIN)
+        .definedBy(BASE_PACKAGE)
+        // Input validation layer
+        .layer(VALIDATION)
+        .definedBy("$BASE_PACKAGE.validation..")
+        // gRPC Server layer including the interceptors
+        .layer(GRPC)
+        .definedBy("$BASE_PACKAGE.grpc..")
+        // Service layer
+        .layer(SERVICE)
+        .definedBy("$BASE_PACKAGE.service..")
+        // Access Checkers
+        .layer(ACCESS)
+        .definedBy("$BASE_PACKAGE.access..")
+        // Repository layer
+        .layer(REPO)
+        .definedBy("$BASE_PACKAGE.repository..")
+        // Table layer
+        .layer(TABLE)
+        .definedBy("$BASE_PACKAGE.table..")
+        // DB layer
+        .layer(DB)
+        .definedBy("$BASE_PACKAGE.db..")
+        // Scheduler / Cron Jobs
+        .layer(SCHEDULER)
+        .definedBy("$BASE_PACKAGE.scheduler..")
+        // Fetcher
+        .layer(FETCHER)
+        .definedBy("$BASE_PACKAGE.fetcher..")
+
     @ArchTest
     fun `When the layer architecture is violated, then this test should fail (all deps)`(classes: JavaClasses) {
         layeredArchitecture()
             .consideringAllDependencies()
-            // Main layer: Main.kt and Module.kt
-            .layer("Main")
-            .definedBy(BASE_PACKAGE)
-            // Input validation layer
-            .layer("Input Validation")
-            .definedBy("$BASE_PACKAGE.validation..")
-            // gRPC Server layer including the interceptors
-            .layer("gRPC Server")
-            .definedBy("$BASE_PACKAGE.grpc..")
-            // Service layer
-            .layer("Service")
-            .definedBy("$BASE_PACKAGE.service..")
-            // Access Checkers
-            .layer("Access")
-            .definedBy("$BASE_PACKAGE.access..")
-            // Repository layer
-            .layer("Repository")
-            .definedBy("$BASE_PACKAGE.repository..")
-            // Table layer
-            .layer("Table")
-            .definedBy("$BASE_PACKAGE.table..")
-            // DB layer
-            .layer("DB")
-            .definedBy("$BASE_PACKAGE.db..")
-            // Scheduler / Cron Jobs
-            .layer("Scheduler")
-            .definedBy("$BASE_PACKAGE.scheduler..")
-            // Fetcher
-            .layer("Fetcher")
-            .definedBy("$BASE_PACKAGE.fetcher..")
+            .snowballRLayers()
             // Checks
-            .whereLayer("Input Validation")
-            .mayOnlyBeAccessedByLayers("gRPC Server")
-            .whereLayer("gRPC Server")
-            .mayOnlyBeAccessedByLayers("Main")
-            .whereLayer("Service")
-            .mayOnlyBeAccessedByLayers("gRPC Server", "Main")
-            .whereLayer("Access")
-            .mayOnlyBeAccessedByLayers("Service", "Main")
-            .whereLayer("Repository")
-            .mayOnlyBeAccessedByLayers("Service", "Access", "Scheduler", "Main", "Fetcher")
-            .whereLayer("Table")
-            .mayOnlyBeAccessedByLayers("Repository", "DB")
-            .whereLayer("DB")
-            .mayOnlyBeAccessedByLayers("Main", "Repository")
-            .whereLayer("Scheduler")
-            .mayOnlyBeAccessedByLayers("gRPC Server", "Main")
-            .whereLayer("Fetcher")
-            .mayOnlyBeAccessedByLayers("Main", "Service")
+            .whereLayer(VALIDATION)
+            .mayOnlyBeAccessedByLayers(GRPC)
+            .whereLayer(GRPC)
+            .mayOnlyBeAccessedByLayers(MAIN)
+            .whereLayer(SERVICE)
+            .mayOnlyBeAccessedByLayers(GRPC, MAIN)
+            .whereLayer(ACCESS)
+            .mayOnlyBeAccessedByLayers(SERVICE, MAIN)
+            .whereLayer(REPO)
+            .mayOnlyBeAccessedByLayers(SERVICE, ACCESS, SCHEDULER, MAIN, FETCHER)
+            .whereLayer(TABLE)
+            .mayOnlyBeAccessedByLayers(REPO, DB)
+            .whereLayer(DB)
+            .mayOnlyBeAccessedByLayers(MAIN, REPO)
+            .whereLayer(SCHEDULER)
+            .mayOnlyBeAccessedByLayers(GRPC, MAIN)
+            .whereLayer(FETCHER)
+            .mayOnlyBeAccessedByLayers(MAIN, SERVICE)
             .check(classes)
     }
 
@@ -96,59 +114,30 @@ private class StructureRules {
     fun `When the layer architecture is violated, then this test should fail (only layer deps)`(classes: JavaClasses) {
         layeredArchitecture()
             .consideringOnlyDependenciesInLayers()
-            // Main layer: Main.kt and Module.kt
-            .layer("Main")
-            .definedBy(BASE_PACKAGE)
-            // Input validation layer
-            .layer("Input Validation")
-            .definedBy("$BASE_PACKAGE.validation..")
-            // gRPC Server layer including the interceptors
-            .layer("gRPC Server")
-            .definedBy("$BASE_PACKAGE.grpc..")
-            // Service layer
-            .layer("Service")
-            .definedBy("$BASE_PACKAGE.service..")
-            // Access Checkers
-            .layer("Access")
-            .definedBy("$BASE_PACKAGE.access..")
-            // Repository layer
-            .layer("Repository")
-            .definedBy("$BASE_PACKAGE.repository..")
-            // Table layer
-            .layer("Table")
-            .definedBy("$BASE_PACKAGE.table..")
-            // DB layer
-            .layer("DB")
-            .definedBy("$BASE_PACKAGE.db..")
-            // Scheduler / Cron Jobs
-            .layer("Scheduler")
-            .definedBy("$BASE_PACKAGE.scheduler..")
-            // Fetcher
-            .layer("Fetcher")
-            .definedBy("$BASE_PACKAGE.fetcher..")
+            .snowballRLayers()
             // Checks
-            .whereLayer("Main")
+            .whereLayer(MAIN)
             .mayNotBeAccessedByAnyLayer()
-            .whereLayer("Main")
-            .mayOnlyAccessLayers("gRPC Server", "Service", "Access", "Repository", "DB", "Scheduler", "Fetcher")
-            .whereLayer("Input Validation")
+            .whereLayer(MAIN)
+            .mayOnlyAccessLayers(GRPC, SERVICE, ACCESS, REPO, DB, SCHEDULER, FETCHER)
+            .whereLayer(VALIDATION)
             .mayNotAccessAnyLayer()
-            .whereLayer("gRPC Server")
-            .mayOnlyAccessLayers("Service", "Input Validation", "Scheduler")
-            .whereLayer("Service")
-            .mayOnlyAccessLayers("Repository", "Access", "Fetcher")
-            .whereLayer("Access")
-            .mayOnlyAccessLayers("Repository")
-            .whereLayer("Repository")
-            .mayOnlyAccessLayers("Table", "DB")
-            .whereLayer("Table")
+            .whereLayer(GRPC)
+            .mayOnlyAccessLayers(SERVICE, VALIDATION, SCHEDULER)
+            .whereLayer(SERVICE)
+            .mayOnlyAccessLayers(REPO, ACCESS, FETCHER)
+            .whereLayer(ACCESS)
+            .mayOnlyAccessLayers(REPO)
+            .whereLayer(REPO)
+            .mayOnlyAccessLayers(TABLE, DB)
+            .whereLayer(TABLE)
             .mayNotAccessAnyLayer()
-            .whereLayer("DB")
-            .mayOnlyAccessLayers("Table")
-            .whereLayer("Scheduler")
-            .mayOnlyAccessLayers("Repository")
-            .whereLayer("Fetcher")
-            .mayOnlyAccessLayers("Repository")
+            .whereLayer(DB)
+            .mayOnlyAccessLayers(TABLE)
+            .whereLayer(SCHEDULER)
+            .mayOnlyAccessLayers(REPO)
+            .whereLayer(FETCHER)
+            .mayOnlyAccessLayers(REPO)
             .check(classes)
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/AuthenticateTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/AuthenticateTest.kt
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
 import se.uulm.snowballr.backend.context.RequestContext
+import se.uulm.snowballr.backend.model.auth.AuthenticationStatus
 import se.uulm.snowballr.backend.model.jwt.ParsedJwtAuthClaims
-import snowballr.Authentication
 import java.util.Date
 import java.util.UUID
 
@@ -28,10 +28,7 @@ class AuthenticateTest {
 
         assertTrue(result.isSuccess)
         assertEquals(parsedClaims, result.getOrNull())
-        assertEquals(
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED,
-            requestContext.authStatus,
-        )
+        assertEquals(AuthenticationStatus.AUTHENTICATED, requestContext.authStatus)
     }
 
     @Test
@@ -51,10 +48,7 @@ class AuthenticateTest {
 
         assertTrue(result.isSuccess)
         assertEquals(parsedRefreshClaims, result.getOrNull())
-        assertEquals(
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED,
-            requestContext.authStatus,
-        )
+        assertEquals(AuthenticationStatus.ACCESS_TOKEN_EXPIRED, requestContext.authStatus)
         assertEquals("newAccessToken", requestContext.cookies[ACCESS_TOKEN_COOKIE_NAME])
     }
 
@@ -69,10 +63,7 @@ class AuthenticateTest {
 
         assertTrue(result.isSuccess)
         assertEquals(parsedRefreshClaims, result.getOrNull())
-        assertEquals(
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_ACCESS_TOKEN_EXPIRED,
-            requestContext.authStatus,
-        )
+        assertEquals(AuthenticationStatus.ACCESS_TOKEN_EXPIRED, requestContext.authStatus)
         assertThat(requestContext.cookies).isEmpty()
     }
 
@@ -86,10 +77,7 @@ class AuthenticateTest {
             authenticationManager.authenticate("invalidAccessToken", "invalidRefreshToken", false, requestContext)
 
         assertTrue(result.isFailure)
-        assertEquals(
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED,
-            requestContext.authStatus,
-        )
+        assertEquals(AuthenticationStatus.UNAUTHENTICATED, requestContext.authStatus)
         assertNull(requestContext.cookies[ACCESS_TOKEN_COOKIE_NAME])
         assertNull(requestContext.cookies[REFRESH_TOKEN_COOKIE_NAME])
     }
@@ -102,10 +90,7 @@ class AuthenticateTest {
         val result = authenticationManager.authenticate("invalidAccessToken", null, false, requestContext)
 
         assertTrue(result.isFailure)
-        assertEquals(
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED,
-            requestContext.authStatus,
-        )
+        assertEquals(AuthenticationStatus.UNAUTHENTICATED, requestContext.authStatus)
         assertNull(requestContext.cookies[ACCESS_TOKEN_COOKIE_NAME])
         assertNull(requestContext.cookies[REFRESH_TOKEN_COOKIE_NAME])
     }
@@ -120,10 +105,7 @@ class AuthenticateTest {
             authenticationManager.authenticate("invalidAccessToken", "invalidRefreshToken", true, requestContext)
 
         assertTrue(result.isFailure)
-        assertEquals(
-            Authentication.AuthenticationStatus.AUTHENTICATION_STATUS_UNAUTHENTICATED,
-            requestContext.authStatus,
-        )
+        assertEquals(AuthenticationStatus.UNAUTHENTICATED, requestContext.authStatus)
         assertThat(requestContext.cookies).isEmpty()
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/DummyUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/DummyUserTest.kt
@@ -1,14 +1,10 @@
 package se.uulm.snowballr.backend.auth
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.dto.user.UserStatus
-import snowballr.ProjectOuterClass.ReviewDecisionMatrix
-import snowballr.ProjectOuterClass.SnowballingType
 import java.util.UUID
 
 class DummyUserTest {
@@ -19,15 +15,6 @@ class DummyUserTest {
         assertEquals("Alice", DummyUser.firstName)
         assertEquals("Smith", DummyUser.lastName)
         assertEquals("VALIDPassword__1234", DummyUser.password)
-        // User Settings
-        assertTrue(DummyUser.areHotkeysShown)
-        assertFalse(DummyUser.isReviewModeEnabled)
-        assertThat(DummyUser.criteriaIds).isEmpty()
-        assertEquals(0F, DummyUser.similarityThreshold)
-        assertTrue(ReviewDecisionMatrix.getDefaultInstance().toByteArray().contentEquals(DummyUser.decisionMatrix))
-        assertThat(DummyUser.fetchers).isEmpty()
-        assertEquals(SnowballingType.SNOWBALLING_TYPE_BOTH, DummyUser.snowballingType)
-        assertTrue(DummyUser.reviewMaybeAllowed)
 
         assertTrue(
             PasswordUtils.verifyPassword(DummyUser.password, DummyUser.passwordHash),

--- a/src/test/kotlin/se/uulm/snowballr/backend/context/RequestContextTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/context/RequestContextTest.kt
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.auth.ACCESS_TOKEN_COOKIE_NAME
 import se.uulm.snowballr.backend.auth.REFRESH_TOKEN_COOKIE_NAME
 import se.uulm.snowballr.backend.auth.setAuthCookies
+import se.uulm.snowballr.backend.model.auth.AuthenticationStatus
 import se.uulm.snowballr.backend.model.exception.internal.missingcontext.MissingRequestContextException
 import se.uulm.snowballr.backend.model.exception.internal.missingcontext.MissingUserIdException
-import snowballr.Authentication.AuthenticationStatus
 import java.util.UUID
 
 class RequestContextTest {
@@ -67,14 +67,14 @@ class RequestContextTest {
     @Nested
     inner class AuthStatus {
         @Test
-        fun `When no status is set, then it defaults to unspecified`() {
-            assertEquals(AuthenticationStatus.AUTHENTICATION_STATUS_UNSPECIFIED, RequestContext().authStatus)
+        fun `When no status is set, then it defaults to UNAUTHENTICATED`() {
+            assertEquals(AuthenticationStatus.UNAUTHENTICATED, RequestContext().authStatus)
         }
 
         @Test
         fun `When a status is set, then it is returned`() {
-            val context = RequestContext(authStatus = AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED)
-            assertEquals(AuthenticationStatus.AUTHENTICATION_STATUS_AUTHENTICATED, context.authStatus)
+            val context = RequestContext(authStatus = AuthenticationStatus.AUTHENTICATED)
+            assertEquals(AuthenticationStatus.AUTHENTICATED, context.authStatus)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -96,12 +96,12 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 val fetcherPaper = paper.toFetcherPaper()
 
                 coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.success(paper)
-                if (type.isBackwardOrBoth()) {
+                if (type.isBackwardOrBoth) {
                     coEvery {
                         fetcherManagerMock.fetchBackwardReferences(fetcherName, fetcherPaper, emptyMap())
                     } throws FetcherException("backward fetching failed")
                 }
-                if (type.isForwardOrBoth()) {
+                if (type.isForwardOrBoth) {
                     coEvery {
                         fetcherManagerMock.fetchForwardReferences(fetcherName, fetcherPaper, emptyMap())
                     } throws FetcherException("forward fetching failed")
@@ -137,7 +137,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 val fetchedPaper = DataBuilder.createExampleFetcherPaper()
 
                 coEvery { paperRepoMock.getPaperById(job.projectPaper.paperId) } returns Result.success(paper)
-                if (type.isBackwardOrBoth()) {
+                if (type.isBackwardOrBoth) {
                     coEvery {
                         fetcherManagerMock.fetchBackwardReferences(fetcher1Name, fetcherPaper, emptyMap())
                     } throws FetcherException("backward fetching failed")
@@ -145,7 +145,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                         fetcherManagerMock.fetchBackwardReferences(fetcher2Name, fetcherPaper, emptyMap())
                     } returns setOf(fetchedPaper)
                 }
-                if (type.isForwardOrBoth()) {
+                if (type.isForwardOrBoth) {
                     coEvery {
                         fetcherManagerMock.fetchForwardReferences(fetcher1Name, fetcherPaper, emptyMap())
                     } throws FetcherException("forward fetching failed")


### PR DESCRIPTION
Closes #567

## What I have made

This removes all remaining imports from other packages than `grpc` and `validation`.
A commit-by-commit review is suggested.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only refactoring)

### Reviewer

- [x] I have checked the changes against the requirements
