### PR TITLE
Paper comparison and merging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -277,6 +277,7 @@ kover {
     currentProject {
         instrumentation {
             disabledForTestTasks.add("integrationTest")
+            disabledForTestTasks.add("createApiSpec")
         }
     }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -908,8 +908,11 @@ style:
         forbiddenImports:
             -   reason: 'Use `org.junit.jupiter.api.Assertions.*` instead.'
                 value: 'kotlin.test.*'
+            # assertNotNull and assertNull from `org.junit.jupiter.api` has better type inference
             -   reason: 'Use `org.junit.jupiter.api.assertNotNull` instead.'
                 value: 'org.junit.jupiter.api.Assertions.assertNotNull'
+            -   reason: 'Use `org.junit.jupiter.api.assertNull` instead.'
+                value: 'org.junit.jupiter.api.Assertions.assertNull'
         allowedImports:
             # `kotlin.test.assertContains` has no JUnit equivalent.
             - 'kotlin.test.assertContains'

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -39,6 +39,8 @@ import se.uulm.snowballr.backend.fetcher.PythonPluginFetcherManager
 import se.uulm.snowballr.backend.mail.EmailManager
 import se.uulm.snowballr.backend.mail.EmailTemplateManager
 import se.uulm.snowballr.backend.mail.IEmailManager
+import se.uulm.snowballr.backend.matching.IPaperMatcher
+import se.uulm.snowballr.backend.matching.PaperMatcher
 import se.uulm.snowballr.backend.repository.CriterionTableRepo
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
@@ -201,7 +203,17 @@ private fun Module.customServicesDeps() {
     singleOf(::CookieManager) { bind<ICookieManager>() }
     singleOf(::EmailManager) { bind<IEmailManager>() }
     singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
-    single<IFetcherOrchestrator> { FetcherOrchestrator(get(), get(), get(), get(), get()) }
+    singleOf(::PaperMatcher) { bind<IPaperMatcher>() }
+    single<IFetcherOrchestrator> {
+        FetcherOrchestrator(
+            fetcherManager = get(),
+            projectRepo = get(),
+            paperRepo = get(),
+            citationRepo = get(),
+            projectPaperRepo = get(),
+            paperMatcher = get(),
+        )
+    }
 }
 
 /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -41,7 +41,6 @@ import se.uulm.snowballr.backend.mail.EmailTemplateManager
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.matching.IPaperMatcher
 import se.uulm.snowballr.backend.matching.PaperMatcher
-import se.uulm.snowballr.backend.matching.PaperMatchingConfig
 import se.uulm.snowballr.backend.repository.CriterionTableRepo
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
@@ -204,15 +203,7 @@ private fun Module.customServicesDeps() {
     singleOf(::CookieManager) { bind<ICookieManager>() }
     singleOf(::EmailManager) { bind<IEmailManager>() }
     singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
-    single<IPaperMatcher> {
-        val config = PaperMatchingConfig(
-            yearTolerance = 1,
-            titleWeight = 0.6,
-            authorsWeight = 0.3,
-            abstractWeight = 0.1,
-        )
-        PaperMatcher(config)
-    }
+    single<IPaperMatcher> { PaperMatcher(PaperMatcher.defaultConfig) }
     single<IFetcherOrchestrator> {
         FetcherOrchestrator(
             fetcherManager = get(),

--- a/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/Module.kt
@@ -41,6 +41,7 @@ import se.uulm.snowballr.backend.mail.EmailTemplateManager
 import se.uulm.snowballr.backend.mail.IEmailManager
 import se.uulm.snowballr.backend.matching.IPaperMatcher
 import se.uulm.snowballr.backend.matching.PaperMatcher
+import se.uulm.snowballr.backend.matching.PaperMatchingConfig
 import se.uulm.snowballr.backend.repository.CriterionTableRepo
 import se.uulm.snowballr.backend.repository.ICriterionTableRepo
 import se.uulm.snowballr.backend.repository.IInvitationTokenTableRepo
@@ -203,7 +204,15 @@ private fun Module.customServicesDeps() {
     singleOf(::CookieManager) { bind<ICookieManager>() }
     singleOf(::EmailManager) { bind<IEmailManager>() }
     singleOf(::AuthenticationManager) { bind<IAuthenticationManager>() }
-    singleOf(::PaperMatcher) { bind<IPaperMatcher>() }
+    single<IPaperMatcher> {
+        val config = PaperMatchingConfig(
+            yearTolerance = 1,
+            titleWeight = 0.6,
+            authorsWeight = 0.3,
+            abstractWeight = 0.1,
+        )
+        PaperMatcher(config)
+    }
     single<IFetcherOrchestrator> {
         FetcherOrchestrator(
             fetcherManager = get(),

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -259,40 +259,60 @@ class FetcherOrchestrator(
      */
     private suspend fun createRefs(refs: Set<FetcherPaper>, threshold: Float): Set<Paper> {
         val result = mutableSetOf<Paper>()
+        val candidatesByYear = mutableMapOf<Int, List<Paper>>()
+
         for (ref in refs) {
-            val paper = resolveExistingPaper(ref, threshold) ?: createNewPaper(ref)
+            val paper = resolveByExternalIds(ref)
+                ?: resolveExistingPaper(ref, threshold, candidatesByYear)
+                ?: createNewPaper(ref)
+
             if (paper != null) result += paper
         }
         return result
     }
 
-    private suspend fun resolveExistingPaper(ref: FetcherPaper, threshold: Float): Paper? {
-        if (ref.externalIds.isNotEmpty()) {
-            val existingPapers = paperRepo.getPapersByExternalIds(ref.externalIds)
-                .sortedBy { it.createdAt }
+    private suspend fun resolveExistingPaper(
+        ref: FetcherPaper,
+        threshold: Float,
+        candidatesByYear: MutableMap<Int, List<Paper>>,
+    ): Paper? {
+        val byExternalId = resolveByExternalIds(ref)
+        if (byExternalId != null) return byExternalId
 
-            if (existingPapers.isNotEmpty()) {
-                if (existingPapers.size > 1) {
-                    logger.error {
-                        "External IDs of fetcher paper (${ref.externalIds}) refer to many existing papers: " +
-                            "$existingPapers"
-                    }
-                }
-
-                val paper = existingPapers.first()
-                updateMetadataIfChanged(paper, ref)
-                return paper
-            }
+        val candidates = candidatesByYear.getOrPut(ref.year) {
+            paperRepo.getPapersByYear(ref.year, paperMatcher.config.yearTolerance)
         }
-
-        val candidates = paperRepo.getPapersByYear(ref.year, paperMatcher.config.yearTolerance)
         val match = paperMatcher.findMatch(ref, candidates, threshold)
+
         if (match != null) {
             updateMetadataIfChanged(match, ref)
             return match
         }
 
         return null
+    }
+
+    /**
+     * Resolves a paper by the external IDs of [ref].
+     */
+    private suspend fun resolveByExternalIds(ref: FetcherPaper): Paper? {
+        if (ref.externalIds.isEmpty()) return null
+
+        val existingPapers = paperRepo.getPapersByExternalIds(ref.externalIds)
+            .sortedBy { it.createdAt }
+
+        if (existingPapers.isEmpty()) return null
+
+        if (existingPapers.size > 1) {
+            logger.error {
+                "External IDs of fetcher paper (${ref.externalIds}) refer to many existing papers: " +
+                    "$existingPapers"
+            }
+        }
+
+        val paper = existingPapers.first()
+        updateMetadataIfChanged(paper, ref)
+        return paper
     }
 
     private suspend fun updateMetadataIfChanged(dbPaper: Paper, ref: FetcherPaper) {

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -62,7 +62,7 @@ class FetcherOrchestrator(
     private val citationRepo: ICitationTableRepo,
     private val projectPaperRepo: IProjectPaperTableRepo,
     private val paperMatcher: IPaperMatcher,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : IFetcherOrchestrator {
     private val queue = Channel<FetcherProcessingJob>(Channel.UNLIMITED)
 
@@ -259,7 +259,7 @@ class FetcherOrchestrator(
             }
         }
 
-        val candidates = paperRepo.getPapersByYear(ref.year, tolerance = 1)
+        val candidates = paperRepo.getPapersByYear(ref.year, paperMatcher.config.yearTolerance)
         val match = if (candidates.isEmpty()) null else paperMatcher.findMatch(ref, candidates, threshold)
         if (match != null) {
             updateMetadataIfChanged(match, ref)

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -207,10 +207,22 @@ class FetcherOrchestrator(
      * Deduplicates the results from the fetching part of the processing job.
      */
     private fun runDeduplication(results: FetchingResults, job: FetcherProcessingJob): FetchingResults {
+        val start = System.currentTimeMillis()
         val dedupedBackward = paperMatcher.deduplicatePapers(results.backwardRefs, job.similarityThreshold)
         val dedupedForward = paperMatcher.deduplicatePapers(results.forwardRefs, job.similarityThreshold)
+        val duration = System.currentTimeMillis() - start
+        logger.debug { "Deduplication took ${duration}ms" }
 
-        return FetchingResults(dedupedBackward, dedupedForward)
+        val dedupResults = FetchingResults(dedupedBackward, dedupedForward)
+
+        if (results.allRefs.size != dedupResults.allRefs.size) {
+            logger.info {
+                "Deduplicated fetching results (Backward: ${dedupedBackward.size}/${results.backwardRefs.size}; " +
+                    "Forward: ${dedupedForward.size}/${results.forwardRefs.size})"
+            }
+        }
+
+        return dedupResults
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -316,10 +316,10 @@ class FetcherOrchestrator(
     }
 
     private suspend fun updateMetadataIfChanged(dbPaper: Paper, ref: FetcherPaper) {
-        val mergedMeta = paperMatcher.mergeMetadata(dbPaper.fetcherMetadata, ref.fetcherMetadata)
-        if (mergedMeta == dbPaper.fetcherMetadata) return
+        if (ref.fetcherMetadata.isEmpty()) return
+
         try {
-            paperRepo.updateFetcherMetadata(dbPaper.id, mergedMeta)
+            paperRepo.mergeFetcherMetadata(dbPaper.id, ref.fetcherMetadata)
         } catch (ex: SQLException) {
             logger.error(ex) {
                 "Failed to update fetcher metadata for paper ${dbPaper.id}: ${ex.message ?: "<empty>"}"

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -137,17 +137,21 @@ class FetcherOrchestrator(
 
         val paper = paperRepo.getPaperById(job.paperId).getOrThrow()
 
-        val fetchingResults = runFetching(job, paper)
+        val (fetchingResults, fetchingTime) = measureTime { runFetching(job, paper) }
 
-        val dedupResults = runDeduplication(fetchingResults, job)
+        val (dedupResults, dedupTime) = measureTime { runDeduplication(fetchingResults, job) }
 
-        val creationResults = runPaperCreation(dedupResults, job)
+        val (creationResults, creationTime) = measureTime { runPaperCreation(dedupResults, job) }
 
-        runPaperCitation(job.paperId, creationResults)
+        val (_, citationTime) = measureTime { runPaperCitation(job.paperId, creationResults) }
 
-        runAddingPapersToProject(job, creationResults)
+        val (_, addingTime) = measureTime { runAddingPapersToProject(job, creationResults) }
 
         logger.info { "Finished fetcher processing job for paper ${job.paperId}" }
+        logger.debug {
+            "Processing Times:\n  - fetching: ${fetchingTime}ms\n  - dedup: ${dedupTime}ms\n" +
+                "  - creation: ${creationTime}ms\n  - citation: ${citationTime}ms\n  - adding: ${addingTime}ms"
+        }
     }
 
     /**
@@ -207,11 +211,8 @@ class FetcherOrchestrator(
      * Deduplicates the results from the fetching part of the processing job.
      */
     private fun runDeduplication(results: FetchingResults, job: FetcherProcessingJob): FetchingResults {
-        val start = System.currentTimeMillis()
         val dedupedBackward = paperMatcher.deduplicatePapers(results.backwardRefs, job.similarityThreshold)
         val dedupedForward = paperMatcher.deduplicatePapers(results.forwardRefs, job.similarityThreshold)
-        val duration = System.currentTimeMillis() - start
-        logger.debug { "Deduplication took ${duration}ms" }
 
         val dedupResults = FetchingResults(dedupedBackward, dedupedForward)
 
@@ -386,5 +387,11 @@ class FetcherOrchestrator(
                 }
             }
         }
+    }
+
+    private suspend fun <T> measureTime(block: suspend () -> T): Pair<T, Long> {
+        val start = System.currentTimeMillis()
+        val result = block()
+        return result to System.currentTimeMillis() - start
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -28,6 +28,7 @@ import se.uulm.snowballr.backend.repository.association.IProjectPaperTableRepo
 import se.uulm.snowballr.backend.repository.isUniqueConstraintViolation
 import java.sql.SQLException
 import java.util.UUID
+import kotlin.math.roundToInt
 
 private val logger = KotlinLogging.logger { }
 
@@ -54,7 +55,7 @@ interface IFetcherOrchestrator {
     suspend fun enqueue(job: FetcherEnqueueJob)
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class FetcherOrchestrator(
     private val fetcherManager: IFetcherManager,
     private val projectRepo: IProjectTableRepo,
@@ -148,9 +149,19 @@ class FetcherOrchestrator(
         val (_, addingTime) = measureTime { runAddingPapersToProject(job, creationResults) }
 
         logger.info { "Finished fetcher processing job for paper ${job.paperId}" }
+        @Suppress("MagicNumber")
         logger.debug {
-            "Processing Times:\n  - fetching: ${fetchingTime}ms\n  - dedup: ${dedupTime}ms\n" +
-                "  - creation: ${creationTime}ms\n  - citation: ${citationTime}ms\n  - adding: ${addingTime}ms"
+            val total = fetchingTime + dedupTime + creationTime + citationTime + addingTime
+            fun per(t: Long) = "${(t / total.toDouble() * 1000.0).roundToInt() / 10.0}%"
+
+            """
+            Processing Times:
+              - fetching: ${fetchingTime.toString().padStart(6, ' ')}ms - ${per(fetchingTime).padStart(3, ' ')}
+              - dedup:    ${dedupTime.toString().padStart(6, ' ')}ms - ${per(dedupTime).padStart(3, ' ')}
+              - creation: ${creationTime.toString().padStart(6, ' ')}ms - ${per(creationTime).padStart(3, ' ')}
+              - citation: ${citationTime.toString().padStart(6, ' ')}ms - ${per(citationTime).padStart(3, ' ')}
+              - adding:   ${addingTime.toString().padStart(6, ' ')}ms - ${per(addingTime).padStart(3, ' ')}
+            """.trimIndent()
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -187,7 +187,7 @@ class FetcherOrchestrator(
 
         for ((fetcher, options) in fetchers) {
             try {
-                val fetchedPapers = fetchCall(fetcher, paper.toFetcherPaper(), options)
+                val fetchedPapers = fetchCall.invoke(fetcher, paper.toFetcherPaper(), options)
                 set += fetchedPapers
             } catch (ex: FetcherException) {
                 logger.error(ex) {
@@ -257,11 +257,13 @@ class FetcherOrchestrator(
     private suspend fun resolveExistingPaper(ref: FetcherPaper, threshold: Float): Paper? {
         if (ref.externalIds.isNotEmpty()) {
             val existingPapers = paperRepo.getPapersByExternalIds(ref.externalIds)
+                .sortedBy { it.createdAt }
 
             if (existingPapers.isNotEmpty()) {
                 if (existingPapers.size > 1) {
                     logger.error {
-                        "Several papers existing for external IDs (${ref.externalIds}) of single fetcher paper"
+                        "External IDs of fetcher paper (${ref.externalIds}) refer to many existing papers: " +
+                            "$existingPapers"
                     }
                 }
 
@@ -272,7 +274,7 @@ class FetcherOrchestrator(
         }
 
         val candidates = paperRepo.getPapersByYear(ref.year, paperMatcher.config.yearTolerance)
-        val match = if (candidates.isEmpty()) null else paperMatcher.findMatch(ref, candidates, threshold)
+        val match = paperMatcher.findMatch(ref, candidates, threshold)
         if (match != null) {
             updateMetadataIfChanged(match, ref)
             return match
@@ -328,7 +330,7 @@ class FetcherOrchestrator(
         var addedCitations = 0
         for (ref in refs) {
             try {
-                citeCall(paperId, ref.id)
+                citeCall.invoke(paperId, ref.id)
                 addedCitations++
             } catch (ex: SQLException) {
                 // A unique constraint violation is okay (no-op)

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import se.uulm.snowballr.backend.matching.IPaperMatcher
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
 import se.uulm.snowballr.backend.model.exception.FetcherException
@@ -53,12 +54,14 @@ interface IFetcherOrchestrator {
     suspend fun enqueue(job: FetcherEnqueueJob)
 }
 
+@Suppress("LongParameterList")
 class FetcherOrchestrator(
     private val fetcherManager: IFetcherManager,
     private val projectRepo: IProjectTableRepo,
     private val paperRepo: IPaperTableRepo,
     private val citationRepo: ICitationTableRepo,
     private val projectPaperRepo: IProjectPaperTableRepo,
+    private val paperMatcher: IPaperMatcher,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : IFetcherOrchestrator {
     private val queue = Channel<FetcherProcessingJob>(Channel.UNLIMITED)
@@ -115,6 +118,7 @@ class FetcherOrchestrator(
             targetStage = job.projectPaper.stage + 1,
             paperId = job.projectPaper.paperId,
             triggeringUserId = job.triggeringUserId,
+            similarityThreshold = project.similarityThreshold,
         )
 
         val result = queue.trySend(processingJob)
@@ -135,11 +139,9 @@ class FetcherOrchestrator(
 
         val fetchingResults = runFetching(job, paper)
 
-        // TODO: paper filtering/merging
-        // fetching from multiple fetchers will probably return the same papers from different fetchers
-        // first merge fetched papers then merge with existing paper in DB (if existent)
+        val dedupResults = runDeduplication(fetchingResults, job)
 
-        val creationResults = runPaperCreation(fetchingResults)
+        val creationResults = runPaperCreation(dedupResults, job)
 
         runPaperCitation(job.paperId, creationResults)
 
@@ -202,55 +204,88 @@ class FetcherOrchestrator(
     }
 
     /**
+     * Deduplicates the results from the fetching part of the processing job.
+     */
+    private fun runDeduplication(results: FetchingResults, job: FetcherProcessingJob): FetchingResults {
+        val dedupedBackward = paperMatcher.deduplicatePapers(results.backwardRefs, job.similarityThreshold)
+        val dedupedForward = paperMatcher.deduplicatePapers(results.forwardRefs, job.similarityThreshold)
+
+        return FetchingResults(dedupedBackward, dedupedForward)
+    }
+
+    /**
      * Runs the paper creation part of the job processing.
      *
      * For both sets in [results] the paper data is stored in the DB if not already existent.
      */
-    private suspend fun runPaperCreation(results: FetchingResults): PaperCreationResults {
-        val createdBackwardRefs = createRefs(results.backwardRefs)
+    private suspend fun runPaperCreation(results: FetchingResults, job: FetcherProcessingJob): PaperCreationResults {
+        val createdBackwardRefs = createRefs(results.backwardRefs, job.similarityThreshold)
         logger.info { "Created ${createdBackwardRefs.size} backward referenced papers" }
-        val createdForwardRefs = createRefs(results.forwardRefs)
+        val createdForwardRefs = createRefs(results.forwardRefs, job.similarityThreshold)
         logger.info { "Created ${createdForwardRefs.size} forward referenced papers" }
 
         return PaperCreationResults(createdBackwardRefs, createdForwardRefs)
     }
 
     /**
-     * Creates a DB paper for each of the [FetcherPaper]s in [refs].
-     *
-     * If a paper already exists in the DB, no paper is added and the existent paper is retrieved and added to the
-     * result set.
+     * Resolves each [FetcherPaper] in [refs] against the DB:
+     * 1. External-ID fast path — if an exact match exists, merge metadata and reuse it.
+     * 2. Year-filtered similarity fallback — if a similar paper is found, merge metadata and reuse it.
+     * 3. No match — create a new paper.
      */
-    private suspend fun createRefs(refs: Set<FetcherPaper>): Set<Paper> {
-        val createdPaperRefs = mutableSetOf<Paper>()
-
+    private suspend fun createRefs(refs: Set<FetcherPaper>, threshold: Float): Set<Paper> {
+        val result = mutableSetOf<Paper>()
         for (ref in refs) {
-            if (ref.externalIds.isNotEmpty()) {
-                // TODO: replace with check for whole paper data by similarity not only external ID
-                val existingPapers = paperRepo.getPapersByExternalIds(ref.externalIds)
+            val paper = resolveExistingPaper(ref, threshold) ?: createNewPaper(ref)
+            if (paper != null) result += paper
+        }
+        return result
+    }
 
-                if (existingPapers.isNotEmpty()) {
-                    if (existingPapers.size > 1) {
-                        logger.error {
-                            "External IDs of fetcher paper (${ref.externalIds}) refer to many existing papers: " +
-                                "$existingPapers"
-                        }
+    private suspend fun resolveExistingPaper(ref: FetcherPaper, threshold: Float): Paper? {
+        if (ref.externalIds.isNotEmpty()) {
+            val existingPapers = paperRepo.getPapersByExternalIds(ref.externalIds)
+
+            if (existingPapers.isNotEmpty()) {
+                if (existingPapers.size > 1) {
+                    logger.error {
+                        "Several papers existing for external IDs (${ref.externalIds}) of single fetcher paper"
                     }
-
-                    // TODO: merge data
-                    createdPaperRefs += existingPapers
-                    continue
                 }
-            }
 
-            try {
-                createdPaperRefs += paperRepo.createPaper(CreatePaperRequest.fromFetcherPaper(ref))
-            } catch (ex: SQLException) {
-                logger.error(ex) { "Failed to create paper for fetched paper: ${ex.message ?: "<empty>"}" }
+                val paper = existingPapers.first()
+                updateMetadataIfChanged(paper, ref)
+                return paper
             }
         }
 
-        return createdPaperRefs
+        val candidates = paperRepo.getPapersByYear(ref.year, tolerance = 1)
+        val match = if (candidates.isEmpty()) null else paperMatcher.findMatch(ref, candidates, threshold)
+        if (match != null) {
+            updateMetadataIfChanged(match, ref)
+            return match
+        }
+
+        return null
+    }
+
+    private suspend fun updateMetadataIfChanged(dbPaper: Paper, ref: FetcherPaper) {
+        val mergedMeta = paperMatcher.mergeMetadata(dbPaper, ref)
+        if (mergedMeta == dbPaper.fetcherMetadata) return
+        try {
+            paperRepo.updateFetcherMetadata(dbPaper.id, mergedMeta)
+        } catch (ex: SQLException) {
+            logger.error(ex) {
+                "Failed to update fetcher metadata for paper ${dbPaper.id}: ${ex.message ?: "<empty>"}"
+            }
+        }
+    }
+
+    private suspend fun createNewPaper(ref: FetcherPaper): Paper? = try {
+        paperRepo.createPaper(CreatePaperRequest.fromFetcherPaper(ref))
+    } catch (ex: SQLException) {
+        logger.error(ex) { "Failed to create paper for fetched paper: ${ex.message ?: "<empty>"}" }
+        null
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -276,16 +276,13 @@ class FetcherOrchestrator(
         threshold: Float,
         candidatesByYear: MutableMap<Int, List<Paper>>,
     ): Paper? {
-        val byExternalId = resolveByExternalIds(ref)
-        if (byExternalId != null) return byExternalId
-
         val candidates = candidatesByYear.getOrPut(ref.year) {
             paperRepo.getPapersByYear(ref.year, paperMatcher.config.yearTolerance)
         }
         val match = paperMatcher.findMatch(ref, candidates, threshold)
 
         if (match != null) {
-            updateMetadataIfChanged(match, ref)
+            mergeMetadata(match, ref)
             return match
         }
 
@@ -311,18 +308,18 @@ class FetcherOrchestrator(
         }
 
         val paper = existingPapers.first()
-        updateMetadataIfChanged(paper, ref)
+        mergeMetadata(paper, ref)
         return paper
     }
 
-    private suspend fun updateMetadataIfChanged(dbPaper: Paper, ref: FetcherPaper) {
+    private suspend fun mergeMetadata(dbPaper: Paper, ref: FetcherPaper) {
         if (ref.fetcherMetadata.isEmpty()) return
 
         try {
             paperRepo.mergeFetcherMetadata(dbPaper.id, ref.fetcherMetadata)
         } catch (ex: SQLException) {
             logger.error(ex) {
-                "Failed to update fetcher metadata for paper ${dbPaper.id}: ${ex.message ?: "<empty>"}"
+                "Failed to merge fetcher metadata for paper ${dbPaper.id}: ${ex.message ?: "<empty>"}"
             }
         }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/fetcher/FetcherOrchestrator.kt
@@ -284,7 +284,7 @@ class FetcherOrchestrator(
     }
 
     private suspend fun updateMetadataIfChanged(dbPaper: Paper, ref: FetcherPaper) {
-        val mergedMeta = paperMatcher.mergeMetadata(dbPaper, ref)
+        val mergedMeta = paperMatcher.mergeMetadata(dbPaper.fetcherMetadata, ref.fetcherMetadata)
         if (mergedMeta == dbPaper.fetcherMetadata) return
         try {
             paperRepo.updateFetcherMetadata(dbPaper.id, mergedMeta)

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/Levenshtein.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/Levenshtein.kt
@@ -1,0 +1,45 @@
+package se.uulm.snowballr.backend.matching
+
+import se.uulm.snowballr.backend.matching.Levenshtein.getDistance
+
+object Levenshtein {
+    /**
+     * Returns the Levenshtein distance between the two passed strings.
+     *
+     * The Levenshtein distance is a string metric for measuring the difference between two sequences. It's the minimum
+     * number of single-character edits (insertions, deletions or substitutions) required to change one sequence into
+     * the other.
+     */
+    fun getDistance(a: String, b: String): Int {
+        if (a.isEmpty()) return b.length
+        if (b.isEmpty()) return a.length
+
+        var prev = IntArray(b.length + 1) { it }
+        for (i in 1..a.length) {
+            val curr = IntArray(b.length + 1)
+            curr[0] = i
+            for (j in 1..b.length) {
+                curr[j] = if (a[i - 1] == b[j - 1]) {
+                    prev[j - 1]
+                } else {
+                    minOf(prev[j - 1], prev[j], curr[j - 1]) + 1
+                }
+            }
+            prev = curr
+        }
+
+        return prev[b.length]
+    }
+
+    /**
+     * Returns the normalized Levenshtein distance between the two passed strings. Higher means more similarity.
+     *
+     * The same as [getDistance], but the distance is normalized according to the maximum length of both sequences.
+     * If both sequences are empty, the normalized distance is 1. Otherwise, the result is calculated by the following
+     * formula: `1 - (levensthein(a, b) / max(a.length, b.length))`
+     */
+    fun getNormalizedDistance(a: String, b: String): Double {
+        if (a.isEmpty() && b.isEmpty()) return 1.0
+        return 1.0 - getDistance(a, b).toDouble() / maxOf(a.length, b.length)
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.matching
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.ExternalId
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
@@ -8,6 +9,8 @@ import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
 import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import kotlin.math.abs
+
+private val logger = KotlinLogging.logger { }
 
 interface IPaperMatcher {
     /**
@@ -234,7 +237,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             externalIds.putAll(paper.externalIds.associate { Pair(it.type, it.value) })
         }
 
-        return FetcherPaper(
+        val result = FetcherPaper(
             title = group.firstNotNullOfOrNull { it.title.ifBlank { null } } ?: first.title,
             externalIds = externalIds.map { ExternalId(it.key, it.value) },
             abstract = group.firstNotNullOfOrNull { it.abstract.ifBlank { null } } ?: first.abstract,
@@ -247,6 +250,12 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             authors = group.firstOrNull { it.authors.isNotEmpty() }?.authors ?: first.authors,
             fetcherMetadata = mergedMetadata,
         )
+
+        logger.debug {
+            "Deduplication result: $result; Sources: $group"
+        }
+
+        return result
     }
 
     private fun Author.isNotBlank() = this.firstName.isNotBlank() && this.lastName.isNotBlank()

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -10,6 +10,11 @@ import kotlin.math.abs
 
 interface IPaperMatcher {
     /**
+     * The [PaperMatchingConfig] used by the matcher.
+     */
+    val config: PaperMatchingConfig
+
+    /**
      * Returns a similarity score in [0.0, 1.0] between two [FetcherPaper]s.
      *
      * Scoring rules:
@@ -67,11 +72,8 @@ interface IPaperMatcher {
 
 /**
  * The [IPaperMatcher] implementation.
- *
- * @param config The weight config that is used by [similarity] to determine how each component accounts to the overall
- * similarity.
  */
-class PaperMatcher(private val config: PaperMatchingConfig) : IPaperMatcher {
+class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
     companion object {
         // Definition of the default config that is used for the matching algorithm
         val defaultConfig = PaperMatchingConfig(

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -1,0 +1,196 @@
+package se.uulm.snowballr.backend.matching
+
+import se.uulm.snowballr.backend.model.dto.paper.ExternalId
+import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
+import se.uulm.snowballr.backend.model.dto.paper.Paper
+import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
+import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
+import kotlin.math.abs
+
+interface IPaperMatcher {
+    /**
+     * Returns a similarity score in [0.0, 1.0] between two [FetcherPaper]s.
+     *
+     * Scoring rules:
+     * - If both papers share at least one [ExternalId], returns 1.0 immediately.
+     * - If the publication years differ by more than one, returns 0.0 immediately.
+     * - Otherwise, the score is a weighted combination of:
+     *   - **Title**: normalized Levenshtein similarity.
+     *   - **Authors**: Jaccard similarity on author name tokens. Omitted when either list is empty.
+     *   - **Abstract**: normalized Levenshtein similarity. Omitted when either abstract is blank.
+     *   Weights are renormalized to sum to 1 after any components are dropped.
+     */
+    fun similarity(a: FetcherPaper, b: FetcherPaper): Double
+
+    /**
+     * Deduplicates a set of [FetcherPaper]s using greedy grouping.
+     *
+     * Papers are iterated in set order. Each paper is placed into the first existing group whose
+     * representative (first member) has a [similarity] score >= [threshold] with it. If no such
+     * group exists, a new group is started. Each group is then merged into a single [FetcherPaper]
+     * where the first member's field values take precedence and metadata is union-merged with the
+     * first member winning on key conflicts.
+     *
+     * @param papers the input papers, possibly containing duplicates.
+     * @param threshold minimum [similarity] score for two papers to be considered duplicates.
+     * @return a deduplicated set with one merged representative per group.
+     */
+    fun deduplicatePapers(papers: Set<FetcherPaper>, threshold: Float): Set<FetcherPaper>
+
+    /**
+     * Finds the best matching [Paper] in [candidates] for the given [fetched] paper.
+     *
+     * All candidates whose [similarity] score with [fetched] is >= [threshold] are considered;
+     * the one with the highest score is returned. Returns `null` if [candidates] is empty or no
+     * candidate meets the threshold.
+     *
+     * @param fetched the paper to match against the candidates.
+     * @param candidates existing DB papers to search, typically pre-filtered by year.
+     * @param threshold minimum [similarity] score required for a candidate to qualify.
+     * @return the highest-scoring candidate above [threshold], or `null` if none qualifies.
+     */
+    fun findMatch(fetched: FetcherPaper, candidates: List<Paper>, threshold: Float): Paper?
+
+    /**
+     * Merges fetcher metadata from a freshly fetched paper into the existing DB paper's metadata.
+     *
+     * The DB paper's values take precedence on key conflicts: keys present in [dbPaper] always
+     * overwrite the same keys from [fetched]. Keys present only in [fetched] are added.
+     *
+     * @param dbPaper the existing paper stored in the database.
+     * @param fetched the newly fetched paper whose metadata may contain new keys.
+     * @return a merged [FetcherMetadata] map.
+     */
+    fun mergeMetadata(dbPaper: Paper, fetched: FetcherPaper): FetcherMetadata
+}
+
+class PaperMatcher : IPaperMatcher {
+    companion object {
+        private const val TITLE_WEIGHT = 0.6
+        private const val AUTHORS_WEIGHT = 0.3
+        private const val ABSTRACT_WEIGHT = 0.1
+    }
+
+    override fun similarity(a: FetcherPaper, b: FetcherPaper): Double {
+        if (haveSameExternalId(a, b)) return 1.0
+        if (abs(a.year - b.year) > 1) return 0.0
+
+        data class Component(val weight: Double, val score: Double)
+
+        val components = mutableListOf<Component>()
+
+        components.add(
+            Component(
+                weight = TITLE_WEIGHT,
+                score = Levenshtein.getNormalizedDistance(a.title.trim().lowercase(), b.title.trim().lowercase()),
+            ),
+        )
+
+        if (a.authors.isNotEmpty() && b.authors.isNotEmpty()) {
+            components.add(
+                Component(
+                    weight = AUTHORS_WEIGHT,
+                    score = jaccardSimilarity(
+                        Tokenization.authorSetTokens(a.authors),
+                        Tokenization.authorSetTokens(b.authors),
+                    ),
+                ),
+            )
+        }
+
+        if (a.abstract.isNotBlank() && b.abstract.isNotBlank()) {
+            components.add(
+                Component(
+                    weight = ABSTRACT_WEIGHT,
+                    score = Levenshtein.getNormalizedDistance(
+                        a.abstract.trim().lowercase(),
+                        b.abstract.trim().lowercase(),
+                    ),
+                ),
+            )
+        }
+
+        val totalWeight = components.sumOf { it.weight }
+        return components.sumOf { it.score * it.weight / totalWeight }
+    }
+
+    override fun deduplicatePapers(papers: Set<FetcherPaper>, threshold: Float): Set<FetcherPaper> {
+        val groups = mutableListOf<MutableList<FetcherPaper>>()
+
+        for (paper in papers) {
+            val group = groups.firstOrNull { similarity(paper, it[0]) >= threshold }
+            if (group != null) {
+                group.add(paper)
+            } else {
+                groups.add(mutableListOf(paper))
+            }
+        }
+
+        return groups.map { mergeFetcherPapers(it) }.toSet()
+    }
+
+    override fun findMatch(fetched: FetcherPaper, candidates: List<Paper>, threshold: Float): Paper? = candidates
+        .map { candidate -> candidate to similarity(fetched, candidate.toFetcherPaper()) }
+        .filter { (_, score) -> score >= threshold }
+        .maxByOrNull { (_, score) -> score }
+        ?.first
+
+    override fun mergeMetadata(dbPaper: Paper, fetched: FetcherPaper): FetcherMetadata {
+        val merged = fetched.fetcherMetadata.toMutableMap()
+        merged.putAll(dbPaper.fetcherMetadata)
+        return merged
+    }
+
+    /**
+     * Returns true if both [FetcherPaper]s have at least one equal external ID.
+     */
+    private fun haveSameExternalId(a: FetcherPaper, b: FetcherPaper) = a.externalIds.any { b.externalIds.contains(it) }
+
+    /**
+     * Returns the Jaccard Similarity of two sets of strings.
+     *
+     * The similarity is calculated based on the size of the intersection of both sets.
+     * If both sets are empty the similarity is 1, if only one is empty, the similarity is 0.
+     */
+    private fun jaccardSimilarity(a: Set<String>, b: Set<String>): Double {
+        if (a.isEmpty() && b.isEmpty()) return 1.0
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        return a.intersect(b).size.toDouble() / a.union(b).size
+    }
+
+    /**
+     * Merges the paper information of the [group] of papers.
+     *
+     * The first in the [group] takes precedence over the others.
+     */
+    private fun mergeFetcherPapers(group: List<FetcherPaper>): FetcherPaper {
+        val first = group.first()
+
+        // Merge metadata; first overwrites last
+        val mergedMetadata = mutableMapOf<String, String>()
+        for (paper in group.reversed()) {
+            mergedMetadata.putAll(paper.fetcherMetadata)
+        }
+
+        // Merge external IDs; first overwrites last
+        val externalIds = mutableMapOf<ExternalIdType, String>()
+        for (paper in group.reversed()) {
+            externalIds.putAll(paper.externalIds.associate { Pair(it.type, it.value) })
+        }
+
+        return FetcherPaper(
+            title = group.firstNotNullOfOrNull { it.title.ifBlank { null } } ?: first.title,
+            externalIds = externalIds.map { ExternalId(it.key, it.value) },
+            abstract = group.firstNotNullOfOrNull { it.abstract.ifBlank { null } } ?: first.abstract,
+            year = first.year,
+            publisher = group.firstNotNullOfOrNull { it.publisher.ifBlank { null } } ?: first.publisher,
+            publicationType = group.firstNotNullOfOrNull { it.publicationType.ifBlank { null } }
+                ?: first.publicationType,
+            publicationName = group.firstNotNullOfOrNull { it.publicationName.ifBlank { null } }
+                ?: first.publicationName,
+            authors = group.firstOrNull { it.authors.isNotEmpty() }?.authors ?: first.authors,
+            fetcherMetadata = mergedMetadata,
+        )
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -14,7 +14,7 @@ interface IPaperMatcher {
      *
      * Scoring rules:
      * - If both papers share at least one [ExternalId], returns 1.0 immediately.
-     * - If the publication years differ by more than one, returns 0.0 immediately.
+     * - If the publication years differ by more than the configured threshold, returns 0.0 immediately.
      * - Otherwise, the score is a weighted combination of:
      *   - **Title**: normalized Levenshtein similarity.
      *   - **Authors**: Jaccard similarity on author name tokens. Omitted when either list is empty.
@@ -72,6 +72,20 @@ interface IPaperMatcher {
  * similarity.
  */
 class PaperMatcher(private val config: PaperMatchingConfig) : IPaperMatcher {
+    companion object {
+        // Definition of the default config that is used for the matching algorithm
+        val defaultConfig = PaperMatchingConfig(
+            // A year difference of greater than one eliminates a paper from being similar
+            yearTolerance = 1,
+            // The title similarity accounts for 60% of the total similarity
+            titleWeight = 0.6,
+            // The authors similarity accounts for 30% of the total similarity
+            authorsWeight = 0.3,
+            // The abstract similarity accounts for 10% of the total similarity
+            abstractWeight = 0.1,
+        )
+    }
+
     override fun similarity(a: FetcherPaper, b: FetcherPaper): Double {
         if (haveSameExternalId(a, b)) return 1.0
         if (abs(a.year - b.year) > config.yearTolerance) return 0.0

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -23,7 +23,7 @@ interface IPaperMatcher {
      * Scoring rules:
      * - If both papers share at least one [ExternalId], returns 1.0 immediately.
      * - If both papers have at least one conflicting [ExternalId], returns 0.0 immediately.
-     *   - A conflict means same type, but different value. The type [ExternalIdType.URL] is excluded from this.
+     *   - A conflict means same type, but different value.
      * - If the publication years differ by more than the configured threshold, returns 0.0 immediately.
      * - Otherwise, the score is a weighted combination of:
      *   - **Title**: normalized Levenshtein similarity.
@@ -169,17 +169,13 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
      * Returns true if both [FetcherPaper]s have at least one conflicting external ID.
      *
      * Two external IDs are conflicting if they both have the same type, but a different value.
-     * The external ID type [ExternalIdType.URL] is excluded from this, since two different URLs might point to the same
-     * resource. I.e, different URLs are not a fast path to a clear no-similarity decision.
      * External IDs with a blank value are filtered out.
      */
     private fun haveConflictingExternalId(a: FetcherPaper, b: FetcherPaper): Boolean {
         val (externalIdsA, externalIdsB) = normalizeExternalIds(a, b)
 
         return externalIdsA.any { exA ->
-            externalIdsB.any { exB ->
-                exA.type != ExternalIdType.URL && exA.type == exB.type && exA.value != exB.value
-            }
+            externalIdsB.any { exB -> exA.type == exB.type && exA.value != exB.value }
         }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -128,6 +128,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
         }
 
         val totalWeight = components.sumOf { it.weight }
+        if (totalWeight == 0.0) return 0.0
         return components.sumOf { it.score * it.weight / totalWeight }
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -61,16 +61,16 @@ interface IPaperMatcher {
     fun findMatch(fetched: FetcherPaper, candidates: List<Paper>, threshold: Float): Paper?
 
     /**
-     * Merges fetcher metadata from a freshly fetched paper into the existing DB paper's metadata.
+     * Merges fetched fetcher metadata into the existing metadata.
      *
-     * The DB paper's values take precedence on key conflicts: keys present in [dbPaper] always
+     * The existing values take precedence on key conflicts: keys present in [existing] always
      * overwrite the same keys from [fetched]. Keys present only in [fetched] are added.
      *
-     * @param dbPaper the existing paper stored in the database.
-     * @param fetched the newly fetched paper whose metadata may contain new keys.
+     * @param existing the existing [FetcherMetadata].
+     * @param fetched the newly fetched [FetcherMetadata].
      * @return a merged [FetcherMetadata] map.
      */
-    fun mergeMetadata(dbPaper: Paper, fetched: FetcherPaper): FetcherMetadata
+    fun mergeMetadata(existing: FetcherMetadata, fetched: FetcherMetadata): FetcherMetadata
 }
 
 /**
@@ -160,9 +160,9 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
         .maxByOrNull { (_, score) -> score }
         ?.first
 
-    override fun mergeMetadata(dbPaper: Paper, fetched: FetcherPaper): FetcherMetadata {
-        val merged = fetched.fetcherMetadata.toMutableMap()
-        merged.putAll(dbPaper.fetcherMetadata)
+    override fun mergeMetadata(existing: FetcherMetadata, fetched: FetcherMetadata): FetcherMetadata {
+        val merged = fetched.toMutableMap()
+        merged.putAll(existing)
         return merged
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -251,8 +251,10 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             fetcherMetadata = mergedMetadata,
         )
 
-        logger.debug {
-            "Deduplication result: $result; Sources: $group"
+        if (group.size > 1) {
+            logger.debug {
+                "Deduplication result: $result; Sources: $group"
+            }
         }
 
         return result

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -6,7 +6,6 @@ import se.uulm.snowballr.backend.model.dto.paper.ExternalId
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
-import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.fetcher.FetcherPaper
 import kotlin.math.abs
 
@@ -62,18 +61,6 @@ interface IPaperMatcher {
      * @return the highest-scoring candidate above [threshold], or `null` if none qualifies.
      */
     fun findMatch(fetched: FetcherPaper, candidates: List<Paper>, threshold: Float): Paper?
-
-    /**
-     * Merges fetched fetcher metadata into the existing metadata.
-     *
-     * The existing values take precedence on key conflicts: keys present in [existing] always
-     * overwrite the same keys from [fetched]. Keys present only in [fetched] are added.
-     *
-     * @param existing the existing [FetcherMetadata].
-     * @param fetched the newly fetched [FetcherMetadata].
-     * @return a merged [FetcherMetadata] map.
-     */
-    fun mergeMetadata(existing: FetcherMetadata, fetched: FetcherMetadata): FetcherMetadata
 }
 
 /**
@@ -164,12 +151,6 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
         .filter { (_, score) -> isSimilarityAboveThreshold(score, threshold) }
         .maxByOrNull { (_, score) -> score }
         ?.first
-
-    override fun mergeMetadata(existing: FetcherMetadata, fetched: FetcherMetadata): FetcherMetadata {
-        val merged = fetched.toMutableMap()
-        merged.putAll(existing)
-        return merged
-    }
 
     /**
      * Returns true if both [FetcherPaper]s have at least one equal external ID.

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -147,8 +147,10 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
     }
 
     override fun findMatch(fetched: FetcherPaper, candidates: List<Paper>, threshold: Float): Paper? = candidates
+        .asSequence()
         .map { candidate -> candidate to similarity(fetched, candidate.toFetcherPaper()) }
         .filter { (_, score) -> isSimilarityAboveThreshold(score, threshold) }
+        .sortedBy { (paper, _) -> paper.createdAt }
         .maxByOrNull { (_, score) -> score }
         ?.first
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -65,16 +65,16 @@ interface IPaperMatcher {
     fun mergeMetadata(dbPaper: Paper, fetched: FetcherPaper): FetcherMetadata
 }
 
-class PaperMatcher : IPaperMatcher {
-    companion object {
-        private const val TITLE_WEIGHT = 0.6
-        private const val AUTHORS_WEIGHT = 0.3
-        private const val ABSTRACT_WEIGHT = 0.1
-    }
-
+/**
+ * The [IPaperMatcher] implementation.
+ *
+ * @param config The weight config that is used by [similarity] to determine how each component accounts to the overall
+ * similarity.
+ */
+class PaperMatcher(private val config: PaperMatchingConfig) : IPaperMatcher {
     override fun similarity(a: FetcherPaper, b: FetcherPaper): Double {
         if (haveSameExternalId(a, b)) return 1.0
-        if (abs(a.year - b.year) > 1) return 0.0
+        if (abs(a.year - b.year) > config.yearTolerance) return 0.0
 
         data class Component(val weight: Double, val score: Double)
 
@@ -82,7 +82,7 @@ class PaperMatcher : IPaperMatcher {
 
         components.add(
             Component(
-                weight = TITLE_WEIGHT,
+                weight = config.titleWeight,
                 score = Levenshtein.getNormalizedDistance(a.title.trim().lowercase(), b.title.trim().lowercase()),
             ),
         )
@@ -90,7 +90,7 @@ class PaperMatcher : IPaperMatcher {
         if (a.authors.isNotEmpty() && b.authors.isNotEmpty()) {
             components.add(
                 Component(
-                    weight = AUTHORS_WEIGHT,
+                    weight = config.authorsWeight,
                     score = jaccardSimilarity(
                         Tokenization.authorSetTokens(a.authors),
                         Tokenization.authorSetTokens(b.authors),
@@ -102,7 +102,7 @@ class PaperMatcher : IPaperMatcher {
         if (a.abstract.isNotBlank() && b.abstract.isNotBlank()) {
             components.add(
                 Component(
-                    weight = ABSTRACT_WEIGHT,
+                    weight = config.abstractWeight,
                     score = Levenshtein.getNormalizedDistance(
                         a.abstract.trim().lowercase(),
                         b.abstract.trim().lowercase(),

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -226,7 +226,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             title = group.firstNotNullOfOrNull { it.title.ifBlank { null } } ?: first.title,
             externalIds = externalIds.map { ExternalId(it.key, it.value) },
             abstract = group.firstNotNullOfOrNull { it.abstract.ifBlank { null } } ?: first.abstract,
-            year = first.year,
+            year = group.firstOrNull { it.year > 0 }?.year ?: first.year,
             publisher = group.firstNotNullOfOrNull { it.publisher.ifBlank { null } } ?: first.publisher,
             publicationType = group.firstNotNullOfOrNull { it.publicationType.ifBlank { null } }
                 ?: first.publicationType,

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -20,6 +20,8 @@ interface IPaperMatcher {
      *
      * Scoring rules:
      * - If both papers share at least one [ExternalId], returns 1.0 immediately.
+     * - If both papers have at least one conflicting [ExternalId], returns 0.0 immediately.
+     *   - A conflict means same type, but different value. The type [ExternalIdType.URL] is excluded from this.
      * - If the publication years differ by more than the configured threshold, returns 0.0 immediately.
      * - Otherwise, the score is a weighted combination of:
      *   - **Title**: normalized Levenshtein similarity.
@@ -93,6 +95,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
 
     override fun similarity(a: FetcherPaper, b: FetcherPaper): Double {
         if (haveSameExternalId(a, b)) return 1.0
+        if (haveConflictingExternalId(a, b)) return 0.0
         if (abs(a.year - b.year) > config.yearTolerance) return 0.0
 
         data class Component(val weight: Double, val score: Double)
@@ -169,10 +172,34 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
      * External IDs with a blank value are filtered out.
      */
     private fun haveSameExternalId(a: FetcherPaper, b: FetcherPaper): Boolean {
+        val (externalIdsA, externalIdsB) = normalizeExternalIds(a, b)
+
+        return externalIdsA.any { externalIdsB.contains(it) }
+    }
+
+    /**
+     * Returns true if both [FetcherPaper]s have at least one conflicting external ID.
+     *
+     * Two external IDs are conflicting if they both have the same type, but a different value.
+     * The external ID type [ExternalIdType.URL] is excluded from this, since two different URLs might point to the same
+     * resource. I.e, different URLs are not a fast path to a clear no-similarity decision.
+     * External IDs with a blank value are filtered out.
+     */
+    private fun haveConflictingExternalId(a: FetcherPaper, b: FetcherPaper): Boolean {
+        val (externalIdsA, externalIdsB) = normalizeExternalIds(a, b)
+
+        return externalIdsA.any { exA ->
+            externalIdsB.any { exB ->
+                exA.type != ExternalIdType.URL && exA.type == exB.type && exA.value != exB.value
+            }
+        }
+    }
+
+    private fun normalizeExternalIds(a: FetcherPaper, b: FetcherPaper): Pair<List<ExternalId>, List<ExternalId>> {
         val externalIdsA = a.externalIds.filter { it.value.isNotBlank() }
         val externalIdsB = b.externalIds.filter { it.value.isNotBlank() }
 
-        return externalIdsA.any { externalIdsB.contains(it) }
+        return externalIdsA to externalIdsB
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -1,5 +1,6 @@
 package se.uulm.snowballr.backend.matching
 
+import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.ExternalId
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
 import se.uulm.snowballr.backend.model.dto.paper.Paper
@@ -86,6 +87,8 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             // The abstract similarity accounts for 10% of the total similarity
             abstractWeight = 0.1,
         )
+
+        const val DELTA = 1e-6
     }
 
     override fun similarity(a: FetcherPaper, b: FetcherPaper): Double {
@@ -103,13 +106,15 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             ),
         )
 
-        if (a.authors.isNotEmpty() && b.authors.isNotEmpty()) {
+        val authorsA = a.authors.filter { it.isNotBlank() }
+        val authorsB = b.authors.filter { it.isNotBlank() }
+        if (authorsA.isNotEmpty() && authorsB.isNotEmpty()) {
             components.add(
                 Component(
                     weight = config.authorsWeight,
                     score = jaccardSimilarity(
-                        Tokenization.authorSetTokens(a.authors),
-                        Tokenization.authorSetTokens(b.authors),
+                        Tokenization.authorSetTokens(authorsA),
+                        Tokenization.authorSetTokens(authorsB),
                     ),
                 ),
             )
@@ -135,7 +140,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
         val groups = mutableListOf<MutableList<FetcherPaper>>()
 
         for (paper in papers) {
-            val group = groups.firstOrNull { similarity(paper, it[0]) >= threshold }
+            val group = groups.firstOrNull { isSimilarityAboveThreshold(similarity(paper, it[0]), threshold) }
             if (group != null) {
                 group.add(paper)
             } else {
@@ -148,7 +153,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
 
     override fun findMatch(fetched: FetcherPaper, candidates: List<Paper>, threshold: Float): Paper? = candidates
         .map { candidate -> candidate to similarity(fetched, candidate.toFetcherPaper()) }
-        .filter { (_, score) -> score >= threshold }
+        .filter { (_, score) -> isSimilarityAboveThreshold(score, threshold) }
         .maxByOrNull { (_, score) -> score }
         ?.first
 
@@ -160,8 +165,15 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
 
     /**
      * Returns true if both [FetcherPaper]s have at least one equal external ID.
+     *
+     * External IDs with a blank value are filtered out.
      */
-    private fun haveSameExternalId(a: FetcherPaper, b: FetcherPaper) = a.externalIds.any { b.externalIds.contains(it) }
+    private fun haveSameExternalId(a: FetcherPaper, b: FetcherPaper): Boolean {
+        val externalIdsA = a.externalIds.filter { it.value.isNotBlank() }
+        val externalIdsB = b.externalIds.filter { it.value.isNotBlank() }
+
+        return externalIdsA.any { externalIdsB.contains(it) }
+    }
 
     /**
      * Returns the Jaccard Similarity of two sets of strings.
@@ -209,4 +221,8 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
             fetcherMetadata = mergedMetadata,
         )
     }
+
+    private fun Author.isNotBlank() = this.firstName.isNotBlank() && this.lastName.isNotBlank()
+
+    private fun isSimilarityAboveThreshold(similarity: Double, threshold: Float) = threshold - similarity < DELTA
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatcher.kt
@@ -105,12 +105,14 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
 
         val components = mutableListOf<Component>()
 
-        components.add(
-            Component(
-                weight = config.titleWeight,
-                score = Levenshtein.getNormalizedDistance(a.title.trim().lowercase(), b.title.trim().lowercase()),
-            ),
-        )
+        if (a.title.isNotBlank() && b.title.isNotBlank()) {
+            components.add(
+                Component(
+                    weight = config.titleWeight,
+                    score = Levenshtein.getNormalizedDistance(a.title.trim().lowercase(), b.title.trim().lowercase()),
+                ),
+            )
+        }
 
         val authorsA = a.authors.filter { it.isNotBlank() }
         val authorsB = b.authors.filter { it.isNotBlank() }
@@ -260,7 +262,7 @@ class PaperMatcher(override val config: PaperMatchingConfig) : IPaperMatcher {
         return result
     }
 
-    private fun Author.isNotBlank() = this.firstName.isNotBlank() && this.lastName.isNotBlank()
+    private fun Author.isNotBlank() = this.firstName.isNotBlank() || this.lastName.isNotBlank()
 
     private fun isSimilarityAboveThreshold(similarity: Double, threshold: Float) = threshold - similarity < DELTA
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatchingConfig.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatchingConfig.kt
@@ -1,0 +1,8 @@
+package se.uulm.snowballr.backend.matching
+
+data class PaperMatchingConfig(
+    val yearTolerance: Int,
+    val titleWeight: Double,
+    val authorsWeight: Double,
+    val abstractWeight: Double,
+)

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatchingConfig.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatchingConfig.kt
@@ -5,4 +5,10 @@ data class PaperMatchingConfig(
     val titleWeight: Double,
     val authorsWeight: Double,
     val abstractWeight: Double,
-)
+) {
+    init {
+        val weightSum = titleWeight + authorsWeight + abstractWeight
+        require(weightSum > 0.0) { "The sum of the weights must be positive." }
+        require(yearTolerance >= 0) { "The year tolerance must be positive or 0." }
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatchingConfig.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/PaperMatchingConfig.kt
@@ -7,8 +7,11 @@ data class PaperMatchingConfig(
     val abstractWeight: Double,
 ) {
     init {
+        require(yearTolerance >= 0) { "The year tolerance must be positive or 0." }
+        require(titleWeight >= 0) { "titleWeight must be positive or 0" }
+        require(authorsWeight >= 0) { "authorsWeight must be positive or 0" }
+        require(abstractWeight >= 0) { "abstractWeight must be positive or 0" }
         val weightSum = titleWeight + authorsWeight + abstractWeight
         require(weightSum > 0.0) { "The sum of the weights must be positive." }
-        require(yearTolerance >= 0) { "The year tolerance must be positive or 0." }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/matching/Tokenization.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/matching/Tokenization.kt
@@ -1,0 +1,37 @@
+package se.uulm.snowballr.backend.matching
+
+import se.uulm.snowballr.backend.model.dto.paper.Author
+
+object Tokenization {
+    /**
+     * Creates a set of tokens for all passed [authors].
+     *
+     * Example:
+     * - Authors: "John Doe" and "Jane Doe"
+     * - Tokens: "john", "j", "doe", "d", "jane"
+     */
+    fun authorSetTokens(authors: List<Author>): Set<String> = authors.flatMap { authorTokens(it) }.toSet()
+
+    /**
+     * Creates a set of tokens for the passed [author].
+     *
+     * Tokens are a set of strings used to compare authors.
+     * They consist of the words of the full name and the first character of each word.
+     * Including the first character, enables comparing abbreviated words of the full author name.
+     *
+     * Tokens for example author "John Doe": "john", "j", "doe", "d"
+     */
+    fun authorTokens(author: Author): Set<String> {
+        val fullName = "${author.firstName} ${author.lastName}".trim()
+        val cleaned = fullName.lowercase().replace(Regex("[^a-z0-9 ]"), "")
+        val tokens = cleaned.split(Regex("\\s+")).filter { it.isNotEmpty() }
+
+        val result = mutableSetOf<String>()
+        for (token in tokens) {
+            result.add(token)
+            if (token.length > 1) result.add(token[0].toString())
+        }
+
+        return result
+    }
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/ExternalIdType.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/dto/paper/ExternalIdType.kt
@@ -45,9 +45,4 @@ enum class ExternalIdType(val displayName: String) {
      * [Semantic Scholar](https://www.semanticscholar.org/).
      */
     SEMANTIC_SCHOLAR("Semantic Scholar"),
-
-    /**
-     * Arbitrary URL.
-     */
-    URL("URL"),
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherProcessingJob.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/fetcher/FetcherProcessingJob.kt
@@ -13,4 +13,5 @@ data class FetcherProcessingJob(
     val targetStage: Int,
     val paperId: UUID,
     val triggeringUserId: UUID,
+    val similarityThreshold: Float,
 )

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -139,6 +139,11 @@ class PaperTableRepo(
         (PaperHasExternalIdTable.type eq it.type) and (PaperHasExternalIdTable.value eq it.value)
     }.fold<Op<Boolean>, Op<Boolean>>(Op.FALSE) { acc, value -> acc or value }
 
+    private fun getPaperIdsFromExternalIds(externalIds: List<ExternalId>): List<UUID> =
+        PaperHasExternalIdTable.selectAll()
+            .where { externalIdsWhereOp(externalIds) }
+            .map { it[PaperHasExternalIdTable.paperId].value }
+
     override suspend fun getPaperById(id: UUID): Result<Paper> = db.query {
         getEntityByKeyAsResult(::getPaperByIdOrNull, EntityType.PAPER, id)
     }
@@ -237,7 +242,11 @@ class PaperTableRepo(
     override suspend fun getPapersByExternalIds(externalIds: List<ExternalId>): List<Paper> = db.query {
         if (externalIds.isEmpty()) return@query emptyList()
 
-        getPapersWhere(where = { externalIdsWhereOp(externalIds) })
+        val paperIds = getPaperIdsFromExternalIds(externalIds)
+
+        if (paperIds.isEmpty()) return@query emptyList()
+
+        getPapersWhere(where = { PaperTable.id inList paperIds })
     }
 
     override suspend fun getPapersByYear(year: Int, tolerance: Int): List<Paper> = db.query {

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.statements.StatementType
@@ -28,6 +29,7 @@ import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.table.PaperTable
 import se.uulm.snowballr.backend.table.association.PaperHasExternalIdTable
 import se.uulm.snowballr.backend.table.association.toExternalIdPair
+import se.uulm.snowballr.backend.table.columntypes.HStoreColumnType
 import se.uulm.snowballr.backend.table.toPaper
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -89,11 +91,13 @@ interface IPaperTableRepo {
     suspend fun getPapersByYear(year: Int, tolerance: Int): List<Paper>
 
     /**
-     * Updates only the fetcher metadata column of the paper with the given [id].
+     * Merges [metadata] into the fetcher metadata of the paper with the given [id].
      *
-     * Does not modify [PaperTable.modifiedAt] — this is a system-internal operation, not a user edit.
+     * Keyss that are already stored keep their stored value, keys that are only in [metadata] are added.
+     *
+     * This does not modify [PaperTable.modifiedAt] — this is a system-internal operation, not a user edit.
      */
-    suspend fun updateFetcherMetadata(id: UUID, metadata: FetcherMetadata)
+    suspend fun mergeFetcherMetadata(id: UUID, metadata: FetcherMetadata)
 }
 
 /**
@@ -253,10 +257,19 @@ class PaperTableRepo(
         getPapersWhere { (PaperTable.year greaterEq year - tolerance) and (PaperTable.year lessEq year + tolerance) }
     }
 
-    override suspend fun updateFetcherMetadata(id: UUID, metadata: FetcherMetadata): Unit = db.query {
-        PaperTable.update({ PaperTable.id eq id }) {
-            it[fetcherMetadata] = metadata
-        }
+    override suspend fun mergeFetcherMetadata(id: UUID, metadata: FetcherMetadata): Unit = db.query {
+        if (metadata.isEmpty()) return@query
+
+        val paperTable = PaperTable.tableName
+        val metadataColumn = PaperTable.fetcherMetadata.name
+
+        // Use hstore concatenation operator to merge metadata key-value pairs.
+        // The operator is right-biased, i.e., an existing value wins on conflict
+        exec(
+            stmt = "UPDATE $paperTable SET $metadataColumn = ?::hstore || $metadataColumn WHERE $paperTable.id = ?",
+            args = listOf(HStoreColumnType() to metadata, UUIDColumnType() to id),
+            explicitStatementType = StatementType.UPDATE,
+        )
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -114,14 +114,13 @@ class PaperTableRepo(
         private const val MINIMUM_SIMILARITY_SCORE = 0.2
     }
 
-    private fun getPapersWhere(where: () -> Op<Boolean>) =
-        PaperTable
-            .joinPaperHasExternalId()
-            .selectAll()
-            .where(where)
-            .groupBy { it[PaperTable.id].value }
-            .values
-            .map { rows -> rows.toPaperWithExternalIds() }
+    private fun getPapersWhere(where: () -> Op<Boolean>) = PaperTable
+        .joinPaperHasExternalId()
+        .selectAll()
+        .where(where)
+        .groupBy { it[PaperTable.id].value }
+        .values
+        .map { rows -> rows.toPaperWithExternalIds() }
 
     private fun getPaperByIdOrNull(id: UUID): Paper? = getPapersWhere(where = { PaperTable.id eq id }).singleOrNull()
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -98,17 +98,16 @@ class PaperTableRepo(
         private const val MINIMUM_SIMILARITY_SCORE = 0.2
     }
 
-    private fun getPaperByIdOrNull(id: UUID): Paper? {
-        val rows = PaperTable
+    private fun getPapersWhere(where: () -> Op<Boolean>) =
+        PaperTable
             .joinPaperHasExternalId()
             .selectAll()
-            .where { PaperTable.id eq id }
-            .toList()
+            .where(where)
+            .groupBy { it[PaperTable.id].value }
+            .values
+            .map { rows -> rows.toPaperWithExternalIds() }
 
-        if (rows.isEmpty()) return null
-
-        return rows.toPaperWithExternalIds()
-    }
+    private fun getPaperByIdOrNull(id: UUID): Paper? = getPapersWhere(where = { PaperTable.id eq id }).singleOrNull()
 
     /**
      * Creates a where clause to find a paper that has any of the passed [externalIds].
@@ -124,11 +123,6 @@ class PaperTableRepo(
     private fun externalIdsWhereOp(externalIds: List<ExternalId>) = externalIds.map {
         (PaperHasExternalIdTable.type eq it.type) and (PaperHasExternalIdTable.value eq it.value)
     }.fold<Op<Boolean>, Op<Boolean>>(Op.FALSE) { acc, value -> acc or value }
-
-    private fun getPaperIdsFromExternalIds(externalIds: List<ExternalId>): List<UUID> =
-        PaperHasExternalIdTable.selectAll()
-            .where { externalIdsWhereOp(externalIds) }
-            .map { it[PaperHasExternalIdTable.paperId].value }
 
     override suspend fun getPaperById(id: UUID): Result<Paper> = db.query {
         getEntityByKeyAsResult(::getPaperByIdOrNull, EntityType.PAPER, id)
@@ -228,17 +222,7 @@ class PaperTableRepo(
     override suspend fun getPapersByExternalIds(externalIds: List<ExternalId>): List<Paper> = db.query {
         if (externalIds.isEmpty()) return@query emptyList()
 
-        val paperIds = getPaperIdsFromExternalIds(externalIds).distinct()
-
-        if (paperIds.isEmpty()) return@query emptyList()
-
-        PaperTable
-            .joinPaperHasExternalId()
-            .selectAll()
-            .where { PaperTable.id inList paperIds }
-            .groupBy { it[PaperTable.id].value }
-            .values
-            .map { rows -> rows.toPaperWithExternalIds() }
+        getPapersWhere(where = { externalIdsWhereOp(externalIds) })
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -93,7 +93,7 @@ interface IPaperTableRepo {
     /**
      * Merges [metadata] into the fetcher metadata of the paper with the given [id].
      *
-     * Keyss that are already stored keep their stored value, keys that are only in [metadata] are added.
+     * Keys that are already stored keep their stored value, keys that are only in [metadata] are added.
      *
      * This does not modify [PaperTable.modifiedAt] — this is a system-internal operation, not a user edit.
      */
@@ -260,7 +260,7 @@ class PaperTableRepo(
     override suspend fun mergeFetcherMetadata(id: UUID, metadata: FetcherMetadata): Unit = db.query {
         if (metadata.isEmpty()) return@query
 
-        val paperTable = PaperTable.tableName
+        val paperTable = "\"${PaperTable.tableName}\""
         val metadataColumn = PaperTable.fetcherMetadata.name
 
         // Use hstore concatenation operator to merge metadata key-value pairs.

--- a/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepo.kt
@@ -5,7 +5,9 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.jdbc.batchInsert
@@ -20,6 +22,7 @@ import se.uulm.snowballr.backend.model.dto.paper.ExternalId
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.exception.NotFoundException
 import se.uulm.snowballr.backend.model.exception.notfound.entity.PaperNotFoundException
+import se.uulm.snowballr.backend.model.fetcher.FetcherMetadata
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.model.incoming.paper.UpdatePaperRequest
 import se.uulm.snowballr.backend.table.PaperTable
@@ -79,6 +82,18 @@ interface IPaperTableRepo {
      * Retrieves all papers that have one or more external ID(s) that matches at least one external ID in [externalIds].
      */
     suspend fun getPapersByExternalIds(externalIds: List<ExternalId>): List<Paper>
+
+    /**
+     * Retrieves all papers whose publication year is within [tolerance] years of [year].
+     */
+    suspend fun getPapersByYear(year: Int, tolerance: Int): List<Paper>
+
+    /**
+     * Updates only the fetcher metadata column of the paper with the given [id].
+     *
+     * Does not modify [PaperTable.modifiedAt] — this is a system-internal operation, not a user edit.
+     */
+    suspend fun updateFetcherMetadata(id: UUID, metadata: FetcherMetadata)
 }
 
 /**
@@ -90,6 +105,7 @@ interface IPaperTableRepo {
  *
  * @param db The database abstraction used for executing queries within a transaction.
  */
+@Suppress("TooManyFunctions")
 class PaperTableRepo(
     private val db: IDatabase,
 ) : IPaperTableRepo {
@@ -223,6 +239,16 @@ class PaperTableRepo(
         if (externalIds.isEmpty()) return@query emptyList()
 
         getPapersWhere(where = { externalIdsWhereOp(externalIds) })
+    }
+
+    override suspend fun getPapersByYear(year: Int, tolerance: Int): List<Paper> = db.query {
+        getPapersWhere { (PaperTable.year greaterEq year - tolerance) and (PaperTable.year lessEq year + tolerance) }
+    }
+
+    override suspend fun updateFetcherMetadata(id: UUID, metadata: FetcherMetadata): Unit = db.query {
+        PaperTable.update({ PaperTable.id eq id }) {
+            it[fetcherMetadata] = metadata
+        }
     }
 
     /**

--- a/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/table/UserTable.kt
@@ -46,7 +46,7 @@ private val MAYBE_MAYBE_PATTERN = patternOf(
 private const val ARE_HOTKEYS_SHOWN_DEFAULT = true
 private const val IS_REVIEW_MODE_ENABLED_DEFAULT = false
 private val CRITERIA_IDS_DEFAULT = emptyList<UUID>()
-private const val SIMILARITY_THRESHOLD_DEFAULT = 0F
+private const val SIMILARITY_THRESHOLD_DEFAULT = 0.85F
 
 /**
  * This default decision matrix assumes two reviewers by default.

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ProjectValidator.kt
@@ -17,7 +17,7 @@ import snowballr.ProjectOuterClass.ReviewDecisionMatrix
  */
 object ProjectValidator {
     const val NAME_MAX_LENGTH = 100
-    const val SIMILARITY_THRESHOLD_MIN_VALUE = 0.0f
+    const val SIMILARITY_THRESHOLD_MIN_VALUE = 0.2f
     const val SIMILARITY_THRESHOLD_MAX_VALUE = 1.0f
     const val NUMBER_OF_REVIEWERS_MIN_VALUE = 1
     const val NUMBER_OF_REVIEWERS_MAX_VALUE = 10

--- a/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/arch/LayerArchitectureTest.kt
@@ -51,6 +51,7 @@ private class StructureRules {
         private const val DB = "DB"
         private const val SCHEDULER = "Scheduler"
         private const val FETCHER = "Fetcher"
+        private const val MATCHING = "Matching"
     }
 
     private fun Architectures.LayeredArchitecture.snowballRLayers() = this
@@ -84,6 +85,9 @@ private class StructureRules {
         // Fetcher
         .layer(FETCHER)
         .definedBy("$BASE_PACKAGE.fetcher..")
+        // Paper Matching
+        .layer(MATCHING)
+        .definedBy("$BASE_PACKAGE.matching..")
 
     @ArchTest
     fun `When the layer architecture is violated, then this test should fail (all deps)`(classes: JavaClasses) {
@@ -109,6 +113,8 @@ private class StructureRules {
             .mayOnlyBeAccessedByLayers(GRPC, MAIN)
             .whereLayer(FETCHER)
             .mayOnlyBeAccessedByLayers(MAIN, SERVICE)
+            .whereLayer(MATCHING)
+            .mayOnlyBeAccessedByLayers(FETCHER, MAIN)
             .check(classes)
     }
 
@@ -121,7 +127,7 @@ private class StructureRules {
             .whereLayer(MAIN)
             .mayNotBeAccessedByAnyLayer()
             .whereLayer(MAIN)
-            .mayOnlyAccessLayers(GRPC, SERVICE, ACCESS, REPO, DB, SCHEDULER, FETCHER)
+            .mayOnlyAccessLayers(GRPC, SERVICE, ACCESS, REPO, DB, SCHEDULER, FETCHER, MATCHING)
             .whereLayer(VALIDATION)
             .mayNotAccessAnyLayer()
             .whereLayer(GRPC)
@@ -139,7 +145,9 @@ private class StructureRules {
             .whereLayer(SCHEDULER)
             .mayOnlyAccessLayers(REPO)
             .whereLayer(FETCHER)
-            .mayOnlyAccessLayers(REPO)
+            .mayOnlyAccessLayers(REPO, MATCHING)
+            .whereLayer(MATCHING)
+            .mayNotAccessAnyLayer()
             .check(classes)
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/context/RequestContextTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/context/RequestContextTest.kt
@@ -4,9 +4,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.auth.ACCESS_TOKEN_COOKIE_NAME
 import se.uulm.snowballr.backend.auth.REFRESH_TOKEN_COOKIE_NAME

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorEnqueueTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorEnqueueTest.kt
@@ -3,14 +3,12 @@ package se.uulm.snowballr.backend.fetcher.orchestrator
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.TestSpecificException
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FetcherOrchestratorEnqueueTest : FetcherOrchestratorTest() {
     @Test
     fun `When a job is enqueued without the orchestrator being started, then an IllegalStateException is thrown`() =

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.fetcher.orchestrator
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,6 +23,7 @@ import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
 import se.uulm.snowballr.backend.model.incoming.paper.CreatePaperRequest
 import se.uulm.snowballr.backend.repository.UNIQUE_CONSTRAINT_VIOLATION_SQL_STATE
 import java.sql.SQLException
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
@@ -165,7 +167,8 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     } returns setOf(fetchedPaper)
                 }
 
-                // Stop at paper creation
+                // Deduplication passes through; stop at paper creation via externalId lookup
+                every { paperMatcherMock.deduplicatePapers(any(), any()) } answers { firstArg() }
                 coEvery {
                     paperRepoMock.getPapersByExternalIds(fetchedPaper.externalIds)
                 } throws TestSpecificException()
@@ -185,7 +188,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
     @Nested
     inner class RunPaperCreation {
         @Test
-        fun `When fetched papers already exist, then they are not created again`() =
+        fun `When fetched papers already exist by external IDs, then they are not created again`() =
             runOrchestratorTest { orchestrator ->
                 val job = DataBuilder.createExampleFetcherEnqueueJob()
                 val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
@@ -196,13 +199,24 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     externalIds = listOf(ExternalId(ExternalIdType.DOI, "ForwardId")),
                 )
 
-                mockRunFetching(job, setOf(backwardRef.toFetcherPaper()), setOf(forwardRef.toFetcherPaper()))
+                val backwardFetcherRef = backwardRef.toFetcherPaper()
+                val forwardFetcherRef = forwardRef.toFetcherPaper()
+                mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+                every {
+                    paperMatcherMock.deduplicatePapers(setOf(backwardFetcherRef), any())
+                } returns setOf(backwardFetcherRef)
+                every {
+                    paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
+                } returns setOf(forwardFetcherRef)
                 coEvery {
                     paperRepoMock.getPapersByExternalIds(backwardRef.externalIds)
                 } returns listOf(backwardRef)
                 coEvery {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns listOf(forwardRef)
+                // fetcherMetadata is empty for both → merged equals DB metadata → no update needed
+                every { paperMatcherMock.mergeMetadata(backwardRef, backwardFetcherRef) } returns emptyMap()
+                every { paperMatcherMock.mergeMetadata(forwardRef, forwardFetcherRef) } returns emptyMap()
 
                 // Stop at paper citation
                 coEvery {
@@ -221,36 +235,38 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 assertAddingPapersToProjectFailure()
             }
 
-        @ParameterizedTest
-        @MethodSource(
-            "se.uulm.snowballr.backend.fetcher.orchestrator.FetcherOrchestratorProcessJobTest#exampleExternalIds",
-        )
-        fun `When fetched papers don't already exist, then they are created`(externalIds: List<ExternalId>) =
+        @Test
+        fun `When fetched papers already exist by similarity, then they are not created again`() =
             runOrchestratorTest { orchestrator ->
                 val job = DataBuilder.createExampleFetcherEnqueueJob()
                 val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
-                val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalIds = externalIds)
-                val backwardFetcherRef = backwardRef.toFetcherPaper()
-                val forwardRef = DataBuilder.createExamplePaper(title = "For", externalIds = externalIds)
-                val forwardFetcherRef = forwardRef.toFetcherPaper()
+                val backwardRef = DataBuilder.createExamplePaper(title = "Backward Paper", year = 2012)
+                val forwardRef = DataBuilder.createExamplePaper(title = "Forward Paper", year = 2013)
+                val metadata = mapOf("foo" to "bar")
 
+                val backwardFetcherRef = backwardRef.toFetcherPaper()
+                val forwardFetcherRef = forwardRef.toFetcherPaper()
                 mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
-                if (externalIds.isNotEmpty()) {
-                    coEvery {
-                        paperRepoMock.getPapersByExternalIds(backwardRef.externalIds)
-                    } returns emptyList()
-                    coEvery {
-                        paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
-                    } returns emptyList()
-                }
+                every {
+                    paperMatcherMock.deduplicatePapers(setOf(backwardFetcherRef), any())
+                } returns setOf(backwardFetcherRef)
+                every {
+                    paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
+                } returns setOf(forwardFetcherRef)
+                coEvery { paperRepoMock.getPapersByYear(backwardFetcherRef.year, 1) } returns listOf(backwardRef)
+                coEvery { paperRepoMock.getPapersByYear(forwardFetcherRef.year, 1) } returns listOf(forwardRef)
                 coEvery {
-                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
+                    paperMatcherMock.findMatch(backwardFetcherRef, listOf(backwardRef), project.similarityThreshold)
                 } returns backwardRef
                 coEvery {
-                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
+                    paperMatcherMock.findMatch(forwardFetcherRef, listOf(forwardRef), project.similarityThreshold)
                 } returns forwardRef
+                every { paperMatcherMock.mergeMetadata(backwardRef, backwardFetcherRef) } returns metadata
+                every { paperMatcherMock.mergeMetadata(forwardRef, forwardFetcherRef) } returns metadata
+                coJustRun { paperRepoMock.updateFetcherMetadata(backwardRef.id, metadata) }
+                coJustRun { paperRepoMock.updateFetcherMetadata(forwardRef.id, metadata) }
 
-                // Stop at adding papers to project
+                // Stop at paper citation
                 coEvery {
                     citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
                 } throws SQLException("Citing backwards failed")
@@ -263,14 +279,191 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
 
                 orchestrator.enqueueTestJob(job, project)
 
+                coVerify(exactly = 0) { paperRepoMock.createPaper(any()) }
                 assertAddingPapersToProjectFailure()
-                coVerify(exactly = 1) {
-                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
-                }
-                coVerify(exactly = 1) {
-                    paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
-                }
             }
+
+        @Test
+        fun `When fetched papers already exist by external IDs as multiple papers, then the first existence is used`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val backwardRef = DataBuilder.createExamplePaper(
+                    externalIds = listOf(ExternalId(ExternalIdType.DOI, "BackwardId")),
+                )
+                val backwardRef2 = backwardRef.copy(id = UUID.randomUUID())
+                val forwardRef = DataBuilder.createExamplePaper(
+                    externalIds = listOf(ExternalId(ExternalIdType.DOI, "ForwardId")),
+                )
+                val forwardRef2 = forwardRef.copy(id = UUID.randomUUID())
+
+                val backwardFetcherRef = backwardRef.toFetcherPaper()
+                val forwardFetcherRef = forwardRef.toFetcherPaper()
+                mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+                every {
+                    paperMatcherMock.deduplicatePapers(setOf(backwardFetcherRef), any())
+                } returns setOf(backwardFetcherRef)
+                every {
+                    paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
+                } returns setOf(forwardFetcherRef)
+                coEvery {
+                    paperRepoMock.getPapersByExternalIds(backwardRef.externalIds)
+                } returns listOf(backwardRef, backwardRef2)
+                coEvery {
+                    paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
+                } returns listOf(forwardRef, forwardRef2)
+                // fetcherMetadata is empty for both → merged equals DB metadata → no update needed
+                every { paperMatcherMock.mergeMetadata(backwardRef, backwardFetcherRef) } returns emptyMap()
+                every { paperMatcherMock.mergeMetadata(forwardRef, forwardFetcherRef) } returns emptyMap()
+
+                // Stop at paper citation
+                coEvery {
+                    citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+                } throws SQLException("Citing backwards failed")
+                coEvery {
+                    citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+                } throws SQLException("Citing forwards failed")
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                coVerify(exactly = 0) { paperRepoMock.createPaper(any()) }
+                coVerify(exactly = 0) { citationRepoMock.addBackwardReferencedPaper(any(), backwardRef2.id) }
+                coVerify(exactly = 0) { citationRepoMock.addForwardReferencedPaper(any(), forwardRef2.id) }
+                assertAddingPapersToProjectFailure()
+            }
+
+        @ParameterizedTest
+        @MethodSource(
+            "se.uulm.snowballr.backend.fetcher.orchestrator.FetcherOrchestratorProcessJobTest#exampleExternalIds",
+        )
+        fun `When fetched papers don't already exist by external ID, then they are created`(
+            externalIds: List<ExternalId>,
+        ) = runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+            val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalIds = externalIds)
+            val backwardFetcherRef = backwardRef.toFetcherPaper()
+            val forwardRef = DataBuilder.createExamplePaper(title = "For", externalIds = externalIds)
+            val forwardFetcherRef = forwardRef.toFetcherPaper()
+
+            mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+            every {
+                paperMatcherMock.deduplicatePapers(setOf(backwardFetcherRef), any())
+            } returns setOf(backwardFetcherRef)
+            every {
+                paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
+            } returns setOf(forwardFetcherRef)
+            if (externalIds.isNotEmpty()) {
+                coEvery {
+                    paperRepoMock.getPapersByExternalIds(backwardRef.externalIds)
+                } returns emptyList()
+                coEvery {
+                    paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
+                } returns emptyList()
+            }
+            coEvery { paperRepoMock.getPapersByYear(backwardRef.year, 1) } returns emptyList()
+            coEvery { paperRepoMock.getPapersByYear(forwardRef.year, 1) } returns emptyList()
+            coEvery {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
+            } returns backwardRef
+            coEvery {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
+            } returns forwardRef
+
+            // Stop at adding papers to project
+            coEvery {
+                citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+            } throws SQLException("Citing backwards failed")
+            coEvery {
+                citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+            } throws SQLException("Citing forwards failed")
+            coEvery {
+                projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+            } throws TestSpecificException()
+
+            orchestrator.enqueueTestJob(job, project)
+
+            assertAddingPapersToProjectFailure()
+            coVerify(exactly = 1) {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
+            }
+            coVerify(exactly = 1) {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+            "se.uulm.snowballr.backend.fetcher.orchestrator.FetcherOrchestratorProcessJobTest#exampleExternalIds",
+        )
+        fun `When fetched papers don't already exist by similarity, then they are created`(
+            externalIds: List<ExternalId>,
+        ) = runOrchestratorTest { orchestrator ->
+            val job = DataBuilder.createExampleFetcherEnqueueJob()
+            val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+            val backwardRef = DataBuilder.createExamplePaper(title = "Back", externalIds = externalIds)
+            val backwardFetcherRef = backwardRef.toFetcherPaper()
+            val forwardRef = DataBuilder.createExamplePaper(title = "For", externalIds = externalIds)
+            val forwardFetcherRef = forwardRef.toFetcherPaper()
+            val candidates = listOf(
+                DataBuilder.createExamplePaper(),
+                DataBuilder.createExamplePaper(),
+            )
+
+            mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+            every {
+                paperMatcherMock.deduplicatePapers(setOf(backwardFetcherRef), any())
+            } returns setOf(backwardFetcherRef)
+            every {
+                paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
+            } returns setOf(forwardFetcherRef)
+            if (externalIds.isNotEmpty()) {
+                coEvery {
+                    paperRepoMock.getPapersByExternalIds(backwardRef.externalIds)
+                } returns emptyList()
+                coEvery {
+                    paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
+                } returns emptyList()
+            }
+            coEvery { paperRepoMock.getPapersByYear(backwardRef.year, 1) } returns candidates
+            coEvery {
+                paperMatcherMock.findMatch(backwardFetcherRef, candidates, project.similarityThreshold)
+            } returns null
+            coEvery { paperRepoMock.getPapersByYear(forwardRef.year, 1) } returns candidates
+            coEvery {
+                paperMatcherMock.findMatch(forwardFetcherRef, candidates, project.similarityThreshold)
+            } returns null
+            coEvery {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
+            } returns backwardRef
+            coEvery {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
+            } returns forwardRef
+
+            // Stop at adding papers to project
+            coEvery {
+                citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, backwardRef.id)
+            } throws SQLException("Citing backwards failed")
+            coEvery {
+                citationRepoMock.addForwardReferencedPaper(job.projectPaper.paperId, forwardRef.id)
+            } throws SQLException("Citing forwards failed")
+            coEvery {
+                projectPaperRepoMock.doesProjectPaperExist(project.id, backwardRef.id)
+            } throws TestSpecificException()
+
+            orchestrator.enqueueTestJob(job, project)
+
+            assertAddingPapersToProjectFailure()
+            coVerify(exactly = 1) {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
+            }
+            coVerify(exactly = 1) {
+                paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(forwardFetcherRef))
+            }
+        }
 
         @Test
         fun `When creating the DB papers fails, then no citations are created`() = runOrchestratorTest { orchestrator ->
@@ -282,6 +475,14 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
             val forwardFetcherRef = forwardRef.toFetcherPaper()
 
             mockRunFetching(job, setOf(backwardFetcherRef), setOf(forwardFetcherRef))
+            every {
+                paperMatcherMock.deduplicatePapers(setOf(backwardFetcherRef), any())
+            } returns setOf(backwardFetcherRef)
+            every {
+                paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
+            } returns setOf(forwardFetcherRef)
+            coEvery { paperRepoMock.getPapersByYear(backwardFetcherRef.year, 1) } returns emptyList()
+            coEvery { paperRepoMock.getPapersByYear(forwardFetcherRef.year, 1) } returns emptyList()
             coEvery {
                 paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
             } throws SQLException("Creating backward paper failed")

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -212,13 +212,6 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 coEvery {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns listOf(forwardRef)
-                // fetcherMetadata is empty for both → merged equals DB metadata → no update needed
-                every {
-                    paperMatcherMock.mergeMetadata(backwardRef.fetcherMetadata, backwardFetcherRef.fetcherMetadata)
-                } returns emptyMap()
-                every {
-                    paperMatcherMock.mergeMetadata(forwardRef.fetcherMetadata, forwardFetcherRef.fetcherMetadata)
-                } returns emptyMap()
 
                 // Stop at paper citation
                 coEvery {
@@ -242,9 +235,16 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
             runOrchestratorTest { orchestrator ->
                 val job = DataBuilder.createExampleFetcherEnqueueJob()
                 val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
-                val backwardRef = DataBuilder.createExamplePaper(title = "Backward Paper", year = 2012)
-                val forwardRef = DataBuilder.createExamplePaper(title = "Forward Paper", year = 2013)
-                val metadata = mapOf("foo" to "bar")
+                val backwardRef = DataBuilder.createExamplePaper(
+                    title = "Backward Paper",
+                    year = 2012,
+                    fetcherMetadata = mapOf("foo" to "bar"),
+                )
+                val forwardRef = DataBuilder.createExamplePaper(
+                    title = "Forward Paper",
+                    year = 2013,
+                    fetcherMetadata = mapOf("foo" to "bar"),
+                )
 
                 val backwardFetcherRef = backwardRef.toFetcherPaper()
                 val forwardFetcherRef = forwardRef.toFetcherPaper()
@@ -264,14 +264,8 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 coEvery {
                     paperMatcherMock.findMatch(forwardFetcherRef, listOf(forwardRef), project.similarityThreshold)
                 } returns forwardRef
-                every {
-                    paperMatcherMock.mergeMetadata(backwardRef.fetcherMetadata, backwardFetcherRef.fetcherMetadata)
-                } returns metadata
-                every {
-                    paperMatcherMock.mergeMetadata(forwardRef.fetcherMetadata, forwardFetcherRef.fetcherMetadata)
-                } returns metadata
-                coJustRun { paperRepoMock.updateFetcherMetadata(backwardRef.id, metadata) }
-                coJustRun { paperRepoMock.updateFetcherMetadata(forwardRef.id, metadata) }
+                coJustRun { paperRepoMock.mergeFetcherMetadata(backwardRef.id, forwardFetcherRef.fetcherMetadata) }
+                coJustRun { paperRepoMock.mergeFetcherMetadata(forwardRef.id, forwardFetcherRef.fetcherMetadata) }
 
                 // Stop at paper citation
                 coEvery {
@@ -319,13 +313,6 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 coEvery {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns listOf(forwardRef, forwardRef2)
-                // fetcherMetadata is empty for both → merged equals DB metadata → no update needed
-                every {
-                    paperMatcherMock.mergeMetadata(backwardRef.fetcherMetadata, backwardFetcherRef.fetcherMetadata)
-                } returns emptyMap()
-                every {
-                    paperMatcherMock.mergeMetadata(forwardRef.fetcherMetadata, forwardFetcherRef.fetcherMetadata)
-                } returns emptyMap()
 
                 // Stop at paper citation
                 coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -253,6 +253,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 every {
                     paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
                 } returns setOf(forwardFetcherRef)
+                every { paperMatcherMock.config.yearTolerance } returns 1
                 coEvery { paperRepoMock.getPapersByYear(backwardFetcherRef.year, 1) } returns listOf(backwardRef)
                 coEvery { paperRepoMock.getPapersByYear(forwardFetcherRef.year, 1) } returns listOf(forwardRef)
                 coEvery {
@@ -364,6 +365,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns emptyList()
             }
+            every { paperMatcherMock.config.yearTolerance } returns 1
             coEvery { paperRepoMock.getPapersByYear(backwardRef.year, 1) } returns emptyList()
             coEvery { paperRepoMock.getPapersByYear(forwardRef.year, 1) } returns emptyList()
             coEvery {
@@ -428,6 +430,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns emptyList()
             }
+            every { paperMatcherMock.config.yearTolerance } returns 1
             coEvery { paperRepoMock.getPapersByYear(backwardRef.year, 1) } returns candidates
             coEvery {
                 paperMatcherMock.findMatch(backwardFetcherRef, candidates, project.similarityThreshold)
@@ -481,6 +484,7 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
             every {
                 paperMatcherMock.deduplicatePapers(setOf(forwardFetcherRef), any())
             } returns setOf(forwardFetcherRef)
+            every { paperMatcherMock.config.yearTolerance } returns 1
             coEvery { paperRepoMock.getPapersByYear(backwardFetcherRef.year, 1) } returns emptyList()
             coEvery { paperRepoMock.getPapersByYear(forwardFetcherRef.year, 1) } returns emptyList()
             coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -213,8 +213,12 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns listOf(forwardRef)
                 // fetcherMetadata is empty for both → merged equals DB metadata → no update needed
-                every { paperMatcherMock.mergeMetadata(backwardRef, backwardFetcherRef) } returns emptyMap()
-                every { paperMatcherMock.mergeMetadata(forwardRef, forwardFetcherRef) } returns emptyMap()
+                every {
+                    paperMatcherMock.mergeMetadata(backwardRef.fetcherMetadata, backwardFetcherRef.fetcherMetadata)
+                } returns emptyMap()
+                every {
+                    paperMatcherMock.mergeMetadata(forwardRef.fetcherMetadata, forwardFetcherRef.fetcherMetadata)
+                } returns emptyMap()
 
                 // Stop at paper citation
                 coEvery {
@@ -260,8 +264,12 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                 coEvery {
                     paperMatcherMock.findMatch(forwardFetcherRef, listOf(forwardRef), project.similarityThreshold)
                 } returns forwardRef
-                every { paperMatcherMock.mergeMetadata(backwardRef, backwardFetcherRef) } returns metadata
-                every { paperMatcherMock.mergeMetadata(forwardRef, forwardFetcherRef) } returns metadata
+                every {
+                    paperMatcherMock.mergeMetadata(backwardRef.fetcherMetadata, backwardFetcherRef.fetcherMetadata)
+                } returns metadata
+                every {
+                    paperMatcherMock.mergeMetadata(forwardRef.fetcherMetadata, forwardFetcherRef.fetcherMetadata)
+                } returns metadata
                 coJustRun { paperRepoMock.updateFetcherMetadata(backwardRef.id, metadata) }
                 coJustRun { paperRepoMock.updateFetcherMetadata(forwardRef.id, metadata) }
 
@@ -312,8 +320,12 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
                     paperRepoMock.getPapersByExternalIds(forwardRef.externalIds)
                 } returns listOf(forwardRef, forwardRef2)
                 // fetcherMetadata is empty for both → merged equals DB metadata → no update needed
-                every { paperMatcherMock.mergeMetadata(backwardRef, backwardFetcherRef) } returns emptyMap()
-                every { paperMatcherMock.mergeMetadata(forwardRef, forwardFetcherRef) } returns emptyMap()
+                every {
+                    paperMatcherMock.mergeMetadata(backwardRef.fetcherMetadata, backwardFetcherRef.fetcherMetadata)
+                } returns emptyMap()
+                every {
+                    paperMatcherMock.mergeMetadata(forwardRef.fetcherMetadata, forwardFetcherRef.fetcherMetadata)
+                } returns emptyMap()
 
                 // Stop at paper citation
                 coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -512,6 +512,49 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
 
             assertPaperCitationFailure()
         }
+
+        @Test
+        fun `When multiple refs share a year, then the candidates for that year are loaded once`() =
+            runOrchestratorTest { orchestrator ->
+                val job = DataBuilder.createExampleFetcherEnqueueJob()
+                val project = DataBuilder.createExampleProject(fetchers = exampleFetchers)
+                val firstRef = DataBuilder.createExamplePaper(
+                    title = "First",
+                    year = 2012,
+                    externalIds = emptyList(),
+                )
+                val secondRef = DataBuilder.createExamplePaper(
+                    title = "Second",
+                    year = 2012,
+                    externalIds = emptyList(),
+                )
+                val firstFetcherRef = firstRef.toFetcherPaper()
+                val secondFetcherRef = secondRef.toFetcherPaper()
+                val refs = setOf(firstFetcherRef, secondFetcherRef)
+                val candidates = listOf(DataBuilder.createExamplePaper(year = 2012))
+
+                mockRunFetching(job, refs, emptySet())
+                every { paperMatcherMock.deduplicatePapers(refs, any()) } returns refs
+                every { paperMatcherMock.deduplicatePapers(emptySet(), any()) } returns emptySet()
+                every { paperMatcherMock.config.yearTolerance } returns 1
+                coEvery { paperRepoMock.getPapersByYear(2012, 1) } returns candidates
+                coEvery { paperMatcherMock.findMatch(any(), candidates, project.similarityThreshold) } returns null
+                coEvery { paperRepoMock.createPaper(any()) } returns firstRef andThen secondRef
+
+                // Stop at adding papers to project
+                coJustRun { citationRepoMock.addBackwardReferencedPaper(job.projectPaper.paperId, any()) }
+                coEvery {
+                    projectPaperRepoMock.doesProjectPaperExist(project.id, any())
+                } throws TestSpecificException()
+
+                orchestrator.enqueueTestJob(job, project)
+
+                assertAddingPapersToProjectFailure()
+                coVerify(exactly = 2) { paperRepoMock.createPaper(any()) }
+                // Both refs are scored, but the year window is only loaded once
+                coVerify(exactly = 2) { paperMatcherMock.findMatch(any(), candidates, project.similarityThreshold) }
+                coVerify(exactly = 1) { paperRepoMock.getPapersByYear(2012, 1) }
+            }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorProcessJobTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -25,7 +24,6 @@ import se.uulm.snowballr.backend.repository.UNIQUE_CONSTRAINT_VIOLATION_SQL_STAT
 import java.sql.SQLException
 import java.util.UUID
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
     private val exampleFetchers = mapOf(
         "foo" to mapOf(
@@ -368,6 +366,8 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
             every { paperMatcherMock.config.yearTolerance } returns 1
             coEvery { paperRepoMock.getPapersByYear(backwardRef.year, 1) } returns emptyList()
             coEvery { paperRepoMock.getPapersByYear(forwardRef.year, 1) } returns emptyList()
+            coEvery { paperMatcherMock.findMatch(backwardFetcherRef, emptyList(), any()) } returns null
+            coEvery { paperMatcherMock.findMatch(forwardFetcherRef, emptyList(), any()) } returns null
             coEvery {
                 paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
             } returns backwardRef
@@ -487,6 +487,8 @@ class FetcherOrchestratorProcessJobTest : FetcherOrchestratorTest() {
             every { paperMatcherMock.config.yearTolerance } returns 1
             coEvery { paperRepoMock.getPapersByYear(backwardFetcherRef.year, 1) } returns emptyList()
             coEvery { paperRepoMock.getPapersByYear(forwardFetcherRef.year, 1) } returns emptyList()
+            coEvery { paperMatcherMock.findMatch(backwardFetcherRef, emptyList(), any()) } returns null
+            coEvery { paperMatcherMock.findMatch(forwardFetcherRef, emptyList(), any()) } returns null
             coEvery {
                 paperRepoMock.createPaper(CreatePaperRequest.fromFetcherPaper(backwardFetcherRef))
             } throws SQLException("Creating backward paper failed")

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorStartStopTest.kt
@@ -1,12 +1,10 @@
 package se.uulm.snowballr.backend.fetcher.orchestrator
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FetcherOrchestratorStartStopTest : FetcherOrchestratorTest() {
     @Test
     fun `When the orchestrator is started and stopped, then no exception is thrown`() = runTest {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -137,6 +137,7 @@ sealed class FetcherOrchestratorTest {
         // No year-based candidates → falls through to createPaper
         for (ref in backwardFetcherRefs + forwardFetcherRefs) {
             coEvery { paperRepoMock.getPapersByYear(ref.year, 1) } returns emptyList()
+            coEvery { paperMatcherMock.findMatch(ref, emptyList(), any()) } returns null
         }
 
         for (backwardRef in backwardRefs) {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -5,6 +5,7 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.AfterEach
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.fetcher.FetcherOrchestrator
 import se.uulm.snowballr.backend.fetcher.IFetcherManager
+import se.uulm.snowballr.backend.matching.IPaperMatcher
 import se.uulm.snowballr.backend.model.dto.paper.Paper
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
 import se.uulm.snowballr.backend.model.fetcher.FetcherEnqueueJob
@@ -31,6 +33,7 @@ sealed class FetcherOrchestratorTest {
     val paperRepoMock = mockk<IPaperTableRepo>()
     val citationRepoMock = mockk<ICitationTableRepo>()
     val projectPaperRepoMock = mockk<IProjectPaperTableRepo>()
+    val paperMatcherMock = mockk<IPaperMatcher>()
 
     private val allMocks = arrayOf(
         fetcherManagerMock,
@@ -38,6 +41,7 @@ sealed class FetcherOrchestratorTest {
         paperRepoMock,
         citationRepoMock,
         projectPaperRepoMock,
+        paperMatcherMock,
     )
 
     @AfterEach
@@ -60,6 +64,7 @@ sealed class FetcherOrchestratorTest {
         paperRepo = paperRepoMock,
         citationRepo = citationRepoMock,
         projectPaperRepo = projectPaperRepoMock,
+        paperMatcher = paperMatcherMock,
         dispatcher = UnconfinedTestDispatcher(scheduler),
     )
 
@@ -122,6 +127,16 @@ sealed class FetcherOrchestratorTest {
         val forwardFetcherRefs = forwardRefs.map(Paper::toFetcherPaper).toSet()
 
         mockRunFetching(job, backwardFetcherRefs, forwardFetcherRefs)
+
+        // Deduplication passes through
+        every { paperMatcherMock.deduplicatePapers(backwardFetcherRefs, any()) } returns backwardFetcherRefs
+        every { paperMatcherMock.deduplicatePapers(forwardFetcherRefs, any()) } returns forwardFetcherRefs
+
+        // No year-based candidates → falls through to createPaper
+        for (ref in backwardFetcherRefs + forwardFetcherRefs) {
+            coEvery { paperRepoMock.getPapersByYear(ref.year, 1) } returns emptyList()
+        }
+
         for (backwardRef in backwardRefs) {
             val backwardFetcherRef = backwardRef.toFetcherPaper()
             coEvery {

--- a/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/fetcher/orchestrator/FetcherOrchestratorTest.kt
@@ -132,6 +132,8 @@ sealed class FetcherOrchestratorTest {
         every { paperMatcherMock.deduplicatePapers(backwardFetcherRefs, any()) } returns backwardFetcherRefs
         every { paperMatcherMock.deduplicatePapers(forwardFetcherRefs, any()) } returns forwardFetcherRefs
 
+        every { paperMatcherMock.config.yearTolerance } returns 1
+
         // No year-based candidates → falls through to createPaper
         for (ref in backwardFetcherRefs + forwardFetcherRefs) {
             coEvery { paperRepoMock.getPapersByYear(ref.year, 1) } returns emptyList()

--- a/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/integration/regression/RegressionTest.kt
@@ -53,7 +53,7 @@ class RegressionTest : IntegrationTest() {
                 val request = CreatePaperRequest.fromPaper(
                     DataBuilder.createExamplePaper(
                         title = "Paper $i",
-                        externalIds = listOf(ExternalId(ExternalIdType.URL, "External ID $i")),
+                        externalIds = listOf(ExternalId(ExternalIdType.DOI, "External ID $i")),
                     ),
                 )
                 papers += paperService.createPaper(request)

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/LevenshteinTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/LevenshteinTest.kt
@@ -1,0 +1,133 @@
+package se.uulm.snowballr.backend.matching
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class LevenshteinTest {
+    companion object {
+        @JvmStatic
+        fun distanceExamples(): List<Arguments> = listOf(
+            Arguments.of("kitten", "sitting", 3),
+            Arguments.of("flaw", "lawn", 2),
+            Arguments.of("intention", "execution", 5),
+            Arguments.of("abc", "abd", 1),
+            Arguments.of("abc", "abcd", 1),
+            Arguments.of("abcd", "abc", 1),
+            Arguments.of("abc", "ab", 1),
+            Arguments.of("book", "back", 2),
+            Arguments.of("a", "b", 1),
+        )
+
+        @JvmStatic
+        fun identicalStringExamples(): List<Arguments> = listOf(
+            Arguments.of(""),
+            Arguments.of("a"),
+            Arguments.of("abc"),
+            Arguments.of("Hello, World!"),
+        )
+
+        @JvmStatic
+        fun caseSensitivityExamples(): List<Arguments> = listOf(
+            Arguments.of("abc", "ABC", 3),
+            Arguments.of("Abc", "abc", 1),
+        )
+
+        @JvmStatic
+        fun normalizedDistanceExamples(): List<Arguments> = listOf(
+            Arguments.of("abc", "abc", 1.0),
+            Arguments.of("abc", "abd", 1.0 - 1.0 / 3.0),
+            Arguments.of("a", "b", 0.0),
+            Arguments.of("abc", "xyz", 0.0),
+            Arguments.of("abc", "", 0.0),
+            Arguments.of("", "abc", 0.0),
+            Arguments.of("kitten", "sitting", 1.0 - 3.0 / 7.0),
+        )
+    }
+
+    @Nested
+    inner class GetDistance {
+        @Test
+        fun `When both strings are empty, then distance is zero`() {
+            val score = Levenshtein.getDistance("", "")
+
+            assertEquals(0, score)
+        }
+
+        @Test
+        fun `When the first string is empty, then distance equals the second string length`() {
+            val score = Levenshtein.getDistance("", "abc")
+
+            assertEquals(3, score)
+        }
+
+        @Test
+        fun `When the second string is empty, then distance equals the first string length`() {
+            val score = Levenshtein.getDistance("abc", "")
+
+            assertEquals(3, score)
+        }
+
+        @ParameterizedTest(name = "distance({0}, {0}) == 0")
+        @MethodSource("se.uulm.snowballr.backend.matching.LevenshteinTest#identicalStringExamples")
+        fun `When both strings are identical, then distance is zero`(value: String) {
+            val score = Levenshtein.getDistance(value, value)
+
+            assertEquals(0, score)
+        }
+
+        @ParameterizedTest(name = "distance({0}, {1}) == {2}")
+        @MethodSource("se.uulm.snowballr.backend.matching.LevenshteinTest#distanceExamples")
+        fun `When strings differ, then the expected edit distance is returned`(a: String, b: String, expected: Int) {
+            val score = Levenshtein.getDistance(a, b)
+
+            assertEquals(expected, score)
+        }
+
+        @ParameterizedTest(name = "distance({0}, {1}) == {2}")
+        @MethodSource("se.uulm.snowballr.backend.matching.LevenshteinTest#caseSensitivityExamples")
+        fun `When strings only differ in casing, then casing is treated as a difference`(
+            a: String,
+            b: String,
+            expected: Int,
+        ) {
+            val score = Levenshtein.getDistance(a, b)
+
+            assertEquals(expected, score)
+        }
+
+        @ParameterizedTest(name = "distance({0}, {1}) == distance({1}, {0})")
+        @MethodSource("se.uulm.snowballr.backend.matching.LevenshteinTest#distanceExamples")
+        fun `When arguments are swapped, then distance is symmetric`(a: String, b: String) {
+            val score = Levenshtein.getDistance(a, b)
+            val swappedScore = Levenshtein.getDistance(b, a)
+
+            assertEquals(score, swappedScore)
+        }
+    }
+
+    @Nested
+    inner class GetNormalizedDistance {
+        @Test
+        fun `When both strings are empty, then normalized distance is one`() {
+            val score = Levenshtein.getNormalizedDistance("", "")
+
+            assertEquals(1.0, score)
+        }
+
+        @ParameterizedTest(name = "normalizedDistance({0}, {1}) == {2}")
+        @MethodSource("se.uulm.snowballr.backend.matching.LevenshteinTest#normalizedDistanceExamples")
+        fun `When strings are compared, then the expected normalized distance is returned`(
+            a: String,
+            b: String,
+            expected: Double,
+        ) {
+            val score = Levenshtein.getNormalizedDistance(a, b)
+
+            assertEquals(expected, score, 1e-9)
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -1,11 +1,11 @@
 package se.uulm.snowballr.backend.matching
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.ExternalId
@@ -152,7 +152,7 @@ class PaperMatcherTest {
             val candidate = DataBuilder.createExamplePaper(title = "Deep Learning", year = 2020)
             val result = matcher.findMatch(fetched, listOf(candidate), 0.5f)
             assertNotNull(result)
-            assertEquals(candidate.id, result!!.id)
+            assertEquals(candidate.id, result.id)
         }
 
         @Test
@@ -167,7 +167,7 @@ class PaperMatcherTest {
             val poor = DataBuilder.createExamplePaper(title = "Machine Learning", year = 2020)
             val result = matcher.findMatch(fetched, listOf(poor, good), 0.5f)
             assertNotNull(result)
-            assertEquals(good.id, result!!.id)
+            assertEquals(good.id, result.id)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -406,25 +406,25 @@ class PaperMatcherTest {
     @Nested
     inner class MergeMetadata {
         @Test
-        fun `When fetched and DB metadata have disjoint and overlapping keys, then DB wins on conflict`() {
-            val dbPaper = DataBuilder.createExamplePaper(fetcherMetadata = mapOf("b" to "DB", "c" to "3"))
-            val fetched = DataBuilder.createExampleFetcherPaper(fetcherMetadata = mapOf("a" to "1", "b" to "2"))
-            val result = matcher.mergeMetadata(dbPaper, fetched)
+        fun `When fetched and existing metadata have disjoint and overlapping keys, then existing wins on conflict`() {
+            val existing = mapOf("b" to "DB", "c" to "3")
+            val fetched = mapOf("a" to "1", "b" to "2")
+            val result = matcher.mergeMetadata(existing, fetched)
             assertEquals(mapOf("a" to "1", "b" to "DB", "c" to "3"), result)
         }
 
         @Test
-        fun `When fetched metadata is empty, then DB metadata is returned unchanged`() {
-            val dbPaper = DataBuilder.createExamplePaper(fetcherMetadata = mapOf("x" to "1"))
-            val fetched = DataBuilder.createExampleFetcherPaper(fetcherMetadata = emptyMap())
-            assertEquals(mapOf("x" to "1"), matcher.mergeMetadata(dbPaper, fetched))
+        fun `When fetched metadata is empty, then existing metadata is returned unchanged`() {
+            val existing = mapOf("x" to "1")
+            val fetched = emptyMap<String, String>()
+            assertEquals(mapOf("x" to "1"), matcher.mergeMetadata(existing, fetched))
         }
 
         @Test
-        fun `When DB metadata is empty, then fetched metadata is returned`() {
-            val dbPaper = DataBuilder.createExamplePaper(fetcherMetadata = emptyMap())
-            val fetched = DataBuilder.createExampleFetcherPaper(fetcherMetadata = mapOf("a" to "1"))
-            assertEquals(mapOf("a" to "1"), matcher.mergeMetadata(dbPaper, fetched))
+        fun `When existing metadata is empty, then fetched metadata is returned`() {
+            val existing = emptyMap<String, String>()
+            val fetched = mapOf("a" to "1")
+            assertEquals(mapOf("a" to "1"), matcher.mergeMetadata(existing, fetched))
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -15,6 +15,7 @@ import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.ExternalId
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
 import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
+import java.time.OffsetDateTime
 
 private const val DELTA = 1e-9
 
@@ -447,6 +448,24 @@ class PaperMatcherTest {
             )
 
             assertNull(matcher.findMatch(fetched, listOf(unrelatedCandidate), 0.85f))
+        }
+
+        @Test
+        fun `When two candidates share the same score, then the one with the earlier creation date is returned`() {
+            val fetched = DataBuilder.createExampleFetcherPaper(title = "Quantum Computing")
+            val candidate1 = DataBuilder.createExamplePaper(
+                title = "Quack Computing",
+                createdAt = OffsetDateTime.parse("2025-03-12T12:00:00+00:00"),
+            )
+            val candidate2 = DataBuilder.createExamplePaper(
+                title = "Quack Computing",
+                createdAt = OffsetDateTime.parse("2024-03-12T12:00:00+00:00"),
+            )
+
+            val match = matcher.findMatch(fetched, listOf(candidate1, candidate2), 0.2f)
+
+            assertNotNull(match)
+            assertEquals(candidate2, match)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -449,29 +449,4 @@ class PaperMatcherTest {
             assertNull(matcher.findMatch(fetched, listOf(unrelatedCandidate), 0.85f))
         }
     }
-
-    @Nested
-    inner class MergeMetadata {
-        @Test
-        fun `When fetched and existing metadata have disjoint and overlapping keys, then existing wins on conflict`() {
-            val existing = mapOf("b" to "DB", "c" to "3")
-            val fetched = mapOf("a" to "1", "b" to "2")
-            val result = matcher.mergeMetadata(existing, fetched)
-            assertEquals(mapOf("a" to "1", "b" to "DB", "c" to "3"), result)
-        }
-
-        @Test
-        fun `When fetched metadata is empty, then existing metadata is returned unchanged`() {
-            val existing = mapOf("x" to "1")
-            val fetched = emptyMap<String, String>()
-            assertEquals(mapOf("x" to "1"), matcher.mergeMetadata(existing, fetched))
-        }
-
-        @Test
-        fun `When existing metadata is empty, then fetched metadata is returned`() {
-            val existing = emptyMap<String, String>()
-            val fetched = mapOf("a" to "1")
-            assertEquals(mapOf("a" to "1"), matcher.mergeMetadata(existing, fetched))
-        }
-    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.dto.paper.Author
@@ -68,14 +69,30 @@ class PaperMatcherTest {
             assertTrue(matcher.similarity(a, b) > 0.0)
         }
 
-        @Test
-        fun `When both author lists are empty, then authors component is dropped`() {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "' ',John Doe",
+                "John Doe,' '",
+                "' ',' '",
+            ],
+        )
+        fun `When at least one author list is empty, then authors component is dropped`(
+            authorA: String,
+            authorB: String,
+        ) {
+            val authorsA = authorA.split(';').filter { it.isNotBlank() }.map { Author(it, "") }
+            val authorsB = authorB.split(';').filter { it.isNotBlank() }.map { Author("", it) }
             val a1 = DataBuilder.createExampleFetcherPaper(
                 title = "Some random title",
-                authors = emptyList(),
+                authors = authorsA,
                 abstract = "Some random abstract",
             )
-            val b1 = a1.copy(title = a1.title.reversed(), abstract = a1.abstract.reversed())
+            val b1 = DataBuilder.createExampleFetcherPaper(
+                title = a1.title.reversed(),
+                authors = authorsB,
+                abstract = a1.abstract.reversed(),
+            )
             val emptyResult = matcher.similarity(a1, b1)
 
             val altMatcher = PaperMatcher(defaultConfig.copy(authorsWeight = 0.0))
@@ -223,6 +240,36 @@ class PaperMatcherTest {
             )
 
             assertEquals(noIdsResult, urlResult, DELTA)
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "' ',Example Title",
+                "Example Title,' '",
+                "' ',' '",
+            ],
+        )
+        fun `When at least one paper has a blank title, then title component is dropped`(
+            titleA: String,
+            titleB: String,
+        ) {
+            val authors = listOf(Author("John", "Doe"))
+            val a1 = DataBuilder.createExampleFetcherPaper(
+                title = titleA,
+                authors = authors,
+                abstract = "Some random abstract",
+            )
+            val b1 = a1.copy(title = titleB, abstract = a1.abstract.reversed())
+            val emptyResult = matcher.similarity(a1, b1)
+
+            val altMatcher = PaperMatcher(defaultConfig.copy(titleWeight = 0.0))
+            val a2 = a1.copy(title = "Some random title")
+            val b2 = b1.copy(title = "Title random some")
+            val noWeightResult = altMatcher.similarity(a2, b2)
+
+            // Dropping title is the same as not weighing its similarity
+            assertEquals(noWeightResult, emptyResult, DELTA)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -371,6 +371,26 @@ class PaperMatcherTest {
             assertEquals(1, result.size)
             assertThat(result.first().externalIds).contains(ExternalId(ExternalIdType.URL, "https://a.example"))
         }
+
+        @Test
+        fun `When the first paper has an unknown year, then the merged paper keeps the known year`() {
+            val sharedExternalId = listOf(ExternalId(ExternalIdType.DOI, "10.1234/5678"))
+            val withoutYear = DataBuilder.createExampleFetcherPaper(
+                title = "Deep Learning",
+                externalIds = sharedExternalId,
+                year = 0,
+            )
+            val withYear = DataBuilder.createExampleFetcherPaper(
+                title = "Deep Learning",
+                externalIds = sharedExternalId,
+                year = 2020,
+            )
+
+            val result = matcher.deduplicatePapers(linkedSetOf(withoutYear, withYear), 0.5f)
+
+            assertEquals(1, result.size)
+            assertEquals(2020, result.first().year)
+        }
     }
 
     @Nested

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -1,21 +1,38 @@
 package se.uulm.snowballr.backend.matching
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import se.uulm.snowballr.backend.DataBuilder
 import se.uulm.snowballr.backend.model.dto.paper.Author
 import se.uulm.snowballr.backend.model.dto.paper.ExternalId
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
+import se.uulm.snowballr.backend.model.dto.paper.toFetcherPaper
 
 private const val DELTA = 1e-9
 
 class PaperMatcherTest {
     private val defaultConfig = PaperMatchingConfig(1, 0.6, 0.3, 0.1)
     private val matcher = PaperMatcher(defaultConfig)
+    private val titleOnlyMatcher = PaperMatcher(PaperMatchingConfig(1, 1.0, 0.0, 0.0))
+
+    /**
+     * Creates two strings with a target similarity in [0, 100].
+     */
+    private fun getSimilarStrings(similarity: Int): Pair<String, String> {
+        require(similarity in 1..100)
+
+        val a = "a".repeat(100)
+        val b = "b".repeat(100 - similarity) + "a".repeat(similarity)
+
+        return Pair(a, b)
+    }
 
     @Nested
     inner class Similarity {
@@ -119,6 +136,56 @@ class PaperMatcherTest {
             val b = DataBuilder.createExampleFetcherPaper(title = "Deep Learning for NLP")
             assertEquals(1.0, matcher.similarity(a, b), DELTA)
         }
+
+        @Test
+        fun `When authors have blank names, then they do not contribute to the authors score`() {
+            val blankAuthors = listOf(Author("", ""))
+            val withBlankAuthors1 = DataBuilder.createExampleFetcherPaper(
+                title = "Quantum Computing",
+                abstract = "",
+                authors = blankAuthors,
+            )
+            val withBlankAuthors2 = DataBuilder.createExampleFetcherPaper(
+                title = "Medieval History",
+                abstract = "",
+                authors = blankAuthors,
+            )
+
+            val blankResult = matcher.similarity(withBlankAuthors1, withBlankAuthors2)
+            val emptyResult = matcher.similarity(
+                withBlankAuthors1.copy(authors = emptyList()),
+                withBlankAuthors2.copy(authors = emptyList()),
+            )
+
+            assertEquals(emptyResult, blankResult, DELTA)
+        }
+
+        @Test
+        fun `When both papers carry a blank external ID value, then it is not treated as an identity`() {
+            val blankExternalId = listOf(ExternalId(ExternalIdType.DOI, ""))
+            val a = DataBuilder.createExampleFetcherPaper(
+                title = "Quantum Computing",
+                abstract = "",
+                authors = emptyList(),
+                externalIds = blankExternalId,
+                year = 1990,
+            )
+            val b = DataBuilder.createExampleFetcherPaper(
+                title = "Medieval History",
+                abstract = "",
+                authors = emptyList(),
+                externalIds = blankExternalId,
+                year = 2020,
+            )
+
+            val blankResult = matcher.similarity(a, b)
+            val emptyResult = matcher.similarity(
+                a.copy(externalIds = emptyList()),
+                b.copy(externalIds = emptyList()),
+            )
+
+            assertEquals(emptyResult, blankResult, DELTA)
+        }
     }
 
     @Nested
@@ -173,6 +240,51 @@ class PaperMatcherTest {
             assertEquals(1, result.size)
             assertEquals("v1", result.first().fetcherMetadata["k"])
         }
+
+        @ParameterizedTest
+        @ValueSource(ints = [42, 69, 85, 100])
+        fun `When two papers score exactly at the threshold, then they are merged`(similarityInt: Int) {
+            val similarity = similarityInt / 100.0
+            val (titleA, titleB) = getSimilarStrings(similarityInt)
+
+            val a = DataBuilder.createExampleFetcherPaper(
+                title = titleA,
+                abstract = "",
+                authors = emptyList(),
+            )
+            val b = DataBuilder.createExampleFetcherPaper(
+                title = titleB,
+                abstract = "",
+                authors = emptyList(),
+            )
+            // Guard: the pair really does score exactly at the threshold
+            assertEquals(similarity, titleOnlyMatcher.similarity(a, b), DELTA)
+
+            val result = titleOnlyMatcher.deduplicatePapers(linkedSetOf(a, b), similarity.toFloat())
+
+            assertEquals(1, result.size)
+        }
+
+        @Test
+        fun `When papers have different external IDs of the same type, then the first is kept`() {
+            val a = DataBuilder.createExampleFetcherPaper(
+                title = "Deep Learning",
+                abstract = "",
+                authors = emptyList(),
+                externalIds = listOf(ExternalId(ExternalIdType.URL, "https://a.example")),
+            )
+            val b = DataBuilder.createExampleFetcherPaper(
+                title = "Deep Learning",
+                abstract = "",
+                authors = emptyList(),
+                externalIds = listOf(ExternalId(ExternalIdType.URL, "https://b.example")),
+            )
+
+            val result = matcher.deduplicatePapers(linkedSetOf(a, b), 0.5f)
+
+            assertEquals(1, result.size)
+            assertThat(result.first().externalIds).contains(ExternalId(ExternalIdType.URL, "https://a.example"))
+        }
     }
 
     @Nested
@@ -205,6 +317,51 @@ class PaperMatcherTest {
             val result = matcher.findMatch(fetched, listOf(poor, good), 0.5f)
             assertNotNull(result)
             assertEquals(good.id, result.id)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [42, 69, 85, 100])
+        fun `When a candidate scores exactly at the threshold, then it is returned`(similarityInt: Int) {
+            val similarity = similarityInt / 100.0
+            val (titleA, titleB) = getSimilarStrings(similarityInt)
+
+            val fetched = DataBuilder.createExampleFetcherPaper(
+                title = titleA,
+                abstract = "",
+                authors = emptyList(),
+            )
+            val candidate = DataBuilder.createExamplePaper(
+                title = titleB,
+                abstract = "",
+                authors = emptyList(),
+            )
+            // Guard: the pair really does score exactly at the threshold
+            assertEquals(similarity, titleOnlyMatcher.similarity(fetched, candidate.toFetcherPaper()), DELTA)
+
+            val result = titleOnlyMatcher.findMatch(fetched, listOf(candidate), similarity.toFloat())
+
+            assertNotNull(result)
+        }
+
+        @Test
+        fun `When a candidate shares only a blank external ID, then it is not matched`() {
+            val blankExternalId = listOf(ExternalId(ExternalIdType.DOI, ""))
+            val fetched = DataBuilder.createExampleFetcherPaper(
+                title = "Quantum Computing",
+                abstract = "",
+                authors = emptyList(),
+                externalIds = blankExternalId,
+                year = 2020,
+            )
+            val unrelatedCandidate = DataBuilder.createExamplePaper(
+                title = "Medieval History",
+                abstract = "",
+                authors = emptyList(),
+                externalIds = blankExternalId,
+                year = 1850,
+            )
+
+            assertNull(matcher.findMatch(fetched, listOf(unrelatedCandidate), 0.85f))
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -1,0 +1,198 @@
+package se.uulm.snowballr.backend.matching
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import se.uulm.snowballr.backend.DataBuilder
+import se.uulm.snowballr.backend.model.dto.paper.Author
+import se.uulm.snowballr.backend.model.dto.paper.ExternalId
+import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
+
+private const val DELTA = 1e-9
+
+class PaperMatcherTest {
+    private val matcher = PaperMatcher()
+
+    @Nested
+    inner class Similarity {
+        @Test
+        fun `When both papers share an External ID, then similarity is 1`() {
+            val externalIds = listOf(ExternalId(ExternalIdType.DOI, "doi:10.1/abc"))
+            val a = DataBuilder.createExampleFetcherPaper(externalIds = externalIds)
+            val b = DataBuilder.createExampleFetcherPaper(externalIds = externalIds)
+            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When both papers share an External ID, but also have others, then similarity is 1`() {
+            val sameExternalId = ExternalId(ExternalIdType.DOI, "doi:10.1/abc")
+            val externalId1 = ExternalId(ExternalIdType.SEMANTIC_SCHOLAR, "12345")
+            val externalId2 = ExternalId(ExternalIdType.URL, "https://example.com")
+            val a = DataBuilder.createExampleFetcherPaper(externalIds = listOf(sameExternalId, externalId1))
+            val b = DataBuilder.createExampleFetcherPaper(externalIds = listOf(externalId2, sameExternalId))
+            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When years differ by more than 1, then similarity is 0`() {
+            val a = DataBuilder.createExampleFetcherPaper(year = 2000)
+            val b = DataBuilder.createExampleFetcherPaper(year = 2002)
+            assertEquals(0.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When years differ by exactly 1, then similarity is positive`() {
+            val a = DataBuilder.createExampleFetcherPaper(year = 2000)
+            val b = DataBuilder.createExampleFetcherPaper(year = 2001)
+            assertTrue(matcher.similarity(a, b) > 0.0)
+        }
+
+        @Test
+        fun `When both author lists are empty, then authors component is dropped`() {
+            // Only title (no abstract, no authors): weight 0.6/0.6 = 1.0
+            val a = DataBuilder.createExampleFetcherPaper(title = "X", authors = emptyList())
+            val b = DataBuilder.createExampleFetcherPaper(title = "X", authors = emptyList())
+            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When one abstract is blank, then abstract component is dropped`() {
+            // Title + Authors, no abstract; weights 0.6 + 0.3 = 0.9
+            val authors = listOf(Author("Alice", "Smith"))
+            val a = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "Some text", authors = authors)
+            val b = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "", authors = authors)
+            // abstract dropped; title=1.0 (weight 0.6/0.9) + authors=1.0 (weight 0.3/0.9) = 1.0
+            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When both abstracts are blank, then only title and authors contribute`() {
+            val authors = listOf(Author("Bob", "Jones"))
+            val a = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "", authors = authors)
+            val b = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "", authors = authors)
+            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When titles are identical, then title score is 1`() {
+            val a = DataBuilder.createExampleFetcherPaper(title = "Deep Learning for NLP")
+            val b = DataBuilder.createExampleFetcherPaper(title = "Deep Learning for NLP")
+            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+        }
+    }
+
+    @Nested
+    inner class DeduplicatePapers {
+        @Test
+        fun `When input is empty, then result is empty`() {
+            val result = matcher.deduplicatePapers(emptySet(), 0.8f)
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        fun `When input has a single paper, then it is returned unchanged`() {
+            val p = DataBuilder.createExampleFetcherPaper(title = "Solo")
+            val result = matcher.deduplicatePapers(setOf(p), 0.8f)
+            assertEquals(setOf(p), result)
+        }
+
+        @Test
+        fun `When two papers are similar above threshold, then they are merged into one`() {
+            val a = DataBuilder.createExampleFetcherPaper(title = "Deep Learning Approaches")
+            val b = DataBuilder.createExampleFetcherPaper(title = "Deep Learning Approach")
+            // similarity > 0 and should exceed a low threshold
+            val result = matcher.deduplicatePapers(setOf(a, b), 0.5f)
+            assertEquals(1, result.size)
+        }
+
+        @Test
+        fun `When two papers are dissimilar below threshold, then both are returned`() {
+            val a = DataBuilder.createExampleFetcherPaper(title = "Quantum Computing")
+            val b = DataBuilder.createExampleFetcherPaper(title = "Medieval History")
+            val result = matcher.deduplicatePapers(setOf(a, b), 0.85f)
+            assertEquals(2, result.size)
+        }
+
+        @Test
+        fun `When A is similar to B and B is similar to C but A is not similar to C, then greedy grouping applies`() {
+            // A and B merge; C is dissimilar to A (the group representative) → new group
+            val a = DataBuilder.createExampleFetcherPaper(title = "aaa bbb")
+            val b = DataBuilder.createExampleFetcherPaper(title = "aaa bbc") // similar to a
+            val c = DataBuilder.createExampleFetcherPaper(title = "zzz yyy") // dissimilar to a
+            // Use ordered set so iteration order is stable: a, b, c
+            val ordered = linkedSetOf(a, b, c)
+            val result = matcher.deduplicatePapers(ordered, 0.5f)
+            assertEquals(2, result.size)
+        }
+
+        @Test
+        fun `When two papers have conflicting metadata keys, then the first paper's value wins`() {
+            val a = DataBuilder.createExampleFetcherPaper(title = "Same Title", fetcherMetadata = mapOf("k" to "v1"))
+            val b = DataBuilder.createExampleFetcherPaper(title = "Same Title", fetcherMetadata = mapOf("k" to "v2"))
+            val result = matcher.deduplicatePapers(linkedSetOf(a, b), 0.5f)
+            assertEquals(1, result.size)
+            assertEquals("v1", result.first().fetcherMetadata["k"])
+        }
+    }
+
+    @Nested
+    inner class FindMatch {
+        private val fetched = DataBuilder.createExampleFetcherPaper(title = "Deep Learning", year = 2020)
+
+        @Test
+        fun `When candidates list is empty, then result is null`() {
+            assertNull(matcher.findMatch(fetched, emptyList(), 0.8f))
+        }
+
+        @Test
+        fun `When one candidate is above threshold, then it is returned`() {
+            val candidate = DataBuilder.createExamplePaper(title = "Deep Learning", year = 2020)
+            val result = matcher.findMatch(fetched, listOf(candidate), 0.5f)
+            assertNotNull(result)
+            assertEquals(candidate.id, result!!.id)
+        }
+
+        @Test
+        fun `When one candidate is below threshold, then result is null`() {
+            val candidate = DataBuilder.createExamplePaper(title = "Quantum Physics", year = 2020)
+            assertNull(matcher.findMatch(fetched, listOf(candidate), 0.85f))
+        }
+
+        @Test
+        fun `When multiple candidates exist, then the highest-scoring one above threshold is returned`() {
+            val good = DataBuilder.createExamplePaper(title = "Deep Learning", year = 2020)
+            val poor = DataBuilder.createExamplePaper(title = "Machine Learning", year = 2020)
+            val result = matcher.findMatch(fetched, listOf(poor, good), 0.5f)
+            assertNotNull(result)
+            assertEquals(good.id, result!!.id)
+        }
+    }
+
+    @Nested
+    inner class MergeMetadata {
+        @Test
+        fun `When fetched and DB metadata have disjoint and overlapping keys, then DB wins on conflict`() {
+            val dbPaper = DataBuilder.createExamplePaper(fetcherMetadata = mapOf("b" to "DB", "c" to "3"))
+            val fetched = DataBuilder.createExampleFetcherPaper(fetcherMetadata = mapOf("a" to "1", "b" to "2"))
+            val result = matcher.mergeMetadata(dbPaper, fetched)
+            assertEquals(mapOf("a" to "1", "b" to "DB", "c" to "3"), result)
+        }
+
+        @Test
+        fun `When fetched metadata is empty, then DB metadata is returned unchanged`() {
+            val dbPaper = DataBuilder.createExamplePaper(fetcherMetadata = mapOf("x" to "1"))
+            val fetched = DataBuilder.createExampleFetcherPaper(fetcherMetadata = emptyMap())
+            assertEquals(mapOf("x" to "1"), matcher.mergeMetadata(dbPaper, fetched))
+        }
+
+        @Test
+        fun `When DB metadata is empty, then fetched metadata is returned`() {
+            val dbPaper = DataBuilder.createExamplePaper(fetcherMetadata = emptyMap())
+            val fetched = DataBuilder.createExampleFetcherPaper(fetcherMetadata = mapOf("a" to "1"))
+            assertEquals(mapOf("a" to "1"), matcher.mergeMetadata(dbPaper, fetched))
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -31,7 +31,7 @@ class PaperMatcherTest {
         val a = "a".repeat(100)
         val b = "b".repeat(100 - similarity) + "a".repeat(similarity)
 
-        return Pair(a, b)
+        return a to b
     }
 
     @Nested
@@ -185,6 +185,44 @@ class PaperMatcherTest {
             )
 
             assertEquals(emptyResult, blankResult, DELTA)
+        }
+
+        @Test
+        fun `When both papers have a conflicting external ID, then the similarity is 0`() {
+            val externalIdsA = listOf(
+                ExternalId(ExternalIdType.MAG, "123456"),
+                ExternalId(ExternalIdType.DOI, "10.1234/abcd"),
+            )
+            val externalIdsB = listOf(
+                ExternalId(ExternalIdType.SEMANTIC_SCHOLAR, "123456"),
+                ExternalId(ExternalIdType.DOI, "10.4321/dcba"),
+            )
+            val a = DataBuilder.createExampleFetcherPaper(externalIds = externalIdsA)
+            val b = DataBuilder.createExampleFetcherPaper(externalIds = externalIdsB)
+
+            assertEquals(0.0, matcher.similarity(a, b), DELTA)
+        }
+
+        @Test
+        fun `When both papers have a conflicting URL, then the similarity is determined by the paper components`() {
+            val externalIdsA = listOf(
+                ExternalId(ExternalIdType.MAG, "123456"),
+                ExternalId(ExternalIdType.URL, "https://example.org"),
+            )
+            val externalIdsB = listOf(
+                ExternalId(ExternalIdType.SEMANTIC_SCHOLAR, "123456"),
+                ExternalId(ExternalIdType.URL, "https://redirect-to-example.org"),
+            )
+            val a = DataBuilder.createExampleFetcherPaper(externalIds = externalIdsA)
+            val b = DataBuilder.createExampleFetcherPaper(externalIds = externalIdsB)
+
+            val urlResult = matcher.similarity(a, b)
+            val noIdsResult = matcher.similarity(
+                a.copy(externalIds = emptyList()),
+                b.copy(externalIds = emptyList()),
+            )
+
+            assertEquals(noIdsResult, urlResult, DELTA)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -1,6 +1,5 @@
 package se.uulm.snowballr.backend.matching
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -50,7 +49,7 @@ class PaperMatcherTest {
         fun `When both papers share an External ID, but also have others, then similarity is 1`() {
             val sameExternalId = ExternalId(ExternalIdType.DOI, "doi:10.1/abc")
             val externalId1 = ExternalId(ExternalIdType.SEMANTIC_SCHOLAR, "12345")
-            val externalId2 = ExternalId(ExternalIdType.URL, "https://example.com")
+            val externalId2 = ExternalId(ExternalIdType.MAG, "1234567890")
             val a = DataBuilder.createExampleFetcherPaper(externalIds = listOf(sameExternalId, externalId1))
             val b = DataBuilder.createExampleFetcherPaper(externalIds = listOf(externalId2, sameExternalId))
             assertEquals(1.0, matcher.similarity(a, b), DELTA)
@@ -221,28 +220,6 @@ class PaperMatcherTest {
             assertEquals(0.0, matcher.similarity(a, b), DELTA)
         }
 
-        @Test
-        fun `When both papers have a conflicting URL, then the similarity is determined by the paper components`() {
-            val externalIdsA = listOf(
-                ExternalId(ExternalIdType.MAG, "123456"),
-                ExternalId(ExternalIdType.URL, "https://example.org"),
-            )
-            val externalIdsB = listOf(
-                ExternalId(ExternalIdType.SEMANTIC_SCHOLAR, "123456"),
-                ExternalId(ExternalIdType.URL, "https://redirect-to-example.org"),
-            )
-            val a = DataBuilder.createExampleFetcherPaper(externalIds = externalIdsA)
-            val b = DataBuilder.createExampleFetcherPaper(externalIds = externalIdsB)
-
-            val urlResult = matcher.similarity(a, b)
-            val noIdsResult = matcher.similarity(
-                a.copy(externalIds = emptyList()),
-                b.copy(externalIds = emptyList()),
-            )
-
-            assertEquals(noIdsResult, urlResult, DELTA)
-        }
-
         @ParameterizedTest
         @CsvSource(
             value = [
@@ -349,27 +326,6 @@ class PaperMatcherTest {
             val result = titleOnlyMatcher.deduplicatePapers(linkedSetOf(a, b), similarity.toFloat())
 
             assertEquals(1, result.size)
-        }
-
-        @Test
-        fun `When papers have different external IDs of the same type, then the first is kept`() {
-            val a = DataBuilder.createExampleFetcherPaper(
-                title = "Deep Learning",
-                abstract = "",
-                authors = emptyList(),
-                externalIds = listOf(ExternalId(ExternalIdType.URL, "https://a.example")),
-            )
-            val b = DataBuilder.createExampleFetcherPaper(
-                title = "Deep Learning",
-                abstract = "",
-                authors = emptyList(),
-                externalIds = listOf(ExternalId(ExternalIdType.URL, "https://b.example")),
-            )
-
-            val result = matcher.deduplicatePapers(linkedSetOf(a, b), 0.5f)
-
-            assertEquals(1, result.size)
-            assertThat(result.first().externalIds).contains(ExternalId(ExternalIdType.URL, "https://a.example"))
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/PaperMatcherTest.kt
@@ -14,7 +14,8 @@ import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
 private const val DELTA = 1e-9
 
 class PaperMatcherTest {
-    private val matcher = PaperMatcher()
+    private val defaultConfig = PaperMatchingConfig(1, 0.6, 0.3, 0.1)
+    private val matcher = PaperMatcher(defaultConfig)
 
     @Nested
     inner class Similarity {
@@ -37,14 +38,14 @@ class PaperMatcherTest {
         }
 
         @Test
-        fun `When years differ by more than 1, then similarity is 0`() {
+        fun `When years differ by more than the tolerance, then similarity is 0`() {
             val a = DataBuilder.createExampleFetcherPaper(year = 2000)
             val b = DataBuilder.createExampleFetcherPaper(year = 2002)
             assertEquals(0.0, matcher.similarity(a, b), DELTA)
         }
 
         @Test
-        fun `When years differ by exactly 1, then similarity is positive`() {
+        fun `When years differ by exactly the tolerance, then similarity is positive`() {
             val a = DataBuilder.createExampleFetcherPaper(year = 2000)
             val b = DataBuilder.createExampleFetcherPaper(year = 2001)
             assertTrue(matcher.similarity(a, b) > 0.0)
@@ -52,28 +53,64 @@ class PaperMatcherTest {
 
         @Test
         fun `When both author lists are empty, then authors component is dropped`() {
-            // Only title (no abstract, no authors): weight 0.6/0.6 = 1.0
-            val a = DataBuilder.createExampleFetcherPaper(title = "X", authors = emptyList())
-            val b = DataBuilder.createExampleFetcherPaper(title = "X", authors = emptyList())
-            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+            val a1 = DataBuilder.createExampleFetcherPaper(
+                title = "Some random title",
+                authors = emptyList(),
+                abstract = "Some random abstract",
+            )
+            val b1 = a1.copy(title = a1.title.reversed(), abstract = a1.abstract.reversed())
+            val emptyResult = matcher.similarity(a1, b1)
+
+            val altMatcher = PaperMatcher(defaultConfig.copy(authorsWeight = 0.0))
+            val a2 = a1.copy(authors = listOf(Author("John", "Doe")))
+            val b2 = b1.copy(authors = listOf(Author("John", "Doe")))
+            val noWeightResult = altMatcher.similarity(a2, b2)
+
+            // Dropping authors is the same as not weighing their similarity
+            assertEquals(noWeightResult, emptyResult, DELTA)
         }
 
         @Test
         fun `When one abstract is blank, then abstract component is dropped`() {
-            // Title + Authors, no abstract; weights 0.6 + 0.3 = 0.9
-            val authors = listOf(Author("Alice", "Smith"))
-            val a = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "Some text", authors = authors)
-            val b = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "", authors = authors)
-            // abstract dropped; title=1.0 (weight 0.6/0.9) + authors=1.0 (weight 0.3/0.9) = 1.0
-            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+            val authors1 = listOf(Author("John", "Doe"), Author("Jane", "Doe"))
+            val authors2 = authors1.map { Author(it.lastName.reversed(), it.firstName.reversed()) }
+            val a1 = DataBuilder.createExampleFetcherPaper(
+                title = "Some random title",
+                authors = authors1,
+                abstract = "Some random abstract",
+            )
+            val b1 = a1.copy(title = a1.title.reversed(), abstract = "", authors = authors2)
+            val emptyResult = matcher.similarity(a1, b1)
+
+            val altMatcher = PaperMatcher(defaultConfig.copy(abstractWeight = 0.0))
+            val a2 = a1.copy(abstract = "Paper Abstract")
+            val b2 = b1.copy(abstract = "Paper Abstract")
+            val noWeightResult = altMatcher.similarity(a2, b2)
+
+            // Dropping the abstract is the same as not weighing its similarity
+            assertEquals(noWeightResult, emptyResult, DELTA)
         }
 
         @Test
         fun `When both abstracts are blank, then only title and authors contribute`() {
-            val authors = listOf(Author("Bob", "Jones"))
-            val a = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "", authors = authors)
-            val b = DataBuilder.createExampleFetcherPaper(title = "X", abstract = "", authors = authors)
-            assertEquals(1.0, matcher.similarity(a, b), DELTA)
+            val authors1 = listOf(Author("John", "Doe"), Author("Jane", "Doe"))
+            val authors2 = authors1.map { Author(it.lastName.reversed(), it.firstName.reversed()) }
+            val a1 = DataBuilder.createExampleFetcherPaper(
+                title = "Some random title",
+                authors = authors1,
+                abstract = "",
+            )
+            val b1 = a1.copy(title = a1.title.reversed(), authors = authors2)
+            val emptyResult = matcher.similarity(a1, b1)
+
+            val altMatcher = PaperMatcher(defaultConfig.copy(abstractWeight = 0.0))
+            val a2 = a1.copy(abstract = "Paper Abstract")
+            val b2 = b1.copy(abstract = "Paper Abstract")
+            val noWeightResult = altMatcher.similarity(a2, b2)
+
+            // Dropping the abstract is the same as not weighing its similarity
+            assertEquals(noWeightResult, emptyResult, DELTA)
+            assertTrue(emptyResult > 0 && noWeightResult > 0)
         }
 
         @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/matching/TokenizationTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/matching/TokenizationTest.kt
@@ -1,0 +1,91 @@
+package se.uulm.snowballr.backend.matching
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import se.uulm.snowballr.backend.model.dto.paper.Author
+
+class TokenizationTest {
+    companion object {
+        @JvmStatic
+        fun authorTokensExamples(): List<Arguments> = listOf(
+            Arguments.of(Author("John", "Doe"), setOf("john", "j", "doe", "d")),
+            Arguments.of(Author("Jane", "Doe"), setOf("jane", "j", "doe", "d")),
+            Arguments.of(Author("JOHN", "DOE"), setOf("john", "j", "doe", "d")),
+            Arguments.of(Author("Jean-Paul", "Sartre"), setOf("jeanpaul", "j", "sartre", "s")),
+            Arguments.of(Author("Conan", "O'Brien"), setOf("conan", "c", "obrien", "o")),
+            Arguments.of(Author("Louis", "XIV2"), setOf("louis", "l", "xiv2", "x")),
+            Arguments.of(Author("John", "  Doe"), setOf("john", "j", "doe", "d")),
+            Arguments.of(Author("X", "Yu"), setOf("x", "yu", "y")),
+        )
+
+        @JvmStatic
+        fun blankAuthorExamples(): List<Arguments> = listOf(
+            Arguments.of(Author("", "")),
+            Arguments.of(Author(" ", " ")),
+            Arguments.of(Author("", " ")),
+        )
+    }
+
+    @Nested
+    inner class AuthorTokens {
+        @ParameterizedTest(name = "authorTokens({0}) == {1}")
+        @MethodSource("se.uulm.snowballr.backend.matching.TokenizationTest#authorTokensExamples")
+        fun `When tokens are created for an author, then the expected tokens are returned`(
+            author: Author,
+            expected: Set<String>,
+        ) {
+            val tokens = Tokenization.authorTokens(author)
+
+            assertEquals(expected, tokens)
+        }
+
+        @ParameterizedTest(name = "authorTokens({0}) is empty")
+        @MethodSource("se.uulm.snowballr.backend.matching.TokenizationTest#blankAuthorExamples")
+        fun `When both name fields are blank, then no tokens are returned`(author: Author) {
+            val tokens = Tokenization.authorTokens(author)
+
+            assertEquals(emptySet<String>(), tokens)
+        }
+    }
+
+    @Nested
+    inner class AuthorSetTokens {
+        @Test
+        fun `When the author list is empty, then no tokens are returned`() {
+            val tokens = Tokenization.authorSetTokens(emptyList())
+
+            assertEquals(emptySet<String>(), tokens)
+        }
+
+        @Test
+        fun `When a single author is passed, then the result equals their individual tokens`() {
+            val author = Author("Jane", "Doe")
+
+            val tokens = Tokenization.authorSetTokens(listOf(author))
+
+            assertEquals(Tokenization.authorTokens(author), tokens)
+        }
+
+        @Test
+        fun `When multiple authors share overlapping tokens, then the tokens are merged without duplicates`() {
+            val authors = listOf(Author("John", "Doe"), Author("Jane", "Doe"))
+
+            val tokens = Tokenization.authorSetTokens(authors)
+
+            assertEquals(setOf("john", "j", "doe", "d", "jane"), tokens)
+        }
+
+        @Test
+        fun `When multiple authors have distinct names, then all of their tokens are included`() {
+            val authors = listOf(Author("Alice", "Smith"), Author("Bob", "Jones"))
+
+            val tokens = Tokenization.authorSetTokens(authors)
+
+            assertEquals(setOf("alice", "a", "smith", "s", "bob", "b", "jones", "j"), tokens)
+        }
+    }
+}

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/EnumOrdinalTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/EnumOrdinalTest.kt
@@ -148,7 +148,6 @@ class EnumOrdinalTest {
                     ExternalIdType.PUB_MED_CENTRAL -> 6
                     ExternalIdType.DBLP -> 7
                     ExternalIdType.SEMANTIC_SCHOLAR -> 8
-                    ExternalIdType.URL -> 9
                 }
             assertEquals(expectedOrdinal, value.ordinal)
         }

--- a/src/test/kotlin/se/uulm/snowballr/backend/model/auth/AuthRequestStateTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/model/auth/AuthRequestStateTest.kt
@@ -5,8 +5,8 @@ import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 
 class AuthRequestStateTest {
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -211,7 +211,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
 
             val updatedPaperDetails = paper.copy(
                 title = "Updated Title",
-                externalIds = listOf(ExternalId(ExternalIdType.URL, "https://updated-ex-id.com")),
+                externalIds = listOf(ExternalId(ExternalIdType.MAG, "1234567890")),
                 abstract = "Updated Abstract",
                 year = paper.year - 10,
                 publisher = "Updated Publisher",
@@ -226,7 +226,7 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
             val end = OffsetDateTime.now()
 
             if ("paper.external_ids" in fieldMask) {
-                val updatedExternalId = ExternalId(ExternalIdType.URL, "https://updated-ex-id.com")
+                val updatedExternalId = ExternalId(ExternalIdType.MAG, "1234567890")
                 assertThat(updatedPaper.externalIds).isEqualTo(listOf(updatedExternalId))
             } else {
                 assertThat(updatedPaper.externalIds).isEqualTo(listOf(externalId))
@@ -371,12 +371,12 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
         fun `When a paper is found by one of its external IDs, then all of its external IDs are returned`() = runTest {
             val paperId = insertPaperAndGetId()
             val doi = insertExternalId(paperId, type = ExternalIdType.DOI, value = "10.1234/5678")
-            val url = insertExternalId(paperId, type = ExternalIdType.URL, value = "https://example.com")
+            val mag = insertExternalId(paperId, type = ExternalIdType.MAG, value = "1234567890")
 
             val papers = repo.getPapersByExternalIds(listOf(doi))
 
             assertEquals(1, papers.size)
-            assertThat(papers.first().externalIds).containsExactlyInAnyOrder(doi, url)
+            assertThat(papers.first().externalIds).containsExactlyInAnyOrder(doi, mag)
         }
     }
 
@@ -434,12 +434,12 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
         fun `When a paper is found by year, then all of its external IDs are returned`() = runTest {
             val paperId = insertPaperAndGetId(year = 2020)
             val doi = insertExternalId(paperId, type = ExternalIdType.DOI, value = "10.1234/5678")
-            val url = insertExternalId(paperId, type = ExternalIdType.URL, value = "https://example.com")
+            val mag = insertExternalId(paperId, type = ExternalIdType.MAG, value = "1234567890")
 
             val papers = repo.getPapersByYear(2020, tolerance = 0)
 
             assertEquals(1, papers.size)
-            assertThat(papers.first().externalIds).containsExactlyInAnyOrder(doi, url)
+            assertThat(papers.first().externalIds).containsExactlyInAnyOrder(doi, mag)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -444,36 +444,56 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
     }
 
     @Nested
-    inner class UpdateFetcherMetadata {
+    inner class MergeFetcherMetadata {
         @Test
-        fun `When fetcher metadata is updated, then the stored metadata is replaced`() = runTest {
+        fun `When the merged metadata has new keys, then they are added to the stored metadata`() = runTest {
             val paperId = insertPaperAndGetId(fetcherMetadata = mapOf("old" to "value"))
-            val newMetadata = mapOf("id" to "123", "foo" to "bar")
 
-            repo.updateFetcherMetadata(paperId, newMetadata)
+            repo.mergeFetcherMetadata(paperId, mapOf("id" to "123", "foo" to "bar"))
 
             val paper = repo.getPaperById(paperId).getOrThrow()
-            assertEquals(newMetadata, paper.fetcherMetadata)
+            assertEquals(mapOf("old" to "value", "id" to "123", "foo" to "bar"), paper.fetcherMetadata)
         }
 
         @Test
-        fun `When fetcher metadata is updated, then modifiedAt is not changed`() = runTest {
+        fun `When the merged metadata has a stored key, then the stored value wins`() = runTest {
+            val paperId = insertPaperAndGetId(fetcherMetadata = mapOf("id" to "stored"))
+
+            repo.mergeFetcherMetadata(paperId, mapOf("id" to "fetched"))
+
+            val paper = repo.getPaperById(paperId).getOrThrow()
+            assertEquals(mapOf("id" to "stored"), paper.fetcherMetadata)
+        }
+
+        @Test
+        fun `When fetcher metadata is merged, then modifiedAt is not changed`() = runTest {
             val paperId = insertPaperAndGetId()
 
-            repo.updateFetcherMetadata(paperId, mapOf("id" to "123"))
+            repo.mergeFetcherMetadata(paperId, mapOf("id" to "123"))
 
             val paper = repo.getPaperById(paperId).getOrThrow()
             assertNull(paper.modifiedAt)
         }
 
         @Test
-        fun `When fetcher metadata is updated with an empty map, then the metadata is cleared`() = runTest {
+        fun `When fetcher metadata is merged with an empty map, then the stored metadata is unchanged`() = runTest {
             val paperId = insertPaperAndGetId(fetcherMetadata = mapOf("old" to "value"))
 
-            repo.updateFetcherMetadata(paperId, emptyMap())
+            repo.mergeFetcherMetadata(paperId, emptyMap())
 
             val paper = repo.getPaperById(paperId).getOrThrow()
-            assertThat(paper.fetcherMetadata).isEmpty()
+            assertEquals(mapOf("old" to "value"), paper.fetcherMetadata)
+        }
+
+        @Test
+        fun `When two merges interleave, then no keys are lost`() = runTest {
+            val paperId = insertPaperAndGetId()
+
+            repo.mergeFetcherMetadata(paperId, mapOf("a" to "1"))
+            repo.mergeFetcherMetadata(paperId, mapOf("b" to "2"))
+
+            val paper = repo.getPaperById(paperId).getOrThrow()
+            assertEquals(mapOf("a" to "1", "b" to "2"), paper.fetcherMetadata)
         }
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -367,4 +367,89 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
             assertEquals(0, papers.size)
         }
     }
+
+    @Nested
+    inner class GetPapersByYear {
+        @Test
+        fun `When a paper's year exactly matches, then the paper is returned`() = runTest {
+            val paperId = insertPaperAndGetId(year = 2020)
+
+            val papers = repo.getPapersByYear(2020, tolerance = 0)
+
+            assertThat(papers.map { it.id }).containsExactly(paperId)
+        }
+
+        @Test
+        fun `When a paper's year is within the tolerance, then the paper is returned`() = runTest {
+            val paperId = insertPaperAndGetId(year = 2018)
+
+            val papers = repo.getPapersByYear(2020, tolerance = 2)
+
+            assertThat(papers.map { it.id }).containsExactly(paperId)
+        }
+
+        @Test
+        fun `When a paper's year is outside the tolerance, then the paper is not returned`() = runTest {
+            insertPaperAndGetId(year = 2015)
+
+            val papers = repo.getPapersByYear(2020, tolerance = 2)
+
+            assertEquals(0, papers.size)
+        }
+
+        @Test
+        fun `When multiple papers are within the tolerance, then all of them are returned`() = runTest {
+            val paper1 = insertPaperAndGetId(year = 2019)
+            val paper2 = insertPaperAndGetId(year = 2020)
+            val paper3 = insertPaperAndGetId(year = 2021)
+            insertPaperAndGetId(year = 1990)
+
+            val papers = repo.getPapersByYear(2020, tolerance = 1)
+
+            assertThat(papers.map { it.id }).containsExactlyInAnyOrder(paper1, paper2, paper3)
+        }
+
+        @Test
+        fun `When no paper matches the year, then an empty list is returned`() = runTest {
+            insertPaperAndGetId(year = 2020)
+
+            val papers = repo.getPapersByYear(1990, tolerance = 0)
+
+            assertEquals(0, papers.size)
+        }
+    }
+
+    @Nested
+    inner class UpdateFetcherMetadata {
+        @Test
+        fun `When fetcher metadata is updated, then the stored metadata is replaced`() = runTest {
+            val paperId = insertPaperAndGetId(fetcherMetadata = mapOf("old" to "value"))
+            val newMetadata = mapOf("id" to "123", "foo" to "bar")
+
+            repo.updateFetcherMetadata(paperId, newMetadata)
+
+            val paper = repo.getPaperById(paperId).getOrThrow()
+            assertEquals(newMetadata, paper.fetcherMetadata)
+        }
+
+        @Test
+        fun `When fetcher metadata is updated, then modifiedAt is not changed`() = runTest {
+            val paperId = insertPaperAndGetId()
+
+            repo.updateFetcherMetadata(paperId, mapOf("id" to "123"))
+
+            val paper = repo.getPaperById(paperId).getOrThrow()
+            assertNull(paper.modifiedAt)
+        }
+
+        @Test
+        fun `When fetcher metadata is updated with an empty map, then the metadata is cleared`() = runTest {
+            val paperId = insertPaperAndGetId(fetcherMetadata = mapOf("old" to "value"))
+
+            repo.updateFetcherMetadata(paperId, emptyMap())
+
+            val paper = repo.getPaperById(paperId).getOrThrow()
+            assertThat(paper.fetcherMetadata).isEmpty()
+        }
+    }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/PaperTableRepoTest.kt
@@ -366,6 +366,18 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
 
             assertEquals(0, papers.size)
         }
+
+        @Test
+        fun `When a paper is found by one of its external IDs, then all of its external IDs are returned`() = runTest {
+            val paperId = insertPaperAndGetId()
+            val doi = insertExternalId(paperId, type = ExternalIdType.DOI, value = "10.1234/5678")
+            val url = insertExternalId(paperId, type = ExternalIdType.URL, value = "https://example.com")
+
+            val papers = repo.getPapersByExternalIds(listOf(doi))
+
+            assertEquals(1, papers.size)
+            assertThat(papers.first().externalIds).containsExactlyInAnyOrder(doi, url)
+        }
     }
 
     @Nested
@@ -416,6 +428,18 @@ class PaperTableRepoTest : RepositoryTest(arrayOf(PaperTable, PaperHasExternalId
             val papers = repo.getPapersByYear(1990, tolerance = 0)
 
             assertEquals(0, papers.size)
+        }
+
+        @Test
+        fun `When a paper is found by year, then all of its external IDs are returned`() = runTest {
+            val paperId = insertPaperAndGetId(year = 2020)
+            val doi = insertExternalId(paperId, type = ExternalIdType.DOI, value = "10.1234/5678")
+            val url = insertExternalId(paperId, type = ExternalIdType.URL, value = "https://example.com")
+
+            val papers = repo.getPapersByYear(2020, tolerance = 0)
+
+            assertEquals(1, papers.size)
+            assertThat(papers.first().externalIds).containsExactlyInAnyOrder(doi, url)
         }
     }
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/repository/UserTableRepoTest.kt
@@ -518,7 +518,7 @@ class UserTableRepoTest : RepositoryTest(arrayOf(UserTable, CriterionTable, Proj
             assertTrue(userSettings.areHotkeysShown)
             assertFalse(userSettings.isReviewModeEnabled)
             assertThat(userSettings.criteriaIds).isEmpty()
-            assertEquals(0F, userSettings.similarityThreshold)
+            assertEquals(0.85F, userSettings.similarityThreshold)
             assertEquals(2, userSettings.decisionMatrix.numberOfReviewers)
             assertNotEquals(ByteArray(0), userSettings.decisionMatrix.toByteArray())
             assertThat(userSettings.fetchers).isEmpty()

--- a/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/service/paper/UpdatePaperTest.kt
@@ -79,7 +79,7 @@ class UpdatePaperTest : PaperServiceTest() {
         runTest {
             val externalIds = listOf(
                 ExternalId(ExternalIdType.DOI, "10.1000/existingdoi"),
-                ExternalId(ExternalIdType.URL, "https://example.com"),
+                ExternalId(ExternalIdType.ACL, "1234567890"),
             )
             val request = getExampleRequest().copy(externalIds = externalIds)
             val existingPapers = listOf(

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -395,3 +395,5 @@ To build the client locally, use the `buildTsClient` Gradle task.
 * [ ] Create Paper -> Existence check via similarity
 * [ ] Update Paper -> Existence check via similarity
 * [ ] Search Fetcher ProjectPaper Candidates -> Existence check via similarity
+* [ ] Investigate performance improvements for paper deduplication
+  * e.g. limit the length of the abstracts before comparing them

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -384,11 +384,14 @@ To build the client locally, use the `buildTsClient` Gradle task.
 * [x] Jobs for fetching references can be enqueued
 * [x] Jobs are processed sequentially
 * [x] References are fetched for each fetcher configured in the project
-* [ ] Fetching results are merged and filtered (no duplicated data)
-* [ ] If fetched paper matches DB paper, paper in DB is updated and no new one is created (only checks externalId yet)
+* [x] Fetching results are merged and filtered (no duplicated data)
+* [x] If fetched paper matches DB paper, paper in DB is updated and no new one is created
 * [x] Non-existent papers are added to the DB
 * [x] Citation references are stored in DB
 * [x] Papers that are not already in another stage are added to the target stage
 * [x] `maxStage` of the project is bumped if necessary
 * [ ] Logging in job processing contains unique job ID (MDC)
 * [x] Failed jobs are caught and discarded so the consumer loop continues
+* [ ] Create Paper -> Existence check via similarity
+* [ ] Update Paper -> Existence check via similarity
+* [ ] Search Fetcher ProjectPaper Candidates -> Existence check via similarity

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -396,4 +396,4 @@ To build the client locally, use the `buildTsClient` Gradle task.
 * [ ] Update Paper -> Existence check via similarity
 * [ ] Search Fetcher ProjectPaper Candidates -> Existence check via similarity
 * [ ] Investigate performance improvements for paper deduplication
-  * e.g. limit the length of the abstracts before comparing them
+    * e.g. limit the length of the abstracts before comparing them


### PR DESCRIPTION
Closes #499

## What I have made

Check out the original plan [here](https://github.com/SE-UUlm/snowballr-backend/blob/tmp/paper-merging-plan/paper-matching-implementation-plan.md)

This mainly adds the `IPaperMatcher` interface and its implementation `PaperMatcher`.

I extracted the similarity logic (levenshtein and tokenization) to separate files to test them separately.

The similarity is currently done via weighted components, i.e., if only the title exists, the similarity of the titles makes up 100% of the overall similarity.

For now, the added functionality is only used in the FetcherOrchestrator, where the fetching results are deduplicated and the paper existence logic now uses the similarity API.

I'd like to hear your opinion about the year gate for the candidates. I'm not sure about it, but somehow we need to request a set of candidates from the DB to run the similarity check against.

There are other locations in the application where we need the deduplication/existence check as well. For now, we concentrate on the FetcherOrchestrator.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - [x] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
