### PR TITLE
Automate npm package publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Java and Gradle
               uses: ./.github/workflows/setup-java-gradle/

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -32,11 +32,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v7
 
-            - name: Setup Java and Gradle
-              uses: ./.github/workflows/setup-java-gradle/
-
-            - name: Setup Python and uv
-              uses: ./.github/workflows/setup-python-uv/
+            - name: Setup Application
+              uses: ./.github/workflows/setup-all/
 
             - name: Run tests and collect coverage
               run: ./gradlew test
@@ -75,11 +72,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v7
 
-            - name: Setup Java and Gradle
-              uses: ./.github/workflows/setup-java-gradle/
-
-            - name: Setup Python and uv
-              uses: ./.github/workflows/setup-python-uv/
+            - name: Setup Application
+              uses: ./.github/workflows/setup-all/
 
             - name: Run integration tests
               run: ./gradlew integrationTest
@@ -194,11 +188,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v7
 
-            - name: Setup Java and Gradle
-              uses: ./.github/workflows/setup-java-gradle/
-
-            - name: Setup Python and uv
-              uses: ./.github/workflows/setup-python-uv/
+            - name: Setup Application
+              uses: ./.github/workflows/setup-all/
 
             - name: Create the API specification
               run: ./gradlew createApiSpec

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -15,6 +15,9 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Java and Gradle
               uses: ./.github/workflows/setup-java-gradle/
@@ -31,6 +34,9 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Application
               uses: ./.github/workflows/setup-all/
@@ -71,6 +77,9 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Application
               uses: ./.github/workflows/setup-all/
@@ -165,6 +174,7 @@ jobs:
               uses: actions/checkout@v7
               with:
                   fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Java and Gradle
               uses: ./.github/workflows/setup-java-gradle/
@@ -187,6 +197,9 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Setup Application
               uses: ./.github/workflows/setup-all/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,8 @@ on:
 jobs:
     publish-alpha:
         name: Publish alpha (PR preview)
-        if: github.event_name == 'pull_request'
+        # We skip publishing when triggered by a Dependabot update
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         runs-on: ubuntu-latest
         permissions:
             id-token: write # Required for OIDC
@@ -30,7 +31,8 @@ jobs:
 
     publish-beta:
         name: Publish beta (develop)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        # We skip publishing when triggered by a Dependabot update
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && github.actor != 'dependabot[bot]'
         runs-on: ubuntu-latest
         permissions:
             id-token: write # Required for OIDC

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,67 @@
+name: NPM Publish
+
+on:
+    pull_request:
+        branches: ["develop"]
+    push:
+        branches: ["develop"]
+        tags: ["v*.*.*"]
+
+jobs:
+    publish-alpha:
+        name: Publish alpha (PR preview)
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # Required for OIDC
+            contents: read
+        steps:
+            - name: Checkout PR branch
+              uses: actions/checkout@v7
+              with:
+                  ref: ${{ github.head_ref }}
+                  fetch-depth: 0
+                  fetch-tags: true
+
+            - name: Publish NPM Package
+              uses: ./.github/workflows/publish-api-client
+              with:
+                  channel: alpha
+
+    publish-beta:
+        name: Publish beta (develop)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # Required for OIDC
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
+
+            - name: Publish NPM Package
+              uses: ./.github/workflows/publish-api-client
+              with:
+                  channel: beta
+
+    publish-stable:
+        name: Publish stable (tag)
+        if: github.ref_type == 'tag'
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # Required for OIDC
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
+
+            - name: Publish NPM Package
+              uses: ./.github/workflows/publish-api-client
+              with:
+                  channel: latest

--- a/.github/workflows/publish-api-client/action.yml
+++ b/.github/workflows/publish-api-client/action.yml
@@ -20,6 +20,10 @@ runs:
           shell: bash
           run: ./gradlew buildTsClient
 
+        - name: Verify API consistency
+          shell: bash
+          run: git diff --exit-code
+
         - name: Publish NPM package
           shell: bash
           run: cd build/generated/ts-client && npm publish --access public --tag ${{ inputs.channel }}

--- a/.github/workflows/publish-api-client/action.yml
+++ b/.github/workflows/publish-api-client/action.yml
@@ -1,0 +1,25 @@
+name: Publish the API Client
+description: Publishes the TS Client to the specified channel on NPM
+inputs:
+    channel:
+        description: The NPM channel where the package should be published
+        required: true
+runs:
+    using: composite
+    steps:
+        - name: Common Setup
+          uses: ./.github/workflows/setup-all/
+
+        - name: Setup Node.js
+          uses: actions/setup-node@v6
+          with:
+              node-version: 24
+              registry-url: "https://registry.npmjs.org"
+
+        - name: Build TS Client
+          shell: bash
+          run: ./gradlew buildTsClient
+
+        - name: Publish NPM package
+          shell: bash
+          run: cd build/generated/ts-client && npm publish --access public --tag ${{ inputs.channel }}

--- a/.github/workflows/setup-all/action.yml
+++ b/.github/workflows/setup-all/action.yml
@@ -1,0 +1,10 @@
+name: Setup Java & Gradle and Python & UV
+description: Setup for Backend CI/CD pipeline
+runs:
+    using: composite
+    steps:
+        - name: Setup Java and Gradle
+          uses: ./.github/workflows/setup-java-gradle/
+
+        - name: Setup Python and UV
+          uses: ./.github/workflows/setup-python-uv/

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   markdownlint-config-path: markdownlint.json
                   source-branch: develop
-                  ignore-links: "https://stackoverflow.com/questions/6720050/foreign-key-constraints-when-to-use-on-update-and-on-delete/6720458#6720458,https://medium.com/@pererikbergman/repository-design-pattern-e28c0f3e4a30"
+                  ignore-links: "https://stackoverflow.com/questions/6720050/foreign-key-constraints-when-to-use-on-update-and-on-delete/6720458#6720458,https://medium.com/@pererikbergman/repository-design-pattern-e28c0f3e4a30,https://www.npmjs.com/package/@se-uulm/snowballr-api-client"
                   ignore-paths: "src/,AGENTS.md,CLAUDE.md"
 
             - name: Calculate implementation progress (dry run)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -273,22 +273,6 @@ tasks.register<Exec>("buildTsClient") {
     }
 }
 
-tasks.register<Exec>("publishTsClient") {
-    dependsOn("buildTsClient")
-    description = "Publishes the generated TypeScript client to npm under the given -PnpmTag (alpha, beta, or latest)"
-    group = "publishing"
-    workingDir = tsClientDir.get().asFile
-
-    doFirst {
-        val npmTag = project.findProperty("npmTag") as String?
-        require(!npmTag.isNullOrBlank()) {
-            "publishTsClient requires -PnpmTag=<alpha|beta|latest> to be set explicitly; " +
-                "refusing to publish without an explicit tag."
-        }
-        commandLine("npm", "publish", "--access", "public", "--tag", npmTag)
-    }
-}
-
 kover {
     currentProject {
         instrumentation {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,10 @@ sonar {
     properties {
         property("sonar.projectKey", "snowballr-backend")
         property("sonar.projectName", "SnowballR Backend")
-        property("sonar.coverage.jacoco.xmlReportPaths", layout.buildDirectory.file("coverageXml/report.xml").get().asFile.path)
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            layout.buildDirectory.file("coverageXml/report.xml").get().asFile.path,
+        )
     }
 }
 
@@ -47,9 +50,21 @@ gitVersioning.apply {
         tag("v(?<version>\\d+\\.\\d+\\.\\d+)") {
             version = $$"${ref.version}"
         }
+        // Beta channel: rolling next-release preview published on every merge to develop.
+        branch("develop") {
+            version =
+                $$"${describe.tag.version.major}.${describe.tag.version.minor}.${describe.tag.version.patch.next}-beta.${commit.short}"
+        }
+        // Alpha channel: per-push preview for any other branch (e.g. feature branches backing an open PR). Must be
+        // listed after the "develop" branch matcher, since the first matching entry wins.
+        branch(".*") {
+            version =
+                $$"${describe.tag.version.major}.${describe.tag.version.minor}.${describe.tag.version.patch.next}-alpha.${commit.short}"
+        }
     }
 
-    // optional fallback configuration in case of no matching ref configuration
+    // optional fallback configuration in case of no matching ref configuration (e.g. detached HEAD without a
+    // matching branch, such as a checkout that isn't on a real branch ref)
     rev {
         version = $$"${commit}"
     }
@@ -122,7 +137,7 @@ kotlin {
             // Handle nullability annotations as strict
             "-Xjsr305=strict",
             // Annotations are applied to both the constructor parameter and the property (interop)
-            "-Xannotation-default-target=param-property"
+            "-Xannotation-default-target=param-property",
         )
     }
     jvmToolchain(25)
@@ -205,20 +220,26 @@ tasks.register<Test>("createApiSpec") {
     reports.junitXml.required.set(false)
 }
 
-// The committed OpenAPI spec (verified against the code by the `createApiSpec` task) is the single source of
-// truth for the generated frontend client. `openApiGenerate` turns it into a publishable TypeScript npm package.
+// The committed OpenAPI spec is the single source of truth for the generated frontend client.
+// `openApiGenerate` turns it into a publishable TypeScript npm package.
 val committedApiSpec: RegularFile = layout.projectDirectory.file("api/openapi.json")
+val tsClientDir: Provider<Directory> = layout.buildDirectory.dir("generated/ts-client")
 
 openApiGenerate {
     generatorName.set("typescript-fetch")
     inputSpec.set(committedApiSpec.asFile.absolutePath)
-    outputDir.set(layout.buildDirectory.dir("generated/ts-client").map { it.asFile.absolutePath })
+    outputDir.set(tsClientDir.map { it.asFile.absolutePath })
+    validateSpec.set(true)
+    gitUserId.set("SE-UUlm")
+    gitRepoId.set("snowballr-backend")
     configOptions.set(
         mapOf(
-            "npmName" to "snowballr-api-client",
+            "npmName" to "@se-uulm/snowballr-api-client",
             "npmVersion" to project.version.toString(),
+            "licenseName" to "GPL-3.0-or-later",
             "supportsES6" to "true",
             "withInterfaces" to "true",
+            "enumPropertyNaming" to "UPPERCASE",
         ),
     )
 }
@@ -229,6 +250,43 @@ tasks.named("openApiGenerate") {
     description = "Generates the TypeScript client from the committed OpenAPI spec"
     group = "build"
     inputs.file(committedApiSpec)
+}
+
+tasks.register<Exec>("buildTsClient") {
+    dependsOn("openApiGenerate")
+    description = "Installs npm dependencies for the generated TypeScript client and builds it"
+    group = "publishing"
+    workingDir = tsClientDir.get().asFile
+    commandLine("npm", "install")
+
+    fun copyToPackage(fileName: String) {
+        val sourceFile = layout.projectDirectory.file(fileName)
+        val targetFile = tsClientDir.get().asFile.resolve(fileName)
+
+        sourceFile.asFile.copyTo(targetFile, overwrite = true)
+    }
+
+    // Copy the license and changelog to the package to make it ready for publishing
+    doFirst {
+        copyToPackage("LICENSE")
+        copyToPackage("CHANGELOG.md")
+    }
+}
+
+tasks.register<Exec>("publishTsClient") {
+    dependsOn("buildTsClient")
+    description = "Publishes the generated TypeScript client to npm under the given -PnpmTag (alpha, beta, or latest)"
+    group = "publishing"
+    workingDir = tsClientDir.get().asFile
+
+    doFirst {
+        val npmTag = project.findProperty("npmTag") as String?
+        require(!npmTag.isNullOrBlank()) {
+            "publishTsClient requires -PnpmTag=<alpha|beta|latest> to be set explicitly; " +
+                "refusing to publish without an explicit tag."
+        }
+        commandLine("npm", "publish", "--access", "public", "--tag", npmTag)
+    }
 }
 
 kover {

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -22,6 +22,7 @@ On this page, we explain how to contribute to the SnowballR backend project. We 
     * [Type Checking](#type-checking)
   * [Release procedure](#release-procedure)
   * [Use another API Version](#use-another-api-version)
+  * [TypeScript API Client](#typescript-api-client)
   * [Fetcher Orchestration Progress](#fetcher-orchestration-progress)
 <!-- TOC -->
 <!-- @formatter:on -->
@@ -357,6 +358,26 @@ To use another API version than the currently used one, go to the `build.gradle.
 `apiVersion` variable to the desired version. Make sure that the version exists in the
 [API repository](https://github.com/SE-UUlm/snowballr-api). After changing the version, recompile the code using
 `./gradlew compileKotlin`.
+
+## TypeScript API Client
+
+The backend generates a TypeScript client from the committed OpenAPI spec (`api/openapi.json`, see `openApiGenerate`
+in `build.gradle.kts`) and publishes it to npm as
+[`@se-uulm/snowballr-api-client`](https://www.npmjs.com/package/@se-uulm/snowballr-api-client). Three release channels
+(npm dist-tags) are published automatically by `.github/workflows/npm-publish.yml`, so in-progress backend changes
+can be tested from the frontend without waiting for a stable release:
+
+| Channel  | Published when                                        | Install with                                      |
+|----------|-------------------------------------------------------|---------------------------------------------------|
+| `alpha`  | Every push to a branch with an open PR into `develop` | `npm install @se-uulm/snowballr-api-client@alpha` |
+| `beta`   | Every merge to `develop`                              | `npm install @se-uulm/snowballr-api-client@beta`  |
+| `latest` | Every `vX.Y.Z` tag push (stable release)              | `npm install @se-uulm/snowballr-api-client`       |
+
+The alpha/beta version numbers (e.g. `0.1.1-alpha.a3f9c2e`) are produced by the `gitVersioning` configuration in
+`build.gradle.kts`: the patch version of the last `vX.Y.Z` tag is bumped by one and suffixed with the channel name and
+the short commit hash.
+
+To build the client locally, use the `buildTsClient` Gradle task.
 
 ## Fetcher Orchestration Progress
 


### PR DESCRIPTION
Closes #581

## What I have made

The TS client is now published to NPM (see https://www.npmjs.com/package/@se-uulm/snowballr-api-client?activeTab=versions).

There are 3 channels:
- **alpha**: triggered on pushes to PRs (development/feature branch)
- **beta**: triggered on push to develop (current dev state/state in between releases)
- **stable**: triggered on tag pushes (production releases)

This makes it possible to use the client in every stage of development.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - [x] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
