### PR TITLE
refactor: replace deprecated ProtoReflectionService with ProtoReflectionServiceV1

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -2,7 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>Deprecation:SnowballRServer.kt:SnowballRServer$newInstance</ID>
     <ID>ForbiddenComment:FetcherOrchestrator.kt:FetcherOrchestrator$// TODO: merge data</ID>
     <ID>ForbiddenComment:FetcherOrchestrator.kt:FetcherOrchestrator$// TODO: paper filtering/merging</ID>
     <ID>ForbiddenComment:FetcherOrchestrator.kt:FetcherOrchestrator$// TODO: replace with check for whole paper data by similarity not only external ID</ID>

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/SnowballRServer.kt
@@ -6,7 +6,7 @@ import io.grpc.Server
 import io.grpc.ServerBuilder
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.protobuf.services.HealthStatusManager
-import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.protobuf.services.ProtoReflectionServiceV1
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import se.uulm.snowballr.backend.context.RequestContext
@@ -104,10 +104,10 @@ class SnowballRServer(
      * for debugging, development, and command-line tools that interact with gRPC servers without requiring
      * precompiled service definitions.
      *
-     * **Note:** ProtoReflectionServiceV1 does not work - calls are not registered by the server.
+     * Serves the `grpc.reflection.v1` protocol only. Clients that only speak the deprecated `v1alpha`
+     * protocol are not supported.
      */
-    @Suppress("Deprecated")
-    private val reflectionService = ProtoReflectionService.newInstance()
+    private val reflectionService = ProtoReflectionServiceV1.newInstance()
 
     /**
      * Manages the scheduling of tasks in the application.


### PR DESCRIPTION
Closes #569

## What I have made

- Replaced the deprecated `ProtoReflectionService` (legacy `grpc.reflection.v1alpha` protocol) with `ProtoReflectionServiceV1` (current `grpc.reflection.v1` protocol) in `SnowballRServer`
- Removed the now-unneeded `@Suppress` annotation and the `Deprecation` entry in `detekt-baseline.xml`
- Updated the outdated code comment claiming `ProtoReflectionServiceV1` "does not work": it stems from tooling that only spoke `v1alpha` at the time; current clients (Kreya >= 1.19, grpcurl >= 1.8.8, grpcui, buf) query `v1` first

Note: clients that only speak `v1alpha` (e.g. Evans, Kreya < 1.19) can no longer discover the API via reflection. If that becomes a problem, the legacy service can be registered alongside V1 (like grpc-go serves both by default).

## How to test the new v1 reflection

1. Start the backend (`./gradlew run`, default port 8080)
2. In Kreya (>= 1.19): add or re-sync a **gRPC server reflection** importer with endpoint `localhost:8080`, TLS disabled
3. Kreya should list `snowballr.SnowballR`, `grpc.health.v1.Health`, and `grpc.reflection.v1.ServerReflection` — the reflection entry showing **v1** (not v1alpha) confirms the switch
4. Invoke a simple method (e.g. `getAvailableFetchers`) to confirm normal operation is unaffected

If an existing Kreya project was imported via v1alpha, delete and re-add the importer instead of just re-syncing, in case the protocol version is cached.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - [x] ~~I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~ (no structural/tooling changes)
- [x] I have manually tested my changes
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ (reflection service registration is gRPC library functionality; not covered by unit tests)

### Reviewer

- [x] I have checked the changes against the requirements