### PR TITLE
Add better external id validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ db-data
 
 ### AI ###
 .claude/worktrees/
+
+### Logs ###
+*.log

--- a/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/model/ValidationIssue.kt
@@ -202,3 +202,17 @@ data class InvalidEnumValue(val value: String, val enumName: String) : Validatio
 data class MultipleOccurrences(val name: String, val occurrences: List<Pair<String, Int>>) : ValidationIssue {
     override fun toString(): String = "The following $name have multiple occurrences: ${occurrences.joinToString("; ")}"
 }
+
+/**
+ * Represents a validation issue where an external ID value does not match the format expected for its type.
+ *
+ * @property type The external ID type the value was validated against.
+ * @property value The invalid external ID value.
+ */
+data class InvalidExternalIdFormat(
+    val type: String,
+    val value: String,
+) : ValidationIssue {
+    override fun toString(): String =
+        "The value '$value' does not match the expected format for external ID type '$type'."
+}

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -14,10 +14,12 @@ object ExternalIdValidator {
     const val EXTERNAL_ID_MAX_LENGTH = 100
 
     /**
-     * Matches a [DOI](https://www.doi.org/) of the form `10.<4-9 digit registrant code>/<suffix>`, e.g.
+     * Matches a [DOI](https://www.doi.org/) of the form `10.<4 digit registrant code>/<suffix>`, e.g.
      * `10.1000/xyz123`.
+     *
+     * [Scheme](https://www.doi.org/the-identifier/what-is-a-doi/).
      */
-    private val DOI_REGEX = Regex("""^10\.\d{4,9}/\S+$""")
+    private val DOI_REGEX = Regex("""^10\.\d{4}/\S+$""")
 
     /**
      * Matches the current [ArXiv](https://arxiv.org/) `YYMM.NNNNN` scheme introduced in 2007, e.g. `2101.00001`,
@@ -34,6 +36,8 @@ object ExternalIdValidator {
     /**
      * Matches an [ArXiv](https://arxiv.org/) identifier in either the [ARXIV_NEW_STYLE_REGEX] or the
      * [ARXIV_OLD_STYLE_REGEX] scheme.
+     *
+     * [Scheme](https://info.arxiv.org/help/arxiv_identifier.html).
      */
     private val ARXIV_REGEX = Regex("${ARXIV_NEW_STYLE_REGEX.pattern}|${ARXIV_OLD_STYLE_REGEX.pattern}")
 
@@ -56,6 +60,26 @@ object ExternalIdValidator {
      */
     private val SEMANTIC_SCHOLAR_REGEX = Regex("""^[a-f0-9]{40}$""")
 
+    /**
+     * Matches the current [ACL Anthology](https://aclanthology.org/) ID scheme introduced in 2020,
+     * `YYYY.<venue>-<volume>.<paper>`, e.g. `2021.acl-long.1`.
+     */
+    private val ACL_NEW_STYLE_REGEX = Regex("""^\d{4}\.[a-z0-9]+-[a-z0-9]+\.\d+$""")
+
+    /**
+     * Matches the legacy [ACL Anthology](https://aclanthology.org/) ID scheme used before 2020,
+     * `<collection letter><2 digit year>-<paper number>`, e.g. `P19-1007`.
+     */
+    private val ACL_OLD_STYLE_REGEX = Regex("""^[A-Z]\d{2}-\d{3,4}$""")
+
+    /**
+     * Matches an [ACL Anthology](https://aclanthology.org/) identifier in either the [ACL_NEW_STYLE_REGEX] or the
+     * [ACL_OLD_STYLE_REGEX] scheme.
+     *
+     * [Scheme](https://aclanthology.org/info/ids/).
+     */
+    private val ACL_REGEX = Regex("${ACL_NEW_STYLE_REGEX.pattern}|${ACL_OLD_STYLE_REGEX.pattern}")
+
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
             { ensureValidEnumValue<ExternalIdType>(externalId.type, "External ID Type") },
@@ -66,19 +90,16 @@ object ExternalIdValidator {
 
     /**
      * The expected value format for the given [ExternalIdType], or `null` if the type does not have a
-     * standardized-enough format to validate meaningfully ([ExternalIdType.ACL]'s Anthology ID scheme and
-     * [ExternalIdType.DBLP]'s key scheme have both changed shape too many times over the years), in which case
-     * only the generic blank/max-length checks apply.
+     * standardized-enough format to validate meaningfully ([ExternalIdType.DBLP]'s key scheme has changed shape
+     * too many times over the years), in which case only the generic blank/max-length checks apply.
      */
     private fun formatRegexFor(type: ExternalIdType): Regex? = when (type) {
         ExternalIdType.DOI -> DOI_REGEX
         ExternalIdType.ARXIV -> ARXIV_REGEX
-        ExternalIdType.MAG -> DIGITS_ONLY_REGEX
-        ExternalIdType.PUB_MED -> DIGITS_ONLY_REGEX
-        ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX
+        ExternalIdType.MAG, ExternalIdType.PUB_MED, ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX
         ExternalIdType.PUB_MED_CENTRAL -> PUB_MED_CENTRAL_REGEX
         ExternalIdType.SEMANTIC_SCHOLAR -> SEMANTIC_SCHOLAR_REGEX
-        ExternalIdType.ACL -> null
+        ExternalIdType.ACL -> ACL_REGEX
         ExternalIdType.DBLP -> null
     }
 

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -14,12 +14,12 @@ object ExternalIdValidator {
     const val EXTERNAL_ID_MAX_LENGTH = 100
 
     /**
-     * Matches a [DOI](https://www.doi.org/) of the form `10.<4 digit registrant code>/<suffix>`, e.g.
-     * `10.1000/xyz123`.
+     * Matches a [DOI](https://www.doi.org/) of the form `10.<registrant code of 4 or more digits>/<suffix>`, e.g.
+     * `10.1000/xyz123` or `10.48550/arXiv.2202.01037`.
      *
      * [Scheme](https://www.doi.org/the-identifier/what-is-a-doi/).
      */
-    private val DOI_REGEX = Regex("""^10\.\d{4}/\S+$""")
+    private val DOI_REGEX = Regex("""^10\.\d{4,}/\S+$""")
 
     /**
      * Matches the current [ArXiv](https://arxiv.org/) `YYMM.NNNNN` scheme introduced in 2007, e.g. `2101.00001`,
@@ -82,11 +82,11 @@ object ExternalIdValidator {
 
     /**
      * Matches a [dblp](https://dblp.org/) record key of the form `<prefix>/<conference-or-journal>/<id-suffix>`,
-     * e.g. `journals/tods/Bernstein83`.
+     * e.g. `journals/tods/Bernstein83` or `journals/corr/abs-2103-05387`.
      *
      * [Scheme](https://dblp.org/xml/docu/dblpxml.pdf).
      */
-    private val DBLP_REGEX = Regex("""^[a-z]+/[A-Za-z0-9]+/[A-Za-z0-9]+$""")
+    private val DBLP_REGEX = Regex("""^[a-z]+/[A-Za-z0-9]+/[A-Za-z0-9_-]+$""")
 
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -1,8 +1,11 @@
 package se.uulm.snowballr.backend.validation
 
 import arrow.core.EitherNel
+import arrow.core.raise.Raise
 import arrow.core.raise.either
+import arrow.core.raise.ensure
 import arrow.core.raise.zipOrAccumulate
+import se.uulm.snowballr.backend.model.InvalidExternalIdFormat
 import se.uulm.snowballr.backend.model.ValidationIssue
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
 import snowballr.PaperOuterClass.Paper.ExternalId
@@ -10,10 +13,48 @@ import snowballr.PaperOuterClass.Paper.ExternalId
 object ExternalIdValidator {
     const val EXTERNAL_ID_MAX_LENGTH = 100
 
+    private val DIGITS_ONLY_REGEX = Regex("""^\d+$""")
+
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
             { ensureValidEnumValue<ExternalIdType>(externalId.type, "External ID Type") },
             { ensureTextFieldValidity("value", externalId.value, EXTERNAL_ID_MAX_LENGTH) },
-        ) { _, _ -> }
+            { ensureExternalIdFormatValidity(externalId.type, externalId.value) },
+        ) { _, _, _ -> }
+    }
+
+    /**
+     * The expected value format for the given [ExternalIdType], or `null` if the type does not have a
+     * standardized-enough format to validate meaningfully (e.g. [ExternalIdType.ACL], [ExternalIdType.DBLP]),
+     * in which case only the generic blank/max-length checks apply.
+     *
+     * This is a `when` over all [ExternalIdType] entries without an `else` branch so that adding a new type
+     * without deciding on its format fails compilation.
+     */
+    private fun formatRegexFor(type: ExternalIdType): Regex? = when (type) {
+        ExternalIdType.DOI -> Regex("""^10\.\d{4,9}/\S+$""")
+        ExternalIdType.ARXIV -> Regex("""^\d{4}\.\d{4,5}(v\d+)?$|^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
+        ExternalIdType.MAG -> DIGITS_ONLY_REGEX
+        ExternalIdType.PUB_MED -> DIGITS_ONLY_REGEX
+        ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX
+        ExternalIdType.PUB_MED_CENTRAL -> Regex("""^PMC\d+$""")
+        ExternalIdType.SEMANTIC_SCHOLAR -> Regex("""^[a-f0-9]{40}$""")
+        ExternalIdType.ACL -> null
+        ExternalIdType.DBLP -> null
+    }
+
+    /**
+     * Ensures that the given external ID [value] matches the format expected for its [type], if such a format is
+     * defined by [formatRegexFor].
+     *
+     * Unknown or unspecified types are ignored here since they are already covered by the enum validity check.
+     *
+     * @param type The raw external ID type string.
+     * @param value The external ID value to check for format validity.
+     */
+    private fun Raise<ValidationIssue>.ensureExternalIdFormatValidity(type: String, value: String) {
+        val regex = runCatching { enumValueOf<ExternalIdType>(type) }.getOrNull()?.let { formatRegexFor(it) }
+            ?: return
+        ensure(regex.matches(value)) { InvalidExternalIdFormat(type, value) }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -30,16 +30,11 @@ object ExternalIdValidator {
     /**
      * Matches the legacy [ArXiv](https://arxiv.org/) `archive.subject-class/YYMMNNN` scheme used before the
      * `YYMM.NNNNN` scheme was introduced in 2007, e.g. `hep-th/9901001`.
-     */
-    private val ARXIV_OLD_STYLE_REGEX = Regex("""^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
-
-    /**
-     * Matches an [ArXiv](https://arxiv.org/) identifier in either the [ARXIV_NEW_STYLE_REGEX] or the
-     * [ARXIV_OLD_STYLE_REGEX] scheme.
      *
+     * An ArXiv identifier matches either this or the [ARXIV_NEW_STYLE_REGEX] scheme.
      * [Scheme](https://info.arxiv.org/help/arxiv_identifier.html).
      */
-    private val ARXIV_REGEX = Regex("${ARXIV_NEW_STYLE_REGEX.pattern}|${ARXIV_OLD_STYLE_REGEX.pattern}")
+    private val ARXIV_OLD_STYLE_REGEX = Regex("""^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
 
     /**
      * Matches a numeric ID as used by both
@@ -69,16 +64,11 @@ object ExternalIdValidator {
     /**
      * Matches the legacy [ACL Anthology](https://aclanthology.org/) ID scheme used before 2020,
      * `<collection letter><2 digit year>-<paper number>`, e.g. `P19-1007`.
-     */
-    private val ACL_OLD_STYLE_REGEX = Regex("""^[A-Z]\d{2}-\d{3,4}$""")
-
-    /**
-     * Matches an [ACL Anthology](https://aclanthology.org/) identifier in either the [ACL_NEW_STYLE_REGEX] or the
-     * [ACL_OLD_STYLE_REGEX] scheme.
      *
+     * An ACL Anthology identifier matches either this or the [ACL_NEW_STYLE_REGEX] scheme.
      * [Scheme](https://aclanthology.org/info/ids/).
      */
-    private val ACL_REGEX = Regex("${ACL_NEW_STYLE_REGEX.pattern}|${ACL_OLD_STYLE_REGEX.pattern}")
+    private val ACL_OLD_STYLE_REGEX = Regex("""^[A-Z]\d{2}-\d{3,4}$""")
 
     /**
      * Matches a [dblp](https://dblp.org/) record key of the form `<prefix>/<conference-or-journal>/<id-suffix>`,
@@ -91,27 +81,29 @@ object ExternalIdValidator {
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
             { ensureValidEnumValue<ExternalIdType>(externalId.type, "External ID Type") },
-            { ensureTextFieldValidity("value", externalId.value, EXTERNAL_ID_MAX_LENGTH) },
-            { ensureExternalIdFormatValidity(externalId.type, externalId.value) },
-        ) { _, _, _ -> }
+            {
+                ensureTextFieldValidity("value", externalId.value, EXTERNAL_ID_MAX_LENGTH)
+                ensureExternalIdFormatValidity(externalId.type, externalId.value)
+            },
+        ) { _, _ -> }
     }
 
     /**
-     * The expected value format for the given [ExternalIdType].
+     * Whether the given [value] matches the format expected for the given [type].
      */
-    private fun formatRegexFor(type: ExternalIdType): Regex = when (type) {
-        ExternalIdType.DOI -> DOI_REGEX
-        ExternalIdType.ARXIV -> ARXIV_REGEX
-        ExternalIdType.MAG, ExternalIdType.PUB_MED, ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX
-        ExternalIdType.PUB_MED_CENTRAL -> PUB_MED_CENTRAL_REGEX
-        ExternalIdType.SEMANTIC_SCHOLAR -> SEMANTIC_SCHOLAR_REGEX
-        ExternalIdType.ACL -> ACL_REGEX
-        ExternalIdType.DBLP -> DBLP_REGEX
+    private fun matchesExpectedFormat(type: ExternalIdType, value: String): Boolean = when (type) {
+        ExternalIdType.DOI -> DOI_REGEX.matches(value)
+        ExternalIdType.ARXIV -> ARXIV_NEW_STYLE_REGEX.matches(value) || ARXIV_OLD_STYLE_REGEX.matches(value)
+        ExternalIdType.MAG, ExternalIdType.PUB_MED, ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX.matches(value)
+        ExternalIdType.PUB_MED_CENTRAL -> PUB_MED_CENTRAL_REGEX.matches(value)
+        ExternalIdType.SEMANTIC_SCHOLAR -> SEMANTIC_SCHOLAR_REGEX.matches(value)
+        ExternalIdType.ACL -> ACL_NEW_STYLE_REGEX.matches(value) || ACL_OLD_STYLE_REGEX.matches(value)
+        ExternalIdType.DBLP -> DBLP_REGEX.matches(value)
     }
 
     /**
      * Ensures that the given external ID [value] matches the format expected for its [type], as defined by
-     * [formatRegexFor].
+     * [matchesExpectedFormat].
      *
      * Unknown or unspecified types are ignored here since they are already covered by the enum validity check.
      *
@@ -120,6 +112,6 @@ object ExternalIdValidator {
      */
     private fun Raise<ValidationIssue>.ensureExternalIdFormatValidity(type: String, value: String) {
         val parsedType = runCatching { enumValueOf<ExternalIdType>(type) }.getOrNull() ?: return
-        ensure(formatRegexFor(parsedType).matches(value)) { InvalidExternalIdFormat(type, value) }
+        ensure(matchesExpectedFormat(parsedType, value)) { InvalidExternalIdFormat(type, value) }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -76,7 +76,7 @@ object ExternalIdValidator {
      *
      * [Scheme](https://dblp.org/xml/docu/dblpxml.pdf).
      */
-    private val DBLP_REGEX = Regex("""^[a-z]+(/[A-Za-z0-9_-]+)+$""")
+    private val DBLP_REGEX = Regex("""^[a-z]+(/[A-Za-z0-9_-]+){2,}$""")
 
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -76,7 +76,7 @@ object ExternalIdValidator {
      *
      * [Scheme](https://dblp.org/xml/docu/dblpxml.pdf).
      */
-    private val DBLP_REGEX = Regex("""^[a-z]+/[A-Za-z0-9]+/[A-Za-z0-9_-]+$""")
+    private val DBLP_REGEX = Regex("""^[a-z]+(/[A-Za-z0-9_-]+)+$""")
 
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -80,6 +80,14 @@ object ExternalIdValidator {
      */
     private val ACL_REGEX = Regex("${ACL_NEW_STYLE_REGEX.pattern}|${ACL_OLD_STYLE_REGEX.pattern}")
 
+    /**
+     * Matches a [dblp](https://dblp.org/) record key of the form `<prefix>/<conference-or-journal>/<id-suffix>`,
+     * e.g. `journals/tods/Bernstein83`.
+     *
+     * [Scheme](https://dblp.org/xml/docu/dblpxml.pdf).
+     */
+    private val DBLP_REGEX = Regex("""^[a-z]+/[A-Za-z0-9]+/[A-Za-z0-9]+$""")
+
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
             { ensureValidEnumValue<ExternalIdType>(externalId.type, "External ID Type") },
@@ -89,23 +97,21 @@ object ExternalIdValidator {
     }
 
     /**
-     * The expected value format for the given [ExternalIdType], or `null` if the type does not have a
-     * standardized-enough format to validate meaningfully ([ExternalIdType.DBLP]'s key scheme has changed shape
-     * too many times over the years), in which case only the generic blank/max-length checks apply.
+     * The expected value format for the given [ExternalIdType].
      */
-    private fun formatRegexFor(type: ExternalIdType): Regex? = when (type) {
+    private fun formatRegexFor(type: ExternalIdType): Regex = when (type) {
         ExternalIdType.DOI -> DOI_REGEX
         ExternalIdType.ARXIV -> ARXIV_REGEX
         ExternalIdType.MAG, ExternalIdType.PUB_MED, ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX
         ExternalIdType.PUB_MED_CENTRAL -> PUB_MED_CENTRAL_REGEX
         ExternalIdType.SEMANTIC_SCHOLAR -> SEMANTIC_SCHOLAR_REGEX
         ExternalIdType.ACL -> ACL_REGEX
-        ExternalIdType.DBLP -> null
+        ExternalIdType.DBLP -> DBLP_REGEX
     }
 
     /**
-     * Ensures that the given external ID [value] matches the format expected for its [type], if such a format is
-     * defined by [formatRegexFor].
+     * Ensures that the given external ID [value] matches the format expected for its [type], as defined by
+     * [formatRegexFor].
      *
      * Unknown or unspecified types are ignored here since they are already covered by the enum validity check.
      *
@@ -113,8 +119,7 @@ object ExternalIdValidator {
      * @param value The external ID value to check for format validity.
      */
     private fun Raise<ValidationIssue>.ensureExternalIdFormatValidity(type: String, value: String) {
-        val regex = runCatching { enumValueOf<ExternalIdType>(type) }.getOrNull()?.let { formatRegexFor(it) }
-            ?: return
-        ensure(regex.matches(value)) { InvalidExternalIdFormat(type, value) }
+        val parsedType = runCatching { enumValueOf<ExternalIdType>(type) }.getOrNull() ?: return
+        ensure(formatRegexFor(parsedType).matches(value)) { InvalidExternalIdFormat(type, value) }
     }
 }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -58,9 +58,6 @@ object ExternalIdValidator {
      * standardized-enough format to validate meaningfully ([ExternalIdType.ACL]'s Anthology ID scheme and
      * [ExternalIdType.DBLP]'s key scheme have both changed shape too many times over the years), in which case
      * only the generic blank/max-length checks apply.
-     *
-     * This is a `when` over all [ExternalIdType] entries without an `else` branch so that adding a new type
-     * without deciding on its format fails compilation.
      */
     private fun formatRegexFor(type: ExternalIdType): Regex? = when (type) {
         ExternalIdType.DOI -> DOI_REGEX

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -83,7 +83,7 @@ object ExternalIdValidator {
             { ensureValidEnumValue<ExternalIdType>(externalId.type, "External ID Type") },
             {
                 ensureTextFieldValidity("value", externalId.value, EXTERNAL_ID_MAX_LENGTH)
-                ensureExternalIdFormatValidity(externalId.type, externalId.value)
+                ensureExternalIdFormatValidity(externalId.type, externalId.value.trim())
             },
         ) { _, _ -> }
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -13,7 +13,37 @@ import snowballr.PaperOuterClass.Paper.ExternalId
 object ExternalIdValidator {
     const val EXTERNAL_ID_MAX_LENGTH = 100
 
+    /**
+     * Matches a [DOI](https://www.doi.org/) of the form `10.<4-9 digit registrant code>/<suffix>`, e.g.
+     * `10.1000/xyz123`.
+     */
+    private val DOI_REGEX = Regex("""^10\.\d{4,9}/\S+$""")
+
+    /**
+     * Matches an [ArXiv](https://arxiv.org/) identifier in either the current `YYMM.NNNNN` scheme introduced in
+     * 2007 (e.g. `2101.00001`, optionally with a `vN` version suffix) or the legacy `archive/YYMMNNN` scheme used
+     * before that (e.g. `hep-th/9901001`).
+     */
+    private val ARXIV_REGEX = Regex("""^\d{4}\.\d{4,5}(v\d+)?$|^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
+
+    /**
+     * Matches a numeric ID as used by both
+     * [Microsoft Academic Graph](https://www.microsoft.com/en-us/research/project/microsoft-academic-graph/) (MAG)
+     * and [PubMed](https://pubmed.ncbi.nlm.nih.gov/)/[Medline](https://www.nlm.nih.gov/medline/medline_home.html)
+     * (PMID), e.g. `12345678`.
+     */
     private val DIGITS_ONLY_REGEX = Regex("""^\d+$""")
+
+    /**
+     * Matches a [PubMed Central](https://pmc.ncbi.nlm.nih.gov/) ID, i.e. the `PMC` prefix followed by digits, e.g.
+     * `PMC1234567`.
+     */
+    private val PUB_MED_CENTRAL_REGEX = Regex("""^PMC\d+$""")
+
+    /**
+     * Matches a [Semantic Scholar](https://www.semanticscholar.org/) paper ID, a 40 character lowercase hex string.
+     */
+    private val SEMANTIC_SCHOLAR_REGEX = Regex("""^[a-f0-9]{40}$""")
 
     fun validateExternalId(externalId: ExternalId): EitherNel<ValidationIssue, Unit> = either {
         zipOrAccumulate(
@@ -25,20 +55,21 @@ object ExternalIdValidator {
 
     /**
      * The expected value format for the given [ExternalIdType], or `null` if the type does not have a
-     * standardized-enough format to validate meaningfully (e.g. [ExternalIdType.ACL], [ExternalIdType.DBLP]),
-     * in which case only the generic blank/max-length checks apply.
+     * standardized-enough format to validate meaningfully ([ExternalIdType.ACL]'s Anthology ID scheme and
+     * [ExternalIdType.DBLP]'s key scheme have both changed shape too many times over the years), in which case
+     * only the generic blank/max-length checks apply.
      *
      * This is a `when` over all [ExternalIdType] entries without an `else` branch so that adding a new type
      * without deciding on its format fails compilation.
      */
     private fun formatRegexFor(type: ExternalIdType): Regex? = when (type) {
-        ExternalIdType.DOI -> Regex("""^10\.\d{4,9}/\S+$""")
-        ExternalIdType.ARXIV -> Regex("""^\d{4}\.\d{4,5}(v\d+)?$|^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
+        ExternalIdType.DOI -> DOI_REGEX
+        ExternalIdType.ARXIV -> ARXIV_REGEX
         ExternalIdType.MAG -> DIGITS_ONLY_REGEX
         ExternalIdType.PUB_MED -> DIGITS_ONLY_REGEX
         ExternalIdType.MEDLINE -> DIGITS_ONLY_REGEX
-        ExternalIdType.PUB_MED_CENTRAL -> Regex("""^PMC\d+$""")
-        ExternalIdType.SEMANTIC_SCHOLAR -> Regex("""^[a-f0-9]{40}$""")
+        ExternalIdType.PUB_MED_CENTRAL -> PUB_MED_CENTRAL_REGEX
+        ExternalIdType.SEMANTIC_SCHOLAR -> SEMANTIC_SCHOLAR_REGEX
         ExternalIdType.ACL -> null
         ExternalIdType.DBLP -> null
     }

--- a/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
+++ b/src/main/kotlin/se/uulm/snowballr/backend/validation/ExternalIdValidator.kt
@@ -20,11 +20,22 @@ object ExternalIdValidator {
     private val DOI_REGEX = Regex("""^10\.\d{4,9}/\S+$""")
 
     /**
-     * Matches an [ArXiv](https://arxiv.org/) identifier in either the current `YYMM.NNNNN` scheme introduced in
-     * 2007 (e.g. `2101.00001`, optionally with a `vN` version suffix) or the legacy `archive/YYMMNNN` scheme used
-     * before that (e.g. `hep-th/9901001`).
+     * Matches the current [ArXiv](https://arxiv.org/) `YYMM.NNNNN` scheme introduced in 2007, e.g. `2101.00001`,
+     * optionally with a `vN` version suffix, e.g. `2101.00001v2`.
      */
-    private val ARXIV_REGEX = Regex("""^\d{4}\.\d{4,5}(v\d+)?$|^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
+    private val ARXIV_NEW_STYLE_REGEX = Regex("""^\d{4}\.\d{4,5}(v\d+)?$""")
+
+    /**
+     * Matches the legacy [ArXiv](https://arxiv.org/) `archive.subject-class/YYMMNNN` scheme used before the
+     * `YYMM.NNNNN` scheme was introduced in 2007, e.g. `hep-th/9901001`.
+     */
+    private val ARXIV_OLD_STYLE_REGEX = Regex("""^[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?$""")
+
+    /**
+     * Matches an [ArXiv](https://arxiv.org/) identifier in either the [ARXIV_NEW_STYLE_REGEX] or the
+     * [ARXIV_OLD_STYLE_REGEX] scheme.
+     */
+    private val ARXIV_REGEX = Regex("${ARXIV_NEW_STYLE_REGEX.pattern}|${ARXIV_OLD_STYLE_REGEX.pattern}")
 
     /**
      * Matches a numeric ID as used by both

--- a/src/main/resources/plugins/fetchers/SemanticScholar.py
+++ b/src/main/resources/plugins/fetchers/SemanticScholar.py
@@ -128,14 +128,17 @@ def _construct_paper_id(paper: Paper) -> Optional[str]:
         "PUB_MED": "PMID:",
         "MEDLINE": "PMID:",
         "PUB_MED_CENTRAL": "PMCID:",
-        "URL": "URL:",
         # DBLP is not available as paper ID
     }
 
     for ex_type, prefix in key_mapping.items():
         if ex_type in ext_id_map:
-            return f"{prefix}{ext_id_map[ex_type]}"
-
+            value = ext_id_map[ex_type]
+            if ex_type == "PUB_MED_CENTRAL":
+                # Our stored value carries the "PMC" prefix, but Semantic Scholar
+                # expects the bare digits.
+                value = value.removeprefix("PMC")
+            return f"{prefix}{value}"
     return None
 
 
@@ -192,21 +195,22 @@ def _author_from_response(res) -> Author:
 
 
 def _external_ids_from_response(res) -> list[ExternalId]:
-    # Map the response key to the target ExternalId type string
+    # Map the response key to the target ExternalId type string and the value prefix
+    # matching our validation.
     key_mapping = {
-        "DOI": "DOI",
-        "ArXiv": "ARXIV",
-        "MAG": "MAG",
-        "ACL": "ACL",
-        "PubMed": "PUB_MED",
-        "Medline": "MEDLINE",
-        "PubMedCentral": "PUB_MED_CENTRAL",
-        "DBLP": "DBLP",
+        "DOI": ("DOI", ""),
+        "ArXiv": ("ARXIV", ""),
+        "MAG": ("MAG", ""),
+        "ACL": ("ACL", ""),
+        "PubMed": ("PUB_MED", ""),
+        "Medline": ("MEDLINE", ""),
+        "PubMedCentral": ("PUB_MED_CENTRAL", "PMC"),  # PubMedCentral required 'PMC' prefix
+        "DBLP": ("DBLP", ""),
     }
 
     return [
-        ExternalId(id_type, res[key])
-        for key, id_type in key_mapping.items()
+        ExternalId(id_type, f"{value_prefix}{res[key]}")
+        for key, (id_type, value_prefix) in key_mapping.items()
         if key in res and res[key] is not None
     ]
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdFixtures.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdFixtures.kt
@@ -1,0 +1,19 @@
+package se.uulm.snowballr.backend.validation
+
+import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
+
+/**
+ * One realistic, well-formed example value per [ExternalIdType], shared across validator tests that need a
+ * generally valid external ID for a given type.
+ */
+val VALID_EXTERNAL_ID_VALUES: Map<ExternalIdType, String> = mapOf(
+    ExternalIdType.DOI to "10.1000/xyz123",
+    ExternalIdType.ARXIV to "2101.00001",
+    ExternalIdType.MAG to "1234567890",
+    ExternalIdType.ACL to "P19-1001",
+    ExternalIdType.PUB_MED to "12345678",
+    ExternalIdType.MEDLINE to "12345678",
+    ExternalIdType.PUB_MED_CENTRAL to "PMC1234567",
+    ExternalIdType.DBLP to "journals/tods/Bernstein83",
+    ExternalIdType.SEMANTIC_SCHOLAR to "204e3073870fae3d05bcbc2f6a8e263d9b72e776",
+)

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -1,6 +1,8 @@
 package se.uulm.snowballr.backend.validation
 
+import arrow.core.Either
 import `in`.rcard.assertj.arrowcore.EitherAssert
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -109,6 +111,7 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<TooLongField>(result)
+        assertThat((result as Either.Left).value).hasSize(1)
     }
 
     @ParameterizedTest
@@ -117,6 +120,7 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<BlankField>(result)
+        assertThat((result as Either.Left).value).hasSize(1)
     }
 
     @ParameterizedTest(name = "{1}")

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -28,6 +28,7 @@ class ExternalIdTest {
             ExternalIdType.PUB_MED_CENTRAL to "1234567",
             ExternalIdType.SEMANTIC_SCHOLAR to "not-a-hash",
             ExternalIdType.ACL to "not-an-acl-id",
+            ExternalIdType.DBLP to "not-a-dblp-key",
         )
 
         @JvmStatic
@@ -121,18 +122,6 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<InvalidExternalIdFormat>(result)
-    }
-
-    @Test
-    fun `When a DBLP external ID has a non-blank value of valid length, then no issues are returned regardless of format`() {
-        val externalId = externalId {
-            type = ExternalIdType.DBLP.name
-            value = "this is not a real dblp key but should still be accepted"
-        }
-
-        val result = validateExternalId(externalId)
-
-        EitherAssert.assertThat(result).isRight()
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -27,6 +27,7 @@ class ExternalIdTest {
             ExternalIdType.MEDLINE to "not-a-number",
             ExternalIdType.PUB_MED_CENTRAL to "1234567",
             ExternalIdType.SEMANTIC_SCHOLAR to "not-a-hash",
+            ExternalIdType.ACL to "not-an-acl-id",
         )
 
         @JvmStatic
@@ -41,6 +42,12 @@ class ExternalIdTest {
         fun validArxivIdOldStyle() = externalId {
             type = ExternalIdType.ARXIV.name
             value = "hep-th/9901001"
+        }
+
+        @JvmStatic
+        fun validAclIdNewStyle() = externalId {
+            type = ExternalIdType.ACL.name
+            value = "2021.acl-long.1"
         }
 
         @JvmStatic
@@ -83,6 +90,13 @@ class ExternalIdTest {
         EitherAssert.assertThat(result).isRight()
     }
 
+    @Test
+    fun `When an ACL ID uses the new-style format, then no issues are returned`() {
+        val result = validateExternalId(validAclIdNewStyle())
+
+        EitherAssert.assertThat(result).isRight()
+    }
+
     @ParameterizedTest
     @MethodSource("se.uulm.snowballr.backend.validation.ExternalIdTest#invalidExternalIdsTooLongValue")
     fun `When an external ID has a too long value, then a 'TooLongField' issue is returned`(externalId: ExternalId) {
@@ -107,18 +121,6 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<InvalidExternalIdFormat>(result)
-    }
-
-    @Test
-    fun `When an ACL external ID has a non-blank value of valid length, then no issues are returned regardless of format`() {
-        val externalId = externalId {
-            type = ExternalIdType.ACL.name
-            value = "this is not a real ACL anthology id but should still be accepted"
-        }
-
-        val result = validateExternalId(externalId)
-
-        EitherAssert.assertThat(result).isRight()
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.InvalidEnumValue
+import se.uulm.snowballr.backend.model.InvalidExternalIdFormat
 import se.uulm.snowballr.backend.model.TooLongField
 import se.uulm.snowballr.backend.model.dto.paper.ExternalIdType
 import se.uulm.snowballr.backend.validation.ExternalIdValidator.validateExternalId
@@ -14,12 +15,32 @@ import snowballr.PaperOuterClass.Paper.ExternalId
 
 class ExternalIdTest {
     companion object {
+        /**
+         * A malformed example value per [ExternalIdType] that has a format check defined, i.e. is neither blank nor
+         * too long, but does not match the expected format.
+         */
+        private val INVALID_FORMAT_VALUES: Map<ExternalIdType, String> = mapOf(
+            ExternalIdType.DOI to "not-a-doi",
+            ExternalIdType.ARXIV to "not-an-arxiv-id",
+            ExternalIdType.MAG to "not-a-number",
+            ExternalIdType.PUB_MED to "not-a-number",
+            ExternalIdType.MEDLINE to "not-a-number",
+            ExternalIdType.PUB_MED_CENTRAL to "1234567",
+            ExternalIdType.SEMANTIC_SCHOLAR to "not-a-hash",
+        )
+
         @JvmStatic
         fun validExternalIds() = ExternalIdType.entries.map {
             externalId {
                 type = it.name
-                value = "${it.name}-value"
+                value = VALID_EXTERNAL_ID_VALUES.getValue(it)
             }
+        }
+
+        @JvmStatic
+        fun validArxivIdOldStyle() = externalId {
+            type = ExternalIdType.ARXIV.name
+            value = "hep-th/9901001"
         }
 
         @JvmStatic
@@ -37,12 +58,27 @@ class ExternalIdTest {
                 value = ""
             }
         }
+
+        @JvmStatic
+        fun invalidExternalIdsFormatValue() = INVALID_FORMAT_VALUES.map { (type, value) ->
+            externalId {
+                this.type = type.name
+                this.value = value
+            }
+        }
     }
 
     @ParameterizedTest
     @MethodSource("se.uulm.snowballr.backend.validation.ExternalIdTest#validExternalIds")
     fun `When an external ID is valid, then no issues are returned`(externalId: ExternalId) {
         val result = validateExternalId(externalId)
+
+        EitherAssert.assertThat(result).isRight()
+    }
+
+    @Test
+    fun `When an ArXiv ID uses the old-style format, then no issues are returned`() {
+        val result = validateExternalId(validArxivIdOldStyle())
 
         EitherAssert.assertThat(result).isRight()
     }
@@ -61,6 +97,40 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<BlankField>(result)
+    }
+
+    @ParameterizedTest
+    @MethodSource("se.uulm.snowballr.backend.validation.ExternalIdTest#invalidExternalIdsFormatValue")
+    fun `When an external ID does not match the format of its type, then a 'InvalidExternalIdFormat' issue is returned`(
+        externalId: ExternalId,
+    ) {
+        val result = validateExternalId(externalId)
+
+        assertInvalidResult<InvalidExternalIdFormat>(result)
+    }
+
+    @Test
+    fun `When an ACL external ID has a non-blank value of valid length, then no issues are returned regardless of format`() {
+        val externalId = externalId {
+            type = ExternalIdType.ACL.name
+            value = "this is not a real ACL anthology id but should still be accepted"
+        }
+
+        val result = validateExternalId(externalId)
+
+        EitherAssert.assertThat(result).isRight()
+    }
+
+    @Test
+    fun `When a DBLP external ID has a non-blank value of valid length, then no issues are returned regardless of format`() {
+        val externalId = externalId {
+            type = ExternalIdType.DBLP.name
+            value = "this is not a real dblp key but should still be accepted"
+        }
+
+        val result = validateExternalId(externalId)
+
+        EitherAssert.assertThat(result).isRight()
     }
 
     @Test

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -3,7 +3,7 @@ package se.uulm.snowballr.backend.validation
 import arrow.core.Either
 import `in`.rcard.assertj.arrowcore.EitherAssert
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -146,5 +146,17 @@ class ExternalIdTest {
 
         assertInvalidResult<InvalidEnumValue>(result)
         assertThat((result as Either.Left).value).hasSize(1)
+    }
+
+    @Test
+    fun `When an external ID is validated, then the value is trimmed before validating`() {
+        val externalId = ExternalId.newBuilder()
+            .setType(ExternalIdType.DOI.name)
+            .setValue("   10.1000/xyz123    ")
+            .build()
+
+        val result = validateExternalId(externalId)
+
+        EitherAssert.assertThat(result).isRight()
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -132,6 +132,7 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<InvalidExternalIdFormat>(result)
+        assertThat((result as Either.Left).value).hasSize(1)
     }
 
     @Test
@@ -144,5 +145,6 @@ class ExternalIdTest {
         val result = validateExternalId(externalId)
 
         assertInvalidResult<InvalidEnumValue>(result)
+        assertThat((result as Either.Left).value).hasSize(1)
     }
 }

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -3,6 +3,7 @@ package se.uulm.snowballr.backend.validation
 import `in`.rcard.assertj.arrowcore.EitherAssert
 import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import se.uulm.snowballr.backend.model.BlankField
 import se.uulm.snowballr.backend.model.InvalidEnumValue
@@ -31,25 +32,43 @@ class ExternalIdTest {
             ExternalIdType.DBLP to "not-a-dblp-key",
         )
 
-        @JvmStatic
-        fun validExternalIds() = ExternalIdType.entries.map {
-            externalId {
-                type = it.name
-                value = VALID_EXTERNAL_ID_VALUES.getValue(it)
+        /**
+         * Extra valid values per [ExternalIdType] beyond the single representative example in
+         * [VALID_EXTERNAL_ID_VALUES], covering alternate schemes (old/new style, version suffixes) and values that
+         * sit at the boundary of what the format regex allows.
+         */
+        private val EXTRA_VALID_VALUES: List<Pair<ExternalIdType, String>> = listOf(
+            ExternalIdType.DOI to "10.48550/arXiv.2202.01037", // registrant code longer than 4 digits
+            ExternalIdType.ARXIV to "2101.00001v2", // new-style with version suffix
+            ExternalIdType.ARXIV to "hep-th/9901001", // legacy old-style
+            ExternalIdType.ACL to "2021.acl-long.1", // new-style (2020 onward)
+            ExternalIdType.DBLP to "journals/corr/abs-2103-05387", // hyphenated id-suffix, e.g. CoRR/arXiv keys
+        )
+
+        /**
+         * Extra malformed values per [ExternalIdType] beyond [INVALID_FORMAT_VALUES], covering values that are
+         * close to, but do not quite match, the expected format.
+         */
+        private val EXTRA_INVALID_FORMAT_VALUES: List<Pair<ExternalIdType, String>> = listOf(
+            ExternalIdType.DOI to "10.100/xyz123", // registrant code shorter than 4 digits
+            ExternalIdType.DOI to "10.1000xyz123", // missing separating slash
+            ExternalIdType.ARXIV to "210.00001", // year-month segment shorter than 4 digits
+            ExternalIdType.ACL to "P19-12345", // paper number longer than 4 digits
+            ExternalIdType.DBLP to "journals/tods", // missing id-suffix segment
+        )
+
+        private fun argumentsFor(type: ExternalIdType, value: String): Arguments {
+            val id = externalId {
+                this.type = type.name
+                this.value = value
             }
+            return Arguments.of(id, "$type '$value'")
         }
 
         @JvmStatic
-        fun validArxivIdOldStyle() = externalId {
-            type = ExternalIdType.ARXIV.name
-            value = "hep-th/9901001"
-        }
-
-        @JvmStatic
-        fun validAclIdNewStyle() = externalId {
-            type = ExternalIdType.ACL.name
-            value = "2021.acl-long.1"
-        }
+        fun validExternalIds(): List<Arguments> =
+            (ExternalIdType.entries.map { it to VALID_EXTERNAL_ID_VALUES.getValue(it) } + EXTRA_VALID_VALUES)
+                .map { (type, value) -> argumentsFor(type, value) }
 
         @JvmStatic
         fun invalidExternalIdsTooLongValue() = ExternalIdType.entries.map {
@@ -68,32 +87,18 @@ class ExternalIdTest {
         }
 
         @JvmStatic
-        fun invalidExternalIdsFormatValue() = INVALID_FORMAT_VALUES.map { (type, value) ->
-            externalId {
-                this.type = type.name
-                this.value = value
-            }
-        }
+        fun invalidExternalIdsFormatValue(): List<Arguments> =
+            (INVALID_FORMAT_VALUES.toList() + EXTRA_INVALID_FORMAT_VALUES)
+                .map { (type, value) -> argumentsFor(type, value) }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{1}")
     @MethodSource("se.uulm.snowballr.backend.validation.ExternalIdTest#validExternalIds")
-    fun `When an external ID is valid, then no issues are returned`(externalId: ExternalId) {
+    fun `When an external ID is valid, then no issues are returned`(
+        externalId: ExternalId,
+        @Suppress("unused") testName: String,
+    ) {
         val result = validateExternalId(externalId)
-
-        EitherAssert.assertThat(result).isRight()
-    }
-
-    @Test
-    fun `When an ArXiv ID uses the old-style format, then no issues are returned`() {
-        val result = validateExternalId(validArxivIdOldStyle())
-
-        EitherAssert.assertThat(result).isRight()
-    }
-
-    @Test
-    fun `When an ACL ID uses the new-style format, then no issues are returned`() {
-        val result = validateExternalId(validAclIdNewStyle())
 
         EitherAssert.assertThat(result).isRight()
     }
@@ -114,10 +119,11 @@ class ExternalIdTest {
         assertInvalidResult<BlankField>(result)
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{1}")
     @MethodSource("se.uulm.snowballr.backend.validation.ExternalIdTest#invalidExternalIdsFormatValue")
     fun `When an external ID does not match the format of its type, then a 'InvalidExternalIdFormat' issue is returned`(
         externalId: ExternalId,
+        @Suppress("unused") testName: String,
     ) {
         val result = validateExternalId(externalId)
 

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/ExternalIdTest.kt
@@ -45,6 +45,7 @@ class ExternalIdTest {
             ExternalIdType.ARXIV to "hep-th/9901001", // legacy old-style
             ExternalIdType.ACL to "2021.acl-long.1", // new-style (2020 onward)
             ExternalIdType.DBLP to "journals/corr/abs-2103-05387", // hyphenated id-suffix, e.g. CoRR/arXiv keys
+            ExternalIdType.DBLP to "books/crc/chb/CarrollR14", // more than 3 segments
         )
 
         /**

--- a/src/test/kotlin/se/uulm/snowballr/backend/validation/PaperValidatorTest.kt
+++ b/src/test/kotlin/se/uulm/snowballr/backend/validation/PaperValidatorTest.kt
@@ -134,7 +134,7 @@ class PaperValidatorTest {
             ExternalIdType.entries.map {
                 externalId {
                     type = it.name
-                    value = "${it.name}-value"
+                    value = VALID_EXTERNAL_ID_VALUES.getValue(it)
                 }
             },
         )


### PR DESCRIPTION
Closes #593

## What I have made

This adds a type-specific validation for the external ID types. Previously, a user could simply provide a URL as a DOI. This is not possible anymore.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
  - ~~[ ] I have updated `AGENTS.md` if the changes affect project structure, commands, tooling, or conventions~~
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Reviewer

- [x] I have checked the changes against the requirements
