### PR TITLE
Use ProjectResponse and use own status enum for exceptions

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -904,7 +904,7 @@ style:
                 value: 'TODO:'
         allowedPatterns: ''
     ForbiddenImport:
-        active: false
+        active: true
         forbiddenImports:
             -   reason: 'Use `org.junit.jupiter.api.Assertions.*` instead.'
                 value: 'kotlin.test.*'

--- a/detekt.yml
+++ b/detekt.yml
@@ -906,12 +906,13 @@ style:
     ForbiddenImport:
         active: false
         forbiddenImports:
-            - value: 'kotlin.test.*'
-              reason: 'Use org.junit.jupiter.api.Assertions.* instead'
-            - value: 'org.junit.jupiter.api.Assertions.assertNotNull'
-              reason: 'Use org.junit.jupiter.api.assertNotNull instead'
+            -   reason: 'Use `org.junit.jupiter.api.Assertions.*` instead.'
+                value: 'kotlin.test.*'
+            -   reason: 'Use `org.junit.jupiter.api.assertNotNull` instead.'
+                value: 'org.junit.jupiter.api.Assertions.assertNotNull'
         allowedImports:
-            - 'kotlin.test.assertContains' # no alternative
+            # `kotlin.test.assertContains` has no JUnit equivalent.
+            - 'kotlin.test.assertContains'
     ForbiddenMethodCall:
         active: true
         methods:

--- a/detekt.yml
+++ b/detekt.yml
@@ -905,8 +905,13 @@ style:
         allowedPatterns: ''
     ForbiddenImport:
         active: false
-        forbiddenImports: [ ]
-        allowedImports: [ ]
+        forbiddenImports:
+            - value: 'kotlin.test.*'
+              reason: 'Use org.junit.jupiter.api.Assertions.* instead'
+            - value: 'org.junit.jupiter.api.Assertions.assertNotNull'
+              reason: 'Use org.junit.jupiter.api.assertNotNull instead'
+        allowedImports:
+            - 'kotlin.test.assertContains' # no alternative
     ForbiddenMethodCall:
         active: true
         methods:

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/ToGrpcConversion.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/ToGrpcConversion.kt
@@ -10,7 +10,6 @@ import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPattern
 import se.uulm.snowballr.backend.model.dto.project.DecisionMatrixPatternEntry
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
@@ -34,6 +33,7 @@ import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionCount
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionStatistics
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectInformation
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 import se.uulm.snowballr.backend.model.outgoing.review.ReviewResponse
 import snowballr.Authentication
@@ -70,7 +70,7 @@ fun Author.toGrpc(): PaperOuterClass.Author = PaperOuterClass.Author.newBuilder(
 
 fun List<Author>.toGrpc(): List<PaperOuterClass.Author> = this.map(Author::toGrpc)
 
-fun Project.toGrpc(): ProjectOuterClass.Project {
+fun ProjectResponse.toGrpc(): ProjectOuterClass.Project {
     val settings =
         ProjectOuterClass.Project.Settings
             .newBuilder()
@@ -100,7 +100,7 @@ fun Project.toGrpc(): ProjectOuterClass.Project {
 }
 
 @JvmName("toGrpcProjectList")
-fun List<Project>.toGrpc(): ProjectOuterClass.Project.List {
+fun List<ProjectResponse>.toGrpc(): ProjectOuterClass.Project.List {
     val builder = ProjectOuterClass.Project.List.newBuilder()
     this.forEach { builder.addProjects(it.toGrpc()) }
     return builder.build()

--- a/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/grpc/interceptor/ExceptionInterceptor.kt
@@ -7,7 +7,15 @@ import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.Status
+import se.uulm.snowballr.backend.model.exception.AlreadyExistsException
+import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
+import se.uulm.snowballr.backend.model.exception.InternalException
+import se.uulm.snowballr.backend.model.exception.InvalidArgumentException
+import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.SnowballRException
+import se.uulm.snowballr.backend.model.exception.UnauthenticatedException
+import se.uulm.snowballr.backend.model.exception.UnauthorizedException
+import se.uulm.snowballr.backend.model.exception.UnauthorizedFetcherPathException
 
 private val logger = KotlinLogging.logger {}
 
@@ -21,7 +29,7 @@ private val logger = KotlinLogging.logger {}
  */
 val exceptionInterceptor =
     object : ServerInterceptor {
-        override fun <ReqT : Any?, RespT : Any?> interceptCall(
+        override fun <ReqT, RespT> interceptCall(
             call: ServerCall<ReqT?, RespT?>,
             headers: Metadata?,
             next: ServerCallHandler<ReqT?, RespT?>,
@@ -74,7 +82,16 @@ private class ExceptionCall<ReqT, RespT>(
      * The [SnowballRException]s are deliberately thrown in this application, e.g., when preconditions aren't met.
      */
     private fun getStatusForSnowballRException(exception: SnowballRException): Status {
-        val status = exception.getGrpcStatus().withDescription(exception.message).withCause(exception.cause)
+        val status = when (exception) {
+            is AlreadyExistsException -> Status.ALREADY_EXISTS
+            is FailedPreconditionException -> Status.FAILED_PRECONDITION
+            is InternalException -> Status.INTERNAL
+            is InvalidArgumentException -> Status.INVALID_ARGUMENT
+            is NotFoundException -> Status.NOT_FOUND
+            is UnauthenticatedException -> Status.UNAUTHENTICATED
+            is UnauthorizedException -> Status.PERMISSION_DENIED
+            is UnauthorizedFetcherPathException -> Status.INTERNAL
+        }.withDescription(exception.message).withCause(exception.cause)
 
         logger.debug {
             "gRPC call failed due to ${exception::class.qualifiedName ?: "<unknown class>"} with status: " +

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/Status.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/Status.kt
@@ -1,0 +1,15 @@
+package se.uulm.snowballr.backend.model
+
+@Suppress("MagicNumber")
+enum class Status(val code: Int) {
+    // --- Client Error --- //
+
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+
+    // --- Server Error -- //
+
+    INTERNAL(500),
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/AlreadyExistsException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/AlreadyExistsException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when something already exists.
@@ -8,6 +8,6 @@ import io.grpc.Status
 open class AlreadyExistsException protected constructor(
     message: String,
 ) : SnowballRException(
-    Status.ALREADY_EXISTS,
+    Status.BAD_REQUEST,
     message,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/FailedPreconditionException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/FailedPreconditionException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when a call has the wrong preconditions.
@@ -9,4 +9,4 @@ import io.grpc.Status
  */
 open class FailedPreconditionException(
     description: String,
-) : SnowballRException(Status.FAILED_PRECONDITION, description)
+) : SnowballRException(Status.FORBIDDEN, description)

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/InternalException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/InternalException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when an unexpected error occurs within the application. These exceptions are not

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/InvalidArgumentException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/InvalidArgumentException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when an invalid argument is provided to a method.
@@ -8,6 +8,6 @@ import io.grpc.Status
 open class InvalidArgumentException protected constructor(
     message: String,
 ) : SnowballRException(
-    Status.INVALID_ARGUMENT,
+    Status.BAD_REQUEST,
     message,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/NotFoundException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/NotFoundException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when something could not be found.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/SnowballRException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/SnowballRException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Base class for all exceptions in the SnowballR application.
@@ -8,14 +8,14 @@ import io.grpc.Status
  * Used to encapsulate specific error details and provide a consistent exception structure.
  * Can be extended to create more detailed exceptions specific to various error scenarios.
  *
- * @param grpcStatus The gRPC status code that should be returned to the client when the exception is thrown.
+ * @param status The status code that should be returned to the client when the exception is thrown.
  * @param message Detailed message describing the reason for the exception.
  * @param cause The cause of the exception, which can be another exception, or null if not provided.
  */
 sealed class SnowballRException(
-    private val grpcStatus: Status,
+    private val status: Status,
     message: String,
     cause: Throwable? = null,
 ) : RuntimeException(message, cause) {
-    fun getGrpcStatus(): Status = grpcStatus
+    fun getStatus(): Status = status
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthenticatedException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthenticatedException.kt
@@ -1,10 +1,10 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when a user is not authenticated.
  *
  * This exception is thrown when an operation requires user authentication, but the user is not authenticated.
  */
-class UnauthenticatedException : SnowballRException(Status.UNAUTHENTICATED, "User is not authenticated.")
+class UnauthenticatedException : SnowballRException(Status.UNAUTHORIZED, "User is not authenticated.")

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedException.kt
@@ -1,7 +1,7 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
 import se.uulm.snowballr.backend.model.AccessType
+import se.uulm.snowballr.backend.model.Status
 import java.util.UUID
 
 /**
@@ -16,6 +16,6 @@ open class UnauthorizedException protected constructor(
     accessType: AccessType,
     accessedEntityMessage: String,
 ) : SnowballRException(
-    Status.PERMISSION_DENIED,
+    Status.FORBIDDEN,
     "User with ID '$currentUserId' is not authorized to $accessType $accessedEntityMessage",
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedFetcherPathException.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedFetcherPathException.kt
@@ -1,6 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
+import se.uulm.snowballr.backend.model.Status
 
 /**
  * Represents an exception that occurs when a fetcher path traverses outside the configured fetchers directory.

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/project/UpdateProjectRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/project/UpdateProjectRequest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.model.incoming.project
 
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import java.util.UUID
 
 data class UpdateProjectRequest(
@@ -16,6 +17,13 @@ data class UpdateProjectRequest(
             name = project.name,
             status = project.status,
             settings = UpdateProjectSettingRequest.fromProject(project),
+        )
+
+        fun fromProjectResponse(project: ProjectResponse) = UpdateProjectRequest(
+            projectId = project.id,
+            name = project.name,
+            status = project.status,
+            settings = UpdateProjectSettingRequest.fromProjectResponse(project),
         )
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/project/UpdateProjectSettingRequest.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/incoming/project/UpdateProjectSettingRequest.kt
@@ -4,6 +4,7 @@ import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
 import se.uulm.snowballr.backend.model.dto.project.SnowballingType
 import se.uulm.snowballr.backend.model.fetcher.FetcherMap
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 
 data class UpdateProjectSettingRequest(
     val similarityThreshold: Float,
@@ -14,6 +15,14 @@ data class UpdateProjectSettingRequest(
 ) {
     companion object {
         fun fromProject(project: Project) = UpdateProjectSettingRequest(
+            similarityThreshold = project.similarityThreshold,
+            snowballingType = project.snowballingType,
+            reviewMaybeAllowed = project.reviewMaybeAllowed,
+            fetchers = project.fetchers,
+            decisionMatrix = project.reviewDecisionMatrix,
+        )
+
+        fun fromProjectResponse(project: ProjectResponse) = UpdateProjectSettingRequest(
             similarityThreshold = project.similarityThreshold,
             snowballingType = project.snowballingType,
             reviewMaybeAllowed = project.reviewMaybeAllowed,

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectResponse.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/outgoing/project/ProjectResponse.kt
@@ -1,0 +1,39 @@
+package se.uulm.snowballr.backend.model.outgoing.project
+
+import se.uulm.snowballr.backend.model.dto.project.Project
+import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
+import se.uulm.snowballr.backend.model.dto.project.ReviewDecisionMatrix
+import se.uulm.snowballr.backend.model.dto.project.SnowballingType
+import se.uulm.snowballr.backend.model.fetcher.FetcherMap
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class ProjectResponse(
+    val id: UUID,
+    val name: String,
+    val status: ProjectStatus,
+    val currentStage: Int,
+    val maxStage: Int,
+    val similarityThreshold: Float,
+    val snowballingType: SnowballingType,
+    val reviewMaybeAllowed: Boolean,
+    val reviewDecisionMatrix: ReviewDecisionMatrix,
+    val fetchers: FetcherMap,
+    val currentStageStartedAt: OffsetDateTime,
+) {
+    companion object {
+        fun fromProject(project: Project) = ProjectResponse(
+            id = project.id,
+            name = project.name,
+            status = project.status,
+            currentStage = project.currentStage,
+            maxStage = project.maxStage,
+            similarityThreshold = project.similarityThreshold,
+            snowballingType = project.snowballingType,
+            reviewMaybeAllowed = project.reviewMaybeAllowed,
+            reviewDecisionMatrix = project.reviewDecisionMatrix,
+            fetchers = project.fetchers,
+            currentStageStartedAt = project.currentStageStartedAt,
+        )
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/service/ProjectService.kt
@@ -4,7 +4,6 @@ import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.grpc.SnowballRServer.SnowballRService
 import se.uulm.snowballr.backend.model.AccessType
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
@@ -19,6 +18,7 @@ import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionCount
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectDecisionStatistics
 import se.uulm.snowballr.backend.model.outgoing.project.ProjectInformation
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -33,37 +33,37 @@ interface IProjectService {
     /**
      * Service implementation of [SnowballRService.getProjectById].
      */
-    suspend fun getProjectById(projectId: UUID): Project
+    suspend fun getProjectById(projectId: UUID): ProjectResponse
 
     /**
      * Service implementation of [SnowballRService.createProject].
      */
-    suspend fun createProject(request: CreateProjectRequest): Project
+    suspend fun createProject(request: CreateProjectRequest): ProjectResponse
 
     /**
      * Service implementation of [SnowballRService.getAllProjects].
      */
-    suspend fun getAllProjects(): List<Project>
+    suspend fun getAllProjects(): List<ProjectResponse>
 
     /**
      * Service implementation of [SnowballRService.getAllProjectsForUser].
      */
-    suspend fun getAllProjectsForUser(userId: UUID): List<Project>
+    suspend fun getAllProjectsForUser(userId: UUID): List<ProjectResponse>
 
     /**
      * Service implementation of [SnowballRService.getAllArchivedProjectsForUser].
      */
-    suspend fun getAllArchivedProjectsForUser(userId: UUID): List<Project>
+    suspend fun getAllArchivedProjectsForUser(userId: UUID): List<ProjectResponse>
 
     /**
      * Service implementation of [SnowballRService.getAllDeletedProjectsForUser].
      */
-    suspend fun getAllDeletedProjectsForUser(userId: UUID): List<Project>
+    suspend fun getAllDeletedProjectsForUser(userId: UUID): List<ProjectResponse>
 
     /**
      * Service implementation of [SnowballRService.updateProject].
      */
-    suspend fun updateProject(request: UpdateProjectRequest, paths: Set<String>): Project
+    suspend fun updateProject(request: UpdateProjectRequest, paths: Set<String>): ProjectResponse
 
     /**
      * Service implementation of [SnowballRService.getProjectInformation].
@@ -108,55 +108,57 @@ class ProjectService(
     private val accessChecker: IProjectAccessChecker,
     private val fetcherManager: IFetcherManager,
 ) : IProjectService {
-    override suspend fun getProjectById(projectId: UUID): Project = withUser(userRepo) { currentUser ->
+    override suspend fun getProjectById(projectId: UUID): ProjectResponse = withUser(userRepo) { currentUser ->
         accessChecker.isAllowedToReadProject(currentUser, projectId)
 
-        repo.getProjectById(projectId).getOrThrow()
+        val project = repo.getProjectById(projectId).getOrThrow()
+        ProjectResponse.fromProject(project)
     }
 
-    override suspend fun createProject(request: CreateProjectRequest): Project = withUser(userRepo) { currentUser ->
-        val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
-        val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
+    override suspend fun createProject(request: CreateProjectRequest): ProjectResponse =
+        withUser(userRepo) { currentUser ->
+            val userSettings = userRepo.getUserSettings(currentUser.id).getOrThrow()
+            val userDefaultCriteria = criterionRepo.getCriteriaByIds(userSettings.criteriaIds)
 
-        val project = repo.createProject(request, currentUser.id, userSettings)
+            val project = repo.createProject(request, currentUser.id, userSettings)
 
-        // Additionally, clone user default criteria into the project as project criteria and add creator as project member
-        for (criterion in userDefaultCriteria) {
-            val createCriterionRequest = CreateCriterionRequest(
-                tag = criterion.tag,
-                name = criterion.name,
-                description = criterion.description,
-                category = criterion.category,
-                projectId = project.id,
-            )
+            // Additionally, clone user default criteria into the project as project criteria and add creator as project member
+            for (criterion in userDefaultCriteria) {
+                val createCriterionRequest = CreateCriterionRequest(
+                    tag = criterion.tag,
+                    name = criterion.name,
+                    description = criterion.description,
+                    category = criterion.category,
+                    projectId = project.id,
+                )
 
-            criterionRepo.createCriterion(createCriterionRequest, currentUser.id)
+                criterionRepo.createCriterion(createCriterionRequest, currentUser.id)
+            }
+
+            projectMemberRepo.addUserToProject(currentUser.id, project.id)
+            projectMemberRepo.updateProjectMemberRole(project.id, currentUser.id, MemberRole.ADMIN)
+
+            ProjectResponse.fromProject(project)
         }
 
-        projectMemberRepo.addUserToProject(currentUser.id, project.id)
-        projectMemberRepo.updateProjectMemberRole(project.id, currentUser.id, MemberRole.ADMIN)
-
-        project
-    }
-
-    override suspend fun getAllProjects(): List<Project> = withUser(userRepo) { currentUser ->
+    override suspend fun getAllProjects(): List<ProjectResponse> = withUser(userRepo) { currentUser ->
         accessChecker.isAllowedToReadAllProjects(currentUser)
 
-        repo.getAllProjects()
+        repo.getAllProjects().map { ProjectResponse.fromProject(it) }
     }
 
-    override suspend fun getAllProjectsForUser(userId: UUID): List<Project> = getAllProjectsForUserAndStatus(
+    override suspend fun getAllProjectsForUser(userId: UUID): List<ProjectResponse> = getAllProjectsForUserAndStatus(
         userId,
         setOf(ProjectStatus.ACTIVE, ProjectStatus.ACTIVE_LOCKED),
     )
 
-    override suspend fun getAllArchivedProjectsForUser(userId: UUID): List<Project> =
+    override suspend fun getAllArchivedProjectsForUser(userId: UUID): List<ProjectResponse> =
         getAllProjectsForUserAndStatus(userId, setOf(ProjectStatus.ARCHIVED))
 
-    override suspend fun getAllDeletedProjectsForUser(userId: UUID): List<Project> =
+    override suspend fun getAllDeletedProjectsForUser(userId: UUID): List<ProjectResponse> =
         getAllProjectsForUserAndStatus(userId, setOf(ProjectStatus.DELETED))
 
-    override suspend fun updateProject(request: UpdateProjectRequest, paths: Set<String>): Project =
+    override suspend fun updateProject(request: UpdateProjectRequest, paths: Set<String>): ProjectResponse =
         withUser(userRepo) { currentUser ->
             accessChecker.isProjectOrServerAdmin(currentUser, request.projectId, AccessType.UPDATE)
 
@@ -174,7 +176,8 @@ class ProjectService(
                 finalRequest = finalRequest.copy(settings = finalRequest.settings.copy(fetchers = sanitizedFetchersMap))
             }
 
-            repo.updateProject(finalRequest, paths)
+            val updatedProject = repo.updateProject(finalRequest, paths)
+            ProjectResponse.fromProject(updatedProject)
         }
 
     override suspend fun getProjectInformation(projectId: UUID, paths: List<String>): ProjectInformation =
@@ -231,14 +234,16 @@ class ProjectService(
         invitationTokenRepo.deleteInvitationTokensForProject(projectId)
     }
 
-    private suspend fun getAllProjectsForUserAndStatus(userId: UUID, statuses: Set<ProjectStatus>): List<Project> =
-        withUser(userRepo) { currentUser ->
-            userRepo.getUserById(userId).getOrThrow()
+    private suspend fun getAllProjectsForUserAndStatus(
+        userId: UUID,
+        statuses: Set<ProjectStatus>,
+    ): List<ProjectResponse> = withUser(userRepo) { currentUser ->
+        userRepo.getUserById(userId).getOrThrow()
 
-            accessChecker.isAllowedToReadUserProjects(currentUser, userId)
+        accessChecker.isAllowedToReadUserProjects(currentUser, userId)
 
-            repo.getUserProjects(userId, statuses)
-        }
+        repo.getUserProjects(userId, statuses).map { ProjectResponse.fromProject(it) }
+    }
 
     /**
      * Validates the update of a project based on the current status and the requested status.

--- a/src/test/kotlin/se/uulm/snowballr/backend/auth/JwtManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/auth/JwtManagerTest.kt
@@ -4,11 +4,11 @@ import io.jsonwebtoken.JwtException
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import org.koin.test.KoinTest
 import se.uulm.snowballr.backend.RandomKeyGenerator

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/JsonExporterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/JsonExporterTest.kt
@@ -1,13 +1,13 @@
 package se.uulm.snowballr.backend.export
 
 import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.export.testdata.emptyProjectExport
 import se.uulm.snowballr.backend.export.testdata.fullProjectExport
 import se.uulm.snowballr.backend.model.export.ProjectExport
-import kotlin.test.assertEquals
 
 class JsonExporterTest {
     companion object {

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportBuilderTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportBuilderTest.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.export
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class ProjectExportBuilderTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/export/ProjectExportManagerTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.export
 
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -16,7 +17,6 @@ import se.uulm.snowballr.backend.model.export.ProjectExport
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class ProjectExportManagerTest {
     companion object {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/PythonPluginFetcherManagerTest.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,8 +25,6 @@ import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 import kotlin.jvm.optionals.getOrElse
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
 class PythonPluginFetcherManagerTest {
@@ -124,8 +124,8 @@ class PythonPluginFetcherManagerTest {
         assertEquals("information_fetcher", result.id)
         assertEquals("test", result.information.name)
         assertEquals("desc", result.information.description)
-        assertEquals(emptyList(), result.information.links)
-        assertEquals(emptyMap(), result.information.optionsSchema)
+        assertEquals(0, result.information.links.size)
+        assertEquals(0, result.information.optionsSchema.size)
     }
 
     @Test
@@ -328,7 +328,7 @@ class PythonPluginFetcherManagerTest {
 
         val options = fetcherManager.searchPapers("symlink_inside", "", emptyMap())
 
-        assertEquals(emptySet(), options)
+        assertEquals(0, options.size)
     }
 
     @Test
@@ -500,7 +500,7 @@ class PythonPluginFetcherManagerTest {
 
         val options = fetcherManager.searchPapers("warning_fetcher", "", emptyMap())
 
-        assertEquals(emptySet(), options)
+        assertEquals(0, options.size)
     }
 
     @Test
@@ -517,7 +517,7 @@ class PythonPluginFetcherManagerTest {
 
         val options = fetcherManager.searchPapers("multiline_fetcher", "", emptyMap())
 
-        assertEquals(emptySet(), options)
+        assertEquals(0, options.size)
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/ResourceBuilderTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/ResourceBuilderTest.kt
@@ -2,8 +2,8 @@ package se.uulm.snowballr.backend.fetcher
 
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class ResourceBuilderTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/formatting/TimeFormatterTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/formatting/TimeFormatterTest.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.formatting
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class TimeFormatterTest {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/BaseIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/BaseIntegrationTest.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.integration
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
-import kotlin.test.assertEquals
 
 class BaseIntegrationTest : IntegrationTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/IntegrationTest.kt
@@ -39,12 +39,12 @@ import se.uulm.snowballr.backend.fetcher.IFetcherOrchestrator
 import se.uulm.snowballr.backend.mail.EmailManager
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.mailServiceDeps
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.email.EmailData
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import se.uulm.snowballr.backend.repository.RepositoryHelper
 import se.uulm.snowballr.backend.repositoryLayerDeps
 import se.uulm.snowballr.backend.service.IAuthenticationService
@@ -213,7 +213,7 @@ open class IntegrationTest : KoinTest {
      * @param acceptInvitation Whether the invitation should be accepted after being sent. If true, the user will be
      * added to the project.
      */
-    protected suspend fun inviteUserToProject(project: Project, user: User, acceptInvitation: Boolean = false) {
+    protected suspend fun inviteUserToProject(project: ProjectResponse, user: User, acceptInvitation: Boolean = false) {
         val invitationToken = inviteHelper(project, user.firstName, user.email)
 
         if (acceptInvitation) {
@@ -228,7 +228,7 @@ open class IntegrationTest : KoinTest {
      * @param project The project to which the user should be invited to.
      * @param email The email of the user that should be invited to the passed project.
      */
-    protected suspend fun inviteEmailToProject(project: Project, email: String) {
+    protected suspend fun inviteEmailToProject(project: ProjectResponse, email: String) {
         inviteHelper(project, "User", email)
     }
 
@@ -245,7 +245,7 @@ open class IntegrationTest : KoinTest {
     }
 
     private suspend fun inviteHelper(
-        project: Project,
+        project: ProjectResponse,
         inviteeFirstName: String,
         inviteeEmail: String,
     ): CapturingSlot<String> {
@@ -265,6 +265,6 @@ open class IntegrationTest : KoinTest {
     /**
      * Adds the [paper] to the [project] in stage 0.
      */
-    protected suspend fun addToProject(project: Project, paper: PaperResponse) =
+    protected suspend fun addToProject(project: ProjectResponse, paper: PaperResponse) =
         projectPaperService.addPaperToProject(project.id, paper.id, 0)
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/access/AccessControlIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
@@ -16,9 +15,10 @@ import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 
 class AccessControlIntegrationTest : IntegrationTest() {
-    private suspend fun setupProjectWithMember(): Pair<Project, User> {
+    private suspend fun setupProjectWithMember(): Pair<ProjectResponse, User> {
         val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
         val member = addUser(DataBuilder.createExampleUser(email = "member@example.com"))
         inviteUserToProject(project, member, acceptInvitation = true)
@@ -41,7 +41,7 @@ class AccessControlIntegrationTest : IntegrationTest() {
         fun `When a non-admin member tries to update a project, then access is denied`() = runTest {
             val (project, member) = setupProjectWithMember()
 
-            val request = UpdateProjectRequest.fromProject(project)
+            val request = UpdateProjectRequest.fromProjectResponse(project)
 
             actAsUser(member.id) {
                 assertThrows<UnauthorizedException> { projectService.updateProject(request, setOf("project.name")) }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.integration.regression
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import se.uulm.snowballr.backend.DataBuilder
@@ -11,7 +12,6 @@ import se.uulm.snowballr.backend.model.dto.user.UserStatus
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.outgoing.paper.PaperResponse
-import kotlin.test.assertEquals
 
 class RegressionTest : IntegrationTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/CriterionIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/CriterionIntegrationTest.kt
@@ -8,15 +8,15 @@ import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.dto.criterion.Criterion
 import se.uulm.snowballr.backend.model.dto.criterion.CriterionCategory
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 
 class CriterionIntegrationTest : IntegrationTest() {
     private suspend fun createProjectAndCriterion(
         criterionName: String = "Test Criterion",
-    ): Pair<Project, Criterion.ProjectCriterion> {
+    ): Pair<ProjectResponse, Criterion.ProjectCriterion> {
         val project = projectService.createProject(CreateProjectRequest(name = "Test Project"))
         val criterion = criterionService.createCriterion(
             CreateCriterionRequest(

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/CriterionIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/CriterionIntegrationTest.kt
@@ -1,6 +1,8 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.integration.IntegrationTest
@@ -10,8 +12,6 @@ import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.incoming.criterion.CreateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.criterion.UpdateCriterionRequest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class CriterionIntegrationTest : IntegrationTest() {
     private suspend fun createProjectAndCriterion(

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ExportIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ExportIntegrationTest.kt
@@ -1,13 +1,13 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class ExportIntegrationTest : IntegrationTest() {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/FetcherIntegrationTest.kt
@@ -1,6 +1,8 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -8,8 +10,6 @@ import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.exception.UnauthorizedException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class FetcherIntegrationTest : IntegrationTest() {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/InvitationIntegrationTest.kt
@@ -1,14 +1,14 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class InvitationIntegrationTest : IntegrationTest() {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/PaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/PaperIntegrationTest.kt
@@ -2,9 +2,9 @@ package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicatePaperException

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectIntegrationTest.kt
@@ -61,7 +61,7 @@ class ProjectIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Original Name"))
 
             val updatedProject = project.copy(name = "Updated Name")
-            val request = UpdateProjectRequest.fromProject(updatedProject)
+            val request = UpdateProjectRequest.fromProjectResponse(updatedProject)
 
             val result = projectService.updateProject(request, setOf("project.name"))
 
@@ -76,7 +76,7 @@ class ProjectIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "To Archive"))
 
             val updatedProject = project.copy(status = ProjectStatus.ARCHIVED)
-            val request = UpdateProjectRequest.fromProject(updatedProject)
+            val request = UpdateProjectRequest.fromProjectResponse(updatedProject)
 
             projectService.updateProject(request, setOf("project.status"))
 
@@ -89,7 +89,7 @@ class ProjectIntegrationTest : IntegrationTest() {
             val project = projectService.createProject(CreateProjectRequest(name = "Archived Project"))
 
             val updatedProject = project.copy(status = ProjectStatus.ARCHIVED)
-            val request = UpdateProjectRequest.fromProject(updatedProject)
+            val request = UpdateProjectRequest.fromProjectResponse(updatedProject)
 
             projectService.updateProject(request, setOf("project.status"))
 
@@ -123,7 +123,7 @@ class ProjectIntegrationTest : IntegrationTest() {
                         "non-existent-fetcher" to emptyMap(),
                     ),
                 )
-                val request = UpdateProjectRequest.fromProject(updatedProject)
+                val request = UpdateProjectRequest.fromProjectResponse(updatedProject)
 
                 val result = projectService.updateProject(request, setOf("project.settings.fetchers"))
 
@@ -160,7 +160,7 @@ class ProjectIntegrationTest : IntegrationTest() {
                         "fetcher" to mapOf("option1" to "value"),
                     ),
                 )
-                val request = UpdateProjectRequest.fromProject(updatedProject)
+                val request = UpdateProjectRequest.fromProjectResponse(updatedProject)
 
                 assertThrows<FailedPreconditionException> {
                     projectService.updateProject(request, setOf("project.settings.fetchers"))

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectIntegrationTest.kt
@@ -2,9 +2,13 @@ package se.uulm.snowballr.backend.integration.services
 
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
@@ -14,10 +18,6 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherInformationWithId
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class ProjectIntegrationTest : IntegrationTest() {
     @Nested
@@ -130,7 +130,8 @@ class ProjectIntegrationTest : IntegrationTest() {
                 val fetchersMap = result.fetchers
                 assertContains(fetchersMap.keys, "existent-fetcher")
                 assertFalse(fetchersMap.containsKey("non-existent-fetcher"))
-                val sanitizedOptions = assertNotNull(fetchersMap["existent-fetcher"])
+                val sanitizedOptions = fetchersMap["existent-fetcher"]
+                assertNotNull(sanitizedOptions)
                 assertContains(sanitizedOptions.keys, "existent-option")
                 assertFalse(sanitizedOptions.containsKey("non-existent-option"))
             }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectMemberIntegrationTest.kt
@@ -1,6 +1,9 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
@@ -8,9 +11,6 @@ import se.uulm.snowballr.backend.integration.IntegrationTest
 import se.uulm.snowballr.backend.model.dto.projectmember.MemberRole
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.projectmember.UpdateProjectMemberRoleRequest
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class ProjectMemberIntegrationTest : IntegrationTest() {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateProjectPaperException
@@ -18,6 +17,7 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedCreate
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 
 class ProjectPaperIntegrationTest : IntegrationTest() {
@@ -30,13 +30,16 @@ class ProjectPaperIntegrationTest : IntegrationTest() {
             ),
         )
 
-    private suspend fun setNumberOfRequiredReviewers(project: Project, numberOfReviewers: Int): Project {
+    private suspend fun setNumberOfRequiredReviewers(
+        project: ProjectResponse,
+        numberOfReviewers: Int,
+    ): ProjectResponse {
         val projectUpdate = project.copy(
             reviewDecisionMatrix = project.reviewDecisionMatrix.copy(numberOfReviewers = numberOfReviewers),
         )
 
         return projectService.updateProject(
-            UpdateProjectRequest.fromProject(projectUpdate),
+            UpdateProjectRequest.fromProjectResponse(projectUpdate),
             setOf("project.settings.decision_matrix.number_of_reviewers"),
         )
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ProjectPaperIntegrationTest.kt
@@ -1,6 +1,9 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -16,9 +19,6 @@ import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class ProjectPaperIntegrationTest : IntegrationTest() {
     private suspend fun reviewPaper(projectPaper: ProjectPaperResponse, decision: ReviewDecision) =

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReadingListIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReadingListIntegrationTest.kt
@@ -1,12 +1,12 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class ReadingListIntegrationTest : IntegrationTest() {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -7,17 +7,17 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.integration.IntegrationTest
-import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
 import se.uulm.snowballr.backend.model.dto.review.ReviewDecision
 import se.uulm.snowballr.backend.model.exception.FailedPreconditionException
 import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
 
 class ReviewIntegrationTest : IntegrationTest() {
-    private suspend fun setupProjectAndPaper(): Pair<Project, ProjectPaperResponse> {
+    private suspend fun setupProjectAndPaper(): Pair<ProjectResponse, ProjectPaperResponse> {
         var project = projectService.createProject(CreateProjectRequest(name = "Review Test Project"))
         val paper = createPaper()
         val projectPaper = projectPaperService.addPaperToProject(project.id, paper.id, 0)
@@ -27,7 +27,7 @@ class ReviewIntegrationTest : IntegrationTest() {
                 numberOfReviewers = 1,
             ),
         )
-        val projectUpdate = UpdateProjectRequest.fromProject(modifiedProject)
+        val projectUpdate = UpdateProjectRequest.fromProjectResponse(modifiedProject)
 
         project = projectService.updateProject(
             projectUpdate,
@@ -126,7 +126,7 @@ class ReviewIntegrationTest : IntegrationTest() {
             )
 
             val updatedProject = project.copy(reviewMaybeAllowed = true)
-            val updateRequest = UpdateProjectRequest.fromProject(updatedProject)
+            val updateRequest = UpdateProjectRequest.fromProjectResponse(updatedProject)
 
             assertThrows<FailedPreconditionException> {
                 projectService.updateProject(updateRequest, setOf("project.settings.review_maybe_allowed"))

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/ReviewIntegrationTest.kt
@@ -1,6 +1,8 @@
 package se.uulm.snowballr.backend.integration.services
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -13,8 +15,6 @@ import se.uulm.snowballr.backend.model.incoming.project.CreateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import se.uulm.snowballr.backend.model.outgoing.projectpaper.ProjectPaperResponse
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ReviewIntegrationTest : IntegrationTest() {
     private suspend fun setupProjectAndPaper(): Pair<Project, ProjectPaperResponse> {

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/services/UserIntegrationTest.kt
@@ -4,6 +4,8 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -17,8 +19,6 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadAl
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
 import se.uulm.snowballr.backend.model.incoming.user.RegisterRequest
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class UserIntegrationTest : IntegrationTest() {
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/ExceptionHelperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/ExceptionHelperTest.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.model
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import kotlin.test.assertEquals
 
 class ExceptionHelperTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/auth/AuthRequestStateTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/auth/AuthRequestStateTest.kt
@@ -4,9 +4,9 @@ import io.grpc.Metadata
 import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class AuthRequestStateTest {
     @Test
@@ -26,7 +26,7 @@ class AuthRequestStateTest {
     fun `When optional values are null, then they remain null in the state`() {
         val call = mockk<ServerCall<String?, String?>>(relaxed = true)
 
-        val state = AuthRequestState<String, String>(call, null, null)
+        val state = AuthRequestState(call, null, null)
 
         assertEquals(call, state.call)
         assertNull(state.headers)

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/dto/PdfTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/dto/PdfTest.kt
@@ -1,11 +1,11 @@
 package se.uulm.snowballr.backend.model.dto
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.dto.paper.Pdf
 import java.util.UUID
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
 
 class PdfTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/exception/NotFoundExceptionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/exception/NotFoundExceptionTest.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.EntityType
@@ -15,7 +16,6 @@ import se.uulm.snowballr.backend.model.exception.notfound.entity.ProjectPaperNot
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundByEmailException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.UserNotFoundException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class NotFoundExceptionTest {
     private val testId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/exception/SnowballRExceptionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/exception/SnowballRExceptionTest.kt
@@ -1,10 +1,10 @@
 package se.uulm.snowballr.backend.model.exception
 
 import io.grpc.Status
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.EntityType
 import se.uulm.snowballr.backend.model.exception.invalidargument.InvalidUUIDException
-import kotlin.test.assertEquals
 
 class SnowballRExceptionTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/exception/SnowballRExceptionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/exception/SnowballRExceptionTest.kt
@@ -1,16 +1,16 @@
 package se.uulm.snowballr.backend.model.exception
 
-import io.grpc.Status
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.model.EntityType
+import se.uulm.snowballr.backend.model.Status
 import se.uulm.snowballr.backend.model.exception.invalidargument.InvalidUUIDException
 
 class SnowballRExceptionTest {
     @Test
-    fun `When getting grpc status from a SnowballR exception, then the configured status is returned`() {
+    fun `When getting the status from a SnowballR exception, then the configured status is returned`() {
         val exception = InvalidUUIDException(EntityType.USER, "invalid-uuid")
 
-        assertEquals(Status.INVALID_ARGUMENT, exception.getGrpcStatus())
+        assertEquals(Status.BAD_REQUEST, exception.getStatus())
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedExceptionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/exception/UnauthorizedExceptionTest.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.model.exception
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -16,7 +17,6 @@ import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedReadEx
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedSingleException
 import se.uulm.snowballr.backend.model.exception.unauthorized.UnauthorizedUpdateException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class UnauthorizedExceptionTest {
     private val currentUserId = UUID.randomUUID()

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/exception/internal/AccessRuleCheckFailedExceptionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/exception/internal/AccessRuleCheckFailedExceptionTest.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.model.exception.internal
 
-import io.grpc.Status
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.model.Status
 
 class AccessRuleCheckFailedExceptionTest {
     @Test
@@ -14,6 +14,6 @@ class AccessRuleCheckFailedExceptionTest {
                 "Please add a more specific exception to each path in the rule chain.",
             exception.message,
         )
-        assertEquals(Status.INTERNAL, exception.getGrpcStatus())
+        assertEquals(Status.INTERNAL, exception.getStatus())
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/exception/internal/AccessRuleCheckFailedExceptionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/exception/internal/AccessRuleCheckFailedExceptionTest.kt
@@ -1,8 +1,8 @@
 package se.uulm.snowballr.backend.model.exception.internal
 
 import io.grpc.Status
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class AccessRuleCheckFailedExceptionTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/export/FileExportTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/export/FileExportTest.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.model.export
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
 
 class FileExportTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/CriterionTableRepoTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -27,7 +28,6 @@ import se.uulm.snowballr.backend.utils.assertResultFailure
 import se.uulm.snowballr.backend.utils.assertResultSuccess
 import java.sql.SQLException
 import java.util.UUID
-import kotlin.test.assertIs
 
 class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTable), true) {
     private val repo = CriterionTableRepo(db)
@@ -52,7 +52,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
             val result = repo.getCriterionById(criterionId)
 
             val criterion = assertResultSuccess(result)
-            assertIs<ProjectCriterion>(criterion)
+            assertInstanceOf<ProjectCriterion>(criterion)
             assertEquals(criterionId, criterion.id)
             assertEquals("Test Tag", criterion.tag)
             assertEquals("Test Criterion", criterion.name)
@@ -85,7 +85,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
                 val criterion = repo.createCriterion(request, testUserId)
 
-                assertIs<ProjectCriterion>(criterion)
+                assertInstanceOf<ProjectCriterion>(criterion)
                 assertEquals("Test Tag", criterion.tag)
                 assertEquals("Test Criterion", criterion.name)
                 assertEquals("Test Description", criterion.description)
@@ -107,7 +107,7 @@ class CriterionTableRepoTest : RepositoryTest(arrayOf(CriterionTable, ProjectTab
 
                 val criterion = repo.createCriterion(request, testUserId)
 
-                assertIs<UserCriterion>(criterion)
+                assertInstanceOf<UserCriterion>(criterion)
                 assertEquals("Test Tag", criterion.tag)
                 assertEquals("Test Criterion", criterion.name)
                 assertEquals("Test Description", criterion.description)

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/association/CitationTableRepoTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.repository.association
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -13,7 +14,6 @@ import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.CitationTable
 import java.sql.SQLException
 import java.util.UUID
-import kotlin.test.assertTrue
 
 class CitationTableRepoTest : RepositoryTest(arrayOf(PaperTable, CitationTable), false) {
     private val repo = CitationTableRepo(db)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/ChangePasswordTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/authentication/ChangePasswordTest.kt
@@ -4,9 +4,9 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CriterionServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/criterion/CriterionServiceTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.criterion
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import se.uulm.snowballr.backend.access.ICriterionAccessChecker
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.context.RequestContext
@@ -12,7 +13,6 @@ import se.uulm.snowballr.backend.repository.IUserTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.CriterionService
 import se.uulm.snowballr.backend.service.withUser
-import kotlin.test.assertEquals
 
 /**
  * Base test class for the [CriterionService].

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/ExportProjectTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coJustRun
 import io.mockk.every
 import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -14,7 +15,6 @@ import se.uulm.snowballr.backend.model.dto.user.UserRole
 import se.uulm.snowballr.backend.model.export.ExportFormat
 import se.uulm.snowballr.backend.model.export.FileExport
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class ExportProjectTest : ExportServiceTest() {
     private val testFormat = ExportFormat.JSON

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/export/GetAvailableExportFormatsTest.kt
@@ -3,10 +3,10 @@ package se.uulm.snowballr.backend.service.export
 import io.mockk.every
 import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.export.ProjectExportManager
 import se.uulm.snowballr.backend.model.export.ExportFormat
-import kotlin.test.assertEquals
 
 class GetAvailableExportFormatsTest : ExportServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/fetcher/SearchLocalProjectPaperCandidatesTest.kt
@@ -3,12 +3,12 @@ package se.uulm.snowballr.backend.service.fetcher
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class SearchLocalProjectPaperCandidatesTest : FetcherServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetPendingInvitationsForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/invitation/GetPendingInvitationsForProjectTest.kt
@@ -4,8 +4,8 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
@@ -80,14 +80,14 @@ class GetPendingInvitationsForProjectTest : InvitationServiceTest() {
             assertNotNull(invitationForNotRegisteredUser)
 
             // Registered user should have user details
-            assertEquals(registeredUser.id, invitationForRegisteredUser?.userId)
-            assertEquals(UserStatus.ACTIVE, invitationForRegisteredUser?.status)
-            assertEquals(registeredUser.firstName, invitationForRegisteredUser?.firstName)
+            assertEquals(registeredUser.id, invitationForRegisteredUser.userId)
+            assertEquals(UserStatus.ACTIVE, invitationForRegisteredUser.status)
+            assertEquals(registeredUser.firstName, invitationForRegisteredUser.firstName)
 
             // Not registered user should not have user details
-            assertEquals(null, invitationForNotRegisteredUser?.userId)
-            assertEquals(UserStatus.ACTIVE_UNCONFIRMED, invitationForNotRegisteredUser?.status)
-            assertEquals("", invitationForNotRegisteredUser?.firstName)
+            assertEquals(null, invitationForNotRegisteredUser.userId)
+            assertEquals(UserStatus.ACTIVE_UNCONFIRMED, invitationForNotRegisteredUser.status)
+            assertEquals("", invitationForNotRegisteredUser.firstName)
         }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetBackwardReferencedPapersTest.kt
@@ -4,13 +4,13 @@ import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class GetBackwardReferencedPapersTest : PaperServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/GetForwardReferencedPapersTest.kt
@@ -4,13 +4,13 @@ import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.just
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class GetForwardReferencedPapersTest : PaperServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllArchivedProjectsForUserTest.kt
@@ -3,12 +3,12 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
-import kotlin.test.assertEquals
 
 class GetAllArchivedProjectsForUserTest : ProjectServiceTest() {
     private val statusFilters = setOf(ProjectStatus.ARCHIVED)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllDeletedProjectsForUserTest.kt
@@ -3,12 +3,12 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
-import kotlin.test.assertEquals
 
 class GetAllDeletedProjectsForUserTest : ProjectServiceTest() {
     private val statusFilters = setOf(ProjectStatus.DELETED)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsForUserTest.kt
@@ -3,12 +3,12 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.project.ProjectStatus
-import kotlin.test.assertEquals
 
 class GetAllProjectsForUserTest : ProjectServiceTest() {
     private val statusFilters = setOf(ProjectStatus.ACTIVE, ProjectStatus.ACTIVE_LOCKED)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetAllProjectsTest.kt
@@ -3,11 +3,11 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import kotlin.test.assertEquals
 
 class GetAllProjectsTest : ProjectServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/GetDecisionStatisticsForStageTest.kt
@@ -3,13 +3,13 @@ package se.uulm.snowballr.backend.service.project
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.projectpaper.PaperDecision
 import se.uulm.snowballr.backend.model.exception.notfound.StageNotFoundException
-import kotlin.test.assertEquals
 
 class GetDecisionStatisticsForStageTest : ProjectServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/ProjectServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/ProjectServiceTest.kt
@@ -8,6 +8,7 @@ import se.uulm.snowballr.backend.context.RequestContext
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
 import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.dto.user.User
+import se.uulm.snowballr.backend.model.outgoing.project.ProjectResponse
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
 import se.uulm.snowballr.backend.repository.IProjectTableRepo
@@ -63,7 +64,7 @@ sealed class ProjectServiceTest : BaseServiceTest {
         coEvery { userRepoMock.getUserById(currentUser.id) } returns Result.success(currentUser)
     }
 
-    protected fun assertProjectEquality(expected: Project, actual: Project) {
+    protected fun assertProjectEquality(expected: Project, actual: ProjectResponse) {
         assertEquals(expected.name, actual.name)
         assertEquals(expected.status, actual.status)
         assertEquals(expected.currentStage, actual.currentStage)

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/ProjectServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/ProjectServiceTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.project
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.context.RequestContext
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
@@ -16,7 +17,6 @@ import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ProjectService
 import se.uulm.snowballr.backend.service.withUser
-import kotlin.test.assertEquals
 
 /**
  * Base test class for the [ProjectService].

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/project/UpdateProjectTest.kt
@@ -6,6 +6,7 @@ import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -19,7 +20,6 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherInformationWithId
 import se.uulm.snowballr.backend.model.fetcher.FetcherOptions
 import se.uulm.snowballr.backend.model.incoming.project.UpdateProjectRequest
 import kotlin.test.assertContains
-import kotlin.test.assertIs
 
 class UpdateProjectTest : ProjectServiceTest() {
     private fun getRequest(project: Project) = UpdateProjectRequest.fromProject(project)
@@ -297,7 +297,7 @@ class UpdateProjectTest : ProjectServiceTest() {
         assertFalse(updatedFetchers.containsKey("non-existent-fetcher"))
 
         val existentFetcher = updatedFetchers["existent-fetcher"]
-        assertIs<FetcherOptions>(existentFetcher)
+        assertInstanceOf<FetcherOptions>(existentFetcher)
         assertContains(existentFetcher.keys, "existent-option")
         assertFalse(existentFetcher.containsKey("non-existent-option"))
     }

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectmember/GetProjectMembersTest.kt
@@ -3,13 +3,13 @@ package se.uulm.snowballr.backend.service.projectmember
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.projectmember.ProjectMemberWithUser
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class GetProjectMembersTest : ProjectMemberServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/AddPaperToProjectTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.service.projectpaper
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -11,7 +12,6 @@ import se.uulm.snowballr.backend.model.dto.project.Project
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateProjectPaperException
 import se.uulm.snowballr.backend.model.exception.invalidargument.StageOutOfRangeException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class AddPaperToProjectTest : ProjectPaperServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/projectpaper/GetAllProjectPapersForProjectTest.kt
@@ -3,13 +3,13 @@ package se.uulm.snowballr.backend.service.projectpaper
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import java.util.UUID
 import kotlin.test.assertContains
-import kotlin.test.assertEquals
 
 class GetAllProjectPapersForProjectTest : ProjectPaperServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/CreateReviewTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
@@ -32,7 +33,6 @@ import se.uulm.snowballr.backend.model.incoming.review.CreateReviewRequest
 import java.util.UUID
 import java.util.stream.Stream
 import kotlin.reflect.KFunction
-import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CreateReviewTest : ReviewServiceTest() {

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetAllReviewsForProjectPaperTest.kt
@@ -3,12 +3,12 @@ package se.uulm.snowballr.backend.service.review
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class GetAllReviewsForProjectPaperTest : ReviewServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/GetReviewByIdTest.kt
@@ -3,12 +3,12 @@ package se.uulm.snowballr.backend.service.review
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import java.util.UUID
-import kotlin.test.assertEquals
 
 class GetReviewByIdTest : ReviewServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/review/ReviewServiceTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.review
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IReviewAccessChecker
 import se.uulm.snowballr.backend.context.RequestContext
@@ -18,7 +19,6 @@ import se.uulm.snowballr.backend.repository.association.IReviewHasCriterionTable
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.ReviewService
 import se.uulm.snowballr.backend.service.withUser
-import kotlin.test.assertEquals
 
 /**
  * Base test class for the [ReviewService].

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetCurrentUserTest.kt
@@ -1,9 +1,9 @@
 package se.uulm.snowballr.backend.service.user
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import se.uulm.snowballr.backend.DataBuilder
-import kotlin.test.assertEquals
 
 class GetCurrentUserTest : UserServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserByEmailTest.kt
@@ -4,12 +4,12 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.UserIdentifierType
-import kotlin.test.assertEquals
 
 class GetUserByEmailTest : UserServiceTest() {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/GetUserSettingsTest.kt
@@ -2,11 +2,11 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
-import kotlin.test.assertEquals
 
 class GetUserSettingsTest : UserServiceTest() {
     @Test
@@ -32,7 +32,7 @@ class GetUserSettingsTest : UserServiceTest() {
             val result = service.getUserSettings()
 
             assertUserSettingsEquality(userSettings, result.settings)
-            assertEquals(emptyList(), result.criteria)
+            assertEquals(0, result.criteria.size)
         }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UpdateUserTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
@@ -11,7 +12,6 @@ import se.uulm.snowballr.backend.TestSpecificException
 import se.uulm.snowballr.backend.model.dto.user.User
 import se.uulm.snowballr.backend.model.exception.alreadyexists.entity.DuplicateUserException
 import se.uulm.snowballr.backend.model.incoming.user.UpdateUserRequest
-import kotlin.test.assertEquals
 
 class UpdateUserTest : UserServiceTest() {
     private fun getExampleRequest(user: User) = UpdateUserRequest(

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/user/UserServiceTest.kt
@@ -2,6 +2,7 @@ package se.uulm.snowballr.backend.service.user
 
 import io.mockk.coEvery
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import se.uulm.snowballr.backend.access.IProjectAccessChecker
 import se.uulm.snowballr.backend.access.IUserAccessChecker
 import se.uulm.snowballr.backend.context.RequestContext
@@ -16,7 +17,6 @@ import se.uulm.snowballr.backend.repository.IVerificationTokenTableRepo
 import se.uulm.snowballr.backend.service.BaseServiceTest
 import se.uulm.snowballr.backend.service.UserService
 import se.uulm.snowballr.backend.service.withUser
-import kotlin.test.assertEquals
 
 /**
  * Base test class for the [UserService].

--- a/src/test/kotlin/se/uulm/snowballr/backend/utils/ResultTestHelper.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/utils/ResultTestHelper.kt
@@ -1,16 +1,16 @@
 package se.uulm.snowballr.backend.utils
 
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertInstanceOf
 import se.uulm.snowballr.backend.model.exception.SnowballRException
-import kotlin.test.assertIs
 
 /**
  * Assert that the passed [Result] is not a [Result.Failure] and contains the data of type [T]. The data is returned.
  */
-inline fun <reified T> assertResultSuccess(result: Result<T>): T {
+inline fun <reified T : Any> assertResultSuccess(result: Result<T>): T {
     assertTrue(result.isSuccess)
-    val data = result.getOrNull()
-    assertIs<T>(data)
+    val data = result.getOrThrow()
+    assertInstanceOf<T>(data)
     return data
 }
 
@@ -20,5 +20,5 @@ inline fun <reified T> assertResultSuccess(result: Result<T>): T {
 inline fun <reified T : SnowballRException> assertResultFailure(result: Result<*>) {
     assertTrue(result.isFailure)
     val exception = result.exceptionOrNull()
-    assertIs<T>(exception)
+    assertInstanceOf<T>(exception)
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/PaperValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/PaperValidatorTest.kt
@@ -8,6 +8,7 @@ import `in`.rcard.assertj.arrowcore.EitherAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -32,7 +33,6 @@ import snowballr.PaperOuterClass.Paper
 import snowballr.author
 import java.time.LocalDate
 import java.util.UUID
-import kotlin.test.assertIs
 
 class PaperValidatorTest {
     companion object {
@@ -413,11 +413,11 @@ class PaperValidatorTest {
 
             val result = validateRequest(request)
 
-            assertIs<Either.Left<NonEmptyList<ValidationIssue>>>(result)
+            assertInstanceOf<Either.Left<NonEmptyList<ValidationIssue>>>(result)
             val issues = result.value.toList()
             assertThat(issues).hasSize(1)
             val compositeIssue = issues[0]
-            assertIs<CompositeIssue>(compositeIssue)
+            assertInstanceOf<CompositeIssue>(compositeIssue)
             assertThat("$compositeIssue").startsWith("Issues of author at index 0")
         }
 


### PR DESCRIPTION
Closes #574

## What I have made

- replaced all kotlin.test imports with ones for junit; also linter now forbids further usage
   - big diff -> review separately
- added ProjectResponse as alternative to returning Project DTO
- added own Status enum for less grpc dependencies

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - [x] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
